### PR TITLE
fix Travis CI and opamdep Make target to use ocaml 4.06.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ branches:
 before_install:
 - wget https://raw.github.com/ocaml/opam/master/shell/opam_installer.sh -O - | sudo sh -s /usr/local/bin
 - opam init -y
-- opam switch -y 4.06.0
+- opam switch -y 4.06.1
 - opam install -y ocaml-migrate-parsetree core cryptokit ppx_sexp_conv yojson batteries angstrom hex ppx_deriving ppx_deriving_yojson menhir oUnit dune stdint fileutils ctypes ctypes-foreign
 - eval `opam config env`
 - rm $HOME/.opam/log/*

--- a/Makefile
+++ b/Makefile
@@ -43,5 +43,5 @@ zilliqa-docker:
 
 opamdep:
 	opam init -y
-	opam switch -y 4.06.0
+	opam switch -y 4.06.1
 	opam install -y ocaml-migrate-parsetree core cryptokit ppx_sexp_conv yojson batteries angstrom hex ppx_deriving ppx_deriving_yojson menhir oUnit dune stdint fileutils ctypes ctypes-foreign


### PR DESCRIPTION
The documentation says 4.06.1 is required, so make Travis CI and the Makefile use that rather than 4.06.0.