### PR TITLE
Rich literals

### DIFF
--- a/src/lang/base/Gas.ml
+++ b/src/lang/base/Gas.ml
@@ -70,6 +70,7 @@ module ScillaGas
               pure (acc + clit')) ~init:0 ll
       (* TODO: Check this *)
       | Clo _ -> pure @@ 0
+      | TClo _ -> pure @@ 0
 
   let expr_static_cost erep =
     let (e, _) = erep in

--- a/src/lang/base/Gas.ml
+++ b/src/lang/base/Gas.ml
@@ -68,6 +68,8 @@ module ScillaGas
           foldM ~f:(fun acc lit' ->
               let%bind clit' = literal_cost lit' in
               pure (acc + clit')) ~init:0 ll
+      (* TODO: Check this *)
+      | Clo _ -> pure @@ 0
 
   let expr_static_cost erep =
     let (e, _) = erep in

--- a/src/lang/base/PrettyPrinters.ml
+++ b/src/lang/base/PrettyPrinters.ml
@@ -135,6 +135,8 @@ let rec pp_literal_simplified l =
           ^ ")"
         )
     | Clo _ -> "<closure>"
+    | TClo _ -> "<type_closure>"
+
 
 let pp_literal_json l =
   literal_to_jstring l

--- a/src/lang/base/PrettyPrinters.ml
+++ b/src/lang/base/PrettyPrinters.ml
@@ -134,6 +134,7 @@ let rec pp_literal_simplified l =
           List.fold_left al ~init:"" ~f:(fun a l' -> a ^ " " ^ (pp_literal_simplified l'))
           ^ ")"
         )
+    | Clo _ -> "<closure>"
 
 let pp_literal_json l =
   literal_to_jstring l

--- a/src/lang/base/Syntax.ml
+++ b/src/lang/base/Syntax.ml
@@ -19,6 +19,7 @@
 
 open Core
 open Sexplib.Std
+open MonadUtil
 
 exception SyntaxError of string
 
@@ -140,6 +141,8 @@ type literal =
   | Map of mtype * (literal, literal) Hashtbl.t
   (* A constructor in HNF *)      
   | ADTValue of string * typ list * literal list
+  (* An embedded closure *)
+  | Clo of (literal -> int -> (literal, string) EvalMonad.eresult)
 [@@deriving sexp]
 
 

--- a/src/lang/base/Syntax.ml
+++ b/src/lang/base/Syntax.ml
@@ -143,7 +143,7 @@ type literal =
   | ADTValue of string * typ list * literal list
   (* An embedded closure *)
   | Clo of (literal -> int -> (literal, string) EvalMonad.eresult)
-  (* A polymorphic type *)
+  (* A type abstraction *)
   | TClo of (typ -> int -> (literal, string) EvalMonad.eresult)
 [@@deriving sexp]
 

--- a/src/lang/base/Syntax.ml
+++ b/src/lang/base/Syntax.ml
@@ -143,6 +143,8 @@ type literal =
   | ADTValue of string * typ list * literal list
   (* An embedded closure *)
   | Clo of (literal -> int -> (literal, string) EvalMonad.eresult)
+  (* A polymorphic type *)
+  | TClo of (typ -> int -> (literal, string) EvalMonad.eresult)
 [@@deriving sexp]
 
 

--- a/src/lang/base/TypeUtil.ml
+++ b/src/lang/base/TypeUtil.ml
@@ -449,6 +449,7 @@ module TypeUtilities
           then fail @@ sprintf "Malformed ADT %s. Arguments do not match expected types" (pp_literal l)
           else pure @@ res
     | Clo _ -> fail @@ "Cannot type-check runtime closure."
+    | TClo _ -> fail @@ "Cannot type-check runtime type function."
 end
 
 (*****************************************************************)

--- a/src/lang/base/TypeUtil.ml
+++ b/src/lang/base/TypeUtil.ml
@@ -448,6 +448,7 @@ module TypeUtilities
           if not args_valid
           then fail @@ sprintf "Malformed ADT %s. Arguments do not match expected types" (pp_literal l)
           else pure @@ res
+    | Clo _ -> fail @@ "Cannot type-check runtime closure."
 end
 
 (*****************************************************************)

--- a/src/lang/eval/Eval.ml
+++ b/src/lang/eval/Eval.ml
@@ -59,7 +59,7 @@ let rec is_pure_literal l = match l with
   | Msg es -> List.for_all es ~f:(fun (_, l') -> is_pure_literal l')
   | ADTValue (_, _, es) -> List.for_all es ~f:(fun e -> is_pure_literal e)
   (* | Map (_, ht) ->
-   *     let es = Hashtbl.data ht in
+   *     let es = Caml.Hashtbl.to_alist ht in
    *     List.for_all es ~f:(fun (k, v) -> is_pure_literal k && is_pure_literal v) *)
   | _ -> true
 

--- a/src/lang/eval/PatternMatching.ml
+++ b/src/lang/eval/PatternMatching.ml
@@ -28,9 +28,6 @@ open EvalSyntax
 let rec match_with_pattern v p = match p with
   | Wildcard -> pure []
   | Binder x -> (match v with
-      | Env.ValTypeClosure _ ->
-          fail @@ sprintf "Cannot pattern match a function:\n%s"
-            (Env.pp_value v)
       | Env.ValLit _ ->
           (* Bound a plain literal *)
           pure @@ [(x, v)]

--- a/src/lang/eval/PatternMatching.ml
+++ b/src/lang/eval/PatternMatching.ml
@@ -28,7 +28,7 @@ open EvalSyntax
 let rec match_with_pattern v p = match p with
   | Wildcard -> pure []
   | Binder x -> (match v with
-      | Env.ValClosure _ | Env.ValFix _ | Env.ValTypeClosure _ ->
+      | Env.ValTypeClosure _ ->
           fail @@ sprintf "Cannot pattern match a function:\n%s"
             (Env.pp_value v)
       | Env.ValLit _ ->

--- a/tests/eval/exp/bad/gold/msg_error.scilla.gold
+++ b/tests/eval/exp/bad/gold/msg_error.scilla.gold
@@ -1,6 +1,2 @@
 Failed execution:
-Cannot store a closure
-<closure>
-as ff
-in a message
-(Message((tag(MTag Main))(amount(MVar(Ident x((fname eval/exp/bad/msg_error.scilla)(lnum 5)(bol 79)(cnum 109)))))(code(MVar(Ident ff((fname eval/exp/bad/msg_error.scilla)(lnum 5)(bol 79)(cnum 118))))))).
+Cannot serialize literal <closure>

--- a/tests/eval/exp/good/gold/times_two.scilla.gold
+++ b/tests/eval/exp/good/gold/times_two.scilla.gold
@@ -1,7 +1,7 @@
 (Int32 8),
 { [fn -> <closure>],
   [f0 -> (Int32 1)],
-  [folder -> <fixpoint>],
+  [folder -> <closure>],
   [three -> (Nat 3)],
   [two -> (Nat 2)],
   [one -> (Nat 1)],


### PR DESCRIPTION
An extensive refactoring, extending literals with two new kinds: for closures and type abstractions. Those literals replace previously used run-time values `ValClosure` and `ValTypeFunction`, allowing for more uniform treatment of runtime values. It also allowed to get rid of additional run-time abstractions, so `Eval.ml` now operates exclusively with literals.

The small downside of this unification is that some additional checks need to be in place, to make sure that instances of literals `Clo` and `TClo` wouldn't be attempted to serialize or store to fields. for instance, the corresponding check needs to be inserted into `Conf.store`.