### PR TITLE
Syntax for events should conform to A-Normal form

### DIFF
--- a/src/lang/base/ContractUtil.ml
+++ b/src/lang/base/ContractUtil.ml
@@ -36,6 +36,7 @@ module MessagePayload = struct
   let sender_label = "_sender"
   let recipient_label = "_recipient"
   let accepted_label = "_accepted"
+  let eventname_label = "_eventname"
 
   let get_value_for_entry lab f es = 
     match List.find es ~f:(fun (l, _) -> l = lab) with

--- a/src/lang/base/ScillaParser.mly
+++ b/src/lang/base/ScillaParser.mly
@@ -244,7 +244,7 @@ stmt:
 | l=ID; BIND; AND; c=CID { (ReadFromBC (asIdL l (toLoc $startpos($2)), c), toLoc $startpos) }
 | ACCEPT                 { (AcceptPayment, toLoc $startpos) }
 | SEND; m = ID;          { (SendMsgs (asIdL m (toLoc $startpos)), toLoc $startpos) }
-| EVENT; s = STRING; m = ID; { (CreateEvnt (s, (asIdL m (toLoc $startpos))), toLoc $startpos) }
+| EVENT; m = ID; { (CreateEvnt (asIdL m (toLoc $startpos)), toLoc $startpos) }
 | MATCH; x = ID; WITH; cs=list(stmt_pm_clause); END
   { (MatchStmt (Ident (x, toLoc $startpos), cs), toLoc $startpos)  }
 

--- a/src/lang/base/Syntax.ml
+++ b/src/lang/base/Syntax.ml
@@ -189,13 +189,6 @@ let pp_literal_list ls =
   let cs = String.concat ~sep:",\n " ps in
   sprintf "[ %s]" cs
 
-let pp_named_literal_list nls =
-  let ps = List.map nls
-      ~f:(fun (n, l) -> sprintf "<%s : %s>" n (pp_literal l)) in
-  let cs = String.concat ~sep:",\n " ps in
-  sprintf "[ %s]" cs
-
-
 (*******************************************************)
 (*                   Annotations                       *)
 (*******************************************************)
@@ -283,7 +276,7 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
     | ReadFromBC of ER.rep ident * string
     | AcceptPayment
     | SendMsgs of ER.rep ident
-    | CreateEvnt of string * ER.rep ident
+    | CreateEvnt of ER.rep ident
     | Throw of ER.rep ident
   [@@deriving sexp]
   
@@ -554,9 +547,9 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
     | SendMsgs i ->
         sprintf "[%s] Error in sending messages `%s`:\n"
           locstr (get_id i)
-    | CreateEvnt (s, _) ->
+    | CreateEvnt i ->
         sprintf "[%s] Error in create event `%s`:\n"
-          locstr s
+          locstr (get_id i)
     | Throw i ->
         sprintf "[%s] Error in throw of '%s':\n"
           locstr (get_id i)

--- a/src/lang/base/TypeChecker.ml
+++ b/src/lang/base/TypeChecker.ml
@@ -346,8 +346,9 @@ module ScillaTypechecker
              (match s with
              | SendMsgs _ ->
                 pure @@ add_stmt_to_stmts_env (TypedSyntax.SendMsgs typed_i, rep) checked_stmts
-             | _ ->
-                pure @@ add_stmt_to_stmts_env (TypedSyntax.CreateEvnt typed_i, rep) checked_stmts)
+             | CreateEvnt _ ->
+                pure @@ add_stmt_to_stmts_env (TypedSyntax.CreateEvnt typed_i, rep) checked_stmts
+             | _ -> fail "Unexpected statement during type-checking")
          | Throw _ ->
              fail @@ sprintf
                "Type-checking of Throw statements is not supported yet."

--- a/src/lang/base/TypeChecker.ml
+++ b/src/lang/base/TypeChecker.ml
@@ -331,7 +331,7 @@ module ScillaTypechecker
          | AcceptPayment ->
              let%bind checked_stmts = type_stmts env sts get_loc in
              pure @@ add_stmt_to_stmts_env (TypedSyntax.AcceptPayment, rep) checked_stmts
-         | SendMsgs i ->
+         | SendMsgs i | CreateEvnt i->
              let%bind r = TEnv.resolveT env.pure (get_id i)
                  ~lopt:(Some (get_rep i)) in
              let i_type = rr_typ r in
@@ -340,18 +340,11 @@ module ScillaTypechecker
                assert_type_equiv expected i_type.tp in
              let typed_i = add_type_to_ident i i_type in
              let%bind checked_stmts = type_stmts env sts get_loc in
-             pure @@ add_stmt_to_stmts_env (TypedSyntax.SendMsgs typed_i, rep) checked_stmts
-         | CreateEvnt (st, i) ->
-             let%bind r = TEnv.resolveT env.pure (get_id i)
-                 ~lopt:(Some (get_loc (get_rep i))) in
-             (* An event is a named message, hence msg_typ. *)
-             let i_type = rr_typ r in
-             let expected = msg_typ in
-             let%bind _ = wrap_type_serr stmt @@
-               assert_type_equiv expected i_type.tp in
-             let typed_i = add_type_to_ident i i_type in
-             let%bind checked_stmts = type_stmts env sts get_loc in
-             pure @@ add_stmt_to_stmts_env (TypedSyntax.CreateEvnt (st, typed_i), rep) checked_stmts
+             (match s with
+             | SendMsgs _ ->
+                pure @@ add_stmt_to_stmts_env (TypedSyntax.SendMsgs typed_i, rep) checked_stmts
+             | _ ->
+                pure @@ add_stmt_to_stmts_env (TypedSyntax.CreateEvnt typed_i, rep) checked_stmts)
          | Throw _ ->
              fail @@ sprintf
                "Type-checking of Throw statements is not supported yet."

--- a/src/lang/checkers/PatternChecker.ml
+++ b/src/lang/checkers/PatternChecker.ml
@@ -187,7 +187,7 @@ module ScillaPatternchecker
                pure @@ (CheckedPatternSyntax.ReadFromBC (i, s), rep)
            | AcceptPayment -> pure @@ (CheckedPatternSyntax.AcceptPayment, rep)
            | SendMsgs i -> pure @@ (CheckedPatternSyntax.SendMsgs i, rep)
-           | CreateEvnt (s, i) -> pure @@ (CheckedPatternSyntax.CreateEvnt (s, i), rep)
+           | CreateEvnt i -> pure @@ (CheckedPatternSyntax.CreateEvnt i, rep)
            | Throw i -> pure @@ (CheckedPatternSyntax.Throw i, rep)
           ) in
         let%bind checked_stmts = pm_check_stmts sts in

--- a/src/lang/eval/Eval.ml
+++ b/src/lang/eval/Eval.ml
@@ -260,9 +260,9 @@ let rec stmt_eval conf stmts =
           let%bind ms_resolved = Configuration.lookup conf ms in
           let%bind conf' = Configuration.send_messages conf ms_resolved in
           stmt_eval conf' sts
-      | CreateEvnt (name, params) ->
+      | CreateEvnt params ->
           let%bind eparams_resolved = Configuration.lookup conf params in
-          let%bind conf' = Configuration.create_event conf name eparams_resolved in
+          let%bind conf' = Configuration.create_event conf eparams_resolved in
           stmt_eval conf' sts
       (* TODO: Implement the rest *)
       | _ -> fail @@ sprintf "The statement %s is not supported yet."

--- a/src/lang/eval/EvalUtil.ml
+++ b/src/lang/eval/EvalUtil.ml
@@ -203,7 +203,7 @@ module Configuration = struct
     (* Emitted messages *)
     emitted : literal list;
     (* Emitted events *)
-    events : (string * literal) list
+    events : literal list
   }
 
   let pp conf =
@@ -214,7 +214,7 @@ module Configuration = struct
     let pp_bc_conf = pp_literal_map conf.blockchain_state in
     let pp_in_funds = Uint128.to_string conf.incoming_funds in
     let pp_emitted = pp_literal_list conf.emitted in
-    let pp_events = pp_named_literal_list conf.events in
+    let pp_events = pp_literal_list conf.events in
     sprintf "Confuration\nEnv =\n%s\nFields =\n%s\nBalance =%s\nAccepted=%s\n\\
     Blockchain conf =\n%s\nIncoming funds = %s\nEmitted Messages =\n%s\nEmitted events =\n%s\n"
       pp_env pp_fields pp_balance pp_accepted pp_bc_conf pp_in_funds pp_emitted pp_events
@@ -301,26 +301,50 @@ module Configuration = struct
             (Env.pp_value v)
       | Env.ValLit l -> convert_to_list l 
 
+  let validate_outgoing_message m' =
+    let open ContractUtil.MessagePayload in
+    match m' with
+    | Msg m ->
+      (* All outgoing messages must have certain mandatory fields *)
+      let tag_found = List.exists ~f:(fun (s, _) -> s = tag_label) m in
+      let amount_found = List.exists ~f:(fun (s, _) -> s = amount_label) m in
+      let recipient_found = List.exists ~f:(fun (s, _) -> s = recipient_label) m in
+      if tag_found && amount_found && recipient_found then pure m'
+      else fail @@ sprintf "Message %s is missing a mandatory field." (pp_literal (Msg m))
+    | _ -> fail @@ sprintf "Literal %s is not a message, cannot be sent." (pp_literal m')
+
   let send_messages conf ms =
-    let%bind ls = get_list_literal ms in
+    let%bind ls' = get_list_literal ms in
+    let%bind ls = mapM ~f:validate_outgoing_message ls' in
     let old_emitted = conf.emitted in
     let emitted = old_emitted @ ls in
     pure {conf with emitted}
 
-  let create_event conf ename eparams_resolved =
+  let validate_event m' =
+    let open ContractUtil.MessagePayload in
+    match m' with
+    | Msg m ->
+      (* All events must have certain mandatory fields *)
+      let eventname_found = List.exists ~f:(fun (s, _) -> s = eventname_label) m in
+      if eventname_found then pure m'
+      else fail @@ sprintf "Event %s is missing a mandatory field." (pp_literal (Msg m))
+    | _ -> fail @@ sprintf "Literal %s is not a valid event argument." (pp_literal m')
+
+
+  let create_event conf eparams_resolved =
     let%bind event = 
       match eparams_resolved with
       | Env.ValLit l -> 
         (match l with
         | Msg _ ->
-          (* An event is a named message. *)
-          pure @@ (ename, l)
+          pure @@ l
         | _ -> fail @@ sprintf "Incorrect event parameter(s): %s\n" (pp_literal l))
       | (Env.ValFix _ | Env.ValClosure _ | Env.ValTypeClosure _ ) as v -> 
         fail @@ sprintf "Incorrect event parameters: %s\n" (Env.pp_value v)
     in
+    let%bind event' = validate_event event in
     let old_events = conf.events in
-    let events = event::old_events in
+    let events = event'::old_events in
     pure {conf with events}
 end
 

--- a/src/lang/eval/JSON.ml
+++ b/src/lang/eval/JSON.ml
@@ -470,11 +470,14 @@ end
 module Event = struct
 
   (* Same as Event_to_jstring, but instead gives out raw json, not it's string *)
-  let event_to_json (name, e) =
-    `Assoc [
-      ("eventname", `String name);
-      ("params", `List (slist_to_json e))
-    ]
+  let event_to_json e =
+    (* extract out "_eventname" from the message *)
+    let (_, eventnamelit) = List.find_exn e ~f:(fun (x, _) -> x = eventname_label) in
+    let eventnames = get_string_literal eventnamelit in
+    (* Get a list without the extracted components *)
+    let filtered_list = List.filter e ~f:(fun (x, _) -> not (x = eventname_label)) in
+    `Assoc [("eventname", `String (BatOption.get eventnames)); 
+            ("params", `List (slist_to_json filtered_list))] 
 
   (** 
    ** Prints a Event (string, (string, literal) list) as a json to the 

--- a/src/lang/eval/JSON.mli
+++ b/src/lang/eval/JSON.mli
@@ -135,12 +135,12 @@ end
 module Event : sig
 
   (** 
-   ** Prints a Event (string, (string, literal) list) as a json to the 
+   ** Prints an Event "(string, literal) list" as a json to the 
    ** and returns the string. pp enables pretty printing.
    **)
-  val event_to_jstring : ?pp:bool -> string * ((string * Syntax.literal) list) -> string
+  val event_to_jstring : ?pp:bool -> (string * Syntax.literal) list -> string
   (* Same as Event_to_jstring, but instead gives out raw json, not it's string *)
-  val event_to_json : string * ((string * Syntax.literal) list) -> Yojson.json
+  val event_to_json : (string * Syntax.literal) list -> Yojson.json
 
 end
 

--- a/src/runners/scilla_runner.ml
+++ b/src/runners/scilla_runner.ml
@@ -76,7 +76,7 @@ let check_after_step name res =
             sprintf "%s" (ContractState.pp cstate) ^
             sprintf "Emitted messages:\n%s\n\n" (pp_literal_list outs) ^
             sprintf"Gas spent:%s\n" (Int.to_string es.gas_used) ^
-            sprintf "Emitted events:\n%s\n\n" (pp_named_literal_list events));
+            sprintf "Emitted events:\n%s\n\n" (pp_literal_list events));
        (cstate, outs, events), es.gas_used
 
 (* Parse the input state json and extract out _balance separately *)
@@ -118,10 +118,9 @@ let rec output_event_json elist =
   match elist with
   | e :: rest ->
     let j = output_event_json rest in
-    let (n, m) = e in
-    (match m with
+    (match e with
     | Msg m' ->
-      let ej = JSON.Event.event_to_json (n, m') in
+      let ej = JSON.Event.event_to_json m' in
       ej :: j
     | _ -> `Null :: j)
   | [] -> []

--- a/tests/checker/bad/mappair.scilla
+++ b/tests/checker/bad/mappair.scilla
@@ -90,7 +90,7 @@ end
 transition createBadEvent()
   m = nat_to_int;
   (* We cannot have a function (which is what "m" is) as part of message/event. *)
-  e = { bad_field : m };
-  event "BadEvent" e;
+  e = { _eventname : "BadEvent"; bad_field : m };
+  event e;
   accept
 end

--- a/tests/contracts/crowdfunding/contract.scilla
+++ b/tests/contracts/crowdfunding/contract.scilla
@@ -73,8 +73,8 @@ transition Donate ()
       msg  = {_tag : ""; _recipient : _sender; _amount : Uint128 0; 
               code : accepted_code};
       msgs = one_msg msg;
-      e = { donor : _sender; amount : _amount };
-      event "DonationAccepted" e;
+      e = { _eventname : "DonationAccepted"; donor : _sender; amount : _amount };
+      event e;
       send msgs     
     end  
   | False => 
@@ -158,8 +158,8 @@ transition ClaimBack ()
         msg  = {_tag : Main; _recipient : _sender; _amount : v; 
                 code : reclaimed_code};
         msgs = one_msg msg;
-        e = { claimed_by : _sender; amount : v };
-        event "ClaimedBack" e;
+        e = { _eventname : "ClaimedBack"; claimed_by : _sender; amount : v };
+        event e;
         send msgs
       end
     end

--- a/tests/contracts/zil-game/contract.scilla
+++ b/tests/contracts/zil-game/contract.scilla
@@ -233,8 +233,8 @@ transition Withdraw ()
   | True =>
     msg = {_tag : Main; _recipient : owner; _amount : bal; code : here_is_the_reward};
     msgs = one_msg msg;
-    e = {};
-    event "GameOver" e;
+    e = { _eventname : "GameOver" };
+    event e;
     send msgs
   | False =>
     msg = {_tag : Main; _recipient : _sender; _amount : Uint128 0; code : cannot_withdraw};


### PR DESCRIPTION
In addition to the "A-Normal form for `event` syntax", this change also adds validation checks to ensure that outgoing messages have certain mandatory fields (previously this was caught during JSON emission, but it's better that it is caught early).

Fixes #181 . 