### PR TITLE
fix broken reference to let.scilla test

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Once the project is built you can try the following things:
 From the project root, execute
 
 ```
-./bin/eval-runner tests/eval/exp/let.scilla src/stdlib
+./bin/eval-runner tests/eval/exp/good/let.scilla src/stdlib
 ```
 
 Instead of `let.scilla` you might want to try any dfferent file in `tests/eval/exp`. The second argument, which is a path


### PR DESCRIPTION
let.scilla actually lives under tests/eval/exp/good, so fix
the reference.