### PR TITLE
scilla-checker: print events info.

### DIFF
--- a/src/lang/base/EventInfo.ml
+++ b/src/lang/base/EventInfo.ml
@@ -1,0 +1,92 @@
+open ParserUtil
+open TypeUtil
+open Syntax
+
+module SR = ParserRep
+module ER = ParserRep
+module STR = SR
+module ETR = TypeChecker.ScillaTypechecker.ETR
+module TypedSyntax = ScillaSyntax (STR) (ETR)
+module TypeUtil = TypeUtilities (SR) (ER)
+
+open TypedSyntax
+open TypeUtil
+open PrimTypes
+open ContractUtil.MessagePayload
+open MonadUtil
+open Core.Result.Let_syntax
+
+(* Given a contract, return a list of events it may create,
+ * and the parameter types of the event. *)
+let event_info (contr : contract) =
+
+  (* Given a message and a current list of event info, extract
+   * info from message and append to the list. *)
+  let extract_from_message m acc =
+    (* Check if this is for an event. *)
+    (match (List.find_opt (fun (label, _) -> label = eventname_label) m) with
+      | Some (_, epld) ->
+        let emsg = "Error determining event name\n" in
+        let%bind eventname = match epld with
+          | MTag s -> pure s
+          | MLit l -> (match l with | StringLit s -> pure s | _ -> fail emsg)
+          | MVar _ -> fail emsg 
+        in
+        (* Get the type of the event parameters. *)
+        let filtered_m = List.filter (fun (label, _) -> not (label = eventname_label)) m in
+        let%bind m_types = mapM ~f:(fun (fname, pl) ->
+          let%bind t = 
+            (match pl with
+            | MTag _ -> pure string_typ
+            | MLit l -> literal_type l
+            | MVar v -> 
+              let t' = ETR.get_type (get_rep v) in
+              pure t'.tp
+            )in pure (fname, t)
+          ) filtered_m in
+        (* If we already have an entry for "eventname" in "acc", 
+          * check that the type matches. Add entry otherwise. *)
+        (match (List.find_opt (fun (n, _) -> n = eventname) acc) with
+          | Some (_, tlist) -> (* verify types match *)
+            let printer tplist =
+              List.fold_left (fun acc (n, t) -> 
+                  acc ^ (Printf.sprintf "(%s : %s); " n (pp_typ t))) "[" tplist
+                  ^ "]" in 
+            if m_types <> tlist then 
+              fail @@ Printf.sprintf "Parameter mismatch for event %s. %s vs %s\n"
+                eventname (printer tlist) (printer m_types)
+            else
+              pure @@ acc
+          | None -> (* No entry. *)
+            let entry = (eventname, m_types) in
+              pure (entry :: acc)
+        )
+      | None -> (* Not for an event. *) pure acc
+    ) in
+
+  (* Loop through each transition *)
+  foldM ~f:(fun acc trans ->
+    (* Loop through each statement, looking for messages. *)
+    let rec stmt_iter stmt_list acc = 
+      match stmt_list with
+      | (stmt, _)::stmt_list' -> 
+        let%bind acc' =
+        (match stmt with
+         | MatchStmt (_, clauses) ->
+            (* Recurse through all clauses. *)
+            foldM ~f:(fun acc'' (_, stmt_list'') ->
+              stmt_iter stmt_list'' acc''
+            ) ~init:acc clauses
+          (* Every message created gets bound to some variable. *)
+         | Bind (_, (e, _)) ->
+            (match e with
+            | Message m -> extract_from_message m acc
+            | _ -> (* Uninteresting expression. *) pure acc
+            )
+         | _ -> (* Uninteresting statement. *) pure acc
+        ) in  stmt_iter stmt_list' acc'
+      | [] -> pure acc
+    in
+      stmt_iter trans.tbody acc
+  ) ~init:[] contr.ctrans
+

--- a/src/lang/eval/JSON.ml
+++ b/src/lang/eval/JSON.ml
@@ -436,7 +436,7 @@ end
 module ContractInfo = struct
   open EvalUtil.EvalSyntax
          
-  let get_string (contr : contract) =
+  let get_string (contr : contract) (event_info : (string * (string * typ) list) list) =
     (* 1. contract name *)
     let namej = ("name", `String (get_id contr.cname)) in
     (* 2. parameters *)
@@ -462,7 +462,17 @@ module ContractInfo = struct
         `Assoc (namej :: paramj :: [] )) in
     
     let transj = ("transitions", `List translj) in
-    let finalj = `Assoc (namej :: paramj :: fieldsj :: transj :: []) in
+    (* 5. event info *)
+    let eventslj = List.map event_info ~f: (fun (eventname, plist) ->
+        let namej = ("name", `String (eventname)) in
+        let paramlj = List.map plist ~f: (fun (pname, ptype) ->
+          `Assoc [("name", `String pname); ("type", `String (pp_typ ptype))]) in
+        let paramj = ("params", `List paramlj) in
+          `Assoc (namej :: paramj :: [])
+      ) in
+    let eventsj = ("events", `List eventslj) in
+
+    let finalj = `Assoc (namej :: paramj :: fieldsj :: transj :: eventsj :: []) in
     pretty_to_string finalj
 
 end

--- a/src/lang/eval/JSON.mli
+++ b/src/lang/eval/JSON.mli
@@ -129,7 +129,7 @@ open EvalUtil.EvalSyntax
           ]
         }
   *)
-  val get_string : contract -> string
+  val get_string : contract -> (string * (string * Syntax.typ) list) list -> string
 end
 
 module Event : sig

--- a/src/runners/scilla_checker.ml
+++ b/src/runners/scilla_checker.ml
@@ -52,6 +52,11 @@ module PM_Checker = ScillaPatternchecker (PM_SR) (PM_ER)
 
 let check_patterns e = PM_Checker.pm_check_module e
 
+let check_events_info einfo =
+  match einfo with
+  | Error msg -> pout @@ sprintf "\n%s\n\n" msg; einfo
+  | Ok _ -> einfo
+
 let () =
   if (Array.length Sys.argv) < 2
   then
@@ -75,10 +80,11 @@ let () =
       let elibs = import_libs cmod.elibs in
       let%bind (typed_cmod, tenv) = check_typing cmod elibs in
       let%bind pm_checked_cmod = check_patterns typed_cmod in
-      pure @@ (cmod, tenv)
+      let%bind event_info = check_events_info @@ EventInfo.event_info typed_cmod.contr in
+      pure @@ (cmod, tenv, event_info)
     ) in
     match r with
     | Error _ -> ()
-    | Ok (cmod, _) ->
-      pout (sprintf "%s\n" (JSON.ContractInfo.get_string cmod.contr));
+    | Ok (cmod, _, event_info) ->
+      pout (sprintf "%s\n" (JSON.ContractInfo.get_string cmod.contr event_info));
   )

--- a/tests/checker/bad/TestCheckerFail.ml
+++ b/tests/checker/bad/TestCheckerFail.ml
@@ -28,6 +28,7 @@ module Tests = TestUtil.DiffBasedTests(
       "bad_fields1.scilla";
       "bad_fields2.scilla";
       "unbound.scilla";
+      "event_bad1.scilla";
       "mappair.scilla"
     ]
     let use_stdlib = true

--- a/tests/checker/bad/event_bad1.scilla
+++ b/tests/checker/bad/event_bad1.scilla
@@ -1,0 +1,169 @@
+(***************************************************)
+(*               Associated library                *)
+(***************************************************)
+
+import BoolUtils
+
+library Crowdfunding
+
+let one_msg = 
+  fun (msg : Message) => 
+    let nil_msg = Nil {Message} in
+    Cons {Message} msg nil_msg
+    
+let check_update = 
+  fun (bs : Map ByStr20 Uint128) =>
+  fun (_sender : ByStr20) =>
+  fun (_amount : Uint128) =>
+    let c = builtin contains bs _sender in
+    match c with 
+    | False => 
+      let bs1 = builtin put bs _sender _amount in
+      Some {Map ByStr20 Uint128} bs1 
+    | True  => None {Map ByStr20 Uint128}
+    end
+
+let blk_leq =
+  fun (blk1 : BNum) =>
+  fun (blk2 : BNum) =>
+    let bc1 = builtin blt blk1 blk2 in 
+    let bc2 = builtin eq blk1 blk2 in 
+    orb bc1 bc2
+
+let accepted_code = Int32 1
+let missed_deadline_code = Int32 2
+let already_backed_code  = Int32 3
+let not_owner_code  = Int32 4
+let too_early_code  = Int32 5
+let got_funds_code  = Int32 6
+let cannot_get_funds  = Int32 7
+let cannot_reclaim_code = Int32 8
+let reclaimed_code = Int32 9
+  
+(***************************************************)
+(*             The contract definition             *)
+(***************************************************)
+contract Crowdfunding
+
+(*  Parameters *)
+(owner     : ByStr20,
+ max_block : BNum,
+ goal      : Uint128)
+
+(* Mutable fields *)
+field backers : Map ByStr20 Uint128 = Emp ByStr20 Uint128
+field funded : Bool = False
+
+transition Donate ()
+  blk <- & BLOCKNUMBER;
+  in_time = blk_leq blk max_block;
+  match in_time with 
+  | True  => 
+    bs  <- backers;
+    res = check_update bs _sender _amount;
+    match res with
+    | None => 
+      msg  = {_tag : ""; _recipient : _sender; _amount : Uint128 0; 
+              code : already_backed_code};
+      msgs = one_msg msg;
+      send msgs
+    | Some bs1 =>
+      backers := bs1; 
+      accept; 
+      msg  = {_tag : ""; _recipient : _sender; _amount : Uint128 0; 
+              code : accepted_code};
+      msgs = one_msg msg;
+      e = { _eventname : "DonationAccepted"; donor : _sender; amount : _amount };
+      event e;
+      send msgs     
+    end  
+  | False => 
+    msg  = {_tag : ""; _recipient : _sender; _amount : Uint128 0; 
+            code : missed_deadline_code};
+    msgs = one_msg msg;
+    send msgs
+  end 
+end
+
+transition GetFunds ()
+  is_owner = builtin eq owner _sender;
+  match is_owner with
+  | False => 
+    msg  = {_tag : ""; _recipient : _sender; _amount : Uint128 0;
+            code : not_owner_code};
+    msgs = one_msg msg;
+    send msgs
+  | True => 
+    blk <- & BLOCKNUMBER;
+    in_time = blk_leq blk max_block;
+    c1 = negb in_time;
+    bal <- _balance;
+    c2 = builtin lt bal goal;
+    c3 = negb c2;
+    c4 = andb c1 c3;
+    match c4 with 
+    | False =>  
+      msg  = {_tag : ""; _recipient : _sender; _amount : Uint128 0;
+              code : cannot_get_funds};
+      msgs = one_msg msg;
+      send msgs
+    | True => 
+      tt = True;
+      funded := tt;
+      msg  = {_tag : Main; _recipient : owner; _amount : bal; 
+              code : got_funds_code};
+      msgs = one_msg msg;
+      send msgs
+    end
+  end   
+end
+
+(* transition ClaimBack *)
+transition ClaimBack ()
+  blk <- & BLOCKNUMBER;
+  after_deadline = builtin blt max_block blk;
+  match after_deadline with
+  | False =>
+    msg  = {_tag : ""; _recipient : _sender; _amount : Uint128 0;
+            code : too_early_code};
+    msgs = one_msg msg;
+    send msgs
+  | True =>
+    bs <- backers;
+    bal <- _balance;
+    (* Goal has not been reached *)
+    f <- funded;
+    c1 = builtin lt bal goal;
+    c2 = builtin contains bs _sender;
+    c3 = negb f;
+    c4 = andb c1 c2;
+    c5 = andb c3 c4;
+    match c5 with
+    | False =>
+      msg  = {_tag : ""; _recipient : _sender; _amount : Uint128 0;
+              code : cannot_reclaim_code};
+      e = { _eventname : "ClaimedBack"; amount : Uint128 0 };
+      event e;
+      msgs = one_msg msg;
+      send msgs
+    | True =>
+      res = builtin get bs _sender;
+      match res with
+      | None =>
+        msg  = {_tag : ""; _recipient : _sender; _amount : Uint128 0;
+                code : cannot_reclaim_code};
+        msgs = one_msg msg;
+        send msgs
+      | Some v =>
+        bs1 = builtin remove bs _sender;
+        backers := bs1;
+        msg  = {_tag : Main; _recipient : _sender; _amount : v; 
+                code : reclaimed_code};
+        msgs = one_msg msg;
+        e = { _eventname : "ClaimedBack"; claimed_by : _sender; amount : v };
+        event e;
+        send msgs
+      end
+    end
+  end  
+end

--- a/tests/checker/bad/gold/event_bad1.scilla.gold
+++ b/tests/checker/bad/gold/event_bad1.scilla.gold
@@ -1,0 +1,4 @@
+
+Parameter mismatch for event ClaimedBack. [(amount : Uint128); ] vs [(claimed_by : ByStr20); (amount : Uint128); ]
+
+

--- a/tests/checker/good/gold/auction.scilla.gold
+++ b/tests/checker/good/gold/auction.scilla.gold
@@ -15,5 +15,6 @@
     { "name": "Bid", "params": [] },
     { "name": "Withdraw", "params": [] },
     { "name": "AuctionEnd", "params": [] }
-  ]
+  ],
+  "events": []
 }

--- a/tests/checker/good/gold/crowdfunding.scilla.gold
+++ b/tests/checker/good/gold/crowdfunding.scilla.gold
@@ -13,5 +13,21 @@
     { "name": "Donate", "params": [] },
     { "name": "GetFunds", "params": [] },
     { "name": "ClaimBack", "params": [] }
+  ],
+  "events": [
+    {
+      "name": "ClaimedBack",
+      "params": [
+        { "name": "claimed_by", "type": "ByStr20" },
+        { "name": "amount", "type": "Uint128" }
+      ]
+    },
+    {
+      "name": "DonationAccepted",
+      "params": [
+        { "name": "donor", "type": "ByStr20" },
+        { "name": "amount", "type": "Uint128" }
+      ]
+    }
   ]
 }

--- a/tests/checker/good/gold/empty.scilla.gold
+++ b/tests/checker/good/gold/empty.scilla.gold
@@ -1,1 +1,7 @@
-{ "name": "Empty", "params": [], "fields": [], "transitions": [] }
+{
+  "name": "Empty",
+  "params": [],
+  "fields": [],
+  "transitions": [],
+  "events": []
+}

--- a/tests/checker/good/gold/fungible-token.scilla.gold
+++ b/tests/checker/good/gold/fungible-token.scilla.gold
@@ -43,5 +43,6 @@
         { "name": "spender", "type": "ByStr20" }
       ]
     }
-  ]
+  ],
+  "events": []
 }

--- a/tests/checker/good/gold/zil-game.scilla.gold
+++ b/tests/checker/good/gold/zil-game.scilla.gold
@@ -18,5 +18,6 @@
       "params": [ { "name": "solution", "type": "Int128" } ]
     },
     { "name": "Withdraw", "params": [] }
-  ]
+  ],
+  "events": [ { "name": "GameOver", "params": [] } ]
 }


### PR DESCRIPTION
For the possible events that may be emitted by a contract, print the parameters and their types.

Flag an error if the type of an event is different in different places in the contract.

Fixes #184 