### PR TITLE
Relax naming restriction for transitions.

### DIFF
--- a/src/lang/syntax/ScillaParser.mly
+++ b/src/lang/syntax/ScillaParser.mly
@@ -260,13 +260,17 @@ param_pair:
 | n = ID; COLON; t = typ { asId n, t }
 
 transition:
-| TRANSITION; t = CID;
+| TRANSITION; t = trans_id;
   LPAREN; params = separated_list(COMMA, param_pair); RPAREN;
   ss = stmts;
   END;
   { { tname = asIdL t (toLoc $startpos);
       tparams = params;
       tbody = ss } }
+
+trans_id:
+| c = CID {c};
+| i = ID {i};
 
 field:
 | FIELD; f = ID; COLON; t=typ;

--- a/tests/contracts/Testcontracts.ml
+++ b/tests/contracts/Testcontracts.ml
@@ -121,8 +121,9 @@ let add_tests bindir testsdir pcli =
     let cfinvoketests = "cfinvoke" >:::(build_contract_tests bindir testsdir pcli "cfinvoke" 1 3) in
     let pingtests = "ping" >:::(build_contract_tests bindir testsdir pcli "ping" 0 3) in
     let pongtests = "pong" >:::(build_contract_tests bindir testsdir pcli "pong" 0 3) in
+    let helloWorldtests = "helloWorld" >:::(build_contract_tests bindir testsdir pcli "helloWorld" 1 2) in
     let fungibletokentests = "fungible-token" >:::(build_contract_tests bindir
     testsdir pcli "fungible-token" 0 8) in
     let misc_tests = "misc_tests" >::: build_misc_tests bindir testsdir pcli in
       "contract_tests" >::: [crowdfundingtests;cfinit_test;zilgametests;zginit_test;cfinvoketests;
-                    misc_tests;pingtests;pongtests;fungibletokentests]
+                    misc_tests;pingtests;pongtests;fungibletokentests;helloWorldtests]

--- a/tests/contracts/helloWorld/contract.scilla
+++ b/tests/contracts/helloWorld/contract.scilla
@@ -11,7 +11,7 @@ let one_msg =
   let nil_msg = Nil {Message} in
   Cons {Message} msg nil_msg
 
-let not_owner_code  = 1
+let not_owner_code = Int32 1
 
 (***************************************************)
 (*             The contract definition             *)
@@ -22,16 +22,16 @@ contract HelloWorld
 
 field msgstr : String = "Hello World"
 
-transition SayHello()
+transition sayHello()
 	is_owner = builtin eq owner _sender;
   match is_owner with
   | False =>
-    msg = {_tag : Main; _recipient : _sender; _amount : 0; code : not_owner_code};
+    msg = {_tag : Main; _recipient : _sender; _amount : Uint128 0; code : not_owner_code};
     msgs = one_msg msg;
     send msgs
   | True =>
     greeting <- msgstr;
-    msg = {_tag : Main; _recipient : _sender; _amount : 0; welcome_msg : greeting};
+    msg = {_tag : Main; _recipient : _sender; _amount : Uint128 0; welcome_msg : greeting};
     msgs = one_msg msg;
     send msgs
   end

--- a/tests/contracts/helloWorld/message_1.json
+++ b/tests/contracts/helloWorld/message_1.json
@@ -1,5 +1,5 @@
 {
-    "_tag": "SayHello",
+    "_tag": "sayHello",
     "_amount": "0",
     "_sender" : "0x1234567890123456789012345678901234567890",
     "params": []

--- a/tests/contracts/helloWorld/message_2.json
+++ b/tests/contracts/helloWorld/message_2.json
@@ -1,5 +1,5 @@
 {
-    "_tag": "SayHello",
+    "_tag": "sayHello",
     "_amount": "0",
     "_sender" : "0xa234567890123456789012345678901234567890",
     "params": []

--- a/tests/contracts/helloWorld/output_1.json
+++ b/tests/contracts/helloWorld/output_1.json
@@ -8,7 +8,7 @@
     ]
   },
   "states": [
-    { "vname": "_balance", "type": "Int", "value": "0" },
+    { "vname": "_balance", "type": "Uint128", "value": "0" },
     { "vname": "msgstr", "type": "String", "value": "Hello World" }
   ]
 }

--- a/tests/contracts/helloWorld/output_2.json
+++ b/tests/contracts/helloWorld/output_2.json
@@ -3,10 +3,10 @@
     "_tag": "Main",
     "_amount": "0",
     "_recipient": "0xa234567890123456789012345678901234567890",
-    "params": [ { "vname": "code", "type": "Int", "value": "1" } ]
+    "params": [ { "vname": "code", "type": "Int32", "value": "1" } ]
   },
   "states": [
-    { "vname": "_balance", "type": "Int", "value": "0" },
+    { "vname": "_balance", "type": "Uint128", "value": "0" },
     { "vname": "msgstr", "type": "String", "value": "Hello World" }
   ]
 }


### PR DESCRIPTION
Transition names can now being with lower case, instead
of just upper cases as was before.

Also add "helloWorld" contract and its tests to the testsuite.
Change the transition name in "helloWorld" to being with lower case.

Issue #86 .