### PR TITLE
msg parameter of tryM is now a thunk

### DIFF
--- a/src/lang/base/BuiltIns.ml
+++ b/src/lang/base/BuiltIns.ml
@@ -1001,7 +1001,8 @@ module ScillaBuiltIns
       let open Caml in
       let dict = Option.value ~default:[] @@ Hashtbl.find_opt built_in_hashtbl opname in
       let%bind (_, (type_elab, res_type, exec)) = tryM dict ~f:finder
-          ~msg:(mk_error1
+          ~msg:(fun () ->
+              mk_error1
                 (sprintf "Cannot find built-in with name \"%s\" and argument types %s." opname (pp_typ_list argtypes))
                 (ER.get_loc (get_rep op)))
       in pure (type_elab, res_type, exec)

--- a/src/lang/base/Gas.ml
+++ b/src/lang/base/Gas.ml
@@ -253,7 +253,7 @@ module ScillaGas
     let msg = sprintf "Unable to determine gas cost for \"%s\"" op in
     let open Caml in
     let dict = match Hashtbl.find_opt builtin_hashtbl op with | Some rows -> rows | None -> [] in
-    let %bind (_, cost) = tryM dict ~f:matcher ~msg:(mk_error0 msg) in
+    let %bind (_, cost) = tryM dict ~f:matcher ~msg:(fun () -> mk_error0 msg) in
     pure cost
 
 end

--- a/src/lang/base/MonadUtil.ml
+++ b/src/lang/base/MonadUtil.ml
@@ -64,7 +64,7 @@ let rec tryM ~f ls ~msg = match ls with
       (match f x  with
        | Ok z -> Ok (x, z)
        | Error _ -> tryM ~f:f ls' ~msg)
-  | [] -> Error msg
+  | [] -> Error (msg ())
 
 let liftPair2 x m = match m with
   | Ok z -> Ok (x, z)
@@ -196,7 +196,7 @@ module EvalMonad = struct
           (match (f x) remaining_cost  with
            | Ok (z, remaining_cost') -> Ok ((x, z), remaining_cost')
            | Error (_, remaining_cost') -> doTry ls' remaining_cost')
-      | [] -> Error (msg, remaining_cost)
+      | [] -> Error (msg (), remaining_cost)
     in
     (fun remaining_cost -> doTry ls remaining_cost)
 

--- a/src/lang/eval/Eval.ml
+++ b/src/lang/eval/Eval.ml
@@ -145,7 +145,7 @@ let rec exp_eval erep env =
       let%bind ((_, e_branch), bnds) =
         tryM clauses
           (* TODO: add location info to error message. *)
-          ~msg:(mk_error0(sprintf "Match expression failed. No clause matched."))
+          ~msg:(fun () -> mk_error0(sprintf "Match expression failed. No clause matched."))
           ~f:(fun (p, _) -> fromR @@ match_with_pattern v p) in
       (* Update the environment for the branch *)
       let env' = List.fold_left bnds ~init:env
@@ -235,7 +235,7 @@ let rec stmt_eval conf stmts =
           let%bind v = Env.lookup conf.env x in 
           let%bind ((_, branch_stmts), bnds) =
             tryM clauses
-              ~msg:(mk_error0 (sprintf "Value %s\ndoes not match any clause of\n%s."
+              ~msg:(fun () -> mk_error0 (sprintf "Value %s\ndoes not match any clause of\n%s."
                       (Env.pp_value v) (pp_stmt s)))
               ~f:(fun (p, _) -> fromR @@ match_with_pattern v p) in 
           (* Update the environment for the branch *)


### PR DESCRIPTION
Fixes #270.

The evaluation of the `msg` parameter of `tryM` is now delayed until it is actually needed to report an error.