### PR TITLE
[WIP] check for duplicate payment acceptances in a transition

### DIFF
--- a/tests/checker/bad/TestCheckerFail.ml
+++ b/tests/checker/bad/TestCheckerFail.ml
@@ -33,7 +33,8 @@ module Tests = TestUtil.DiffBasedTests(
       "lib_bad1.scilla";
       "zil_mod.scilla";
       "mappair2.scilla";
-      "mappair.scilla"
+      "mappair.scilla";
+      "multiple_accepts.scilla"
     ]
     let use_stdlib = true
   end)

--- a/tests/checker/bad/gold/multiple_accepts.scilla.gold
+++ b/tests/checker/bad/gold/multiple_accepts.scilla.gold
@@ -1,0 +1,4 @@
+
+transition donate had duplicate accept statements:
+  Accept at checker/bad/multiple_accepts.scilla:5:3
+  Accept at checker/bad/multiple_accepts.scilla:6:3

--- a/tests/checker/bad/multiple_accepts.scilla
+++ b/tests/checker/bad/multiple_accepts.scilla
@@ -1,0 +1,7 @@
+contract MultipleAccepts
+()
+
+transition donate()
+  accept;
+  accept
+end

--- a/tests/checker/good/TestCheckerSuccess.ml
+++ b/tests/checker/good/TestCheckerSuccess.ml
@@ -26,7 +26,8 @@ module Tests = TestUtil.DiffBasedTests(
     let runner = "scilla-checker"
     let tests = [
       "crowdfunding.scilla"; "zil-game.scilla"; "fungible-token.scilla"; "auction.scilla";
-      "empty.scilla"; "schnorr.scilla"
+      "empty.scilla"; "schnorr.scilla";
+      "one_accept.scilla"
     ]
     let use_stdlib = true
   end)

--- a/tests/checker/good/gold/one_accept.scilla.gold
+++ b/tests/checker/good/gold/one_accept.scilla.gold
@@ -1,0 +1,7 @@
+{
+  "name": "OneAccept",
+  "params": [],
+  "fields": [],
+  "transitions": [ { "name": "donate", "params": [] } ],
+  "events": []
+}

--- a/tests/checker/good/one_accept.scilla
+++ b/tests/checker/good/one_accept.scilla
@@ -1,0 +1,6 @@
+contract OneAccept
+()
+
+transition donate()
+  accept
+end


### PR DESCRIPTION
If a transition has multiple "accept" statements, flag an error.

This is an attempt to solve [the "No transition accepts payment more than once" hackathon challenge](https://github.com/ilyasergey/scilla-demo/blame/master/hackathon/Tasks.md#L29).  However, since I never saw Scilla or touched OCaml before today, it's entirely possible that I slightly misunderstood what was being requested :-)

TODO:

- [ ] Confirm with a guru exactly how the check should work
- [ ] Allow multiple `accept`s in different branches of the same control-flow statement
- [ ] Add test for nested accept statements