### PR TITLE
On errors / failures, print a structured (JSON) output, indictating

### DIFF
--- a/src/lang/base/BuiltIns.ml
+++ b/src/lang/base/BuiltIns.ml
@@ -18,6 +18,7 @@
 
 open Syntax
 open Core
+open ErrorUtils
 open MonadUtil
 open Result.Let_syntax
 open Big_int
@@ -39,7 +40,7 @@ module ScillaBuiltIns
     PrettyPrinters.pp_literal_list ls
 
   let builtin_fail name ls =
-    fail @@ sprintf "Cannot apply built-in %s to a list of arguments:%s."
+    fail0 @@ sprintf "Cannot apply built-in %s to a list of arguments:%s."
       name (print_literal_list ls)
 
   module UsefulLiterals = struct
@@ -134,7 +135,7 @@ module ScillaBuiltIns
              is_uint_type u1 &&
              is_uint_type u2 ->
           elab_tfun_with_args substr_type ts
-      | _ -> fail "Failed to elaborate"
+      | _ -> fail0 "Failed to elaborate"
 
     let substr ls _ = match ls with
       | [StringLit x; UintLit (Uint32L s); UintLit (Uint32L e)] ->
@@ -274,13 +275,13 @@ module ScillaBuiltIns
     let eq_type = tfun_typ "'A" (fun_typ (tvar "'A") @@ fun_typ (tvar "'A") bool_typ)
     let eq_elab t ts = match ts with
       | [i1; i2] when i1 = i2 && is_int_type i1 -> elab_tfun_with_args t [i1]
-      | _ -> fail "Failed to elaborate"
+      | _ -> fail0 "Failed to elaborate"
 
     let binop_arity = 2
     let binop_type = tfun_typ "'A" (fun_typ (tvar "'A") @@ fun_typ (tvar "'A") (tvar "'A"))
     let binop_elab t ts = match ts with
       | [i1; i2] when i1 = i2 && is_int_type i1 -> elab_tfun_with_args t [i1]
-      | _ -> fail "Failed to elaborate"
+      | _ -> fail0 "Failed to elaborate"
 
     let eq ls _ = match ls with
       | [IntLit (Int32L _) as x; IntLit (Int32L _) as y]
@@ -390,7 +391,7 @@ module ScillaBuiltIns
       | 64 -> pure int64_typ
       | 128 -> pure int128_typ
       | 256 -> pure int256_typ
-      | _ -> fail "Failed to convert" 
+      | _ -> fail0 "Failed to convert" 
 
     let to_int_arity = 1
     let to_int_type = tfun_typ "'A" @@ tfun_typ "'B" (fun_typ (tvar "'A") (option_typ (tvar "'B")))
@@ -398,7 +399,7 @@ module ScillaBuiltIns
       | [t] when is_int_type t || is_uint_type t ->
           let%bind ityp = mk_int_type w in
           elab_tfun_with_args sc [t; ityp]
-      | _ -> fail "Failed to elaborate"
+      | _ -> fail0 "Failed to elaborate"
 
     let to_int_helper ls w = 
       let%bind xs = match ls with
@@ -430,13 +431,13 @@ module ScillaBuiltIns
     let eq_type = tfun_typ "'A" (fun_typ (tvar "'A") @@ fun_typ (tvar "'A") bool_typ)
     let eq_elab sc ts = match ts with
       | [i1; i2] when i1 = i2 && is_uint_type i1 -> elab_tfun_with_args sc [i1]
-      | _ -> fail "Failed to elaborate"
+      | _ -> fail0 "Failed to elaborate"
 
     let binop_arity = 2
     let binop_type = tfun_typ "'A" (fun_typ (tvar "'A") @@ fun_typ (tvar "'A") (tvar "'A"))
     let binop_elab sc ts = match ts with
       | [i1; i2] when i1 = i2 && is_uint_type i1 -> elab_tfun_with_args sc [i1]
-      | _ -> fail "Failed to elaborate"
+      | _ -> fail0 "Failed to elaborate"
 
     let eq ls _ = match ls with
       | [UintLit (Uint32L _) as x; UintLit (Uint32L _) as y]
@@ -546,7 +547,7 @@ module ScillaBuiltIns
       | 64 -> pure uint64_typ
       | 128 -> pure uint128_typ
       | 256 -> pure uint256_typ
-      | _ -> fail "Failed to convert" 
+      | _ -> fail0 "Failed to convert" 
 
     let to_uint_arity = 1
     let to_uint_type = tfun_typ "'A" @@ tfun_typ "'B"
@@ -556,7 +557,7 @@ module ScillaBuiltIns
       | [t] when is_uint_type t || is_int_type t ->
           let%bind ityp = mk_uint_type w in
           elab_tfun_with_args sc [t; ityp]
-      | _ -> fail "Failed to elaborate"
+      | _ -> fail0 "Failed to elaborate"
 
     let to_uint_helper ls w = 
       let%bind xs = match ls with
@@ -581,7 +582,7 @@ module ScillaBuiltIns
     let to_nat_elab sc ts = match ts with
       | [t] when is_uint_type t ->
           elab_tfun_with_args sc [t]
-      | _ -> fail "Failed to elaborate"
+      | _ -> fail0 "Failed to elaborate"
 
     let to_nat ls _ = match ls with
       | [UintLit (Uint32L n)] ->
@@ -630,7 +631,7 @@ module ScillaBuiltIns
     let badd_elab sc ts = match ts with
       | [s; u] when s = bnum_typ && is_uint_type u ->
           elab_tfun_with_args sc ts
-      | _ -> fail "Failed to elaborate"
+      | _ -> fail0 "Failed to elaborate"
 
     let badd ls _ = match ls with
       | [BNum x; UintLit y] ->
@@ -638,7 +639,7 @@ module ScillaBuiltIns
           let i2 = big_int_of_string (string_of_uint_lit y) in
           if ge_big_int i2 (big_int_of_int 0)
           then pure @@ BNum (string_of_big_int (add_big_int i1 i2))
-          else fail @@ sprintf
+          else fail0 @@ sprintf
               "Cannot add a negative value (%s) to a block." (string_of_uint_lit y)
       | _ -> builtin_fail "BNum.badd" ls
 
@@ -669,7 +670,7 @@ module ScillaBuiltIns
           (* We want both the types to be ByStr with equal width. *)
           is_bystrx_type bstyp1 && is_bystrx_type bstyp2 && bstyp1 = bstyp2
         -> elab_tfun_with_args sc [bstyp1]
-      | _ -> fail "Failed to elaborate"
+      | _ -> fail0 "Failed to elaborate"
     let eq ls _ = match ls with
       | [ByStrX (w1, x1); ByStrX(w2, x2)] ->
           pure @@ to_Bool (w1 = w2 && x1 = x2)
@@ -679,7 +680,7 @@ module ScillaBuiltIns
     let hash_arity = 1
     let hash_elab sc ts = match ts with
       | [_]  -> elab_tfun_with_args sc ts
-      | _ -> fail "Failed to elaborate"
+      | _ -> fail0 "Failed to elaborate"
     let sha256hash ls _ = match ls with
       | [l] ->
           let lstr = 
@@ -726,7 +727,7 @@ module ScillaBuiltIns
     let to_bystr_arity = 1
     let to_bystr_elab sc ts = match ts with
       | [t] when is_bystrx_type t -> elab_tfun_with_args sc ts
-      | _ -> fail "Failed to elaborate"
+      | _ -> fail0 "Failed to elaborate"
     let to_bystr ls _ = match ls with
       | [ByStrX(_, s)] -> 
         let res = build_prim_literal bystr_typ s in
@@ -793,7 +794,7 @@ module ScillaBuiltIns
     let contains_elab sc ts = match ts with
       | [MapType (kt, vt); u] when kt = u  ->
           elab_tfun_with_args sc [kt; vt]
-      | _ -> fail "Failed to elaborate"
+      | _ -> fail0 "Failed to elaborate"
     let contains ls _ = match ls with
       | [Map (_, entries); key] ->
           let res = Caml.Hashtbl.mem entries key in
@@ -810,7 +811,7 @@ module ScillaBuiltIns
     let put_elab sc ts = match ts with
       | [MapType (kt, vt); kt'; vt'] when kt = kt' && vt = vt'  ->
           elab_tfun_with_args sc [kt; vt]
-      | _ -> fail "Failed to elaborate"
+      | _ -> fail0 "Failed to elaborate"
     let put ls _ = match ls with
       | [Map (tm, entries); key; value] ->
           (* Scilla semantics is not in-place modification. *)
@@ -829,7 +830,7 @@ module ScillaBuiltIns
     let get_elab sc ts = match ts with
       | [MapType (kt, vt); kt'] when kt = kt'  ->
           elab_tfun_with_args sc [kt; vt]
-      | _ -> fail "Failed to elaborate"
+      | _ -> fail0 "Failed to elaborate"
     (* Notice that get passes return type *)
     let get ls rt = match ls, rt with
       | [Map (_, entries); key], ADT ("Option", [targ]) ->
@@ -847,7 +848,7 @@ module ScillaBuiltIns
     let remove_elab sc ts = match ts with
       | [MapType (kt, vt); u] when kt = u  ->
           elab_tfun_with_args sc [kt; vt]
-      | _ -> fail "Failed to elaborate" 
+      | _ -> fail0 "Failed to elaborate" 
     let remove ls _ = match ls with
       | [Map (tm, entries); key] ->
           (* Scilla semantics is not in-place modification. *)
@@ -864,7 +865,7 @@ module ScillaBuiltIns
        (list_typ (pair_typ (tvar "'K") (tvar "'V"))))
     let to_list_elab sc ts = match ts with
       | [MapType (kt, vt)]  -> elab_tfun_with_args sc [kt; vt]
-      | _ -> fail "Failed to elaborate" 
+      | _ -> fail0 "Failed to elaborate" 
     let to_list ls _ = match ls with
       | [Map ((kt, vt), entries)] ->
           (* The type of the output list will be "Pair (kt) (vt)" *)
@@ -891,10 +892,10 @@ module ScillaBuiltIns
   module BuiltInDictionary = struct 
 
     (* Elaborates the operation type based on the arguments types *)
-    type elaborator = typ -> typ list -> (typ, string) result      
+    type elaborator = typ -> typ list -> (typ, scilla_error list) result      
 
     (* Takes the expected type as an argument to elaborate the result *)
-    type built_in_executor = literal list -> typ -> (literal, string) result
+    type built_in_executor = literal list -> typ -> (literal, scilla_error list) result
 
     (* A built-in record type:
        * built-in name
@@ -984,12 +985,13 @@ module ScillaBuiltIns
             (* Second: check applicability *)
             let%bind res_type = fun_type_applies type_elab argtypes in
             pure (type_elab, res_type, exec)
-          else fail @@ "Name or arity don't match") in
+          else fail0 @@ "Name or arity don't match") in
       let open Caml in
       let dict = Option.value ~default:[] @@ Hashtbl.find_opt built_in_hashtbl opname in
       let%bind (_, (type_elab, res_type, exec)) = tryM dict ~f:finder
-          ~msg:(sprintf "[%s] Cannot find built-in with name \"%s\" and argument types %s."
-                  (ER.get_loc (get_rep op) |> get_loc_str) opname (pp_typ_list argtypes))
+          ~msg:(mk_error1
+                (sprintf "Cannot find built-in with name \"%s\" and argument types %s." opname (pp_typ_list argtypes))
+                (ER.get_loc (get_rep op)))
       in pure (type_elab, res_type, exec)
 
   end

--- a/src/lang/base/BuiltIns.mli
+++ b/src/lang/base/BuiltIns.mli
@@ -17,6 +17,7 @@
 *)
 
 open Syntax
+open ErrorUtils
 open Core
 
 module ScillaBuiltIns
@@ -25,7 +26,7 @@ module ScillaBuiltIns
 
   module BuiltInDictionary : sig
     type built_in_executor =
-      literal list -> typ -> (literal, string) result
+      literal list -> typ -> (literal, scilla_error list) result
 
     (* The return result is a triple:
      * The full elaborated type of the operation, e.g., string -> Bool
@@ -33,10 +34,10 @@ module ScillaBuiltIns
      * Executor for evaluating the operation      
     *)
     val find_builtin_op :
-      ER.rep ident -> typ list -> ((typ * typ * built_in_executor), string) result
+      ER.rep ident -> typ list -> ((typ * typ * built_in_executor), scilla_error list) result
   end
 
   (* Elaborator for the built-in typ *)
-  val elab_id : typ -> typ list -> (typ, string) result
+  val elab_id : typ -> typ list -> (typ, scilla_error list) result
 
 end

--- a/src/lang/base/ContractUtil.ml
+++ b/src/lang/base/ContractUtil.ml
@@ -38,12 +38,12 @@ module MessagePayload = struct
 
   let get_value_for_entry lab f es = 
     match List.find es ~f:(fun (l, _) -> l = lab) with
-    | None -> fail @@ sprintf "No field \"%s\" in message [%s]."
+    | None -> fail0 @@ sprintf "No field \"%s\" in message [%s]."
           lab (pp_literal_map es)
     | Some (_, p) ->
         (match f p with 
          | Some x -> x
-         | None -> fail @@ sprintf "Wrong value of the entry \"%s\": %s."
+         | None -> fail0 @@ sprintf "Wrong value of the entry \"%s\": %s."
                lab (pp_literal p)) 
 
   let get_tag = get_value_for_entry tag_label
@@ -59,9 +59,9 @@ module MessagePayload = struct
                if (compare i Uint128.zero) >= 0
                then Some (pure i)
                else
-                 Some (fail @@ sprintf "Amount should be non-negative: %s" (Uint128.to_string i))
+                 Some (fail0 @@ sprintf "Amount should be non-negative: %s" (Uint128.to_string i))
              with
-              | Failure _ -> Some (fail @@
+              | Failure _ -> Some (fail0 @@
                   sprintf "Could not convert string %s to Stdint.Uint128." (Uint128.to_string i)))
         | _ -> None)
   

--- a/src/lang/base/Datatypes.ml
+++ b/src/lang/base/Datatypes.ml
@@ -126,7 +126,7 @@ module DataTypeDictionary = struct
     let open Caml in
     match Hashtbl.find_opt adt_name_dict name with
     | None ->
-      fail @@ sprintf "ADT %s not found" name
+      fail0 @@ sprintf "ADT %s not found" name
     | Some a ->
         pure (a)
 
@@ -134,7 +134,7 @@ module DataTypeDictionary = struct
   let lookup_constructor cn =
     let open Caml in
     match Hashtbl.find_opt adt_cons_dict cn with
-    | None -> fail @@
+    | None -> fail0 @@
         sprintf "No data type with constructor %s found" cn
     | Some dt ->
       pure dt

--- a/src/lang/base/Datatypes.mli
+++ b/src/lang/base/Datatypes.mli
@@ -17,6 +17,7 @@
 *)
 
 open Syntax
+open ErrorUtils
 open Core
 
 (**********************************************************)
@@ -39,9 +40,9 @@ module DataTypeDictionary : sig
   (* Hiding the actual data type dicionary *)
 
   (*  Get ADT by name  *)
-  val lookup_name : string -> (adt, string) result
+  val lookup_name : string -> (adt, scilla_error list) result
   (*  Get ADT by the constructor  *)
-  val lookup_constructor : string -> (adt * constructor, string) result
+  val lookup_constructor : string -> (adt * constructor, scilla_error list) result
   (* Get typing map for a constructor *)
   val constr_tmap : adt -> string -> (typ list) option
   

--- a/src/lang/base/ErrorUtils.ml
+++ b/src/lang/base/ErrorUtils.ml
@@ -1,0 +1,56 @@
+(*
+  This file is part of scilla.
+
+  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+
+  scilla is free software: you can redistribute it and/or modify it under the
+  terms of the GNU General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option) any later
+  version.
+
+  scilla is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along with
+  scilla.  If not, see <http://www.gnu.org/licenses/>.
+*)
+
+open Core
+
+(* Location info, slightly more usable than Lexing.position *)
+type loc = {
+  fname : string; (* file name *)
+  lnum : int;     (* line number *)
+  cnum : int;     (* column number *)
+}
+[@@deriving sexp]
+
+let toLoc (p : Lexing.position) : loc = {
+  fname = p.pos_fname;
+  lnum = p.pos_lnum; 
+  (* Translate from Lexing.position *)
+  cnum = p.pos_cnum - p.pos_bol + 1;
+}
+
+let dummy_loc =
+  toLoc Lexing.dummy_pos
+
+let get_loc_str (l : loc) : string =
+  l.fname ^ ":" ^ Int.to_string l.lnum ^ 
+      ":" ^ Int.to_string (l.cnum)
+
+type scilla_error = {
+  emsg : string;
+  startl : loc;
+  endl : loc;
+}
+
+let sprint_scilla_error_list elist =
+    List.fold elist ~init:"" ~f:(fun acc e ->
+        acc ^ "\n\n" ^ e.emsg ^ "[" ^ (get_loc_str e.startl) ^ "][" 
+        ^ (get_loc_str e.endl) ^"]" ^ "\n")
+
+let mk_error0 msg = [{ emsg = msg; startl = dummy_loc; endl = dummy_loc }]
+let mk_error1 msg sloc = [{ emsg = msg; startl = sloc; endl = dummy_loc }]
+let mk_error2 msg sloc eloc = [{ emsg = msg; startl = sloc; endl = eloc }]

--- a/src/lang/base/Gas.ml
+++ b/src/lang/base/Gas.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core
+open ErrorUtils
 open Result.Let_syntax
 open MonadUtil
 open Syntax
@@ -103,7 +104,7 @@ module ScillaGas
 
   (* A signature for functions that determine dynamic cost of built-in ops. *)
   (* op -> arguments -> base cost -> total cost *)
-  type coster = string -> literal list -> int -> (int, string) result
+  type coster = string -> literal list -> int -> (int, scilla_error list) result
   (* op, arg types, coster, base cost. *)
   type builtin_record = string * (typ list) * coster * int
   (* a static coster that only looks at base cost. *)
@@ -116,7 +117,7 @@ module ScillaGas
         pure @@ (String.length s1 + String.length s2) * base
     | "substr", [StringLit s; UintLit (Uint32L _); UintLit (Uint32L _)] ->
         pure @@ (String.length s) * base
-    | _ -> fail @@ "Gas cost error for string built-in"
+    | _ -> fail0 @@ "Gas cost error for string built-in"
 
   let hash_coster op args base =
     let open BatOption in
@@ -134,18 +135,18 @@ module ScillaGas
         pure @@ (String.length s) * base
     | "to_bystr", [a], _
       when is_bystrx_type a -> pure @@ get (bystrx_width a) * base
-    | _ -> fail @@ "Gas cost error for hash built-in"
+    | _ -> fail0 @@ "Gas cost error for hash built-in"
 
   let map_coster _ args base =
     match args with
     | Map _ :: _ -> pure base
-    | _ -> fail @@ "Gas cost error for map built-in"
+    | _ -> fail0 @@ "Gas cost error for map built-in"
 
   let to_nat_coster _ args base =
     match args with
     (* TODO: Is this good? *)
     | [UintLit (Uint32L i)] -> pure @@  (Stdint.Uint32.to_int i) * base
-    | _ -> fail @@ "Gas cost error for to_nat built-in"
+    | _ -> fail0 @@ "Gas cost error for to_nat built-in"
 
   let int_coster _ args base =
     let base' =
@@ -160,12 +161,12 @@ module ScillaGas
         pure @@ int_lit_width i
       | [UintLit i] | [UintLit i; UintLit _] ->
         pure @@ uint_lit_width i
-      | _ -> fail @@ "Gas cost error for integer built-in"
+      | _ -> fail0 @@ "Gas cost error for integer built-in"
     in
       if w = 32 || w = 64 then pure base'
       else if w = 128 then pure (base' * 2)
       else if w = 256 then pure (base' * 4)
-      else fail @@ "Gas cost error for integer built-in"
+      else fail0 @@ "Gas cost error for integer built-in"
 
   let tvar s = TypeVar(s)
 
@@ -241,12 +242,12 @@ module ScillaGas
              (match t2 with | TypeVar _ -> true | _ -> false)) 
              arg_types types)
       then fcoster op arg_literals base (* this can fail too *)
-      else fail @@ "Name or arity doesn't match"
+      else fail0 @@ "Name or arity doesn't match"
     in
     let msg = sprintf "Unable to determine gas cost for \"%s\"" op in
     let open Caml in
     let dict = match Hashtbl.find_opt builtin_hashtbl op with | Some rows -> rows | None -> [] in
-    let %bind (_, cost) = tryM dict ~f:matcher ~msg:msg in
+    let %bind (_, cost) = tryM dict ~f:matcher ~msg:(mk_error0 msg) in
     pure cost
 
 end

--- a/src/lang/base/JSON.ml
+++ b/src/lang/base/JSON.ml
@@ -18,6 +18,7 @@
 
 
 open Syntax
+open ErrorUtils
 open ParserUtil
 open Core
 open Yojson
@@ -33,7 +34,9 @@ module JSONBuiltIns = ScillaBuiltIns (ParserRep) (ParserRep)
 
 open JSONTypeUtilities
 
-exception Invalid_json of string
+exception Invalid_json of scilla_error list
+
+let mk_invalid_json msg = Invalid_json (mk_error0 msg)
 
 (****************************************************************)
 (*                    Exception wrappers                        *)
@@ -42,13 +45,13 @@ exception Invalid_json of string
 let parse_typ_exn t = 
   (try FrontEndParser.parse_type t
     with _ ->
-      raise (Invalid_json (sprintf "Invalid type in json: %s\n" t)))
+      raise (mk_invalid_json (sprintf "Invalid type in json: %s\n" t)))
 
 let member_exn m j =
   let open Basic.Util in
   let v = member m j in
   match v with
-  | `Null -> raise (Invalid_json ("Member '" ^ m ^ "' not found in json"))
+  | `Null -> raise (mk_invalid_json ("Member '" ^ m ^ "' not found in json"))
   | j -> j
 
 (* Given a literal, return its full type name *)
@@ -63,7 +66,7 @@ let literal_type_exn l =
 let build_prim_lit_exn t v =
   let exn_wrapper t v r = 
     match v with
-    | None -> raise (Invalid_json ("Invalid " ^ (pp_typ t) ^ " value " ^ r ^ " in JSON"))
+    | None -> raise (mk_invalid_json ("Invalid " ^ (pp_typ t) ^ " value " ^ r ^ " in JSON"))
     | Some v' -> v'
   in
     exn_wrapper t (build_prim_literal t v) v
@@ -87,13 +90,13 @@ let rec json_to_adtargs cname tlist ajs =
     if provided <> expected then
       let p = Int.to_string provided in
       let e = Int.to_string expected in
-      raise (Invalid_json ("Malformed ADT constructor " ^ cname ^ 
+      raise (mk_invalid_json ("Malformed ADT constructor " ^ cname ^ 
         ": expected " ^ e ^ " args, but provided " ^ p ^ "."))
   in
   let dt =
   (match DataTypeDictionary.lookup_constructor cname with
   | Error emsg ->
-    raise (Invalid_json(emsg))
+    raise (Invalid_json (emsg))
   | Ok (r, _) ->
     r
   ) in
@@ -140,14 +143,14 @@ let rec json_to_adtargs cname tlist ajs =
     let lit = read_adt_json dt.tname j tlist in
       ADTValue (cname, [], lit::[])
   | _ ->
-    raise (Invalid_json ("JSON parsing: Unsupported ADT type"))
+    raise (mk_invalid_json ("JSON parsing: Unsupported ADT type"))
 
 and read_adt_json name j tlist_verify =
   let open Basic.Util in
   let dt =
   (match DataTypeDictionary.lookup_name name with
     | Error emsg ->
-      raise (Invalid_json(emsg))
+      raise (Invalid_json (emsg))
     | Ok r ->
       r
     ) in
@@ -157,17 +160,17 @@ and read_adt_json name j tlist_verify =
       let dt' =
       (match DataTypeDictionary.lookup_constructor constr with
       | Error emsg ->
-        raise (Invalid_json(emsg))
+        raise (Invalid_json (emsg))
       | Ok (r, _) ->
         r
       ) in
       if (dt <> dt') then
-        raise (Invalid_json ("ADT type " ^ dt.tname ^ " does not match constructor " ^ constr));
+        raise (mk_invalid_json ("ADT type " ^ dt.tname ^ " does not match constructor " ^ constr));
       let argtypes = member_exn "argtypes" j |> to_list in
       let arguments = member_exn "arguments" j |> to_list in
       let tlist = json_to_adttyps argtypes in
         json_to_adtargs constr tlist arguments
-  | _ -> raise (Invalid_json ("JSON parsing: error parsing ADT " ^ name))
+  | _ -> raise (mk_invalid_json ("JSON parsing: error parsing ADT " ^ name))
   in
   (* match tlist1 with adt's tlist. *)
   let verify_exn name tlist1 adt =
@@ -177,9 +180,9 @@ and read_adt_json name j tlist_verify =
       else
       let expected = pp_typ_list tlist1 in
       let observed = pp_typ_list tlist2 in
-      raise (Invalid_json ("Type mismatch in parsing ADT " ^ name ^ 
+      raise (mk_invalid_json ("Type mismatch in parsing ADT " ^ name ^ 
                 ". Expected: " ^ expected ^ " vs Observed: " ^ observed))
-    | _ -> raise (Invalid_json ("Type mismatch in parsing ADT " ^ name))
+    | _ -> raise (mk_invalid_json ("Type mismatch in parsing ADT " ^ name))
   in
     (* verify built ADT *)
     verify_exn name tlist_verify res;
@@ -194,7 +197,7 @@ and read_map_json kt vt j =
      let kvallist = mapvalues_from_json kt vt vli (List.length vli) in
      Map ((kt, vt), kvallist)
   | `Null -> Map ((kt, vt), Caml.Hashtbl.create 0)
-  | _ -> raise (Invalid_json ("JSON parsing: error parsing Map"))
+  | _ -> raise (mk_invalid_json ("JSON parsing: error parsing Map"))
  
 and mapvalues_from_json kt vt l size = 
   let open Basic.Util in
@@ -205,7 +208,7 @@ and mapvalues_from_json kt vt l size =
         (match kt with
          | PrimType _ ->
             build_prim_lit_exn kt (to_string kjson)
-         | _ -> raise (Invalid_json ("Key in Map JSON is not a PrimType"))
+         | _ -> raise (mk_invalid_json ("Key in Map JSON is not a PrimType"))
          ) in
       let vjson = member_exn "val" first in
       let vallit =
@@ -217,7 +220,7 @@ and mapvalues_from_json kt vt l size =
               vl
          | PrimType _ ->
             build_prim_lit_exn vt (to_string vjson)
-         | _ -> raise (Invalid_json ("Unknown type in Map value in JSON"))
+         | _ -> raise (mk_invalid_json ("Unknown type in Map value in JSON"))
         ) in
         let m = mapvalues_from_json kt vt remaining size in
           let _ = Caml.Hashtbl.replace m keylit vallit in

--- a/src/lang/base/JSON.mli
+++ b/src/lang/base/JSON.mli
@@ -144,4 +144,6 @@ module Event : sig
 
 end
 
-exception Invalid_json of string
+open ErrorUtils
+exception Invalid_json of scilla_error list
+val mk_invalid_json : string -> exn

--- a/src/lang/base/MonadUtil.ml
+++ b/src/lang/base/MonadUtil.ml
@@ -18,14 +18,22 @@
 
 open Core
 open Result.Let_syntax
+open ErrorUtils
+
+(* Monadic evaluation results *)
+let fail (s : scilla_error list) = Error s
+let pure e = return e
+
+(* fail with just a message, no location info. *)
+let fail0 (msg : string) = fail @@ mk_error0 msg
+(* fail with a message and start location. *)
+let fail1 msg sloc = fail @@ mk_error1 msg sloc
+(* fail with a message and both start and end locations. *)
+let fail2 msg sloc eloc = fail @@ mk_error2 msg sloc eloc
 
 (****************************************************************)
 (*               Utilities for the result monad                 *)
 (****************************************************************)
-
-(* Monadic evaluation results *)
-let fail s = Error s
-let pure e = return e
 
 (* Monadic fold-left for error *)
 let rec foldM ~f ~init ls = match ls with
@@ -108,8 +116,15 @@ module EvalMonad = struct
     end)
 
   (* Monadic evaluation results *)
-  let fail s = (fun remaining_gas -> Error (s, remaining_gas))
+  let fail (s : scilla_error list) = (fun remaining_gas -> Error (s, remaining_gas))
   let pure e = return e
+
+  (* fail with just a message, no location info. *)
+  let fail0 (msg : string) = fail @@ mk_error0 msg
+  (* fail with a message and start location. *)
+  let fail1 msg sloc = fail @@ mk_error1 msg sloc
+  (* fail with a message and both start and end locations. *)
+  let fail2 msg sloc eloc = fail @@ mk_error2 msg sloc eloc
 
   let fromR r =
     match r with
@@ -129,7 +144,7 @@ module EvalMonad = struct
          let res = op_thunk() in
          mapR res (remaining_gas - cost)
        else 
-         Error ("Ran out of gas", remaining_gas))
+         Error (mk_error0 "Ran out of gas", remaining_gas))
 
   (* Wrap an op with cost check when op returns "eresult". *)
   let checkwrap_op op_thunk cost emsg =

--- a/src/lang/base/ParserUtil.ml
+++ b/src/lang/base/ParserUtil.ml
@@ -17,6 +17,8 @@
 *)
 
 open Syntax
+open ErrorUtils
+
     
 (*******************************************************)
 (*                   Annotations                       *)

--- a/src/lang/base/ScillaParser.mly
+++ b/src/lang/base/ScillaParser.mly
@@ -19,6 +19,7 @@
 
 %{
   open Syntax
+  open ErrorUtils
   open ParserUtil
 
   open ParsedSyntax

--- a/src/lang/base/TypeCache.ml
+++ b/src/lang/base/TypeCache.ml
@@ -18,6 +18,7 @@
 
 open Core
 open Syntax
+open ErrorUtils
 open TypeUtil
 
 (*****************************************************************)

--- a/src/lang/base/TypeUtil.ml
+++ b/src/lang/base/TypeUtil.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core
+open ErrorUtils
 open Sexplib.Std
 open Syntax
 open MonadUtil
@@ -64,10 +65,10 @@ module type MakeTEnvFunctor = functor
       (* Add type variable to the environment *)
       val addV : t -> R.rep ident -> t
       (* Check type for well-formedness in the type environment *)
-      val is_wf_type : t -> typ -> (unit, string) result
+      val is_wf_type : t -> typ -> (unit, scilla_error list) result
       (* Resolve the identifier *)
       val resolveT : 
-        ?lopt:(R.rep option) -> t -> string -> (resolve_result, string) result
+        ?lopt:(R.rep option) -> t -> string -> (resolve_result, scilla_error list) result
       (* Copy the environment *)
       val copy : t -> t
       (* Convert to list *)
@@ -134,7 +135,7 @@ module MakeTEnv: MakeTEnvFunctor = functor
               let open Datatypes.DataTypeDictionary in
               let%bind adt = lookup_name n in
               if List.length ts <> List.length adt.tparams then
-                fail @@ sprintf "ADT type %s expects %d arguments but got %d.\n" 
+                fail0 @@ sprintf "ADT type %s expects %d arguments but got %d.\n" 
                   n (List.length adt.tparams) (List.length ts) 
               else
                 foldM ~f:(fun _ ts' -> is_wf_typ' ts' tb) ~init:(()) ts
@@ -146,7 +147,7 @@ module MakeTEnv: MakeTEnvFunctor = functor
               else
                 (match List.findi (tvars tenv) ~f:(fun _ (x, _) -> x = a) with
                  | Some _ -> pure()
-                 | None -> fail @@ sprintf "Unbound type variable %s in type %s" a (pp_typ t))
+                 | None -> fail0 @@ sprintf "Unbound type variable %s in type %s" a (pp_typ t))
           | PolyFun (arg, bt) -> is_wf_typ' bt (arg::tb)
         in
         is_wf_typ' t []
@@ -163,12 +164,12 @@ module MakeTEnv: MakeTEnvFunctor = functor
         match Hashtbl.find_opt env.tenv id with
         | Some r -> pure r
         | None ->
-            let loc_str = (match lopt with
-                | Some l -> sprintf "[%s]: " (get_loc_str (R.get_loc l))
-                | None -> "") in
-            fail @@ sprintf
-              "%sCouldn't resolve the identifier \"%s\".\n"
-              loc_str id
+            let sloc = (match lopt with
+                | Some l -> R.get_loc l
+                | None -> dummy_loc) in
+            fail1 (sprintf
+              "Couldn't resolve the identifier \"%s\".\n" id)
+              sloc
 
       let copy e = {
         tenv = Hashtbl.copy e.tenv;
@@ -230,7 +231,7 @@ module TypeUtilities
   let assert_type_equiv expected given =
     if type_equiv expected given
     then pure ()
-    else fail @@ sprintf
+    else fail0 @@ sprintf
         "Type mismatch: %s expected, but %s provided."
         (pp_typ expected) (pp_typ given)
 
@@ -266,7 +267,7 @@ module TypeUtilities
         fun_type_applies rest ats
     | FunType (argt, rest), [] when argt = Unit -> pure rest
     | t, []  -> pure t
-    | _ -> fail @@ sprintf
+    | _ -> fail0 @@ sprintf
           "The type\n%s\ndoesn't apply, as a function, to the arguments of types\n%s." (pp_typ ft)
           (pp_typ_list argtypes)
 
@@ -275,7 +276,7 @@ module TypeUtilities
         let afv = free_tvars a in
         let%bind (n, tp) = (match refresh_tfun pf afv with
             | PolyFun (a, b) -> pure (a, b)
-            | _ -> fail "This can't happen!") in
+            | _ -> fail0 "This can't happen!") in
         let tp' = subst_type_in_type n a tp in
         elab_tfun_with_args tp' args'
     | t, [] -> pure t
@@ -283,7 +284,7 @@ module TypeUtilities
         let msg = sprintf
             "Cannot elaborate expression of type\n%s\napplied, as a type function, to type arguments\n%s." (pp_typ tf)
             (pp_typ_list args) in
-        fail msg
+        fail0 msg
 
   (****************************************************************)
   (*                        Working with ADTs                     *)
@@ -295,7 +296,7 @@ module TypeUtilities
 
   let validate_param_length cn plen alen =
     if plen <> alen
-    then fail @@ sprintf
+    then fail0 @@ sprintf
         "Constructor %s expects %d type arguments, but got %d." cn plen alen
     else pure ()
 
@@ -344,10 +345,10 @@ module TypeUtilities
           let alen = List.length targs in        
           let%bind _ = validate_param_length cn plen alen in
           pure targs
-        else fail @@ sprintf
+        else fail0 @@ sprintf
             "Types don't match: pattern uses a constructor of type %s, but value of type %s is given."
             adt.tname name
-    | _ -> fail @@ sprintf
+    | _ -> fail0 @@ sprintf
           "Not an algebraic data type: %s" (pp_typ atyp)
 
   let constr_pattern_arg_types atyp cn =
@@ -363,11 +364,11 @@ module TypeUtilities
         pure @@ List.map ~f:(apply_type_subst subst) tms 
 
   let assert_all_same_type ts = match ts with
-    | [] -> fail "Checking an empty type list."
+    | [] -> fail0 "Checking an empty type list."
     | t :: ts' ->
         match List.find ts' ~f:(fun t' -> not (type_equiv t t')) with
         | None -> pure ()
-        | Some _ -> fail @@ sprintf
+        | Some _ -> fail0 @@ sprintf
               "Not all types of the branches %s are equivalent." (pp_typ_list ts)
 
   (****************************************************************)
@@ -390,11 +391,11 @@ module TypeUtilities
     | ByStr _ -> 
       if validate_bystr_literal l
       then pure bystr_typ
-      else fail @@ (sprintf "Malformed byte string " ^ (pp_literal l))
+      else fail0 @@ (sprintf "Malformed byte string " ^ (pp_literal l))
     | ByStrX (b, _) ->
         if validate_bystrx_literal l
         then pure (bystrx_typ b)
-        else fail @@ (sprintf "Malformed byte string " ^ (pp_literal l))
+        else fail0 @@ (sprintf "Malformed byte string " ^ (pp_literal l))
     (* Check that messages and events have storable parameters. *)
     | Msg m -> 
         let%bind all_storable = foldM ~f:(fun acc (_, l) ->
@@ -403,7 +404,7 @@ module TypeUtilities
             ~init:true m
         in
         if not all_storable then
-          fail @@ sprintf "Message/Event has invalid / non-storable parameters"
+          fail0 @@ sprintf "Message/Event has invalid / non-storable parameters"
         else pure msg_typ
     | Map ((kt, vt), kv) ->
         if PrimTypes.is_prim_type kt
@@ -417,25 +418,25 @@ module TypeUtilities
                 pure @@
                 ((type_equiv kt kt') && (type_equiv vt vt'))
             ) kv (pure true) in
-          if not valid then fail @@ (sprintf "Malformed literal %s" (pp_literal l))
+          if not valid then fail0 @@ (sprintf "Malformed literal %s" (pp_literal l))
           (* We have a valid Map literal. *)
           else pure (MapType (kt, vt))
         else if ((Caml.Hashtbl.length kv) = 0) && (match kt with | TypeVar _ -> true | _ -> false) then
           (* we make an exception for Emp as it may be parameterized. *)
           pure (MapType (kt, vt))
         else
-          fail @@
+          fail0 @@
           (sprintf "Not a primitive map key type: %s." (pp_typ kt))
     | ADTValue (cname, ts, args) ->
         let%bind (adt, constr) = DataTypeDictionary.lookup_constructor cname in
         let tparams = adt.tparams in
         let tname = adt.tname in
         if not (List.length tparams = List.length ts)
-        then fail @@
+        then fail0 @@
           sprintf "Wrong number of type parameters for ADT %s (%i) in constructor %s."
             tname (List.length ts) cname
         else if not (List.length args = constr.arity)
-        then fail @@
+        then fail0 @@
           sprintf "Wrong number of arguments to ADT %s (%i) in constructor %s."
             tname (List.length args) cname
             (* Verify that the types of args match that declared. *)
@@ -446,10 +447,10 @@ module TypeUtilities
           let args_valid = List.for_all2_exn tmap arg_typs 
               ~f:(fun t1 t2 -> type_equiv t1 t2) in
           if not args_valid
-          then fail @@ sprintf "Malformed ADT %s. Arguments do not match expected types" (pp_literal l)
+          then fail0 @@ sprintf "Malformed ADT %s. Arguments do not match expected types" (pp_literal l)
           else pure @@ res
-    | Clo _ -> fail @@ "Cannot type-check runtime closure."
-    | TAbs _ -> fail @@ "Cannot type-check runtime type function."
+    | Clo _ -> fail0 @@ "Cannot type-check runtime closure."
+    | TAbs _ -> fail0 @@ "Cannot type-check runtime type function."
 end
 
 (*****************************************************************)

--- a/src/lang/base/TypeUtil.mli
+++ b/src/lang/base/TypeUtil.mli
@@ -17,6 +17,7 @@
 *)
 
 open Core
+open ErrorUtils
 open Syntax
 
 (* An inferred type with possible qualifiers *)
@@ -57,10 +58,10 @@ module type MakeTEnvFunctor = functor
       (* Add type variable to the environment *)
       val addV : t -> R.rep ident -> t
       (* Check type for well-formedness in the type environment *)
-      val is_wf_type : t -> typ -> (unit, string) result
+      val is_wf_type : t -> typ -> (unit, scilla_error list) result
       (* Resolve the identifier *)    
       val resolveT : ?lopt:(R.rep option) -> t -> string ->
-        (resolve_result, string) result
+        (resolve_result, scilla_error list) result
       (* Copy the environment *)
       val copy : t -> t
       (* Convert to list *)
@@ -80,7 +81,7 @@ module TypeUtilities
 
   module MakeTEnv : MakeTEnvFunctor
     
-  val literal_type : literal -> (typ, string) result
+  val literal_type : literal -> (typ, scilla_error list) result
 
   (* Useful generic types *)
   val fun_typ : typ -> typ -> typ
@@ -103,13 +104,13 @@ module TypeUtilities
   val type_equiv : typ -> typ -> bool
   val type_equiv_list : typ list -> typ list -> bool
 
-  val assert_type_equiv : typ -> typ -> (unit, string) result
+  val assert_type_equiv : typ -> typ -> (unit, scilla_error list) result
 
   (* Applying a function type *)
-  val fun_type_applies : typ -> typ list -> (typ, string) result
+  val fun_type_applies : typ -> typ list -> (typ, scilla_error list) result
 
   (* Applying a type function *)
-  val elab_tfun_with_args : typ -> typ list -> (typ, string) result
+  val elab_tfun_with_args : typ -> typ list -> (typ, scilla_error list) result
 
   val pp_typ_list : typ list -> string  
 
@@ -121,16 +122,16 @@ module TypeUtilities
   val apply_type_subst : (string * typ) list -> typ -> typ
 
   (*  Get elaborated type for a constructor and list of type arguments *)    
-  val elab_constr_type : string -> typ list -> (typ, string) result  
+  val elab_constr_type : string -> typ list -> (typ, scilla_error list) result  
 
   (* For a given instantiated ADT and a construtor name, get type *
      assignemnts. This is the main working horse of type-checking
      pattern-matching. *)    
-  val constr_pattern_arg_types : typ -> string -> (typ list, string) result  
+  val constr_pattern_arg_types : typ -> string -> (typ list, scilla_error list) result  
 
-  val validate_param_length : string -> int -> int -> (unit, string) result
+  val validate_param_length : string -> int -> int -> (unit, scilla_error list) result
 
-  val assert_all_same_type : typ list -> (unit, string) result
+  val assert_all_same_type : typ list -> (unit, scilla_error list) result
 
 end
 

--- a/src/lang/checkers/EventInfo.ml
+++ b/src/lang/checkers/EventInfo.ml
@@ -1,6 +1,5 @@
 open TypeUtil
 open Syntax
-
 open PrimTypes
 open ContractUtil.MessagePayload
 open MonadUtil
@@ -36,8 +35,8 @@ module ScillaEventInfo
            let emsg = "Error determining event name\n" in
            let%bind eventname = match epld with
              | MTag s -> pure s
-             | MLit l -> (match l with | StringLit s -> pure s | _ -> fail emsg)
-             | MVar _ -> fail emsg 
+             | MLit l -> (match l with | StringLit s -> pure s | _ -> fail0 emsg)
+             | MVar _ -> fail0 emsg 
            in
            (* Get the type of the event parameters. *)
            let filtered_m = List.filter (fun (label, _) -> not (label = eventname_label)) m in
@@ -60,7 +59,7 @@ module ScillaEventInfo
                       acc ^ (Printf.sprintf "(%s : %s); " n (pp_typ t))) "[" tplist
                   ^ "]" in 
                 if m_types <> tlist then 
-                  fail @@ Printf.sprintf "Parameter mismatch for event %s. %s vs %s\n"
+                  fail0 @@ Printf.sprintf "Parameter mismatch for event %s. %s vs %s\n"
                     eventname (printer tlist) (printer m_types)
                 else
                   pure @@ acc

--- a/src/lang/eval/Eval.ml
+++ b/src/lang/eval/Eval.ml
@@ -19,6 +19,7 @@
 
 open Syntax
 open Core
+open ErrorUtils
 open EvalUtil
 open MonadUtil
 open EvalMonad
@@ -44,7 +45,7 @@ let reserved_names =
 let pp_result r exclude_names = 
   let enames = List.append exclude_names reserved_names in
   match r with
-  | Error (s, _) -> s
+  | Error (s, _) -> sprint_scilla_error_list s
   | Ok ((e, env), _) ->
       let filter_prelude = fun (k, _) ->
         not (List.mem enames k ~equal:(fun s1 s2 -> s1 = s2))
@@ -72,7 +73,7 @@ let is_serializable_literal l = match l with
 let sanitize_literal l =
   if is_serializable_literal l
   then pure l
-  else fail @@ sprintf "Cannot serialize literal %s" (pp_literal l)
+  else fail0 @@ sprintf "Cannot serialize literal %s" (pp_literal l)
 
 (*******************************************************)
 (* A monadic big-step evaluator for Scilla expressions *)
@@ -128,7 +129,7 @@ let rec exp_eval erep env =
       let%bind (_, constr) = fromR @@ lookup_constructor cname in
       let alen = List.length actuals in
       if (constr.arity <> alen)
-      then fail @@ sprintf
+      then fail0 @@ sprintf
           "Constructor %s expects %d arguments, but got %d."
           cname constr.arity alen
       else
@@ -144,7 +145,7 @@ let rec exp_eval erep env =
       let%bind ((_, e_branch), bnds) =
         tryM clauses
           (* TODO: add location info to error message. *)
-          ~msg:(sprintf "Match expression failed. No clause matched.")
+          ~msg:(mk_error0(sprintf "Match expression failed. No clause matched."))
           ~f:(fun (p, _) -> fromR @@ match_with_pattern v p) in
       (* Update the environment for the branch *)
       let env' = List.fold_left bnds ~init:env
@@ -161,7 +162,7 @@ let rec exp_eval erep env =
         let%bind (fbody, _) = exp_eval_wrapper body env1 in
         match fbody with
         | Clo f -> f arg
-        | _ -> fail "Cannot apply fxpoint argument to a value"
+        | _ -> fail0 "Cannot apply fxpoint argument to a value"
       and clo_fix = Clo fix          
       in pure (clo_fix, env)
   | TFun (tv, body) ->
@@ -184,20 +185,22 @@ and try_apply_as_closure v arg =
   match v with
   | Clo clo -> clo arg
   |  _ ->
-      fail @@ sprintf "Not a functional value: %s." (Env.pp_value v)
+      fail0 @@ sprintf "Not a functional value: %s." (Env.pp_value v)
 
 and try_apply_as_type_closure v arg_type =
   match v with
   | TAbs tclo -> tclo arg_type
   | _ ->
-      fail @@ sprintf "Not a type closure: %s." (Env.pp_value v)
+      fail0 @@ sprintf "Not a type closure: %s." (Env.pp_value v)
 
 (* Adding gas cost to the reduction *)
 and exp_eval_wrapper expr env =
+  let (_, eloc) = expr in
   let thunk () = exp_eval expr env in
   let%bind cost = fromR @@ EvalGas.expr_static_cost expr in
   let emsg = sprintf "Ran out of gas.\n" in
-  checkwrap_op thunk cost emsg
+  (* Add end location too: https://github.com/Zilliqa/scilla/issues/134 *)
+  checkwrap_op thunk cost (mk_error1 emsg eloc)
 
 
 open EvalSyntax
@@ -207,33 +210,33 @@ open EvalSyntax
 let rec stmt_eval conf stmts =
   match stmts with
   | [] -> pure conf
-  | (s, _) :: sts -> (match s with
+  | (s, sloc) :: sts -> (match s with
       | Load (x, r) ->
           let%bind (l, scon) = Configuration.load conf r in
           let conf' = Configuration.bind conf (get_id x) l in
-          let%bind _ = stmt_gas_wrap scon in
+          let%bind _ = stmt_gas_wrap scon sloc in
           stmt_eval conf' sts
       | Store (x, r) ->
           let%bind v = Configuration.lookup conf r in
           let%bind (conf', scon) = Configuration.store conf (get_id x) v in
-          let%bind _ = stmt_gas_wrap scon in
+          let%bind _ = stmt_gas_wrap scon sloc in
           stmt_eval conf' sts
       | Bind (x, e) ->
           let%bind (lval, _) = exp_eval_wrapper e conf.env in
           let conf' = Configuration.bind conf (get_id x) lval in
-          let%bind _ = stmt_gas_wrap G_Bind in
+          let%bind _ = stmt_gas_wrap G_Bind sloc in
           stmt_eval conf' sts
       | ReadFromBC (x, bf) ->
           let%bind l = Configuration.bc_lookup conf bf in
           let conf' = Configuration.bind conf (get_id x) l in
-          let%bind _ = stmt_gas_wrap G_ReadFromBC in
+          let%bind _ = stmt_gas_wrap G_ReadFromBC sloc in
           stmt_eval conf' sts                            
       | MatchStmt (x, clauses) ->
           let%bind v = Env.lookup conf.env x in 
           let%bind ((_, branch_stmts), bnds) =
             tryM clauses
-              ~msg:(sprintf "Value %s\ndoes not match any clause of\n%s."
-                      (Env.pp_value v) (pp_stmt s))
+              ~msg:(mk_error0 (sprintf "Value %s\ndoes not match any clause of\n%s."
+                      (Env.pp_value v) (pp_stmt s)))
               ~f:(fun (p, _) -> fromR @@ match_with_pattern v p) in 
           (* Update the environment for the branch *)
           let conf' = List.fold_left bnds ~init:conf
@@ -241,25 +244,25 @@ let rec stmt_eval conf stmts =
           let%bind conf'' = stmt_eval conf' branch_stmts in
           (* Restore initial immutable bindings *)
           let cont_conf = {conf'' with env = conf.env} in
-          let%bind _ = stmt_gas_wrap (G_MatchStmt (List.length clauses)) in
+          let%bind _ = stmt_gas_wrap (G_MatchStmt (List.length clauses)) sloc in
           stmt_eval cont_conf sts
       | AcceptPayment ->
           let%bind conf' = Configuration.accept_incoming conf in
-          let%bind _ = stmt_gas_wrap G_AcceptPayment in
+          let%bind _ = stmt_gas_wrap G_AcceptPayment sloc in
           stmt_eval conf' sts
       (* Caution emitting messages does not change balance immediately! *)      
       | SendMsgs ms ->
           let%bind ms_resolved = Configuration.lookup conf ms in
           let%bind (conf', scon) = Configuration.send_messages conf ms_resolved in
-          let%bind _ = stmt_gas_wrap scon in
+          let%bind _ = stmt_gas_wrap scon sloc in
           stmt_eval conf' sts
       | CreateEvnt params ->
           let%bind eparams_resolved = Configuration.lookup conf params in
           let%bind (conf', scon) = Configuration.create_event conf eparams_resolved in
-          let%bind _ = stmt_gas_wrap scon in
+          let%bind _ = stmt_gas_wrap scon sloc in
           stmt_eval conf' sts
       (* TODO: Implement Throw *)
-      | Throw _ -> fail @@ sprintf "Throw statements are not supported yet."
+      | Throw _ -> fail1 (sprintf "Throw statements are not supported yet.") sloc
     )
 
 (*******************************************************)
@@ -279,7 +282,7 @@ let check_blockchain_entries entries =
   if c1 && c2 then
     pure entries
   else
-    fail @@sprintf "Mismatch in input blockchain variables:\nexpected:\n%s\nprovided:\n%s\n"
+    fail0 @@sprintf "Mismatch in input blockchain variables:\nexpected:\n%s\nprovided:\n%s\n"
       (pp_literal_map expected) (pp_literal_map entries)
 
 (*******************************************************)
@@ -318,7 +321,7 @@ let init_fields env fs =
     let%bind (v, _) = exp_eval_wrapper fexp env in
     match v with
     | l when is_pure_literal l -> pure (fname, l)
-    | _ -> fail @@ sprintf "Closure cannot be stored in a field %s." fname
+    | _ -> fail0 @@ sprintf "Closure cannot be stored in a field %s." fname
   in
   mapM fs ~f:(fun (i, t, e) -> init_field (get_id i) t e)
 
@@ -339,7 +342,7 @@ let init_contract clibs elibs cparams' cfields args init_bal  =
       (* For each parameter there is an argument *)
       List.exists args ~f:(fun a -> p = fst a)) in  
   if not (valid_args && valid_params)
-  then fail @@ sprintf
+  then fail0 @@ sprintf
       "Mismatch between the vector of arguments:\n%s\nand expected parameters%s\n"
       (pp_literal_map args) (pp_cparams cparams)
   else
@@ -369,15 +372,16 @@ let create_cur_state_fields initcstate curcstate =
         (* Combine filtered list and curcstate *)
         pure (filtered_init @ curcstate)
   else
-    fail @@sprintf "Mismatch in input state variables:\nexpected:\n%s\nprovided:\n%s\n"
+    fail0 @@sprintf "Mismatch in input state variables:\nexpected:\n%s\nprovided:\n%s\n"
                    (pp_literal_map initcstate) (pp_literal_map curcstate)
 
 
 let literal_list_gas llit =
-  mapM ~f:(fun (_, lit) ->
-    let%bind c = fromR @@ EvalGas.literal_cost lit in
-    let dummy () = pure () in (* the literal is already created. *)
-    checkwrap_op dummy c "Ran out of gas") llit
+  mapM ~f:(fun (name, lit) ->
+      let%bind c = fromR @@ EvalGas.literal_cost lit in
+      let dummy () = pure () in (* the literal is already created. *)
+      checkwrap_op dummy c (mk_error0("Ran out of gas initializing " ^ name))
+    ) llit
 
 (* Initialize a module with given arguments and initial balance *)
 let init_module md initargs curargs init_bal bstate elibs =
@@ -409,7 +413,7 @@ let preprocess_message es =
 let get_transition ctr tag =
   let ts = ctr.ctrans in
   match List.find ts ~f:(fun t -> (get_id t.tname) = tag) with
-  | None -> fail @@ sprintf
+  | None -> fail0 @@ sprintf
         "No contract transition for tag %s found." tag
   | Some t ->
       let params = t.tparams in
@@ -429,7 +433,7 @@ let check_message_entries tparams_o entries =
   let uniq_entries = List.for_all entries
       ~f:(fun e -> (List.count entries ~f:(fun e' -> fst e = fst e')) = 1) in
   if not (valid_entries && uniq_entries && valid_params)
-  then fail @@ sprintf
+  then fail0 @@ sprintf
       "Duplicate entries or mismatch b/w message entries:\n%s\nand expected transition parameters%s\n"
       (pp_literal_map entries) (pp_cparams tparams)
   else
@@ -443,20 +447,20 @@ let prepare_for_message contr m =
       let%bind (tparams, tbody) = get_transition contr tag in
       let%bind tenv = check_message_entries tparams other in
       pure (tenv, incoming_amount, tbody)
-  | _ -> fail @@ sprintf "Not a message literal: %s." (pp_literal m)
+  | _ -> fail0 @@ sprintf "Not a message literal: %s." (pp_literal m)
 
 (* Subtract the amounts to be transferred *)
 let post_process_msgs cstate outs =
   (* Evey outgoing message should carry an "_amount" tag *)
   let%bind amounts = mapM outs ~f:(fun l -> match l with
       | Msg es -> fromR @@ MessagePayload.get_amount es
-      | _ -> fail @@ sprintf "Not a message literal: %s." (pp_literal l)) in
+      | _ -> fail0 @@ sprintf "Not a message literal: %s." (pp_literal l)) in
   let open Uint128 in
   let to_be_transferred = List.fold_left amounts ~init:zero
       ~f:(fun z a -> add z a) in
   let open ContractState in
   if (compare cstate.balance to_be_transferred) < 0
-  then fail @@ sprintf
+  then fail0 @@ sprintf
       "The balance is too low (%s) to transfer all the funds in the messages (%s)"
       (to_string cstate.balance) (to_string to_be_transferred)
   else

--- a/src/lang/eval/PatternMatching.ml
+++ b/src/lang/eval/PatternMatching.ml
@@ -33,7 +33,7 @@ let rec match_with_pattern v p = match p with
         DataTypeDictionary.lookup_constructor cn in
       (* Check that the pattern is well-formed *)
       if ctr.arity <> List.length ps
-      then fail @@
+      then fail0 @@
         sprintf "Constructor %s requires %d parameters, but %d are provided."
           ctr.cname ctr.arity (List.length ps)
       (* Pattern is well-formed, processing the value *)    
@@ -43,7 +43,7 @@ let rec match_with_pattern v p = match p with
                  (List.length ls') = ctr.arity  ->
               (* The value structure matches the pattern *)
               (match List.zip ls' ps with
-               | None -> fail "Pattern and value lists have different length"
+               | None -> fail0 "Pattern and value lists have different length"
                | Some sub_matches ->
                    let%bind res_list =
                      mapM sub_matches
@@ -52,7 +52,7 @@ let rec match_with_pattern v p = match p with
                    (* We will need to catch this statically. *)
                    pure @@ ListLabels.flatten res_list)
 
-          | _ -> fail @@
+          | _ -> fail0 @@
               sprintf "Cannot match value %s againts pattern %s."
                 (Env.pp_value v)
                 (sexp_of_pattern p |> Sexplib.Sexp.to_string))

--- a/src/runners/scilla_runner.ml
+++ b/src/runners/scilla_runner.ml
@@ -19,6 +19,7 @@
 
 open Syntax
 open Core
+open ErrorUtils
 open EvalUtil
 open Eval
 open DebugMessage
@@ -45,9 +46,8 @@ let check_libs clibs elibs name gas_limit =
          name);
       gas_remaining
    | Error (err, gas_remaining) ->
-      perr (sprintf "\nFailed to initialize libraries:\n%s\n" err);
-      perr "Execution stopped";
-      gas_remaining
+      perr @@ scilla_error_gas_jstring gas_remaining err;
+      exit 1
 
 (****************************************************)
 (*     Checking initialized contract state          *)
@@ -55,9 +55,7 @@ let check_libs clibs elibs name gas_limit =
 let check_extract_cstate name res gas_limit = 
   match res gas_limit with
   | Error (err, remaining_gas) ->
-      perr (sprintf "Failed to initialize fields:\n%s\n" err);
-      perr (sprintf"Gas remaining:%s\n" (Int.to_string remaining_gas));
-      perr "Execution stopped";
+      perr @@ scilla_error_gas_jstring remaining_gas err;
       exit 1
   | Ok ((_, cstate), remaining_gas) ->
       plog (sprintf "[Initializing %s's fields]\nSuccess!\n"
@@ -71,9 +69,7 @@ let check_extract_cstate name res gas_limit =
 let check_after_step name res gas_limit =
   match res gas_limit with
   | Error (err, remaining_gas) ->
-      perr (sprintf "Failed to execute transition in %s:\n%s\n" name err);
-      perr (sprintf"Gas remaining:%s\n" (Int.to_string remaining_gas));
-      perr "Execution halted";
+      perr @@ scilla_error_gas_jstring remaining_gas err;
       exit 1
   | Ok ((cstate, outs, events), remaining_gas) ->
       plog (sprintf "Success! Here's what we got:\n" ^
@@ -90,11 +86,11 @@ let input_state_json filename =
   let match_balance ((vname : string), _) : bool = vname = balance_label in
   let bal_lit = match List.find states ~f:match_balance with
     | Some (_, lit) -> lit
-    | None -> raise (JSON.Invalid_json (balance_label ^ " field missing"))
+    | None -> raise (JSON.mk_invalid_json (balance_label ^ " field missing"))
   in
   let bal_int = match bal_lit with
     | UintLit (Uint128L x) -> x
-    | _ -> raise (JSON.Invalid_json (balance_label ^ " invalid"))
+    | _ -> raise (JSON.mk_invalid_json (balance_label ^ " invalid"))
   in
   let no_bal_states = List.filter  states ~f:(fun c -> not @@ match_balance c) in
      no_bal_states, bal_int
@@ -154,7 +150,7 @@ let () =
           JSON.ContractState.get_json_data cli.input_init
         with
         | JSON.Invalid_json s -> 
-            perr (sprintf "Failed to parse json %s: %s\n" cli.input_init s);
+            perr (sprintf "Failed to parse json %s: %s\n" cli.input_init (sprint_scilla_error_list s));
             exit 1
       in
       (* Retrieve block chain state  *)
@@ -163,7 +159,7 @@ let () =
         JSON.BlockChainState.get_json_data cli.input_blockchain 
       with
         | JSON.Invalid_json s -> 
-            perr (sprintf "Failed to parse json %s: %s\n" cli.input_blockchain s);
+            perr (sprintf "Failed to parse json %s: %s\n" cli.input_blockchain (sprint_scilla_error_list s));
             exit 1
       in
       let (output_msg_json, output_state_json, output_events_json), gas = 
@@ -183,7 +179,7 @@ let () =
           JSON.Message.get_json_data cli.input_message 
         with
         | JSON.Invalid_json s -> 
-            perr (sprintf "Failed to parse json %s: %s\n" cli.input_message s);
+            perr (sprintf "Failed to parse json %s: %s\n" cli.input_message (sprint_scilla_error_list s));
             exit 1
         in
         let m = Msg mmsg in
@@ -194,7 +190,7 @@ let () =
           input_state_json cli.input_state
         with
         | JSON.Invalid_json s -> 
-            perr (sprintf "Failed to parse json %s: %s\n" cli.input_state s);
+            perr (sprintf "Failed to parse json %s: %s\n" cli.input_state (sprint_scilla_error_list s));
             exit 1
         in
 

--- a/src/runners/type_checker.ml
+++ b/src/runners/type_checker.ml
@@ -24,9 +24,11 @@ open TypeUtil
 open Recursion
 open RunnerUtil
 open DebugMessage
+open ErrorUtils
 open MonadUtil
 open Result.Let_syntax
 open PatternChecker
+open PrettyPrinters
 
 
 module ParsedSyntax = ParserUtil.ParsedSyntax
@@ -44,7 +46,7 @@ let check_parsing filename =
     let parse_module =
       FrontEndParser.parse_file ScillaParser.exps filename in
     match parse_module with
-    | None -> fail (sprintf "%s\n" "Failed to parse input file.")
+    | None -> fail0 (sprintf "Failed to parse input file %s\n." filename)
     | Some e ->
         plog @@ sprintf
           "\n[Parsing]:\nExpression in [%s] is successfully parsed.\n" filename;
@@ -91,8 +93,8 @@ let () =
          | Ok ((_, (e_typ, _)) as typed_erep) ->
              (match check_patterns typed_erep with
               | Ok _ -> printf "%s\n" (pp_typ e_typ.tp)
-              | Error s -> printf "Type checking failed:\n%s\n" s
+              | Error el -> pout @@ scilla_error_to_jstring el
              )
-         | Error s -> printf "Type checking failed:\n%s\n" s)
+         | Error el -> pout @@ scilla_error_to_jstring el)
     | Some _ | None ->
-        printf "%s\n" "Failed to parse input file.")
+        pout @@ scilla_error_to_jstring (mk_error0 "Failed to parse input file"))

--- a/tests/checker/bad/gold/bad_fields1.scilla.gold
+++ b/tests/checker/bad/gold/bad_fields1.scilla.gold
@@ -1,7 +1,24 @@
-
-Type error(s) in contract Empty:
-
-
-[checker/bad/bad_fields1.scilla:4:7] Type error in field bad_foo:
-Values of the type "Int32 -> Int32" cannot be stored.
-
+{
+  "errors": [
+    {
+      "error_message": "Type error(s) in contract Empty:\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type error in field bad_foo:\n",
+      "start_location": {
+        "file": "checker/bad/bad_fields1.scilla",
+        "line": 4,
+        "column": 7
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Values of the type \"Int32 -> Int32\" cannot be stored.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/checker/bad/gold/bad_fields2.scilla.gold
+++ b/tests/checker/bad/gold/bad_fields2.scilla.gold
@@ -1,7 +1,24 @@
-
-Type error(s) in contract Empty:
-
-
-[checker/bad/bad_fields2.scilla:4:7] Type error in field bad_bar:
-Values of the type "Map (Int64) (String -> Int32)" cannot be stored.
-
+{
+  "errors": [
+    {
+      "error_message": "Type error(s) in contract Empty:\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type error in field bad_bar:\n",
+      "start_location": {
+        "file": "checker/bad/bad_fields2.scilla",
+        "line": 4,
+        "column": 7
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Values of the type \"Map (Int64) (String -> Int32)\" cannot be stored.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/checker/bad/gold/event_bad1.scilla.gold
+++ b/tests/checker/bad/gold/event_bad1.scilla.gold
@@ -1,4 +1,10 @@
-
-Parameter mismatch for event ClaimedBack. [(amount : Uint128); ] vs [(claimed_by : ByStr20); (amount : Uint128); ]
-
-
+{
+  "errors": [
+    {
+      "error_message":
+        "Parameter mismatch for event ClaimedBack. [(amount : Uint128); ] vs [(claimed_by : ByStr20); (amount : Uint128); ]\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/checker/bad/gold/lib_bad1.scilla.gold
+++ b/tests/checker/bad/gold/lib_bad1.scilla.gold
@@ -1,14 +1,73 @@
-
-Type error(s) in contract BadLibTest1:
-
-
-[checker/bad/lib_bad1.scilla:7:5] Type error in library one_msg:
-
-Type mismatch: Message expected, but Uint128 provided.[checker/bad/lib_bad1.scilla:16:5] Type error in library two_msg:
-
-Type mismatch: Message expected, but Uint128 provided.[checker/bad/lib_bad1.scilla:29:5] Type error in library andb:
-
-[checker/bad/lib_bad1.scilla:32:5] Type error in pattern matching on `b` of type Bool (or one of its branches):
-[checker/bad/lib_bad1.scilla:35:7] Type error in pattern matching on `c` of type Int32 (or one of its branches):
-Not an algebraic data type: Int32
-
+{
+  "errors": [
+    {
+      "error_message": "Type error(s) in contract BadLibTest1:\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type error in library one_msg:\n\n",
+      "start_location": {
+        "file": "checker/bad/lib_bad1.scilla",
+        "line": 7,
+        "column": 5
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Type mismatch: Message expected, but Uint128 provided.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type error in library two_msg:\n\n",
+      "start_location": {
+        "file": "checker/bad/lib_bad1.scilla",
+        "line": 16,
+        "column": 5
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Type mismatch: Message expected, but Uint128 provided.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type error in library andb:\n\n",
+      "start_location": {
+        "file": "checker/bad/lib_bad1.scilla",
+        "line": 29,
+        "column": 5
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Type error in pattern matching on `b` of type Bool (or one of its branches):\n",
+      "start_location": {
+        "file": "checker/bad/lib_bad1.scilla",
+        "line": 32,
+        "column": 5
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Type error in pattern matching on `c` of type Int32 (or one of its branches):\n",
+      "start_location": {
+        "file": "checker/bad/lib_bad1.scilla",
+        "line": 35,
+        "column": 7
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Not an algebraic data type: Int32",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/checker/bad/gold/mappair.scilla.gold
+++ b/tests/checker/bad/gold/mappair.scilla.gold
@@ -1,17 +1,88 @@
-
-Type error(s) in contract Test:
-
-
-[checker/bad/mappair.scilla:39:1] Type error in transition testMapPair:
-[checker/bad/mappair.scilla:41:3] Type error in pattern matching on `is_owner` of type Bool (or one of its branches):
-[checker/bad/mappair.scilla:54:5] Type error in the binding to into `p`:
-Type mismatch: Int32 expected, but Int64 provided.
-
-[checker/bad/mappair.scilla:61:1] Type error in transition addNumToList:
-[checker/bad/mappair.scilla:70:3] Type error in the binding to into `l2`:
-Type mismatch: Int32 expected, but Int64 provided.
-
-[checker/bad/mappair.scilla:90:1] Type error in transition createBadEvent:
-[checker/bad/mappair.scilla:93:3] Type error in the binding to into `e`:
-Cannot send values of type Nat -> Uint32.
-
+{
+  "errors": [
+    {
+      "error_message": "Type error(s) in contract Test:\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type error in transition testMapPair:\n",
+      "start_location": {
+        "file": "checker/bad/mappair.scilla",
+        "line": 39,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Type error in pattern matching on `is_owner` of type Bool (or one of its branches):\n",
+      "start_location": {
+        "file": "checker/bad/mappair.scilla",
+        "line": 41,
+        "column": 3
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type error in the binding to into `p`:\n",
+      "start_location": {
+        "file": "checker/bad/mappair.scilla",
+        "line": 54,
+        "column": 5
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type mismatch: Int32 expected, but Int64 provided.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type error in transition addNumToList:\n",
+      "start_location": {
+        "file": "checker/bad/mappair.scilla",
+        "line": 61,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type error in the binding to into `l2`:\n",
+      "start_location": {
+        "file": "checker/bad/mappair.scilla",
+        "line": 70,
+        "column": 3
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type mismatch: Int32 expected, but Int64 provided.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type error in transition createBadEvent:\n",
+      "start_location": {
+        "file": "checker/bad/mappair.scilla",
+        "line": 90,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type error in the binding to into `e`:\n",
+      "start_location": {
+        "file": "checker/bad/mappair.scilla",
+        "line": 93,
+        "column": 3
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Cannot send values of type Nat -> Uint32.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/checker/bad/gold/mappair2.scilla.gold
+++ b/tests/checker/bad/gold/mappair2.scilla.gold
@@ -1,9 +1,56 @@
-
-[checker/bad/mappair2.scilla:92:1] Identifier malMessage1 used more than once
-[checker/bad/mappair2.scilla:105:24] Identifier num1 used more than once
-[checker/bad/mappair2.scilla:94:7] Missing _amount or _recipient in Message
-[checker/bad/mappair2.scilla:107:7] [:0:0] Identifier status used more than once
-[checker/bad/mappair2.scilla:113:1] Paramter _sender in transition malTransition1 cannot be explicit.
-[checker/bad/mappair2.scilla:30:2] Contract parameter _creation_block cannot be explicit.
-
-
+{
+  "errors": [
+    {
+      "error_message": "Identifier malMessage1 used more than once\n",
+      "start_location": {
+        "file": "checker/bad/mappair2.scilla",
+        "line": 92,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Identifier num1 used more than once\n",
+      "start_location": {
+        "file": "checker/bad/mappair2.scilla",
+        "line": 105,
+        "column": 24
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Missing _amount or _recipient in Message\n",
+      "start_location": {
+        "file": "checker/bad/mappair2.scilla",
+        "line": 94,
+        "column": 7
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Identifier status used more than once\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Paramter _sender in transition malTransition1 cannot be explicit.\n",
+      "start_location": {
+        "file": "checker/bad/mappair2.scilla",
+        "line": 113,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Contract parameter _creation_block cannot be explicit.\n",
+      "start_location": {
+        "file": "checker/bad/mappair2.scilla",
+        "line": 30,
+        "column": 2
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/checker/bad/gold/unbound.scilla.gold
+++ b/tests/checker/bad/gold/unbound.scilla.gold
@@ -1,26 +1,135 @@
-
-Type error(s) in contract Crowdfunding:
-
-
-[checker/bad/unbound.scilla:14:5] Type error in library check_update:
-
-ADT Uint12 not found
-
-[checker/bad/unbound.scilla:57:1] Type error in transition Donate:
-[checker/bad/unbound.scilla:59:3] Type error in the binding to into `in_time`:
-[checker/bad/unbound.scilla:59:13] Type error in application of `blk_leq`:
-[checker/bad/unbound.scilla:59:13]: Couldn't resolve the identifier "blk_leq".
-
-
-[checker/bad/unbound.scilla:88:1] Type error in transition GetFunds:
-[checker/bad/unbound.scilla:90:3] Type error in pattern matching on `is_owner` of type Bool (or one of its branches):
-[checker/bad/unbound.scilla:92:5] Type error in the binding to into `msg`:
-[checker/bad/unbound.scilla:93:20]: Couldn't resolve the identifier "not_owner_code".
-
-
-[checker/bad/unbound.scilla:122:1] Type error in transition ClaimBack:
-[checker/bad/unbound.scilla:125:3] Type error in pattern matching on `after_deadline` of type Bool (or one of its branches):
-[checker/bad/unbound.scilla:127:5] Type error in the binding to into `msg`:
-[checker/bad/unbound.scilla:128:20]: Couldn't resolve the identifier "too_early_code".
-
-
+{
+  "errors": [
+    {
+      "error_message": "Type error(s) in contract Crowdfunding:\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type error in library check_update:\n\n",
+      "start_location": {
+        "file": "checker/bad/unbound.scilla",
+        "line": 14,
+        "column": 5
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "ADT Uint12 not found",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type error in transition Donate:\n",
+      "start_location": {
+        "file": "checker/bad/unbound.scilla",
+        "line": 57,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type error in the binding to into `in_time`:\n",
+      "start_location": {
+        "file": "checker/bad/unbound.scilla",
+        "line": 59,
+        "column": 3
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type error in application of `blk_leq`:\n",
+      "start_location": {
+        "file": "checker/bad/unbound.scilla",
+        "line": 59,
+        "column": 13
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Couldn't resolve the identifier \"blk_leq\".\n",
+      "start_location": {
+        "file": "checker/bad/unbound.scilla",
+        "line": 59,
+        "column": 13
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type error in transition GetFunds:\n",
+      "start_location": {
+        "file": "checker/bad/unbound.scilla",
+        "line": 88,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Type error in pattern matching on `is_owner` of type Bool (or one of its branches):\n",
+      "start_location": {
+        "file": "checker/bad/unbound.scilla",
+        "line": 90,
+        "column": 3
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type error in the binding to into `msg`:\n",
+      "start_location": {
+        "file": "checker/bad/unbound.scilla",
+        "line": 92,
+        "column": 5
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Couldn't resolve the identifier \"not_owner_code\".\n",
+      "start_location": {
+        "file": "checker/bad/unbound.scilla",
+        "line": 93,
+        "column": 20
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type error in transition ClaimBack:\n",
+      "start_location": {
+        "file": "checker/bad/unbound.scilla",
+        "line": 122,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Type error in pattern matching on `after_deadline` of type Bool (or one of its branches):\n",
+      "start_location": {
+        "file": "checker/bad/unbound.scilla",
+        "line": 125,
+        "column": 3
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type error in the binding to into `msg`:\n",
+      "start_location": {
+        "file": "checker/bad/unbound.scilla",
+        "line": 127,
+        "column": 5
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Couldn't resolve the identifier \"too_early_code\".\n",
+      "start_location": {
+        "file": "checker/bad/unbound.scilla",
+        "line": 128,
+        "column": 20
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/checker/bad/gold/zil_mod.scilla.gold
+++ b/tests/checker/bad/gold/zil_mod.scilla.gold
@@ -1,6 +1,34 @@
-
-Type error(s) in contract ZilGame:
-[checker/bad/zil_mod.scilla:54:5] Error during pattern-match checking of library check_validity:
-[checker/bad/zil_mod.scilla:65:5] Type error in pattern matching on `xa` of type Pair (Bool) (Option (ByStr32)) (or one of its branches):
-Pattern 3 is unreachable.
-
+{
+  "errors": [
+    {
+      "error_message": "Type error(s) in contract ZilGame:\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Error during pattern-match checking of library check_validity:\n",
+      "start_location": {
+        "file": "checker/bad/zil_mod.scilla",
+        "line": 54,
+        "column": 5
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Type error in pattern matching on `xa` of type Pair (Bool) (Option (ByStr32)) (or one of its branches):\n",
+      "start_location": {
+        "file": "checker/bad/zil_mod.scilla",
+        "line": 65,
+        "column": 5
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Pattern 3 is unreachable.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/app_error1.scilla.gold
+++ b/tests/eval/exp/bad/gold/app_error1.scilla.gold
@@ -1,2 +1,10 @@
-Failed execution:
-Not a functional value: (Int32 2).
+{
+  "gas_remaining": 1750,
+  "errors": [
+    {
+      "error_message": "Not a functional value: (Int32 2).",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/app_error2.scilla.gold
+++ b/tests/eval/exp/bad/gold/app_error2.scilla.gold
@@ -1,2 +1,10 @@
-Failed execution:
-Not a functional value: (Int64 1).
+{
+  "gas_remaining": 1754,
+  "errors": [
+    {
+      "error_message": "Not a functional value: (Int64 1).",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/builtin-divzero.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-divzero.scilla.gold
@@ -1,3 +1,11 @@
-Failed execution:
-Cannot apply built-in Int.div: Division by zero / IntOverflow error occurred to a list of arguments:[  (Int32 99999),
-  (Int32 0)].
+{
+  "gas_remaining": 1753,
+  "errors": [
+    {
+      "error_message":
+        "Cannot apply built-in Int.div: Division by zero / IntOverflow error occurred to a list of arguments:[  (Int32 99999),\n  (Int32 0)].",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/builtin-divzero2.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-divzero2.scilla.gold
@@ -1,3 +1,11 @@
-Failed execution:
-Cannot apply built-in Int.div: Division by zero / IntOverflow error occurred to a list of arguments:[  (Int32 -2147483648),
-  (Int32 -1)].
+{
+  "gas_remaining": 1753,
+  "errors": [
+    {
+      "error_message":
+        "Cannot apply built-in Int.div: Division by zero / IntOverflow error occurred to a list of arguments:[  (Int32 -2147483648),\n  (Int32 -1)].",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/builtin-divzero3.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-divzero3.scilla.gold
@@ -1,3 +1,11 @@
-Failed execution:
-Cannot apply built-in Int.div: Division by zero / IntOverflow error occurred to a list of arguments:[  (Int256 1001),
-  (Int256 0)].
+{
+  "gas_remaining": 1741,
+  "errors": [
+    {
+      "error_message":
+        "Cannot apply built-in Int.div: Division by zero / IntOverflow error occurred to a list of arguments:[  (Int256 1001),\n  (Int256 0)].",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/builtin-divzero4.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-divzero4.scilla.gold
@@ -1,3 +1,11 @@
-Failed execution:
-Cannot apply built-in Int.div: Division by zero / IntOverflow error occurred to a list of arguments:[  (Int256 -57896044618658097711785492504343953926634992332820282019728792003956564819968),
-  (Int256 -1)].
+{
+  "gas_remaining": 1741,
+  "errors": [
+    {
+      "error_message":
+        "Cannot apply built-in Int.div: Division by zero / IntOverflow error occurred to a list of arguments:[  (Int256 -57896044618658097711785492504343953926634992332820282019728792003956564819968),\n  (Int256 -1)].",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/builtin-overflow1.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow1.scilla.gold
@@ -1,3 +1,11 @@
-Failed execution:
-Cannot apply built-in Int.add: an overflow/underflow occurred to a list of arguments:[  (Int32 999999999),
-  (Int32 1999999998)].
+{
+  "gas_remaining": 1746,
+  "errors": [
+    {
+      "error_message":
+        "Cannot apply built-in Int.add: an overflow/underflow occurred to a list of arguments:[  (Int32 999999999),\n  (Int32 1999999998)].",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/builtin-overflow10.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow10.scilla.gold
@@ -1,3 +1,11 @@
-Failed execution:
-Cannot apply built-in Uint.add: an overflow/underflow occurred to a list of arguments:[  (Uint256 115792089237316195423570985008687907853269984665640564039457584007913129639935),
-  (Uint256 1)].
+{
+  "gas_remaining": 1741,
+  "errors": [
+    {
+      "error_message":
+        "Cannot apply built-in Uint.add: an overflow/underflow occurred to a list of arguments:[  (Uint256 115792089237316195423570985008687907853269984665640564039457584007913129639935),\n  (Uint256 1)].",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/builtin-overflow11.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow11.scilla.gold
@@ -1,3 +1,11 @@
-Failed execution:
-Cannot apply built-in Int.sub: an overflow/underflow occurred to a list of arguments:[  (Int256 -2),
-  (Int256 57896044618658097711785492504343953926634992332820282019728792003956564819967)].
+{
+  "gas_remaining": 1741,
+  "errors": [
+    {
+      "error_message":
+        "Cannot apply built-in Int.sub: an overflow/underflow occurred to a list of arguments:[  (Int256 -2),\n  (Int256 57896044618658097711785492504343953926634992332820282019728792003956564819967)].",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/builtin-overflow2.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow2.scilla.gold
@@ -1,3 +1,11 @@
-Failed execution:
-Cannot apply built-in Uint.mul: an overflow/underflow occurred to a list of arguments:[  (Uint32 99999),
-  (Uint32 99999)].
+{
+  "gas_remaining": 1749,
+  "errors": [
+    {
+      "error_message":
+        "Cannot apply built-in Uint.mul: an overflow/underflow occurred to a list of arguments:[  (Uint32 99999),\n  (Uint32 99999)].",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/builtin-overflow3.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow3.scilla.gold
@@ -1,3 +1,11 @@
-Failed execution:
-Cannot apply built-in Int.mul: an overflow/underflow occurred to a list of arguments:[  (Int32 99999),
-  (Int32 99999)].
+{
+  "gas_remaining": 1749,
+  "errors": [
+    {
+      "error_message":
+        "Cannot apply built-in Int.mul: an overflow/underflow occurred to a list of arguments:[  (Int32 99999),\n  (Int32 99999)].",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/builtin-overflow4.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow4.scilla.gold
@@ -1,2 +1,11 @@
-Failed to parse input file.
-Syntax error in file eval/exp/bad/builtin-overflow4.scilla: line 8, position 29.: Invalid Int32 literal -2147483649
+{
+  "gas_remaining": 2000,
+  "errors": [
+    {
+      "error_message":
+        "Failed to parse input file.eval/exp/bad/builtin-overflow4.scilla",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}Syntax error in file eval/exp/bad/builtin-overflow4.scilla: line 8, position 29.: Invalid Int32 literal -2147483649

--- a/tests/eval/exp/bad/gold/builtin-overflow5.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow5.scilla.gold
@@ -1,3 +1,11 @@
-Failed execution:
-Cannot apply built-in Int.mul: an overflow/underflow occurred to a list of arguments:[  (Int32 -2147483648),
-  (Int32 -1)].
+{
+  "gas_remaining": 1753,
+  "errors": [
+    {
+      "error_message":
+        "Cannot apply built-in Int.mul: an overflow/underflow occurred to a list of arguments:[  (Int32 -2147483648),\n  (Int32 -1)].",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/builtin-overflow6.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow6.scilla.gold
@@ -1,3 +1,11 @@
-Failed execution:
-Cannot apply built-in Int.mul: an overflow/underflow occurred to a list of arguments:[  (Int32 -1),
-  (Int32 -2147483648)].
+{
+  "gas_remaining": 1753,
+  "errors": [
+    {
+      "error_message":
+        "Cannot apply built-in Int.mul: an overflow/underflow occurred to a list of arguments:[  (Int32 -1),\n  (Int32 -2147483648)].",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/builtin-overflow7.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow7.scilla.gold
@@ -1,3 +1,11 @@
-Failed execution:
-Cannot apply built-in Int.add: an overflow/underflow occurred to a list of arguments:[  (Int32 -2147483648),
-  (Int32 -1)].
+{
+  "gas_remaining": 1753,
+  "errors": [
+    {
+      "error_message":
+        "Cannot apply built-in Int.add: an overflow/underflow occurred to a list of arguments:[  (Int32 -2147483648),\n  (Int32 -1)].",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/builtin-overflow8.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow8.scilla.gold
@@ -1,3 +1,11 @@
-Failed execution:
-Cannot apply built-in Uint.sub: an overflow/underflow occurred to a list of arguments:[  (Uint32 0),
-  (Uint32 1)].
+{
+  "gas_remaining": 1753,
+  "errors": [
+    {
+      "error_message":
+        "Cannot apply built-in Uint.sub: an overflow/underflow occurred to a list of arguments:[  (Uint32 0),\n  (Uint32 1)].",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/builtin-overflow9.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow9.scilla.gold
@@ -1,3 +1,11 @@
-Failed execution:
-Cannot apply built-in Uint.add: an overflow/underflow occurred to a list of arguments:[  (Uint32 4294967295),
-  (Uint32 1)].
+{
+  "gas_remaining": 1753,
+  "errors": [
+    {
+      "error_message":
+        "Cannot apply built-in Uint.add: an overflow/underflow occurred to a list of arguments:[  (Uint32 4294967295),\n  (Uint32 1)].",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/builtin-remzero.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-remzero.scilla.gold
@@ -1,3 +1,11 @@
-Failed execution:
-Cannot apply built-in Int.rem: Division by zero error occurred to a list of arguments:[  (Int32 99999),
-  (Int32 0)].
+{
+  "gas_remaining": 1753,
+  "errors": [
+    {
+      "error_message":
+        "Cannot apply built-in Int.rem: Division by zero error occurred to a list of arguments:[  (Int32 99999),\n  (Int32 0)].",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/builtin4.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin4.scilla.gold
@@ -1,2 +1,15 @@
-Failed execution:
-[eval/exp/bad/builtin4.scilla:7:10] Cannot find built-in with name "add" and argument types [Int64; Int32].
+{
+  "gas_remaining": 1750,
+  "errors": [
+    {
+      "error_message":
+        "Cannot find built-in with name \"add\" and argument types [Int64; Int32].",
+      "start_location": {
+        "file": "eval/exp/bad/builtin4.scilla",
+        "line": 7,
+        "column": 10
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/builtin_error1.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin_error1.scilla.gold
@@ -1,2 +1,15 @@
-Failed execution:
-[eval/exp/bad/builtin_error1.scilla:10:20] Cannot find built-in with name "hack" and argument types [Int32; Int32].
+{
+  "gas_remaining": 1747,
+  "errors": [
+    {
+      "error_message":
+        "Cannot find built-in with name \"hack\" and argument types [Int32; Int32].",
+      "start_location": {
+        "file": "eval/exp/bad/builtin_error1.scilla",
+        "line": 10,
+        "column": 20
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/let-error.scilla.gold
+++ b/tests/eval/exp/bad/gold/let-error.scilla.gold
@@ -1,3 +1,14 @@
-Failed execution:
-Identifier "oops" at eval/exp/bad/let-error.scilla:4:9 is not bound in environment:
-
+{
+  "gas_remaining": 1757,
+  "errors": [
+    {
+      "error_message": "Identifier \"oops\" is not bound in environment:\n",
+      "start_location": {
+        "file": "eval/exp/bad/let-error.scilla",
+        "line": 4,
+        "column": 9
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/msg_error.scilla.gold
+++ b/tests/eval/exp/bad/gold/msg_error.scilla.gold
@@ -1,2 +1,10 @@
-Failed execution:
-Cannot serialize literal <closure>
+{
+  "gas_remaining": 1755,
+  "errors": [
+    {
+      "error_message": "Cannot serialize literal <closure>",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/msg_error2.scilla.gold
+++ b/tests/eval/exp/bad/gold/msg_error2.scilla.gold
@@ -1,2 +1,11 @@
-Failed execution:
-Cannot serialize literal (Message [(tag : (String "Main")) ; (amount : (Int32 42)) ; (code : (Int32 42))])
+{
+  "gas_remaining": 1753,
+  "errors": [
+    {
+      "error_message":
+        "Cannot serialize literal (Message [(tag : (String \"Main\")) ; (amount : (Int32 42)) ; (code : (Int32 42))])",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/msg_error3.scilla.gold
+++ b/tests/eval/exp/bad/gold/msg_error3.scilla.gold
@@ -1,3 +1,14 @@
-Failed execution:
-Identifier "o" at eval/exp/bad/msg_error3.scilla:6:40 is not bound in environment:
-
+{
+  "gas_remaining": 1753,
+  "errors": [
+    {
+      "error_message": "Identifier \"o\" is not bound in environment:\n",
+      "start_location": {
+        "file": "eval/exp/bad/msg_error3.scilla",
+        "line": 6,
+        "column": 40
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/eval/exp/bad/gold/string_error1.scilla.gold
+++ b/tests/eval/exp/bad/gold/string_error1.scilla.gold
@@ -1,2 +1,11 @@
-Failed to parse input file.
-Syntax error in file eval/exp/bad/string_error1.scilla: line 2, position 19.: String is not terminated
+{
+  "gas_remaining": 2000,
+  "errors": [
+    {
+      "error_message":
+        "Failed to parse input file.eval/exp/bad/string_error1.scilla",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}Syntax error in file eval/exp/bad/string_error1.scilla: line 2, position 19.: String is not terminated

--- a/tests/pm_check/bad/gold/pm1.scilla.gold
+++ b/tests/pm_check/bad/gold/pm1.scilla.gold
@@ -1,3 +1,19 @@
-Type checking failed:
-[pm_check/bad/pm1.scilla:6:1] Type error in pattern matching on `b` of type Bool (or one of its branches):
-Non-exhaustive pattern match.
+{
+  "errors": [
+    {
+      "error_message":
+        "Type error in pattern matching on `b` of type Bool (or one of its branches):\n",
+      "start_location": {
+        "file": "pm_check/bad/pm1.scilla",
+        "line": 6,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Non-exhaustive pattern match.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/pm_check/bad/gold/pm2.scilla.gold
+++ b/tests/pm_check/bad/gold/pm2.scilla.gold
@@ -1,3 +1,19 @@
-Type checking failed:
-[pm_check/bad/pm2.scilla:7:1] Type error in pattern matching on `b` of type Option (Int32) (or one of its branches):
-Non-exhaustive pattern match.
+{
+  "errors": [
+    {
+      "error_message":
+        "Type error in pattern matching on `b` of type Option (Int32) (or one of its branches):\n",
+      "start_location": {
+        "file": "pm_check/bad/pm2.scilla",
+        "line": 7,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Non-exhaustive pattern match.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/pm_check/bad/gold/pm3.scilla.gold
+++ b/tests/pm_check/bad/gold/pm3.scilla.gold
@@ -1,3 +1,19 @@
-Type checking failed:
-[pm_check/bad/pm3.scilla:8:1] Type error in pattern matching on `y` of type List (Int32) (or one of its branches):
-Non-exhaustive pattern match.
+{
+  "errors": [
+    {
+      "error_message":
+        "Type error in pattern matching on `y` of type List (Int32) (or one of its branches):\n",
+      "start_location": {
+        "file": "pm_check/bad/pm3.scilla",
+        "line": 8,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Non-exhaustive pattern match.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/pm_check/bad/gold/pm_nesting1.scilla.gold
+++ b/tests/pm_check/bad/gold/pm_nesting1.scilla.gold
@@ -1,3 +1,19 @@
-Type checking failed:
-[pm_check/bad/pm_nesting1.scilla:9:1] Type error in pattern matching on `y` of type List (Option (Int32)) (or one of its branches):
-Non-exhaustive pattern match.
+{
+  "errors": [
+    {
+      "error_message":
+        "Type error in pattern matching on `y` of type List (Option (Int32)) (or one of its branches):\n",
+      "start_location": {
+        "file": "pm_check/bad/pm_nesting1.scilla",
+        "line": 9,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Non-exhaustive pattern match.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/pm_check/bad/gold/pm_nesting2.scilla.gold
+++ b/tests/pm_check/bad/gold/pm_nesting2.scilla.gold
@@ -1,3 +1,19 @@
-Type checking failed:
-[pm_check/bad/pm_nesting2.scilla:9:1] Type error in pattern matching on `y` of type List (Option (Int32)) (or one of its branches):
-Non-exhaustive pattern match.
+{
+  "errors": [
+    {
+      "error_message":
+        "Type error in pattern matching on `y` of type List (Option (Int32)) (or one of its branches):\n",
+      "start_location": {
+        "file": "pm_check/bad/pm_nesting2.scilla",
+        "line": 9,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Non-exhaustive pattern match.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/pm_check/bad/gold/pm_nesting3.scilla.gold
+++ b/tests/pm_check/bad/gold/pm_nesting3.scilla.gold
@@ -1,3 +1,19 @@
-Type checking failed:
-[pm_check/bad/pm_nesting3.scilla:9:1] Type error in pattern matching on `y` of type List (Option (Int32)) (or one of its branches):
-Non-exhaustive pattern match.
+{
+  "errors": [
+    {
+      "error_message":
+        "Type error in pattern matching on `y` of type List (Option (Int32)) (or one of its branches):\n",
+      "start_location": {
+        "file": "pm_check/bad/pm_nesting3.scilla",
+        "line": 9,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Non-exhaustive pattern match.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/pm_check/bad/gold/pm_unreachable1.scilla.gold
+++ b/tests/pm_check/bad/gold/pm_unreachable1.scilla.gold
@@ -1,3 +1,19 @@
-Type checking failed:
-[pm_check/bad/pm_unreachable1.scilla:6:1] Type error in pattern matching on `b` of type Bool (or one of its branches):
-Pattern 2 is unreachable.
+{
+  "errors": [
+    {
+      "error_message":
+        "Type error in pattern matching on `b` of type Bool (or one of its branches):\n",
+      "start_location": {
+        "file": "pm_check/bad/pm_unreachable1.scilla",
+        "line": 6,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Pattern 2 is unreachable.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/pm_check/bad/gold/pm_unreachable2.scilla.gold
+++ b/tests/pm_check/bad/gold/pm_unreachable2.scilla.gold
@@ -1,3 +1,19 @@
-Type checking failed:
-[pm_check/bad/pm_unreachable2.scilla:6:1] Type error in pattern matching on `b` of type Bool (or one of its branches):
-Pattern 2 is unreachable.
+{
+  "errors": [
+    {
+      "error_message":
+        "Type error in pattern matching on `b` of type Bool (or one of its branches):\n",
+      "start_location": {
+        "file": "pm_check/bad/pm_unreachable2.scilla",
+        "line": 6,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Pattern 2 is unreachable.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/pm_check/bad/gold/pm_unreachable_nesting1.scilla.gold
+++ b/tests/pm_check/bad/gold/pm_unreachable_nesting1.scilla.gold
@@ -1,3 +1,19 @@
-Type checking failed:
-[pm_check/bad/pm_unreachable_nesting1.scilla:9:1] Type error in pattern matching on `y` of type List (Option (Int32)) (or one of its branches):
-Pattern 4 is unreachable.
+{
+  "errors": [
+    {
+      "error_message":
+        "Type error in pattern matching on `y` of type List (Option (Int32)) (or one of its branches):\n",
+      "start_location": {
+        "file": "pm_check/bad/pm_unreachable_nesting1.scilla",
+        "line": 9,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Pattern 4 is unreachable.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/pm_check/bad/gold/pm_unreachable_nesting2.scilla.gold
+++ b/tests/pm_check/bad/gold/pm_unreachable_nesting2.scilla.gold
@@ -1,3 +1,19 @@
-Type checking failed:
-[pm_check/bad/pm_unreachable_nesting2.scilla:9:1] Type error in pattern matching on `y` of type List (Option (Int32)) (or one of its branches):
-Pattern 7 is unreachable.
+{
+  "errors": [
+    {
+      "error_message":
+        "Type error in pattern matching on `y` of type List (Option (Int32)) (or one of its branches):\n",
+      "start_location": {
+        "file": "pm_check/bad/pm_unreachable_nesting2.scilla",
+        "line": 9,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Pattern 7 is unreachable.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/typecheck/bad/gold/adt-error1.scilla.gold
+++ b/tests/typecheck/bad/gold/adt-error1.scilla.gold
@@ -1,4 +1,18 @@
-Type checking failed:
-[typecheck/bad/adt-error1.scilla:5:1] Type error in the initialiser of `l4`:
-ADT type Pair expects 2 arguments but got 1.
-
+{
+  "errors": [
+    {
+      "error_message": "Type error in the initialiser of `l4`:\n",
+      "start_location": {
+        "file": "typecheck/bad/adt-error1.scilla",
+        "line": 5,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "ADT type Pair expects 2 arguments but got 1.\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/typecheck/bad/gold/branch-mismatch.scilla.gold
+++ b/tests/typecheck/bad/gold/branch-mismatch.scilla.gold
@@ -1,3 +1,20 @@
-Type checking failed:
-[typecheck/bad/branch-mismatch.scilla:8:2] Type error in pattern matching on `c` of type Bool (or one of its branches):
-Not all types of the branches ['X; 'Y] are equivalent.
+{
+  "errors": [
+    {
+      "error_message":
+        "Type error in pattern matching on `c` of type Bool (or one of its branches):\n",
+      "start_location": {
+        "file": "typecheck/bad/branch-mismatch.scilla",
+        "line": 8,
+        "column": 2
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Not all types of the branches ['X; 'Y] are equivalent.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/typecheck/bad/gold/folder-error.scilla.gold
+++ b/tests/typecheck/bad/gold/folder-error.scilla.gold
@@ -1,7 +1,28 @@
-Type checking failed:
-[typecheck/bad/folder-error.scilla:1:1] Type error in the initialiser of `list_map`:
-[typecheck/bad/folder-error.scilla:3:3] Type error in the initialiser of `folder`:
-Cannot elaborate expression of type
-('A -> 'B -> 'B) -> 'B -> List ('A) -> 'B
-applied, as a type function, to type arguments
-['A].
+{
+  "errors": [
+    {
+      "error_message": "Type error in the initialiser of `list_map`:\n",
+      "start_location": {
+        "file": "typecheck/bad/folder-error.scilla",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type error in the initialiser of `folder`:\n",
+      "start_location": {
+        "file": "typecheck/bad/folder-error.scilla",
+        "line": 3,
+        "column": 3
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Cannot elaborate expression of type\n('A -> 'B -> 'B) -> 'B -> List ('A) -> 'B\napplied, as a type function, to type arguments\n['A].",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/typecheck/bad/gold/fun2.scilla.gold
+++ b/tests/typecheck/bad/gold/fun2.scilla.gold
@@ -1,3 +1,13 @@
-Type checking failed:
-[typecheck/bad/fun2.scilla:1:20]: Couldn't resolve the identifier "y".
-
+{
+  "errors": [
+    {
+      "error_message": "Couldn't resolve the identifier \"y\".\n",
+      "start_location": {
+        "file": "typecheck/bad/fun2.scilla",
+        "line": 1,
+        "column": 20
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/typecheck/bad/gold/fun3.scilla.gold
+++ b/tests/typecheck/bad/gold/fun3.scilla.gold
@@ -1,2 +1,9 @@
-Type checking failed:
-ADT Int54 not found
+{
+  "errors": [
+    {
+      "error_message": "ADT Int54 not found",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/typecheck/bad/gold/fun4.scilla.gold
+++ b/tests/typecheck/bad/gold/fun4.scilla.gold
@@ -1,2 +1,9 @@
-Type checking failed:
-Unbound type variable 'A in type 'A -> Int32
+{
+  "errors": [
+    {
+      "error_message": "Unbound type variable 'A in type 'A -> Int32",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/typecheck/bad/gold/list-error.scilla.gold
+++ b/tests/typecheck/bad/gold/list-error.scilla.gold
@@ -1,3 +1,18 @@
-Type checking failed:
-[typecheck/bad/list-error.scilla:20:1] Type error in the initialiser of `l4`:
-Constructor Cons expects 2 arguments, but got 1.
+{
+  "errors": [
+    {
+      "error_message": "Type error in the initialiser of `l4`:\n",
+      "start_location": {
+        "file": "typecheck/bad/list-error.scilla",
+        "line": 20,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Constructor Cons expects 2 arguments, but got 1.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/typecheck/bad/gold/list-error2.scilla.gold
+++ b/tests/typecheck/bad/gold/list-error2.scilla.gold
@@ -1,3 +1,19 @@
-Type checking failed:
-[typecheck/bad/list-error2.scilla:20:1] Type error in the initialiser of `l4`:
-Constructor Cons expects 1 type arguments, but got 2.
+{
+  "errors": [
+    {
+      "error_message": "Type error in the initialiser of `l4`:\n",
+      "start_location": {
+        "file": "typecheck/bad/list-error2.scilla",
+        "line": 20,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Constructor Cons expects 1 type arguments, but got 2.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/typecheck/bad/gold/list-lit.scilla.gold
+++ b/tests/typecheck/bad/gold/list-lit.scilla.gold
@@ -1,3 +1,19 @@
-Type checking failed:
-[typecheck/bad/list-lit.scilla:6:1] Type error in the initialiser of `l3`:
-Type mismatch: List (Int32) expected, but List (Int64) provided.
+{
+  "errors": [
+    {
+      "error_message": "Type error in the initialiser of `l3`:\n",
+      "start_location": {
+        "file": "typecheck/bad/list-lit.scilla",
+        "line": 6,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Type mismatch: List (Int32) expected, but List (Int64) provided.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/typecheck/bad/gold/list-lit2.scilla.gold
+++ b/tests/typecheck/bad/gold/list-lit2.scilla.gold
@@ -1,3 +1,18 @@
-Type checking failed:
-[typecheck/bad/list-lit2.scilla:6:1] Type error in the initialiser of `l3`:
-Type mismatch: Int64 expected, but Int32 provided.
+{
+  "errors": [
+    {
+      "error_message": "Type error in the initialiser of `l3`:\n",
+      "start_location": {
+        "file": "typecheck/bad/list-lit2.scilla",
+        "line": 6,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type mismatch: Int64 expected, but Int32 provided.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/typecheck/bad/gold/map-error.scilla.gold
+++ b/tests/typecheck/bad/gold/map-error.scilla.gold
@@ -1,4 +1,28 @@
-Type checking failed:
-[typecheck/bad/map-error.scilla:1:1] Type error in the initialiser of `list_map`:
-[typecheck/bad/map-error.scilla:8:5] Type error in application of `folder`:
-Type mismatch: 'A -> 'B -> 'B expected, but 'A -> List ('B) -> List ('B) provided.
+{
+  "errors": [
+    {
+      "error_message": "Type error in the initialiser of `list_map`:\n",
+      "start_location": {
+        "file": "typecheck/bad/map-error.scilla",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type error in application of `folder`:\n",
+      "start_location": {
+        "file": "typecheck/bad/map-error.scilla",
+        "line": 8,
+        "column": 5
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Type mismatch: 'A -> 'B -> 'B expected, but 'A -> List ('B) -> List ('B) provided.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/typecheck/bad/gold/map-lit.scilla.gold
+++ b/tests/typecheck/bad/gold/map-lit.scilla.gold
@@ -1,4 +1,32 @@
-Type checking failed:
-[typecheck/bad/map-lit.scilla:8:1] Type error in the initialiser of `m2`:
-[typecheck/bad/map-lit.scilla:8:10] Type error in built-in application of `put`:
-[typecheck/bad/map-lit.scilla:8:18] Cannot find built-in with name "put" and argument types [Map (Uint32) (Uint32); Uint32; Uint64].
+{
+  "errors": [
+    {
+      "error_message": "Type error in the initialiser of `m2`:\n",
+      "start_location": {
+        "file": "typecheck/bad/map-lit.scilla",
+        "line": 8,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type error in built-in application of `put`:\n",
+      "start_location": {
+        "file": "typecheck/bad/map-lit.scilla",
+        "line": 8,
+        "column": 10
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Cannot find built-in with name \"put\" and argument types [Map (Uint32) (Uint32); Uint32; Uint64].",
+      "start_location": {
+        "file": "typecheck/bad/map-lit.scilla",
+        "line": 8,
+        "column": 18
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/typecheck/bad/gold/nth-error.scilla.gold
+++ b/tests/typecheck/bad/gold/nth-error.scilla.gold
@@ -1,6 +1,37 @@
-Type checking failed:
-[typecheck/bad/nth-error.scilla:1:1] Type error in the initialiser of `list_nth`:
-[typecheck/bad/nth-error.scilla:5:5] Type error in the initialiser of `list_nth_helper`:
-[typecheck/bad/nth-error.scilla:13:9] Type error in the initialiser of `iter`:
-ADT type Pair expects 2 arguments but got 1.
-
+{
+  "errors": [
+    {
+      "error_message": "Type error in the initialiser of `list_nth`:\n",
+      "start_location": {
+        "file": "typecheck/bad/nth-error.scilla",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Type error in the initialiser of `list_nth_helper`:\n",
+      "start_location": {
+        "file": "typecheck/bad/nth-error.scilla",
+        "line": 5,
+        "column": 5
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Type error in the initialiser of `iter`:\n",
+      "start_location": {
+        "file": "typecheck/bad/nth-error.scilla",
+        "line": 13,
+        "column": 9
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "ADT type Pair expects 2 arguments but got 1.\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/typecheck/bad/gold/pm-error1.scilla.gold
+++ b/tests/typecheck/bad/gold/pm-error1.scilla.gold
@@ -1,4 +1,29 @@
-Type checking failed:
-[typecheck/bad/pm-error1.scilla:3:1] Type error in the initialiser of `f`:
-[typecheck/bad/pm-error1.scilla:4:3] Type error in pattern matching on `c` of type Bool (or one of its branches):
-Not all types of the branches [Int32; Int64] are equivalent.
+{
+  "errors": [
+    {
+      "error_message": "Type error in the initialiser of `f`:\n",
+      "start_location": {
+        "file": "typecheck/bad/pm-error1.scilla",
+        "line": 3,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Type error in pattern matching on `c` of type Bool (or one of its branches):\n",
+      "start_location": {
+        "file": "typecheck/bad/pm-error1.scilla",
+        "line": 4,
+        "column": 3
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Not all types of the branches [Int32; Int64] are equivalent.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/typecheck/bad/gold/pm-error2.scilla.gold
+++ b/tests/typecheck/bad/gold/pm-error2.scilla.gold
@@ -1,4 +1,29 @@
-Type checking failed:
-[typecheck/bad/pm-error2.scilla:3:1] Type error in the initialiser of `f`:
-[typecheck/bad/pm-error2.scilla:4:3] Type error in pattern matching on `c` of type Bool (or one of its branches):
-Types don't match: pattern uses a constructor of type Option, but value of type Bool is given.
+{
+  "errors": [
+    {
+      "error_message": "Type error in the initialiser of `f`:\n",
+      "start_location": {
+        "file": "typecheck/bad/pm-error2.scilla",
+        "line": 3,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Type error in pattern matching on `c` of type Bool (or one of its branches):\n",
+      "start_location": {
+        "file": "typecheck/bad/pm-error2.scilla",
+        "line": 4,
+        "column": 3
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Types don't match: pattern uses a constructor of type Option, but value of type Bool is given.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}

--- a/tests/typecheck/bad/gold/some.scilla.gold
+++ b/tests/typecheck/bad/gold/some.scilla.gold
@@ -1,3 +1,19 @@
-Type checking failed:
-[typecheck/bad/some.scilla:4:1] Type error in the initialiser of `p`:
-Type mismatch: Option (Bool) expected, but Bool provided.
+{
+  "errors": [
+    {
+      "error_message": "Type error in the initialiser of `p`:\n",
+      "start_location": {
+        "file": "typecheck/bad/some.scilla",
+        "line": 4,
+        "column": 1
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Type mismatch: Option (Bool) expected, but Bool provided.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ]
+}


### PR DESCRIPTION
the different error messages with their source locations.

TODO:
1. There is an issue with `wrapp_with_info` leading to multiple
messages for the same error, with only one having location info.
2. For contract tests (`scilla-runner`) with expected failures,
the outputs haven't been updated as the Testsuite doesn't compare
outputs on errors for `scilla-runner` (contract tests).

These two issues will be fixed in subsequent PRs. Since this PR
is invasive, I'd like to merge this first and then fix the TODOs
above.

Issue #214.