### PR TITLE
Provide schnorr builtins in Scilla

### DIFF
--- a/misc/emacs-mode/scilla.el
+++ b/misc/emacs-mode/scilla.el
@@ -17,9 +17,10 @@
 (defvar scilla-constants
   '("False" "True" "Some" "None"))
 
+;; We can't define a simple list of scilla-types as we want
+;; a regexp for ByStr[0-9]*, and that won't work with regexp-opt later.
 (defvar scilla-types
-  '("String" "Int32" "Int64" "Int128" "Uint32" "Uint64" "Uint128"
-    "Int256" "Uint256" "BNum" "Address" "Hash" "Message" "Map" "ADT"))
+  "\\(String\\|Int32\\|Int64\\|Int128\\|Uint32\\|Uint64\\|Uint128\\|Int256\\|Uint256\\|BNum\\|ByStr[0-9]*\\|Message\\|Map\\|ADT\\)")
 
 (defvar scilla-keywords
   '("builtin" "block" "library" "let" "in" "match" "with" "end"
@@ -42,7 +43,7 @@
     ;; ; : , ; { } =>  @ $ = are all special elements
     ;; (":\\|,\\|;\\|{\\|}\\|=>\\|@\\|$\\|=" . font-lock-keyword-face)
     ( ,(regexp-opt scilla-keywords 'words) . font-lock-keyword-face)
-    (, (regexp-opt scilla-types 'words) . font-lock-type-face)
+    ( ,scilla-types . font-lock-type-face)
     ;; Some known constants like True/False etc.
     ( ,(regexp-opt scilla-constants 'words) . font-lock-constant-face)
     ;; Numerical constants. Decimal or Hexadecimal integers.

--- a/src/lang/base/ContractUtil.ml
+++ b/src/lang/base/ContractUtil.ml
@@ -51,7 +51,7 @@ module MessagePayload = struct
       (function StringLit s -> Some (pure s) | _ -> None)
 
   let get_sender = get_value_for_entry sender_label
-      (function ByStr(len, _) as a when len = address_length -> Some (pure a) | _ -> None)
+      (function ByStrX(len, _) as a when len = address_length -> Some (pure a) | _ -> None)
 
   let get_amount = get_value_for_entry amount_label
       (function 
@@ -75,7 +75,7 @@ end
 
 let append_implict_trans_params tparams mk_id_address mk_id_uint128 =
   let open PrimTypes in
-  let sender = (mk_id_address MessagePayload.sender_label, bystr_typ address_length) in
+  let sender = (mk_id_address MessagePayload.sender_label, bystrx_typ address_length) in
   let amount = (mk_id_uint128 MessagePayload.amount_label, uint128_typ) in
   amount :: sender :: tparams
 

--- a/src/lang/base/PrimTypes.mli
+++ b/src/lang/base/PrimTypes.mli
@@ -26,7 +26,7 @@ open Syntax
 val is_prim_type : typ -> bool
 val is_int_type : typ -> bool
 val is_uint_type : typ -> bool
-val is_bystr_type : typ -> bool
+val is_bystrx_type : typ -> bool
 
 val int32_typ : typ
 val int64_typ : typ
@@ -39,9 +39,10 @@ val uint256_typ : typ
 val string_typ : typ
 val bnum_typ : typ
 val msg_typ : typ
-val bystr_typ : int -> typ
+val bystr_typ : typ
+val bystrx_typ : int -> typ
 (* Given a ByStrX, return integer X *)
-val bystr_width : typ -> int option
+val bystrx_width : typ -> int option
 
 (****************************************************************)
 (*            PrimType Literal utilities                        *)
@@ -53,5 +54,7 @@ val build_prim_literal : typ -> string -> literal option
 val validate_int_literal : literal -> bool
 (* Is input literal a valid BNum? *)
 val validate_bnum_literal : literal -> bool
+(* Is input a valid ByStrX literal? *)
+val validate_bystrx_literal : literal -> bool
 (* Is input a valid ByStr literal? *)
 val validate_bystr_literal : literal -> bool

--- a/src/lang/base/ScillaParser.mly
+++ b/src/lang/base/ScillaParser.mly
@@ -149,7 +149,7 @@ simple_exp :
 (* Atomic expression *)
 | a = atomic_exp {a} 
 (* Built-in call *)
-| BUILTIN; b = ID; args = nonempty_list(ID)
+| BUILTIN; b = ID; args = list(ID)
   { let xs = List.map (fun i -> Ident (i, dummy_loc)) args
     in (Builtin ((Ident (b, toLoc $startpos)), xs), toLoc $startpos) }
 (* Message construction *)
@@ -188,7 +188,7 @@ lit :
   }
 | h = HEXLIT   { 
   let l = String.length h in
-  build_prim_literal_exn (PrimTypes.bystr_typ ((l-1)/2)) h
+  build_prim_literal_exn (PrimTypes.bystrx_typ ((l-1)/2)) h
 }
 | s = STRING   { StringLit s }
 | EMP; kt = targ; vt = targ

--- a/src/lang/base/TypeHelpers.ml
+++ b/src/lang/base/TypeHelpers.ml
@@ -34,7 +34,7 @@ module TypecheckerERep (R : Rep) = struct
     match s with
     | Ident (n, r) -> Ident (n, (PlainTypes.mk_qualified_type t, r))
 
-  let mk_msg_payload_id_address s = mk_msg_payload_id (R.mk_msg_payload_id_address s) (bystr_typ address_length)
+  let mk_msg_payload_id_address s = mk_msg_payload_id (R.mk_msg_payload_id_address s) (bystrx_typ address_length)
   let mk_msg_payload_id_uint128 s = mk_msg_payload_id (R.mk_msg_payload_id_uint128 s) uint128_typ
   
   let mk_rep (r : R.rep) (t : PlainTypes.t inferred_type) = (t, r)

--- a/src/lang/base/TypeUtil.mli
+++ b/src/lang/base/TypeUtil.mli
@@ -87,6 +87,7 @@ module TypeUtilities
   val tvar : string -> typ
   val tfun_typ : string -> typ -> typ
   val map_typ : typ -> typ -> typ
+  val unit_typ : typ
 
   (****************************************************************)
   (*                       Type sanitization                      *)

--- a/src/lang/base/dune
+++ b/src/lang/base/dune
@@ -13,7 +13,7 @@
               ppx_deriving.show
               ppx_deriving_yojson.runtime
               cryptokit
-              yojson)
+              yojson scilla-cpp-deps)
   (preprocess (pps ppx_sexp_conv
                     ppx_let 
                     ppx_deriving.show

--- a/src/lang/eval/EvalUtil.ml
+++ b/src/lang/eval/EvalUtil.ml
@@ -36,7 +36,7 @@ module EvalBuiltIns = ScillaBuiltIns (SR) (ER)
 open EvalSyntax
     
 let rec subst_type_in_type tvar tp tm = match tm with
-  | PrimType _ as p -> p
+  | PrimType _ | Unit as p -> p
   (* Make sure the map's type is still primitive! *)
   | MapType (kt, vt) -> 
       let kts = subst_type_in_type tvar tp kt in

--- a/src/lang/eval/JSON.ml
+++ b/src/lang/eval/JSON.ml
@@ -276,8 +276,8 @@ and adttyps_to_json tlist =
 
 and literal_to_json lit = 
   match lit with
-  | StringLit (x) | BNum (x) -> `String (x)
-  | IntLit (_, x) | UintLit (_, x) | ByStr(_, x) -> `String (x)
+  | StringLit (x) | BNum (x) | ByStr(x) -> `String (x)
+  | IntLit (_, x) | UintLit (_, x) | ByStrX(_, x) -> `String (x)
   | Map ((_, _), kvs) ->
       `List (mapvalues_to_json kvs)
   | ADTValue (n, t, v) ->
@@ -318,7 +318,7 @@ let get_uint_literal l =
 
 let get_address_literal l =
   match l with
-  | ByStr(len, al) when len = address_length -> Some al
+  | ByStrX(len, al) when len = address_length -> Some al
   | _ -> None
 
 
@@ -370,7 +370,7 @@ let get_json_data filename =
   (* Make tag, amount and sender into a literal *)
   let tag = (tag_label, build_prim_lit_exn PrimTypes.string_typ tags) in
   let amount = (amount_label, build_prim_lit_exn PrimTypes.uint128_typ amounts) in
-  let sender = (sender_label, build_prim_lit_exn (PrimTypes.bystr_typ address_length) senders) in
+  let sender = (sender_label, build_prim_lit_exn (PrimTypes.bystrx_typ address_length) senders) in
   let pjlist = member_exn "params" json |> to_list in
   let params = List.map pjlist ~f:jobj_to_statevar in
     tag :: amount :: sender :: params

--- a/tests/contracts/Testcontracts.ml
+++ b/tests/contracts/Testcontracts.ml
@@ -157,12 +157,13 @@ let add_tests env =
     let mappairtests_f = "mappair" >:::(build_contract_tests env "mappair" fail_code 6 8) in
     let nonfungibletokentests = "nonfungible-token" >:::(build_contract_tests env "nonfungible-token" succ_code 1 12) in
     let nonfungibletokentests_expected_f = "nonfungible-token" >:::(build_contract_tests env "nonfungible-token" succ_code 21 27) in
-   
+    let schnorrtests = "schnorr" >:::(build_contract_tests env "schnorr" succ_code 1 4) in
     let emptytests = "empty_contract" >::: (build_contract_tests env "empty" succ_code 1 1) in
-
     let fungibletokentests = "fungible-token" >:::(build_contract_tests env "fungible-token" succ_code 0 8) in
     let misc_tests = "misc_tests" >::: build_misc_tests env in
+
       "contract_tests" >::: [crowdfundingtests;cfinit_test;zilgametests;zginit_test;cfinvoketests;mappairtests; mappairtests_f;
                              misc_tests;pingtests;pongtests;fungibletokentests;helloWorldtests;helloWorldtests_f;
-                             auctiontests;emptytests;bookstoretests;nonfungibletokentests_expected_f;nonfungibletokentests]
+                             auctiontests;emptytests;bookstoretests;nonfungibletokentests_expected_f;nonfungibletokentests;
+                             schnorrtests]
 

--- a/tests/contracts/schnorr/blockchain_1.json
+++ b/tests/contracts/schnorr/blockchain_1.json
@@ -1,0 +1,1 @@
+[ { "vname": "BLOCKNUMBER", "type": "BNum", "value": "100" } ]

--- a/tests/contracts/schnorr/blockchain_2.json
+++ b/tests/contracts/schnorr/blockchain_2.json
@@ -1,0 +1,1 @@
+[ { "vname": "BLOCKNUMBER", "type": "BNum", "value": "100" } ]

--- a/tests/contracts/schnorr/blockchain_3.json
+++ b/tests/contracts/schnorr/blockchain_3.json
@@ -1,0 +1,1 @@
+[ { "vname": "BLOCKNUMBER", "type": "BNum", "value": "100" } ]

--- a/tests/contracts/schnorr/blockchain_4.json
+++ b/tests/contracts/schnorr/blockchain_4.json
@@ -1,0 +1,1 @@
+[ { "vname": "BLOCKNUMBER", "type": "BNum", "value": "100" } ]

--- a/tests/contracts/schnorr/contract.scilla
+++ b/tests/contracts/schnorr/contract.scilla
@@ -1,0 +1,83 @@
+import PairUtils
+
+library Schnorr
+
+let one_msg = 
+  fun (msg : Message) => 
+    let nil_msg = Nil {Message} in
+    Cons {Message} msg nil_msg
+
+let fst_f = @fst (ByStr32) (ByStr33)
+let snd_f = @snd (ByStr32) (ByStr33)
+
+contract Schnorr
+()
+
+field priv_key : Option (ByStr32) = None {ByStr32}
+field pub_key : Option (ByStr33) = None {ByStr32}
+
+transition sign_and_verify (msg : ByStr)
+  pubk_o <- pub_key;
+  privk_o <- priv_key;
+  match pubk_o with
+  | Some pubk =>
+    match privk_o with
+    | Some privk =>
+      (* We have both privk and pubk. Sign the message. *)
+      sig = builtin schnorr_sign privk pubk msg;
+      ver = builtin schnorr_verify pubk msg sig;
+      match ver with
+      | True =>
+        m = { _tag : "Main"; _recipient : _sender; _amount : Uint128 0; status : "signed and verified" };
+        mone = one_msg m;
+        send mone
+      | False =>
+        m = { _tag : "Main"; _recipient : _sender; _amount : Uint128 0; status : "signed and verify failed" };
+        mone = one_msg m;
+        send mone
+      end
+    | None =>
+      m = { _tag : "Main"; _recipient : _sender; _amount : Uint128 0; status : "internal error" };
+      mone = one_msg m;
+      send mone
+    end
+  | None =>
+    (* We don't have a key-pair, generate one and store it. *)
+    kpair = builtin schnorr_gen_key_pair;
+    privk = fst_f kpair;
+    pubk = snd_f kpair;
+    (* We have both privk and pubk. Sign the message. *)
+    sig = builtin schnorr_sign privk pubk msg;
+    m = { _tag : "Main"; _recipient : _sender; _amount : Uint128 0; signature : sig };
+    mone = one_msg m;
+    (* Update state *)
+    privk_c = Some{ByStr32} privk;
+    priv_key := privk_c;
+    pubk_c = Some{ByStr33} pubk;
+    pub_key := pubk_c;
+    send mone
+  end
+end
+
+transition verify(msg : ByStr, sig : ByStr64)
+  pubk_o <- pub_key;
+  match pubk_o with
+  | Some pubk =>
+    sig = builtin schnorr_verify pubk msg sig;
+    match sig with
+    | True =>
+      m = { _tag : "Main"; _recipient : _sender; _amount : Uint128 0; status : "verification successful" };
+      mone = one_msg m;
+      send mone
+    | False =>
+      m = { _tag : "Main"; _recipient : _sender; _amount : Uint128 0; status : "verification failed" };
+      mone = one_msg m;
+      send mone
+    end
+  | None =>
+    (* We don't have a key-pair. *)
+    m = { _tag : "Main"; _recipient : _sender; _amount : Uint128 0; status : "no key error" };
+    mone = one_msg m;
+    send mone
+  end
+end

--- a/tests/contracts/schnorr/init.json
+++ b/tests/contracts/schnorr/init.json
@@ -1,0 +1,7 @@
+[
+    {
+        "vname" : "_creation_block",
+        "type" : "BNum",
+        "value" : "1"
+    }
+]

--- a/tests/contracts/schnorr/message_1.json
+++ b/tests/contracts/schnorr/message_1.json
@@ -1,0 +1,12 @@
+{
+    "_tag": "sign_and_verify",
+    "_amount": "0",
+    "_sender" : "0x12345678901234567890123456789012345678ab",
+    "params": [
+        {
+            "vname" : "msg",
+            "type" : "ByStr",
+            "value" : "0x0ffe45aa23"
+        }
+    ]
+}

--- a/tests/contracts/schnorr/message_2.json
+++ b/tests/contracts/schnorr/message_2.json
@@ -1,0 +1,17 @@
+{
+    "_tag": "verify",
+    "_amount": "0",
+    "_sender" : "0x12345678901234567890123456789012345678ab",
+    "params": [
+        {
+            "vname" : "msg",
+            "type" : "ByStr",
+            "value" : "0x0ffe45aa23"
+        },
+        {
+            "vname" : "sig",
+            "type" : "ByStr64",
+            "value" : "0x125ddeb7d68c36f381d24fd23e871f1a270533e8efc49b66922ab8603c7e79d3aeb79374b0fbb8b571f8eebd84b51dbda844b7d0fdbadf3011393343b5b040fd"
+        }
+    ]
+}

--- a/tests/contracts/schnorr/message_3.json
+++ b/tests/contracts/schnorr/message_3.json
@@ -1,0 +1,17 @@
+{
+    "_tag": "verify",
+    "_amount": "0",
+    "_sender" : "0x12345678901234567890123456789012345678ab",
+    "params": [
+        {
+            "vname" : "msg",
+            "type" : "ByStr",
+            "value" : "0xff0ffe45aa23"
+        },
+        {
+            "vname" : "sig",
+            "type" : "ByStr64",
+            "value" : "0x125ddeb7d68c36f381d24fd23e871f1a270533e8efc49b66922ab8603c7e79d3aeb79374b0fbb8b571f8eebd84b51dbda844b7d0fdbadf3011393343b5b040fd"
+        }
+    ]
+}

--- a/tests/contracts/schnorr/message_4.json
+++ b/tests/contracts/schnorr/message_4.json
@@ -1,0 +1,17 @@
+{
+    "_tag": "verify",
+    "_amount": "0",
+    "_sender" : "0x12345678901234567890123456789012345678ab",
+    "params": [
+        {
+            "vname" : "msg",
+            "type" : "ByStr",
+            "value" : "0x0ffe45aa23"
+        },
+        {
+            "vname" : "sig",
+            "type" : "ByStr64",
+            "value" : "0x125ddeb7d68c36f381d24fd23e871f1a270533e8efc49b66922ab8603c7e79d3aeb79374b0fbb8b571f8eebd84b51dbda844b7d0fdbadf3011393343b5b040ff"
+        }
+    ]
+}

--- a/tests/contracts/schnorr/output_1.json
+++ b/tests/contracts/schnorr/output_1.json
@@ -1,0 +1,37 @@
+{
+  "message": {
+    "_tag": "Main",
+    "_amount": "0",
+    "_accepted": "false",
+    "_recipient": "0x12345678901234567890123456789012345678ab",
+    "params": [
+      { "vname": "status", "type": "String", "value": "signed and verified" }
+    ]
+  },
+  "states": [
+    { "vname": "_balance", "type": "Uint128", "value": "0" },
+    {
+      "vname": "pub_key",
+      "type": "Option (ByStr33)",
+      "value": {
+        "constructor": "Some",
+        "argtypes": [ "ByStr33" ],
+        "arguments": [
+          "0x0331cca11ff9bc747e20fd0aef3425e3fe0a6be27c9cb60348fac0a9077403a029"
+        ]
+      }
+    },
+    {
+      "vname": "priv_key",
+      "type": "Option (ByStr32)",
+      "value": {
+        "constructor": "Some",
+        "argtypes": [ "ByStr32" ],
+        "arguments": [
+          "0x383f7c2af7edcd955bee9b78122d14cbebc7fd12b4efeedc6063cee78de74baf"
+        ]
+      }
+    }
+  ],
+  "events": []
+}

--- a/tests/contracts/schnorr/output_2.json
+++ b/tests/contracts/schnorr/output_2.json
@@ -1,0 +1,41 @@
+{
+  "message": {
+    "_tag": "Main",
+    "_amount": "0",
+    "_accepted": "false",
+    "_recipient": "0x12345678901234567890123456789012345678ab",
+    "params": [
+      {
+        "vname": "status",
+        "type": "String",
+        "value": "verification successful"
+      }
+    ]
+  },
+  "states": [
+    { "vname": "_balance", "type": "Uint128", "value": "0" },
+    {
+      "vname": "pub_key",
+      "type": "Option (ByStr33)",
+      "value": {
+        "constructor": "Some",
+        "argtypes": [ "ByStr33" ],
+        "arguments": [
+          "0x0331cca11ff9bc747e20fd0aef3425e3fe0a6be27c9cb60348fac0a9077403a029"
+        ]
+      }
+    },
+    {
+      "vname": "priv_key",
+      "type": "Option (ByStr32)",
+      "value": {
+        "constructor": "Some",
+        "argtypes": [ "ByStr32" ],
+        "arguments": [
+          "0x383f7c2af7edcd955bee9b78122d14cbebc7fd12b4efeedc6063cee78de74baf"
+        ]
+      }
+    }
+  ],
+  "events": []
+}

--- a/tests/contracts/schnorr/output_3.json
+++ b/tests/contracts/schnorr/output_3.json
@@ -1,0 +1,37 @@
+{
+  "message": {
+    "_tag": "Main",
+    "_amount": "0",
+    "_accepted": "false",
+    "_recipient": "0x12345678901234567890123456789012345678ab",
+    "params": [
+      { "vname": "status", "type": "String", "value": "verification failed" }
+    ]
+  },
+  "states": [
+    { "vname": "_balance", "type": "Uint128", "value": "0" },
+    {
+      "vname": "pub_key",
+      "type": "Option (ByStr33)",
+      "value": {
+        "constructor": "Some",
+        "argtypes": [ "ByStr33" ],
+        "arguments": [
+          "0x0331cca11ff9bc747e20fd0aef3425e3fe0a6be27c9cb60348fac0a9077403a029"
+        ]
+      }
+    },
+    {
+      "vname": "priv_key",
+      "type": "Option (ByStr32)",
+      "value": {
+        "constructor": "Some",
+        "argtypes": [ "ByStr32" ],
+        "arguments": [
+          "0x383f7c2af7edcd955bee9b78122d14cbebc7fd12b4efeedc6063cee78de74baf"
+        ]
+      }
+    }
+  ],
+  "events": []
+}

--- a/tests/contracts/schnorr/output_4.json
+++ b/tests/contracts/schnorr/output_4.json
@@ -1,0 +1,37 @@
+{
+  "message": {
+    "_tag": "Main",
+    "_amount": "0",
+    "_accepted": "false",
+    "_recipient": "0x12345678901234567890123456789012345678ab",
+    "params": [
+      { "vname": "status", "type": "String", "value": "verification failed" }
+    ]
+  },
+  "states": [
+    { "vname": "_balance", "type": "Uint128", "value": "0" },
+    {
+      "vname": "pub_key",
+      "type": "Option (ByStr33)",
+      "value": {
+        "constructor": "Some",
+        "argtypes": [ "ByStr33" ],
+        "arguments": [
+          "0x0331cca11ff9bc747e20fd0aef3425e3fe0a6be27c9cb60348fac0a9077403a029"
+        ]
+      }
+    },
+    {
+      "vname": "priv_key",
+      "type": "Option (ByStr32)",
+      "value": {
+        "constructor": "Some",
+        "argtypes": [ "ByStr32" ],
+        "arguments": [
+          "0x383f7c2af7edcd955bee9b78122d14cbebc7fd12b4efeedc6063cee78de74baf"
+        ]
+      }
+    }
+  ],
+  "events": []
+}

--- a/tests/contracts/schnorr/state_1.json
+++ b/tests/contracts/schnorr/state_1.json
@@ -1,0 +1,25 @@
+[
+    { "vname": "_balance", "type": "Uint128", "value": "0" },
+    {
+      "vname": "pub_key",
+      "type": "Option (ByStr33)",
+      "value": {
+        "constructor": "Some",
+        "argtypes": [ "ByStr33" ],
+        "arguments": [
+          "0x0331cca11ff9bc747e20fd0aef3425e3fe0a6be27c9cb60348fac0a9077403a029"
+        ]
+      }
+    },
+    {
+      "vname": "priv_key",
+      "type": "Option (ByStr32)",
+      "value": {
+        "constructor": "Some",
+        "argtypes": [ "ByStr32" ],
+        "arguments": [
+          "0x383f7c2af7edcd955bee9b78122d14cbebc7fd12b4efeedc6063cee78de74baf"
+        ]
+      }
+    }
+]

--- a/tests/contracts/schnorr/state_2.json
+++ b/tests/contracts/schnorr/state_2.json
@@ -1,0 +1,25 @@
+[
+    { "vname": "_balance", "type": "Uint128", "value": "0" },
+    {
+      "vname": "pub_key",
+      "type": "Option (ByStr33)",
+      "value": {
+        "constructor": "Some",
+        "argtypes": [ "ByStr33" ],
+        "arguments": [
+          "0x0331cca11ff9bc747e20fd0aef3425e3fe0a6be27c9cb60348fac0a9077403a029"
+        ]
+      }
+    },
+    {
+      "vname": "priv_key",
+      "type": "Option (ByStr32)",
+      "value": {
+        "constructor": "Some",
+        "argtypes": [ "ByStr32" ],
+        "arguments": [
+          "0x383f7c2af7edcd955bee9b78122d14cbebc7fd12b4efeedc6063cee78de74baf"
+        ]
+      }
+    }
+]

--- a/tests/contracts/schnorr/state_3.json
+++ b/tests/contracts/schnorr/state_3.json
@@ -1,0 +1,25 @@
+[
+    { "vname": "_balance", "type": "Uint128", "value": "0" },
+    {
+      "vname": "pub_key",
+      "type": "Option (ByStr33)",
+      "value": {
+        "constructor": "Some",
+        "argtypes": [ "ByStr33" ],
+        "arguments": [
+          "0x0331cca11ff9bc747e20fd0aef3425e3fe0a6be27c9cb60348fac0a9077403a029"
+        ]
+      }
+    },
+    {
+      "vname": "priv_key",
+      "type": "Option (ByStr32)",
+      "value": {
+        "constructor": "Some",
+        "argtypes": [ "ByStr32" ],
+        "arguments": [
+          "0x383f7c2af7edcd955bee9b78122d14cbebc7fd12b4efeedc6063cee78de74baf"
+        ]
+      }
+    }
+]

--- a/tests/contracts/schnorr/state_4.json
+++ b/tests/contracts/schnorr/state_4.json
@@ -1,0 +1,25 @@
+[
+    { "vname": "_balance", "type": "Uint128", "value": "0" },
+    {
+      "vname": "pub_key",
+      "type": "Option (ByStr33)",
+      "value": {
+        "constructor": "Some",
+        "argtypes": [ "ByStr33" ],
+        "arguments": [
+          "0x0331cca11ff9bc747e20fd0aef3425e3fe0a6be27c9cb60348fac0a9077403a029"
+        ]
+      }
+    },
+    {
+      "vname": "priv_key",
+      "type": "Option (ByStr32)",
+      "value": {
+        "constructor": "Some",
+        "argtypes": [ "ByStr32" ],
+        "arguments": [
+          "0x383f7c2af7edcd955bee9b78122d14cbebc7fd12b4efeedc6063cee78de74baf"
+        ]
+      }
+    }
+]


### PR DESCRIPTION
The internal representation for what was previously `ByStr` has now been renamed to `ByStrX` and a new existential type `ByStr` has been introduced. Messages for `Schnorr` (to be signed / signature verified) will have type `ByStr`.

Conversion has been provided from `ByStrX` to `ByStr` (but not the other way round). Conversion from `String -> ByStr` may be added in the future easily if found necessary.

Fixes #66 