### PR TITLE
Fix error checking in makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,14 @@ docker:
 
 # Build a zilliqa-plus-scilla docker based on from zilliqa image ZILLIQA_IMAGE
 zilliqa-docker:
-	@[ -z "$(ZILLIQA_IMAGE)" ] && \
+	@if [ -z "$(ZILLIQA_IMAGE)" ]; \
+	then \
 		echo "ZILLIQA_IMAGE not specified" && \
 		echo "Usage:\n\tmake zilliqa-docker ZILLIQA_IMAGE=zilliqa:zilliqa" && \
 		echo "" && \
-		exit 1
-	docker build --build-arg=$(ZILLIQA_IMAGE) .
+		exit 1; \
+	fi
+	docker build --build-arg BASE_IMAGE=$(ZILLIQA_IMAGE) .
 
 opamdep:
 	opam init -y


### PR DESCRIPTION
This pr fixes an issue in #104 where
- error checking for `make zilliqa-docker` is not done properly 
- `--build-arg` is not used correctly