### PR TITLE
document that SCILLA_STDLIB_PATH should be an absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,12 @@ From the project root, execute
 ./bin/eval-runner tests/eval/exp/good/let.scilla src/stdlib
 ```
 
-Instead of `let.scilla` you might want to try any dfferent file in `tests/eval/exp`. The second argument, which is a path
-to the Scilla standard library can alternatively be specified in the
-environment variable `SCILLA_STDLIB_PATH`.
+Instead of `let.scilla` you might want to try any dfferent file in
+`tests/eval/exp`. The second argument, which is a path to the Scilla
+standard library can alternatively be specified in the environment
+variable `SCILLA_STDLIB_PATH`. This should be an absolute path; if it
+is a relative path then things (such as `make test`) which run from
+other working directories will break.
 
 #### Type-checking a contract
 
@@ -45,7 +48,8 @@ Instead of `auction.scilla` you might want to try any dfferent file in
 `tests/checker` with a complete implementation of a contract, or your
 own contract code. The second argument, which is a path to the Scilla
 standard library can alternatively be specified in the environment
-variable `SCILLA_STDLIB_PATH`.
+variable `SCILLA_STDLIB_PATH`. As above, this should be an absolute
+path.
 
 If the checker only returns the contract structure in JSON format, it
 means that the contract has no type errors. Otherwise, a type error


### PR DESCRIPTION
Doing

    export SCILLA_STDLIB_PATH=./src/stdlib

is enough to break `make test`, even when it's run from the directory containing `./src/stdlib`.  Other things will most likely break if the working directory does not contain `./src/stdlib`.