### PR TITLE
Improve quality of error messages from type checker

### DIFF
--- a/src/lang/base/ScillaParser.mly
+++ b/src/lang/base/ScillaParser.mly
@@ -166,7 +166,7 @@ simple_exp :
   }
 (* Match expression *)
 | MATCH; x = ID; WITH; cs=list(exp_pm_clause); END
-  { (MatchExpr (Ident (x, toLoc $startpos), cs), toLoc $startpos) }
+  { (MatchExpr (Ident (x, toLoc $startpos(x)), cs), toLoc $startpos) }
 (* Type function *)
 | TFUN; i = TID ARROW; e = exp
   { (TFun (Ident (i, toLoc $startpos), e), toLoc $startpos) } 
@@ -251,7 +251,7 @@ stmt:
 | SEND; m = ID;          { (SendMsgs (asIdL m (toLoc $startpos)), toLoc $startpos) }
 | EVENT; m = ID; { (CreateEvnt (asIdL m (toLoc $startpos)), toLoc $startpos) }
 | MATCH; x = ID; WITH; cs=list(stmt_pm_clause); END
-  { (MatchStmt (Ident (x, toLoc $startpos), cs), toLoc $startpos)  }
+  { (MatchStmt (Ident (x, toLoc $startpos(x)), cs), toLoc $startpos)  }
 
 stmt_pm_clause:
 | BAR ; p = pattern ; ARROW ;
@@ -274,13 +274,13 @@ transition:
   LPAREN; params = separated_list(COMMA, param_pair); RPAREN;
   ss = stmts;
   END;
-  { { tname = asIdL t (toLoc $startpos);
+  { { tname = t;
       tparams = params;
       tbody = ss } }
 
 trans_id:
-| c = CID {c};
-| i = ID {i};
+| c = CID { asIdL c (toLoc $startpos(c)) };
+| i = ID { asIdL i (toLoc $startpos(i)) };
 
 field:
 | FIELD; f = ID; COLON; t=typ;

--- a/src/lang/base/TypeChecker.ml
+++ b/src/lang/base/TypeChecker.ml
@@ -236,8 +236,8 @@ module ScillaTypechecker
                let rtp = t.tp in
                if is_storable_type rtp
                then pure @@ TypedSyntax.MVar (add_type_to_ident i t)
-               else fail0 @@ sprintf
-                   "Cannot send values of type %s." (pp_typ rtp))
+               else fail1 (sprintf "Cannot send values of type %s." (pp_typ rtp))
+                          (ER.get_loc (get_rep i)))
         in
         let%bind typed_bs =
           (* Make sure we resolve all the payload *)
@@ -344,9 +344,10 @@ module ScillaTypechecker
                    ~lopt:(Some (get_rep x)) in
                let sctype = rr_typ sctyp in
                let sct = sctype.tp in
-               let msg = sprintf " of type %s" (pp_typ sct) in
+               let msg = sprintf "Error in pattern matching \"%s\" of type %s" (get_id x) (pp_typ sct) in
+               let sloc = ER.get_loc (get_rep x) in
                let typed_x = add_type_to_ident x sctype in
-               let%bind checked_clauses = wrap_type_serr stmt ~opt:msg @@
+               let%bind checked_clauses = wrap_with_info (msg, sloc) @@
                  mapM clauses ~f:(fun (ptrn, ex) ->
                      type_match_stmt_branch env sct ptrn ex get_loc ) in
                let%bind checked_stmts = type_stmts env sts get_loc in
@@ -398,7 +399,7 @@ module ScillaTypechecker
     let append_params = CU.append_implict_trans_params tparams in
     let tenv1 = TEnv.addTs tenv0 append_params in
     let env = {env0 with pure = tenv1} in
-    let msg = sprintf "Type error in transition %s:\n" (get_id tname) in
+    let msg = sprintf "Type error(s) in transition %s:\n" (get_id tname) in
     let%bind (typed_stmts, _) = wrap_with_info (msg, SR.get_loc (get_rep tname)) @@
       type_stmts env tbody ER.get_loc in
     pure @@ ({ TypedSyntax.tname = tname ;

--- a/tests/checker/bad/gold/homonymous_vars.scilla.gold
+++ b/tests/checker/bad/gold/homonymous_vars.scilla.gold
@@ -6,36 +6,22 @@
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message": "Type error in transition ExecuteTransaction:\n",
+      "error_message": "Type error(s) in transition ExecuteTransaction:\n",
       "start_location": {
         "file": "checker/bad/homonymous_vars.scilla",
         "line": 11,
-        "column": 1
+        "column": 12
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
       "error_message":
-        "Type error in the binding to into `not_enough_money`:\n",
-      "start_location": {
-        "file": "checker/bad/homonymous_vars.scilla",
-        "line": 13,
-        "column": 3
-      },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Type error in built-in application of `lt`:\n",
+        "Type error in the binding to into `not_enough_money`:\nType error in built-in application of `lt`:\nCouldn't resolve the identifier \"sxamount\".\n",
       "start_location": {
         "file": "checker/bad/homonymous_vars.scilla",
         "line": 13,
         "column": 22
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Couldn't resolve the identifier \"sxamount\".\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/checker/bad/gold/lib_bad1.scilla.gold
+++ b/tests/checker/bad/gold/lib_bad1.scilla.gold
@@ -46,27 +46,12 @@
     },
     {
       "error_message":
-        "Type error in pattern matching on `b` of type Bool (or one of its branches):\n",
-      "start_location": {
-        "file": "checker/bad/lib_bad1.scilla",
-        "line": 32,
-        "column": 5
-      },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message":
-        "Type error in pattern matching on `c` of type Int32 (or one of its branches):\n",
+        "Type error in pattern matching on `b` of type Bool (or one of its branches):\nType error in pattern matching on `c` of type Int32 (or one of its branches):\nNot an algebraic data type: Int32",
       "start_location": {
         "file": "checker/bad/lib_bad1.scilla",
         "line": 35,
         "column": 7
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Not an algebraic data type: Int32",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/checker/bad/gold/mappair.scilla.gold
+++ b/tests/checker/bad/gold/mappair.scilla.gold
@@ -6,26 +6,26 @@
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message": "Type error in transition testMapPair:\n",
+      "error_message": "Type error(s) in transition testMapPair:\n",
       "start_location": {
         "file": "checker/bad/mappair.scilla",
         "line": 39,
-        "column": 1
+        "column": 12
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Error in pattern matching \"is_owner\" of type Bool",
+      "start_location": {
+        "file": "checker/bad/mappair.scilla",
+        "line": 41,
+        "column": 9
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
       "error_message":
-        "Type error in pattern matching on `is_owner` of type Bool (or one of its branches):\n",
-      "start_location": {
-        "file": "checker/bad/mappair.scilla",
-        "line": 41,
-        "column": 3
-      },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Type error in the binding to into `p`:\n",
+        "Type error in the binding to into `p`:\nType mismatch: Int32 expected, but Int64 provided.",
       "start_location": {
         "file": "checker/bad/mappair.scilla",
         "line": 54,
@@ -34,21 +34,17 @@
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message": "Type mismatch: Int32 expected, but Int64 provided.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Type error in transition addNumToList:\n",
+      "error_message": "Type error(s) in transition addNumToList:\n",
       "start_location": {
         "file": "checker/bad/mappair.scilla",
         "line": 61,
-        "column": 1
+        "column": 12
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message": "Type error in the binding to into `l2`:\n",
+      "error_message":
+        "Type error in the binding to into `l2`:\nType mismatch: Int32 expected, but Int64 provided.",
       "start_location": {
         "file": "checker/bad/mappair.scilla",
         "line": 70,
@@ -57,31 +53,22 @@
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message": "Type mismatch: Int32 expected, but Int64 provided.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Type error in transition createBadEvent:\n",
+      "error_message": "Type error(s) in transition createBadEvent:\n",
       "start_location": {
         "file": "checker/bad/mappair.scilla",
         "line": 90,
-        "column": 1
+        "column": 12
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message": "Type error in the binding to into `e`:\n",
+      "error_message":
+        "Type error in the binding to into `e`:\nCannot send values of type Nat -> Uint32.",
       "start_location": {
         "file": "checker/bad/mappair.scilla",
         "line": 93,
-        "column": 3
+        "column": 46
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Cannot send values of type Nat -> Uint32.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/checker/bad/gold/mappair2.scilla.gold
+++ b/tests/checker/bad/gold/mappair2.scilla.gold
@@ -5,7 +5,7 @@
       "start_location": {
         "file": "checker/bad/mappair2.scilla",
         "line": 92,
-        "column": 1
+        "column": 12
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
@@ -38,7 +38,7 @@
       "start_location": {
         "file": "checker/bad/mappair2.scilla",
         "line": 113,
-        "column": 1
+        "column": 12
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     },

--- a/tests/checker/bad/gold/unbound.scilla.gold
+++ b/tests/checker/bad/gold/unbound.scilla.gold
@@ -20,25 +20,17 @@
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message": "Type error in transition Donate:\n",
+      "error_message": "Type error(s) in transition Donate:\n",
       "start_location": {
         "file": "checker/bad/unbound.scilla",
         "line": 57,
-        "column": 1
+        "column": 12
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message": "Type error in the binding to into `in_time`:\n",
-      "start_location": {
-        "file": "checker/bad/unbound.scilla",
-        "line": 59,
-        "column": 3
-      },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Type error in application of `blk_leq`:\n",
+      "error_message":
+        "Type error in the binding to into `in_time`:\nType error in application of `blk_leq`:\nCouldn't resolve the identifier \"blk_leq\".\n",
       "start_location": {
         "file": "checker/bad/unbound.scilla",
         "line": 59,
@@ -47,45 +39,26 @@
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message": "Couldn't resolve the identifier \"blk_leq\".\n",
-      "start_location": {
-        "file": "checker/bad/unbound.scilla",
-        "line": 59,
-        "column": 13
-      },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Type error in transition GetFunds:\n",
+      "error_message": "Type error(s) in transition GetFunds:\n",
       "start_location": {
         "file": "checker/bad/unbound.scilla",
         "line": 88,
-        "column": 1
+        "column": 12
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message":
-        "Type error in pattern matching on `is_owner` of type Bool (or one of its branches):\n",
+      "error_message": "Error in pattern matching \"is_owner\" of type Bool",
       "start_location": {
         "file": "checker/bad/unbound.scilla",
         "line": 90,
-        "column": 3
-      },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Type error in the binding to into `msg`:\n",
-      "start_location": {
-        "file": "checker/bad/unbound.scilla",
-        "line": 92,
-        "column": 5
+        "column": 9
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
       "error_message":
-        "Couldn't resolve the identifier \"not_owner_code\".\n",
+        "Type error in the binding to into `msg`:\nCouldn't resolve the identifier \"not_owner_code\".\n",
       "start_location": {
         "file": "checker/bad/unbound.scilla",
         "line": 93,
@@ -94,36 +67,27 @@
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message": "Type error in transition ClaimBack:\n",
+      "error_message": "Type error(s) in transition ClaimBack:\n",
       "start_location": {
         "file": "checker/bad/unbound.scilla",
         "line": 122,
-        "column": 1
+        "column": 12
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
       "error_message":
-        "Type error in pattern matching on `after_deadline` of type Bool (or one of its branches):\n",
+        "Error in pattern matching \"after_deadline\" of type Bool",
       "start_location": {
         "file": "checker/bad/unbound.scilla",
         "line": 125,
-        "column": 3
-      },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Type error in the binding to into `msg`:\n",
-      "start_location": {
-        "file": "checker/bad/unbound.scilla",
-        "line": 127,
-        "column": 5
+        "column": 9
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
       "error_message":
-        "Couldn't resolve the identifier \"too_early_code\".\n",
+        "Type error in the binding to into `msg`:\nCouldn't resolve the identifier \"too_early_code\".\n",
       "start_location": {
         "file": "checker/bad/unbound.scilla",
         "line": 128,

--- a/tests/checker/bad/gold/zil_mod.scilla.gold
+++ b/tests/checker/bad/gold/zil_mod.scilla.gold
@@ -17,17 +17,12 @@
     },
     {
       "error_message":
-        "Type error in pattern matching on `xa` of type Pair (Bool) (Option (ByStr32)) (or one of its branches):\n",
+        "Type error in pattern matching on `xa` of type Pair (Bool) (Option (ByStr32)) (or one of its branches):\nPattern 3 is unreachable.",
       "start_location": {
         "file": "checker/bad/zil_mod.scilla",
         "line": 65,
         "column": 5
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Pattern 3 is unreachable.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/pm_check/bad/gold/pm1.scilla.gold
+++ b/tests/pm_check/bad/gold/pm1.scilla.gold
@@ -2,17 +2,12 @@
   "errors": [
     {
       "error_message":
-        "Type error in pattern matching on `b` of type Bool (or one of its branches):\n",
+        "Type error in pattern matching on `b` of type Bool (or one of its branches):\nNon-exhaustive pattern match.",
       "start_location": {
         "file": "pm_check/bad/pm1.scilla",
         "line": 6,
         "column": 1
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Non-exhaustive pattern match.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/pm_check/bad/gold/pm2.scilla.gold
+++ b/tests/pm_check/bad/gold/pm2.scilla.gold
@@ -2,17 +2,12 @@
   "errors": [
     {
       "error_message":
-        "Type error in pattern matching on `b` of type Option (Int32) (or one of its branches):\n",
+        "Type error in pattern matching on `b` of type Option (Int32) (or one of its branches):\nNon-exhaustive pattern match.",
       "start_location": {
         "file": "pm_check/bad/pm2.scilla",
         "line": 7,
         "column": 1
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Non-exhaustive pattern match.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/pm_check/bad/gold/pm3.scilla.gold
+++ b/tests/pm_check/bad/gold/pm3.scilla.gold
@@ -2,17 +2,12 @@
   "errors": [
     {
       "error_message":
-        "Type error in pattern matching on `y` of type List (Int32) (or one of its branches):\n",
+        "Type error in pattern matching on `y` of type List (Int32) (or one of its branches):\nNon-exhaustive pattern match.",
       "start_location": {
         "file": "pm_check/bad/pm3.scilla",
         "line": 8,
         "column": 1
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Non-exhaustive pattern match.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/pm_check/bad/gold/pm_nesting1.scilla.gold
+++ b/tests/pm_check/bad/gold/pm_nesting1.scilla.gold
@@ -2,17 +2,12 @@
   "errors": [
     {
       "error_message":
-        "Type error in pattern matching on `y` of type List (Option (Int32)) (or one of its branches):\n",
+        "Type error in pattern matching on `y` of type List (Option (Int32)) (or one of its branches):\nNon-exhaustive pattern match.",
       "start_location": {
         "file": "pm_check/bad/pm_nesting1.scilla",
         "line": 9,
         "column": 1
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Non-exhaustive pattern match.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/pm_check/bad/gold/pm_nesting2.scilla.gold
+++ b/tests/pm_check/bad/gold/pm_nesting2.scilla.gold
@@ -2,17 +2,12 @@
   "errors": [
     {
       "error_message":
-        "Type error in pattern matching on `y` of type List (Option (Int32)) (or one of its branches):\n",
+        "Type error in pattern matching on `y` of type List (Option (Int32)) (or one of its branches):\nNon-exhaustive pattern match.",
       "start_location": {
         "file": "pm_check/bad/pm_nesting2.scilla",
         "line": 9,
         "column": 1
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Non-exhaustive pattern match.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/pm_check/bad/gold/pm_nesting3.scilla.gold
+++ b/tests/pm_check/bad/gold/pm_nesting3.scilla.gold
@@ -2,17 +2,12 @@
   "errors": [
     {
       "error_message":
-        "Type error in pattern matching on `y` of type List (Option (Int32)) (or one of its branches):\n",
+        "Type error in pattern matching on `y` of type List (Option (Int32)) (or one of its branches):\nNon-exhaustive pattern match.",
       "start_location": {
         "file": "pm_check/bad/pm_nesting3.scilla",
         "line": 9,
         "column": 1
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Non-exhaustive pattern match.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/pm_check/bad/gold/pm_unreachable1.scilla.gold
+++ b/tests/pm_check/bad/gold/pm_unreachable1.scilla.gold
@@ -2,17 +2,12 @@
   "errors": [
     {
       "error_message":
-        "Type error in pattern matching on `b` of type Bool (or one of its branches):\n",
+        "Type error in pattern matching on `b` of type Bool (or one of its branches):\nPattern 2 is unreachable.",
       "start_location": {
         "file": "pm_check/bad/pm_unreachable1.scilla",
         "line": 6,
         "column": 1
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Pattern 2 is unreachable.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/pm_check/bad/gold/pm_unreachable2.scilla.gold
+++ b/tests/pm_check/bad/gold/pm_unreachable2.scilla.gold
@@ -2,17 +2,12 @@
   "errors": [
     {
       "error_message":
-        "Type error in pattern matching on `b` of type Bool (or one of its branches):\n",
+        "Type error in pattern matching on `b` of type Bool (or one of its branches):\nPattern 2 is unreachable.",
       "start_location": {
         "file": "pm_check/bad/pm_unreachable2.scilla",
         "line": 6,
         "column": 1
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Pattern 2 is unreachable.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/pm_check/bad/gold/pm_unreachable_nesting1.scilla.gold
+++ b/tests/pm_check/bad/gold/pm_unreachable_nesting1.scilla.gold
@@ -2,17 +2,12 @@
   "errors": [
     {
       "error_message":
-        "Type error in pattern matching on `y` of type List (Option (Int32)) (or one of its branches):\n",
+        "Type error in pattern matching on `y` of type List (Option (Int32)) (or one of its branches):\nPattern 4 is unreachable.",
       "start_location": {
         "file": "pm_check/bad/pm_unreachable_nesting1.scilla",
         "line": 9,
         "column": 1
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Pattern 4 is unreachable.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/pm_check/bad/gold/pm_unreachable_nesting2.scilla.gold
+++ b/tests/pm_check/bad/gold/pm_unreachable_nesting2.scilla.gold
@@ -2,17 +2,12 @@
   "errors": [
     {
       "error_message":
-        "Type error in pattern matching on `y` of type List (Option (Int32)) (or one of its branches):\n",
+        "Type error in pattern matching on `y` of type List (Option (Int32)) (or one of its branches):\nPattern 7 is unreachable.",
       "start_location": {
         "file": "pm_check/bad/pm_unreachable_nesting2.scilla",
         "line": 9,
         "column": 1
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Pattern 7 is unreachable.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/typecheck/bad/gold/adt-error1.scilla.gold
+++ b/tests/typecheck/bad/gold/adt-error1.scilla.gold
@@ -1,17 +1,13 @@
 {
   "errors": [
     {
-      "error_message": "Type error in the initialiser of `l4`:\n",
+      "error_message":
+        "Type error in the initialiser of `l4`:\nADT type Pair expects 2 arguments but got 1.\n",
       "start_location": {
         "file": "typecheck/bad/adt-error1.scilla",
         "line": 5,
         "column": 1
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "ADT type Pair expects 2 arguments but got 1.\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/typecheck/bad/gold/branch-mismatch.scilla.gold
+++ b/tests/typecheck/bad/gold/branch-mismatch.scilla.gold
@@ -2,18 +2,12 @@
   "errors": [
     {
       "error_message":
-        "Type error in pattern matching on `c` of type Bool (or one of its branches):\n",
+        "Type error in pattern matching on `c` of type Bool (or one of its branches):\nNot all types of the branches ['X; 'Y] are equivalent.",
       "start_location": {
         "file": "typecheck/bad/branch-mismatch.scilla",
         "line": 8,
         "column": 2
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message":
-        "Not all types of the branches ['X; 'Y] are equivalent.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/typecheck/bad/gold/folder-error.scilla.gold
+++ b/tests/typecheck/bad/gold/folder-error.scilla.gold
@@ -1,27 +1,13 @@
 {
   "errors": [
     {
-      "error_message": "Type error in the initialiser of `list_map`:\n",
-      "start_location": {
-        "file": "typecheck/bad/folder-error.scilla",
-        "line": 1,
-        "column": 1
-      },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Type error in the initialiser of `folder`:\n",
+      "error_message":
+        "Type error in the initialiser of `list_map`:\nType error in the initialiser of `folder`:\nCannot elaborate expression of type\n('A -> 'B -> 'B) -> 'B -> List ('A) -> 'B\napplied, as a type function, to type arguments\n['A].",
       "start_location": {
         "file": "typecheck/bad/folder-error.scilla",
         "line": 3,
         "column": 3
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message":
-        "Cannot elaborate expression of type\n('A -> 'B -> 'B) -> 'B -> List ('A) -> 'B\napplied, as a type function, to type arguments\n['A].",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/typecheck/bad/gold/list-error.scilla.gold
+++ b/tests/typecheck/bad/gold/list-error.scilla.gold
@@ -1,17 +1,13 @@
 {
   "errors": [
     {
-      "error_message": "Type error in the initialiser of `l4`:\n",
+      "error_message":
+        "Type error in the initialiser of `l4`:\nConstructor Cons expects 2 arguments, but got 1.",
       "start_location": {
         "file": "typecheck/bad/list-error.scilla",
         "line": 20,
         "column": 1
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Constructor Cons expects 2 arguments, but got 1.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/typecheck/bad/gold/list-error2.scilla.gold
+++ b/tests/typecheck/bad/gold/list-error2.scilla.gold
@@ -1,18 +1,13 @@
 {
   "errors": [
     {
-      "error_message": "Type error in the initialiser of `l4`:\n",
+      "error_message":
+        "Type error in the initialiser of `l4`:\nConstructor Cons expects 1 type arguments, but got 2.",
       "start_location": {
         "file": "typecheck/bad/list-error2.scilla",
         "line": 20,
         "column": 1
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message":
-        "Constructor Cons expects 1 type arguments, but got 2.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/typecheck/bad/gold/list-lit.scilla.gold
+++ b/tests/typecheck/bad/gold/list-lit.scilla.gold
@@ -1,18 +1,13 @@
 {
   "errors": [
     {
-      "error_message": "Type error in the initialiser of `l3`:\n",
+      "error_message":
+        "Type error in the initialiser of `l3`:\nType mismatch: List (Int32) expected, but List (Int64) provided.",
       "start_location": {
         "file": "typecheck/bad/list-lit.scilla",
         "line": 6,
         "column": 1
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message":
-        "Type mismatch: List (Int32) expected, but List (Int64) provided.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/typecheck/bad/gold/list-lit2.scilla.gold
+++ b/tests/typecheck/bad/gold/list-lit2.scilla.gold
@@ -1,17 +1,13 @@
 {
   "errors": [
     {
-      "error_message": "Type error in the initialiser of `l3`:\n",
+      "error_message":
+        "Type error in the initialiser of `l3`:\nType mismatch: Int64 expected, but Int32 provided.",
       "start_location": {
         "file": "typecheck/bad/list-lit2.scilla",
         "line": 6,
         "column": 1
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Type mismatch: Int64 expected, but Int32 provided.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/typecheck/bad/gold/map-error.scilla.gold
+++ b/tests/typecheck/bad/gold/map-error.scilla.gold
@@ -1,27 +1,13 @@
 {
   "errors": [
     {
-      "error_message": "Type error in the initialiser of `list_map`:\n",
-      "start_location": {
-        "file": "typecheck/bad/map-error.scilla",
-        "line": 1,
-        "column": 1
-      },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Type error in application of `folder`:\n",
+      "error_message":
+        "Type error in the initialiser of `list_map`:\nType error in application of `folder`:\nType mismatch: 'A -> 'B -> 'B expected, but 'A -> List ('B) -> List ('B) provided.",
       "start_location": {
         "file": "typecheck/bad/map-error.scilla",
         "line": 8,
         "column": 5
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message":
-        "Type mismatch: 'A -> 'B -> 'B expected, but 'A -> List ('B) -> List ('B) provided.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/typecheck/bad/gold/map-lit.scilla.gold
+++ b/tests/typecheck/bad/gold/map-lit.scilla.gold
@@ -1,26 +1,8 @@
 {
   "errors": [
     {
-      "error_message": "Type error in the initialiser of `m2`:\n",
-      "start_location": {
-        "file": "typecheck/bad/map-lit.scilla",
-        "line": 8,
-        "column": 1
-      },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Type error in built-in application of `put`:\n",
-      "start_location": {
-        "file": "typecheck/bad/map-lit.scilla",
-        "line": 8,
-        "column": 10
-      },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
       "error_message":
-        "Cannot find built-in with name \"put\" and argument types [Map (Uint32) (Uint32); Uint32; Uint64].",
+        "Type error in the initialiser of `m2`:\nType error in built-in application of `put`:\nCannot find built-in with name \"put\" and argument types [Map (Uint32) (Uint32); Uint32; Uint64].",
       "start_location": {
         "file": "typecheck/bad/map-lit.scilla",
         "line": 8,

--- a/tests/typecheck/bad/gold/nth-error.scilla.gold
+++ b/tests/typecheck/bad/gold/nth-error.scilla.gold
@@ -1,36 +1,13 @@
 {
   "errors": [
     {
-      "error_message": "Type error in the initialiser of `list_nth`:\n",
-      "start_location": {
-        "file": "typecheck/bad/nth-error.scilla",
-        "line": 1,
-        "column": 1
-      },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
       "error_message":
-        "Type error in the initialiser of `list_nth_helper`:\n",
-      "start_location": {
-        "file": "typecheck/bad/nth-error.scilla",
-        "line": 5,
-        "column": 5
-      },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Type error in the initialiser of `iter`:\n",
+        "Type error in the initialiser of `list_nth`:\nType error in the initialiser of `list_nth_helper`:\nType error in the initialiser of `iter`:\nADT type Pair expects 2 arguments but got 1.\n",
       "start_location": {
         "file": "typecheck/bad/nth-error.scilla",
         "line": 13,
         "column": 9
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "ADT type Pair expects 2 arguments but got 1.\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/typecheck/bad/gold/pm-error1.scilla.gold
+++ b/tests/typecheck/bad/gold/pm-error1.scilla.gold
@@ -1,28 +1,13 @@
 {
   "errors": [
     {
-      "error_message": "Type error in the initialiser of `f`:\n",
-      "start_location": {
-        "file": "typecheck/bad/pm-error1.scilla",
-        "line": 3,
-        "column": 1
-      },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
       "error_message":
-        "Type error in pattern matching on `c` of type Bool (or one of its branches):\n",
+        "Type error in the initialiser of `f`:\nType error in pattern matching on `c` of type Bool (or one of its branches):\nNot all types of the branches [Int32; Int64] are equivalent.",
       "start_location": {
         "file": "typecheck/bad/pm-error1.scilla",
         "line": 4,
         "column": 3
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message":
-        "Not all types of the branches [Int32; Int64] are equivalent.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/typecheck/bad/gold/pm-error2.scilla.gold
+++ b/tests/typecheck/bad/gold/pm-error2.scilla.gold
@@ -1,28 +1,13 @@
 {
   "errors": [
     {
-      "error_message": "Type error in the initialiser of `f`:\n",
-      "start_location": {
-        "file": "typecheck/bad/pm-error2.scilla",
-        "line": 3,
-        "column": 1
-      },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
       "error_message":
-        "Type error in pattern matching on `c` of type Bool (or one of its branches):\n",
+        "Type error in the initialiser of `f`:\nType error in pattern matching on `c` of type Bool (or one of its branches):\nTypes don't match: pattern uses a constructor of type Option, but value of type Bool is given.",
       "start_location": {
         "file": "typecheck/bad/pm-error2.scilla",
         "line": 4,
         "column": 3
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message":
-        "Types don't match: pattern uses a constructor of type Option, but value of type Bool is given.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]

--- a/tests/typecheck/bad/gold/some.scilla.gold
+++ b/tests/typecheck/bad/gold/some.scilla.gold
@@ -1,18 +1,13 @@
 {
   "errors": [
     {
-      "error_message": "Type error in the initialiser of `p`:\n",
+      "error_message":
+        "Type error in the initialiser of `p`:\nType mismatch: Option (Bool) expected, but Bool provided.",
       "start_location": {
         "file": "typecheck/bad/some.scilla",
         "line": 4,
         "column": 1
       },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message":
-        "Type mismatch: Option (Bool) expected, but Bool provided.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]


### PR DESCRIPTION
This PR merges the `scilla_error` objects of the most precise error (when it doesn't have location information) with the outer error (statement, expression) which has location information. This provides location information for all errors, making it easy to highlight in the IDE.

Fixes #214 