### PR TITLE
auction: outbid has to be strict

### DIFF
--- a/tests/contracts/auction/contract.scilla
+++ b/tests/contracts/auction/contract.scilla
@@ -154,7 +154,6 @@ end
 (* Transition 2: claiming money back *)
 transition Withdraw ()
   prs <- pendingReturns;
-  b = builtin contains prs _sender;
   pr = builtin get prs _sender;
   match pr with
   | None =>


### PR DESCRIPTION
1. Outbid only if strictly greater than previous highest bid (before this change, even if the bid is equal to previous one, the new bidder replaces the previous highest bidder).
2. Bunch of indentation fixes. Note: Please set your diff viewer to ignore whitespace changes.