### PR TITLE
Use extended result only for eval

### DIFF
--- a/src/lang/base/BuiltIns.ml
+++ b/src/lang/base/BuiltIns.ml
@@ -22,7 +22,7 @@
 open Syntax
 open Core
 open MonadUtil
-open MonadUtil.Let_syntax
+open Result.Let_syntax
 open Big_int
 open Stdint
 open TypeUtil
@@ -838,10 +838,10 @@ let elab_id = fun t _ -> pure t
 module BuiltInDictionary = struct 
 
   (* Elaborates the operation type based on the arguments types *)
-  type elaborator = typ -> typ list -> (typ, string) eresult      
+  type elaborator = typ -> typ list -> (typ, string) result      
 
   (* Takes the expected type as an argument to elaborate the result *)
-  type built_in_executor = literal list -> typ -> (literal, string) eresult
+  type built_in_executor = literal list -> typ -> (literal, string) result
 
   (* A built-in record type:
      * built-in name

--- a/src/lang/base/BuiltIns.mli
+++ b/src/lang/base/BuiltIns.mli
@@ -17,11 +17,11 @@
 *)
 
 open Syntax
-open MonadUtil
+open Core
 
 module BuiltInDictionary : sig
   type built_in_executor =
-    literal list -> typ -> (literal, string) eresult
+    literal list -> typ -> (literal, string) result
 
   (*  
    The return result is a triple:
@@ -30,7 +30,7 @@ module BuiltInDictionary : sig
    * Executor for evaluating the operation      
    *)
   val find_builtin_op :
-    loc ident -> typ list -> ((typ * typ * built_in_executor), string) eresult
+    loc ident -> typ list -> ((typ * typ * built_in_executor), string) result
 end
 
 (* The first parameter is a string type *)
@@ -39,4 +39,4 @@ val is_int_type : typ -> bool
 val is_uint_type : typ -> bool
 
 (* Elaborator for the built-in typ *)
-val elab_id : typ -> typ list -> (typ, string) eresult
+val elab_id : typ -> typ list -> (typ, string) result

--- a/src/lang/base/Datatypes.mli
+++ b/src/lang/base/Datatypes.mli
@@ -17,7 +17,7 @@
 *)
 
 open Syntax
-open MonadUtil
+open Core
 
 (**********************************************************)
 (*                 Built-in Algebraic Data Types          *)
@@ -39,9 +39,9 @@ module DataTypeDictionary : sig
   (* Hiding the actual data type dicionary *)
 
   (*  Get ADT by name  *)
-  val lookup_name : string -> (adt, string) eresult
+  val lookup_name : string -> (adt, string) result
   (*  Get ADT by the constructor  *)
-  val lookup_constructor : string -> (adt * constructor, string) eresult
+  val lookup_constructor : string -> (adt * constructor, string) result
   (* Get typing map for a constructor *)
   val constr_tmap : adt -> string -> (typ list) option
   

--- a/src/lang/base/PatternChecker.ml
+++ b/src/lang/base/PatternChecker.ml
@@ -11,7 +11,7 @@
 open Syntax
 open Core
 open MonadUtil
-open MonadUtil.Let_syntax
+open Result.Let_syntax
 open TypeUtil
 open Datatypes
 open Utils

--- a/src/lang/base/TypeUtil.ml
+++ b/src/lang/base/TypeUtil.ml
@@ -20,7 +20,7 @@ open Core
 open Sexplib.Std
 open Syntax
 open MonadUtil
-open MonadUtil.Let_syntax
+open Result.Let_syntax
 open Datatypes
 
 (****************************************************************)
@@ -210,10 +210,10 @@ module type MakeTEnvFunctor = functor
     (* Add type variable to the environment *)
     val addV : t -> R.rep ident -> t
     (* Check type for well-formedness in the type environment *)
-    val is_wf_type : t -> typ -> (unit, string) eresult
+    val is_wf_type : t -> typ -> (unit, string) result
     (* Resolve the identifier *)
     val resolveT : 
-      ?lopt:(R.rep option) -> t -> string -> (resolve_result, string) eresult
+      ?lopt:(R.rep option) -> t -> string -> (resolve_result, string) result
     (* Copy the environment *)
     val copy : t -> t
     (* Convert to list *)
@@ -631,7 +631,7 @@ let get_failure_msg_stmt s opt get_loc = match s with
 
 let wrap_with_info msg res = match res with
   | Ok _ -> res
-  | Error (msg', es) -> Error((sprintf "%s%s" msg msg'), es)
+  | Error msg' -> Error(sprintf "%s%s" msg msg')
 
 let wrap_err e get_loc ?opt:(opt = "") = wrap_with_info (get_failure_msg e opt get_loc)
 

--- a/src/lang/base/TypeUtil.mli
+++ b/src/lang/base/TypeUtil.mli
@@ -16,7 +16,7 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open MonadUtil
+open Core
 open Syntax
 
 val subst_type_in_type: string -> typ -> typ -> typ
@@ -58,10 +58,10 @@ module type MakeTEnvFunctor = functor
     (* Add type variable to the environment *)
     val addV : t -> R.rep ident -> t
     (* Check type for well-formedness in the type environment *)
-    val is_wf_type : t -> typ -> (unit, string) eresult
+    val is_wf_type : t -> typ -> (unit, string) result
     (* Resolve the identifier *)    
     val resolveT : ?lopt:(R.rep option) -> t -> string ->
-      (resolve_result, string) eresult
+      (resolve_result, string) result
     (* Copy the environment *)
     val copy : t -> t
     (* Convert to list *)
@@ -76,7 +76,7 @@ end
 module PlainTypes : QualifiedTypes
 module MakeTEnv : MakeTEnvFunctor
 
-val literal_type : literal -> (typ, string) eresult
+val literal_type : literal -> (typ, string) result
 
 (* Useful generic types *)
 val fun_typ : typ -> typ -> typ
@@ -98,13 +98,13 @@ val is_ground_type : typ -> bool
 val type_equiv : typ -> typ -> bool
 val type_equiv_list : typ list -> typ list -> bool
 
-val assert_type_equiv : typ -> typ -> (unit, string) eresult
+val assert_type_equiv : typ -> typ -> (unit, string) result
 
 (* Applying a function type *)
-val fun_type_applies : typ -> typ list -> (typ, string) eresult
+val fun_type_applies : typ -> typ list -> (typ, string) result
 
 (* Applying a type function *)
-val elab_tfun_with_args : typ -> typ list -> (typ, string) eresult
+val elab_tfun_with_args : typ -> typ list -> (typ, string) result
 
 val pp_typ_list : typ list -> string  
 
@@ -116,28 +116,28 @@ val pp_typ_list : typ list -> string
 val apply_type_subst : (string * typ) list -> typ -> typ
 
 (*  Get elaborated type for a constructor and list of type arguments *)    
-val elab_constr_type : string -> typ list -> (typ, string) eresult  
+val elab_constr_type : string -> typ list -> (typ, string) result  
 
 (* For a given instantiated ADT and a construtor name, get type *
    assignemnts. This is the main working horse of type-checking
    pattern-matching. *)    
-val constr_pattern_arg_types : typ -> string -> (typ list, string) eresult  
+val constr_pattern_arg_types : typ -> string -> (typ list, string) result  
 
-val validate_param_length : string -> int -> int -> (unit, string) eresult
+val validate_param_length : string -> int -> int -> (unit, string) result
 
-val assert_all_same_type : typ list -> (unit, string) eresult
+val assert_all_same_type : typ list -> (unit, string) result
 
 (****************************************************************)
 (*                  Better error reporting                      *)
 (****************************************************************)
 
-val wrap_with_info : string -> ('a, string) eresult -> ('a, string) eresult
+val wrap_with_info : string -> ('a, string) result -> ('a, string) result
 
 val wrap_err : 'rep expr -> ('rep ident -> loc) -> ?opt:string ->
-  ('a, string) eresult -> ('a, string) eresult
+  ('a, string) result -> ('a, string) result
 
 val wrap_serr : ('srep, 'erep) stmt -> ('erep ident -> loc) -> ?opt:string ->
-  ('a, string) eresult -> ('a, string) eresult
+  ('a, string) result -> ('a, string) result
 
 (****************************************************************)
 (*                  Built-in typed entities                     *)

--- a/src/lang/eval/Eval.ml
+++ b/src/lang/eval/Eval.ml
@@ -21,7 +21,8 @@ open Syntax
 open Core
 open EvalUtil
 open MonadUtil
-open MonadUtil.Let_syntax
+open EvalMonad
+open EvalMonad.Let_syntax
 open PatternMatching
 open BuiltIns
 open Stdint
@@ -121,7 +122,7 @@ let rec exp_eval erep env =
       pure (fully_applied, env)          
   | Constr (cname, ts, actuals) ->
       let open Datatypes.DataTypeDictionary in 
-      let%bind (_, constr) = lookup_constructor cname in
+      let%bind (_, constr) = from_result @@ lookup_constructor cname in
       let alen = List.length actuals in
       if (constr.arity <> alen)
       then fail @@ sprintf
@@ -142,7 +143,7 @@ let rec exp_eval erep env =
         tryM clauses
           ~msg:(sprintf "Value %s\ndoes not match any clause of\n%s."
                   (Env.pp_value v) (pp_expr e))
-          ~f:(fun (p, _) -> match_with_pattern v p) in
+          ~f:(fun (p, _) -> from_result @@ match_with_pattern v p) in
       (* Update the environment for the branch *)
       let env' = List.fold_left bnds ~init:env
           ~f:(fun z (i, w) -> Env.bind z (get_id i) w) in
@@ -150,9 +151,9 @@ let rec exp_eval erep env =
   | Builtin (i, actuals) ->
       let%bind args = mapM actuals ~f:(fun arg -> Env.lookup env arg) in
       let%bind arg_literals = vals_to_literals args in
-      let%bind tps = mapM arg_literals ~f:literal_type in
-      let%bind (_, ret_typ, op) = BuiltInDictionary.find_builtin_op i tps in
-      let%bind res = op arg_literals ret_typ in 
+      let%bind tps = from_result @@ MonadUtil.mapM arg_literals ~f:literal_type in
+      let%bind (_, ret_typ, op) = from_result @@ BuiltInDictionary.find_builtin_op i tps in
+      let%bind res = from_result @@ op arg_literals ret_typ in 
       pure (Env.ValLit res, env)
   | Fixpoint (f, t, body) ->
       let fix = Env.ValFix (f, t, body, env) in
@@ -240,7 +241,7 @@ let rec stmt_eval conf stmts =
             tryM clauses
               ~msg:(sprintf "Value %s\ndoes not match any clause of\n%s."
                       (Env.pp_value v) (stmt_str stmt))
-              ~f:(fun (p, _) -> match_with_pattern v p) in 
+              ~f:(fun (p, _) -> from_result @@ match_with_pattern v p) in 
           (* Update the environment for the branch *)
           let conf' = List.fold_left bnds ~init:conf
               ~f:(fun z (i, w) -> Configuration.bind z (get_id i) w) in
@@ -399,8 +400,8 @@ let init_module md initargs curargs init_bal bstate elibs =
 
 (* Extract necessary bits from the message *)
 let preprocess_message es =
-  let%bind tag = MessagePayload.get_tag es in
-  let%bind amount = MessagePayload.get_amount es in
+  let%bind tag = from_result @@ MessagePayload.get_tag es in
+  let%bind amount = from_result @@ MessagePayload.get_amount es in
   let other = MessagePayload.get_other_entries es in
   pure (tag, amount, other)
 
@@ -448,7 +449,7 @@ let prepare_for_message contr m =
 let post_process_msgs cstate outs =
   (* Evey outgoing message should carry an "_amount" tag *)
   let%bind amounts = mapM outs ~f:(fun l -> match l with
-      | Msg es -> MessagePayload.get_amount es
+      | Msg es -> from_result @@ MessagePayload.get_amount es
       | _ -> fail @@ sprintf "Not a message literal: %s." (pp_literal l)) in
   let open Uint128 in
   let to_be_transferred = List.fold_left amounts ~init:zero

--- a/src/lang/eval/EvalUtil.ml
+++ b/src/lang/eval/EvalUtil.ml
@@ -19,7 +19,8 @@
 open Syntax
 open Core
 open MonadUtil
-open MonadUtil.Let_syntax
+open EvalMonad
+open EvalMonad.Let_syntax
 open Stdint
 open ContractUtil
 

--- a/src/lang/eval/JSON.ml
+++ b/src/lang/eval/JSON.ml
@@ -47,9 +47,9 @@ let member_exn m j =
 let literal_type_exn l =
   let t = TypeUtil.literal_type l in
   match t with
-  | Error (emsg, _) ->
+  | Error emsg ->
     raise (Invalid_json (emsg))
-  | Ok (s, _)->
+  | Ok s->
     pp_typ s
 
 let build_prim_lit_exn t v =
@@ -84,9 +84,9 @@ let rec json_to_adtargs cname tlist ajs =
   in
   let dt =
   (match DataTypeDictionary.lookup_constructor cname with
-  | Error (emsg, _) ->
+  | Error emsg ->
     raise (Invalid_json(emsg))
-  | Ok ((r, _), _) ->
+  | Ok (r, _) ->
     r
   ) in
   match cname with
@@ -138,9 +138,9 @@ and read_adt_json name j tlist_verify =
   let open Basic.Util in
   let dt =
   (match DataTypeDictionary.lookup_name name with
-    | Error (emsg, _) ->
+    | Error emsg ->
       raise (Invalid_json(emsg))
-    | Ok (r, _) ->
+    | Ok r ->
       r
     ) in
   let res = match j with
@@ -148,9 +148,9 @@ and read_adt_json name j tlist_verify =
       let constr = member_exn "constructor" j |> to_string in
       let dt' =
       (match DataTypeDictionary.lookup_constructor constr with
-      | Error (emsg, _) ->
+      | Error emsg ->
         raise (Invalid_json(emsg))
-      | Ok ((r, _), _) ->
+      | Ok (r, _) ->
         r
       ) in
       if (dt <> dt') then

--- a/src/lang/eval/PatternMatching.ml
+++ b/src/lang/eval/PatternMatching.ml
@@ -21,7 +21,7 @@ open Datatypes
 open Syntax
 open EvalUtil
 open MonadUtil
-open MonadUtil.Let_syntax
+open Result.Let_syntax
 
 let rec match_with_pattern v p = match p with
   | Wildcard -> pure []

--- a/src/runners/scilla_checker.ml
+++ b/src/runners/scilla_checker.ml
@@ -21,7 +21,7 @@ open Syntax
 open Core
 open DebugMessage
 open MonadUtil
-open MonadUtil.Let_syntax
+open Result.Let_syntax
 open RunnerUtil
 
 open TypeChecker.Typechecker_Contracts
@@ -41,7 +41,7 @@ let check_parsing ctr =
 let check_typing cmod elibs =
   let res = type_module cmod elibs in
   match res with
-  | Error (msg, _) -> pout @@ sprintf "\n%s\n\n" msg; res
+  | Error msg -> pout @@ sprintf "\n%s\n\n" msg; res
   | Ok _ ->
       let cn = get_id cmod.cname in 
         plog @@ sprintf
@@ -75,6 +75,6 @@ let () =
     ) in
     match r with
     | Error _ -> ()
-    | Ok ((cmod, _), _) ->
+    | Ok (cmod, _) ->
       pout (sprintf "%s\n" (JSON.ContractInfo.get_string cmod.contr));
   )

--- a/src/runners/scilla_runner.ml
+++ b/src/runners/scilla_runner.ml
@@ -26,7 +26,7 @@ open ContractUtil
 open Stdint
 open RunnerUtil
 open GlobalConfig
-open MonadUtil
+open MonadUtil.EvalMonad
 
 (****************************************************)
 (*          Checking initialized libraries          *)
@@ -215,7 +215,7 @@ let () =
           (omj, osj, oej), gas)
       in
       let output_json = `Assoc [
-        (* ("gas_consumed", `String (Int.to_string gas)); *)
+        (* "gas_consumed", `String (Int.to_string gas); *)
         ("message", output_msg_json); 
         ("states", output_state_json);
         ("events", output_events_json)

--- a/src/runners/type_checker.ml
+++ b/src/runners/type_checker.ml
@@ -26,7 +26,7 @@ open Recursion
 open RunnerUtil
 open DebugMessage
 open MonadUtil
-open MonadUtil.Let_syntax
+open Result.Let_syntax
 
 module SimpleTEnv = MakeTEnv(PlainTypes) (ParserRep)
 open SimpleTEnv
@@ -79,8 +79,8 @@ let () =
         (* Import whatever libs we want. *)
         let std_lib = import_libs [] in
         (match check_typing e std_lib with
-         | Ok (res, _) ->
+         | Ok res ->
              printf "%s\n" (pp_typ res.tp)
-         | Error (s, _) -> printf "Type checking failed:\n%s\n" s)
+         | Error s -> printf "Type checking failed:\n%s\n" s)
     | Some _ | None ->
         printf "%s\n" "Failed to parse input file.")


### PR DESCRIPTION
This is a cleanup following #183. Now, the monad for tracking gas is separated out and is used only in `Eval` phase. The other phases will use `Core.result`.