### PR TITLE
fine grained type checking for libraries

### DIFF
--- a/src/lang/base/Syntax.ml
+++ b/src/lang/base/Syntax.ml
@@ -517,10 +517,10 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
     let get_pattern_bounds p =
       let rec accfunc p acc =
         match p with
-        | Wildcard -> []
+        | Wildcard -> acc
         | Binder i -> i::acc
         | Constructor (_, plist) ->
-          List.fold plist ~init:[] ~f:(fun acc p' -> accfunc p' acc)
+          List.fold plist ~init:acc ~f:(fun acc p' -> accfunc p' acc)
       in accfunc p []
     in
 

--- a/tests/checker/bad/TestCheckerFail.ml
+++ b/tests/checker/bad/TestCheckerFail.ml
@@ -29,6 +29,7 @@ module Tests = TestUtil.DiffBasedTests(
       "bad_fields2.scilla";
       "unbound.scilla";
       "event_bad1.scilla";
+      "lib_bad1.scilla";
       "mappair.scilla"
     ]
     let use_stdlib = true

--- a/tests/checker/bad/gold/lib_bad1.scilla.gold
+++ b/tests/checker/bad/gold/lib_bad1.scilla.gold
@@ -1,0 +1,14 @@
+
+Type error(s) in contract BadLibTest1:
+
+
+[:0:0] Type error in library one_msg:
+
+Type mismatch: Message expected, but Uint128 provided.[:0:0] Type error in library two_msg:
+
+Type mismatch: Message expected, but Uint128 provided.[:0:0] Type error in library andb:
+
+[checker/bad/lib_bad1.scilla:32:5] Type error in pattern matching on `b` of type Bool (or one of its branches):
+[checker/bad/lib_bad1.scilla:35:7] Type error in pattern matching on `c` of type Int32 (or one of its branches):
+Not an algebraic data type: Int32
+

--- a/tests/checker/bad/gold/unbound.scilla.gold
+++ b/tests/checker/bad/gold/unbound.scilla.gold
@@ -3,6 +3,7 @@ Type error(s) in contract Crowdfunding:
 
 
 [:0:0] Type error in library check_update:
+
 ADT Uint12 not found
 
 [checker/bad/unbound.scilla:57:1] Type error in transition Donate:

--- a/tests/checker/bad/lib_bad1.scilla
+++ b/tests/checker/bad/lib_bad1.scilla
@@ -1,0 +1,63 @@
+(* The purpose of this test contract is to demonstrate that *)
+(* type errors in different library functions are independently *)
+(* handled by the type checker. *)
+
+library BadLib1
+
+let one_msg =
+  fun (msg : Uint128) =>        (* We have a type error here *)
+    let nil_msg = Nil {Message} in
+    Cons {Message} msg nil_msg
+
+let one_msg1 =
+  fun (msg : Message) =>
+    one_msg msg
+
+let two_msg = 
+  fun (msg : Message) =>  
+  fun (msg2 : Uint128) =>       (* We have a type error here *)
+    let nil_msg = Nil {Message} in
+    let one = Cons {Message} msg nil_msg in
+    Cons {Message} msg2 one
+
+let two_msg2 = 
+  fun (msg : Message) =>
+  fun(msg2 : Message) =>
+    two_msg msg msg2
+
+
+let andb = 
+  fun (b : Bool) =>
+  fun (c : Int32) =>            (* We have a type error here *)
+    match b with 
+    | False => False
+    | True  =>
+      match c with 
+      | False => False
+      | True  => True
+      end
+    end
+
+let andb_wrap =                 (* This depends on andb and shouldn't be reported *)
+  fun (b : Bool) =>
+  fun (c : Bool) =>
+    andb b c
+
+let bool_wrap2 =                 (* This *doesn't* depend on any bad above and should be reported *)
+  fun (andb : Bool) =>
+     andb
+
+
+
+(***************************************************)
+(*             The contract definition             *)
+(***************************************************)
+contract BadLibTest1
+
+(*  Parameters *)
+()
+
+
+transition Foo ()
+
+end


### PR DESCRIPTION
Fixes #167.

Slightly differing from the approach described by @ilyasergey in #167, this change does not add blacklist tracking to `TEnv` but tracks it outside in `type_library`. Hence this adopts the idea described there but is less invasive in effect.