### PR TITLE
Support docker image creation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+_build
+bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# escape=\
+ARG BASE_IMAGE=ubuntu:16.04
+
+FROM ${BASE_IMAGE}
+
+COPY . /scilla
+
+WORKDIR /scilla
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    m4 \
+    ocaml \
+    opam \
+    pkg-config \
+    zlib1g-dev \
+    libgmp-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN make opamdep && echo \
+    ". ~/.opam/opam-init/init.sh > /dev/null 2> /dev/null || true " >> ~/.bashrc && \
+    eval `opam config env` && make

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Invoke `make` to build, `make clean` to clean up, etc.
 
-.PHONY: default all utop test clean
+.PHONY: default all utop test clean docker zilliqa-docker
 
 default: all
 
@@ -25,6 +25,19 @@ clean:
 	jbuilder clean
 # Remove remaining files/folders ignored by git as defined in .gitignore (-X).
 	git clean -dfXq
+
+# Build a standalone scilla docker
+docker:
+	docker build .
+
+# Build a zilliqa-plus-scilla docker based on from zilliqa image ZILLIQA_IMAGE
+zilliqa-docker:
+	@[ -z "$(ZILLIQA_IMAGE)" ] && \
+		echo "ZILLIQA_IMAGE not specified" && \
+		echo "Usage:\n\tmake zilliqa-docker ZILLIQA_IMAGE=zilliqa:zilliqa" && \
+		echo "" && \
+		exit 1
+	docker build --build-arg=$(ZILLIQA_IMAGE) .
 
 opamdep:
 	opam init -y


### PR DESCRIPTION
This pr brings basic docker image support required for Kubernetes testnet deployment.

Details:
- add target 'docker' and 'zilliqa-docker' to `Makefile`
- add Dockefile and .dockerignore
- doc is currently hosted [here](https://github.com/Zilliqa/dev-docs/wiki/Docker)

Future work:
- need some work to reduce the image size (currently, 1.7 GB)