### PR TITLE
Cleanup stdlib related stuff for runners

### DIFF
--- a/src/lang/eval/GlobalConfig.ml
+++ b/src/lang/eval/GlobalConfig.ml
@@ -91,5 +91,28 @@ let get_trace_file () =
 let set_trace_file s =
   trace_file := s
 
-(* Environment variable to look for stdlib *)
-let scilla_stdlib_path = "SCILLA_STDLIB_PATH"
+module StdlibTracker = struct
+
+(* Environment variable: where to look for stdlib.
+ * Multiple entries can be specified, separated by ';'.
+ *)
+let scilla_stdlib_env = "SCILLA_STDLIB_PATH"
+
+(* List of directories to look for stdlib *)
+let stdlib_dirs = ref []
+
+(* List of directories to look for stdlib.
+ * Entries from scilla_stdlib_env will be first. *)
+let get_stdlib_dirs () =
+  let env_dirs = 
+    match (Sys.getenv_opt scilla_stdlib_env) with 
+    | Some s -> String.split_on_char ';' s
+    | None -> []
+  in
+    List.append env_dirs !stdlib_dirs
+
+(* Update stdlib dirs with more locations *)
+let add_stdlib_dirs dirs =
+  stdlib_dirs := List.append !stdlib_dirs dirs
+
+end

--- a/src/lang/eval/GlobalConfig.ml
+++ b/src/lang/eval/GlobalConfig.ml
@@ -115,4 +115,10 @@ let get_stdlib_dirs () =
 let add_stdlib_dirs dirs =
   stdlib_dirs := List.append !stdlib_dirs dirs
 
+(* Try find library "name" in known locations *)
+let find_lib_dir name =
+  let dirs = get_stdlib_dirs () in
+  BatList.find_opt 
+    (fun d -> Caml.Sys.file_exists (d ^ Filename.dir_sep ^ name ^ ".scilla")) dirs
+
 end

--- a/src/lang/eval/GlobalConfig.mli
+++ b/src/lang/eval/GlobalConfig.mli
@@ -38,5 +38,16 @@ val set_trace_level : trace_kind -> unit
 val get_trace_file : unit -> string
 val set_trace_file : string -> unit
 
-(* Environment variable to look for stdlib *)
-val scilla_stdlib_path : string
+module StdlibTracker : sig
+
+(* Environment variable: where to look for stdlib.
+ * Multiple entries can be specified, separated by ';'.
+ *)
+val scilla_stdlib_env : string
+(* List of directories to look for stdlib.
+ * Entries from scilla_stdlib_env will be first. *)
+val get_stdlib_dirs : unit -> string list
+(* Update stdlib dirs with more locations *)
+val add_stdlib_dirs : string list -> unit
+
+end

--- a/src/lang/eval/GlobalConfig.mli
+++ b/src/lang/eval/GlobalConfig.mli
@@ -49,5 +49,7 @@ val scilla_stdlib_env : string
 val get_stdlib_dirs : unit -> string list
 (* Update stdlib dirs with more locations *)
 val add_stdlib_dirs : string list -> unit
+(* Try find library "name" in known locations *)
+val find_lib_dir : string -> string option
 
 end

--- a/src/runners/RunnerUtil.ml
+++ b/src/runners/RunnerUtil.ml
@@ -23,7 +23,7 @@ open Syntax
 open GlobalConfig
 open DebugMessage
 
-(* Parse external libraries "names" by looking for it in "ldirs". *)
+(* Parse external libraries "names" (by looking for in StdlibTracker). *)
 let import_libs names =
   List.map (fun id -> 
     let name = get_id id in

--- a/src/runners/RunnerUtil.ml
+++ b/src/runners/RunnerUtil.ml
@@ -23,37 +23,6 @@ open Syntax
 open GlobalConfig
 open DebugMessage
 
-(* A path to standard library. This is not for the main "scilla-runner" as that
-   gets the path in a different way. This is only for the auxiliary runners which
-   have a simple command line option. *)
-let stdlib_dir () =
-  if (Array.length Sys.argv) <= 2
-  then
-    match Sys.getenv_opt scilla_stdlib_path with
-    | Some d -> d
-    | None -> printf "\n%s\n"
-       ("A path to Scilla stdlib not found. Please set " ^ scilla_stdlib_path ^ 
-       " environment variable, or pass as the second command-line argument for this script.\n" ^
-       "Example:\n" ^ Sys.argv.(0) ^ " list_sort.scilla ./src/stdlib/\n"); exit 1
-  else Sys.argv.(2)
-
-(* parse all files in dir, assuming they are scilla library files. *)
-let parse_stdlib dir =
-  let files = Array.to_list (Sys.readdir dir) in
-  let f file' = 
-    let file = dir ^ Filename.dir_sep ^ file' in
-    let name = Filename.remove_extension file in
-    let errmsg = (sprintf "%s. " ("Failed to import library " ^ name)) in
-    try
-      let parse_lib = FrontEndParser.parse_file ScillaParser.lmodule file in
-      match parse_lib with
-      | None -> fprintf stderr "%s" (errmsg ^ "Failed to parse.\n"); exit 1
-      | Some lib ->
-        lib
-    with | _ -> fprintf stderr "%s" (errmsg ^ "Failed to parse.\n"); exit 1
-  in
-    List.map f files
-
 (* Parse external libraries "names" by looking for it in "ldirs". *)
 let import_libs names ldirs =
   List.map (fun id -> 
@@ -75,3 +44,41 @@ let import_libs names ldirs =
         lib
     with | _ -> perr (errmsg ^ "Failed to parse.\n"); exit 1
     ) names 
+
+(* Parse all libraries that can be found in ldirs. *)
+let import_all_libs ldirs =
+  (* Get list of scilla libraries in dir *)
+  let get_lib_list dir =
+    let files = Array.to_list (Sys.readdir dir) in
+    List.fold_right (fun file names ->
+      if Filename.extension file = ".scilla"
+      then 
+        let name = Filename.remove_extension (Filename.basename file) in
+          asId name :: names
+      else
+        names) files []
+  in
+  (* Make a list of all libraries and parse them through import_libs above. *)
+  let names = List.fold_right (fun dir names ->
+    let names' = get_lib_list dir in
+      List.append names names') ldirs []
+  in
+    import_libs names ldirs
+
+(* Treat 2nd command line argument as a list of stdlib dirs
+ * and add it to StdlibTracker to be tracked. *)
+let add_cmd_stdlib () =
+  (* If we have a 2nd command line argument, that is a list
+     of directories to stdlib. Add that to the stdlib tracker. *)
+  if (Array.length Sys.argv) == 3
+  then
+    (let dirs = Sys.argv.(2) in
+    let dir_list = String.split_on_char ';' dirs in
+    StdlibTracker.add_stdlib_dirs dir_list)
+
+let stdlib_not_found_err () =
+  printf "\n%s\n"
+  ("A path to Scilla stdlib not found. Please set " ^ StdlibTracker.scilla_stdlib_env ^ 
+    " environment variable, or pass as the second command-line argument for this script.\n" ^
+    "Example:\n" ^ Sys.argv.(0) ^ " list_sort.scilla ./src/stdlib/\n");
+   exit 1

--- a/src/runners/RunnerUtil.ml
+++ b/src/runners/RunnerUtil.ml
@@ -24,13 +24,11 @@ open GlobalConfig
 open DebugMessage
 
 (* Parse external libraries "names" by looking for it in "ldirs". *)
-let import_libs names ldirs =
+let import_libs names =
   List.map (fun id -> 
     let name = get_id id in
     let errmsg = (sprintf "%s. " ("Failed to import library " ^ name)) in
-    let dir = BatList.find_opt 
-      (fun d -> Caml.Sys.file_exists (d ^ Filename.dir_sep ^ name ^ ".scilla")) 
-      ldirs in
+    let dir = StdlibTracker.find_lib_dir name in
     let open Core in 
     let f = match dir with
       | None -> perr (errmsg ^ "Not found.\n") ; exit 1
@@ -63,7 +61,7 @@ let import_all_libs ldirs =
     let names' = get_lib_list dir in
       List.append names names') ldirs []
   in
-    import_libs names ldirs
+    import_libs names
 
 (* Treat 2nd command line argument as a list of stdlib dirs
  * and add it to StdlibTracker to be tracked. *)

--- a/src/runners/scilla_checker.ml
+++ b/src/runners/scilla_checker.ml
@@ -54,13 +54,20 @@ let () =
     (perr (sprintf "Usage: %s foo.scilla\n" Sys.argv.(0))
     )
   else (
-    GlobalConfig.set_debug_level GlobalConfig.Debug_None;
+    let open GlobalConfig in
+    set_debug_level Debug_None;
     (* Testsuite runs this executable with cwd=tests and ends
        up complaining about missing _build directory for logger.
        So disable the logger. *)
     let r = (
       let%bind cmod = check_parsing Sys.argv.(1) in
-      let lib_dirs = [stdlib_dir()] in
+      (* This is an auxiliary executable, it's second argument must
+       * have a list of stdlib dirs, so note that down. *)
+      add_cmd_stdlib();
+      (* Get list of stdlib dirs. *)
+      let lib_dirs = StdlibTracker.get_stdlib_dirs() in
+      if lib_dirs = [] then stdlib_not_found_err ();
+      (* Import whatever libs we want. *)
       let elibs = import_libs cmod.elibs lib_dirs in
       let%bind typing_res = check_typing cmod elibs in
         pure (cmod, typing_res)

--- a/src/runners/scilla_checker.ml
+++ b/src/runners/scilla_checker.ml
@@ -68,7 +68,7 @@ let () =
       let lib_dirs = StdlibTracker.get_stdlib_dirs() in
       if lib_dirs = [] then stdlib_not_found_err ();
       (* Import whatever libs we want. *)
-      let elibs = import_libs cmod.elibs lib_dirs in
+      let elibs = import_libs cmod.elibs in
       let%bind typing_res = check_typing cmod elibs in
         pure (cmod, typing_res)
     ) in

--- a/src/runners/scilla_runner.ml
+++ b/src/runners/scilla_runner.ml
@@ -25,6 +25,7 @@ open DebugMessage
 open ContractUtil
 open Stdint
 open RunnerUtil
+open GlobalConfig
 
 (****************************************************)
 (*          Checking initialized libraries          *)
@@ -119,7 +120,8 @@ let () =
 
       (* Parse external libraries. *)
       let lib_dirs = (Filename.dirname cli.input::cli.libdirs) in
-      let elibs = import_libs cmod.elibs lib_dirs in
+      StdlibTracker.add_stdlib_dirs lib_dirs;
+      let elibs = import_libs cmod.elibs in
       (* Contract library. *)
       let clibs = cmod.libs in
   


### PR DESCRIPTION
I have cleaned up how we find and load stdlib. No external behaviour has changed, but only the code is reorganized.

This is as a first step towards #140 .

It may be easier if this part is reviewed and merged before I proceed. Please do not delete the branch (or do a squash merge) as I'll use it further for the feature.