### PR TITLE
Use a proper parser for CLI for all runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,20 +26,21 @@ Once the project is built you can try the following things:
 From the project root, execute
 
 ```
-./bin/eval-runner tests/eval/exp/good/let.scilla src/stdlib
+./bin/eval-runner -libdir src/stdlib tests/eval/exp/good/let.scilla
 ```
 
 Instead of `let.scilla` you might want to try any dfferent file in
 `tests/eval/exp`. The second argument, which is a path to the Scilla
 standard library can alternatively be specified in the environment
-variable `SCILLA_STDLIB_PATH`. This must be an absolute path;
+variable `SCILLA_STDLIB_PATH`. This must be an absolute path (or a
+list of `;` separated paths.
 
 #### Type-checking a contract
 
 From the project root, execute
 
 ```
-./bin/scilla-checker tests/checker/good/auction.scilla
+./bin/scilla-checker -libdir src/stdlib tests/checker/good/auction.scilla
 ```
 
 Instead of `auction.scilla` you might want to try any dfferent file in
@@ -47,7 +48,7 @@ Instead of `auction.scilla` you might want to try any dfferent file in
 own contract code. The second argument, which is a path to the Scilla
 standard library can alternatively be specified in the environment
 variable `SCILLA_STDLIB_PATH`. As above, this must be an absolute
-path.
+path(s).
 
 If the checker only returns the contract structure in JSON format, it
 means that the contract has no type errors. Otherwise, a type error

--- a/src/lang/base/GlobalConfig.ml
+++ b/src/lang/base/GlobalConfig.ml
@@ -113,8 +113,8 @@ let stdlib_dirs = ref []
 let get_stdlib_dirs () =
   let env_dirs = 
     match (Sys.getenv_opt scilla_stdlib_env) with 
-    | Some s -> String.split_on_char ';' s
-    | None -> []
+    | Some s when s != "" -> String.split_on_char ';' s
+    | _ -> []
   in
     List.append env_dirs !stdlib_dirs
 

--- a/src/runners/RunnerUtil.ml
+++ b/src/runners/RunnerUtil.ml
@@ -81,12 +81,10 @@ let parse_cli () =
   (* Only one input file allowed, so the last anonymous argument will be *it*. *)
   let anon_handler s = r_input_file := s in
   let () = Arg.parse speclist anon_handler ("Usage:\n" ^ usage) in
-
-  if !r_input_file = "" || !r_stdlib_dir = "" then
+  if !r_input_file = "" then
     (DebugMessage.perr @@ "Usage:\n" ^ Sys.argv.(0) ^ usage ^ "\n"; exit 1);
-
-  let stdlib_dirs = String.split_on_char ';' !r_stdlib_dir in
-    { input_file = !r_input_file; stdlib_dirs = stdlib_dirs; simple_errors = !r_simple_errors }
+  let stdlib_dirs = if !r_stdlib_dir = "" then [] else String.split_on_char ';' !r_stdlib_dir in
+  { input_file = !r_input_file; stdlib_dirs = stdlib_dirs; simple_errors = !r_simple_errors }
 
 let stdlib_not_found_err () =
   DebugMessage.perr @@ sprintf "\n%s\n"

--- a/src/runners/RunnerUtil.ml
+++ b/src/runners/RunnerUtil.ml
@@ -43,10 +43,18 @@ let import_libs names =
     with | _ -> perr (errmsg ^ "Failed to parse.\n"); exit 1
     ) names 
 
+let stdlib_not_found_err () =
+  DebugMessage.perr @@ sprintf "\n%s\n"
+  ("A path to Scilla stdlib not found. Please set " ^ StdlibTracker.scilla_stdlib_env ^ 
+    " environment variable, or pass through command-line argument for this script.\n" ^
+    "Example:\n" ^ Sys.argv.(0) ^ " list_sort.scilla -libdir ./src/stdlib/\n");
+   exit 1
+
 (* Parse all libraries that can be found in ldirs. *)
 let import_all_libs ldirs =
   (* Get list of scilla libraries in dir *)
   let get_lib_list dir =
+    if not (Sys.file_exists dir) then stdlib_not_found_err ();
     let files = Array.to_list (Sys.readdir dir) in
     List.fold_right (fun file names ->
       if Filename.extension file = ".scilla"
@@ -85,10 +93,3 @@ let parse_cli () =
     (DebugMessage.perr @@ "Usage:\n" ^ Sys.argv.(0) ^ usage ^ "\n"; exit 1);
   let stdlib_dirs = if !r_stdlib_dir = "" then [] else String.split_on_char ';' !r_stdlib_dir in
   { input_file = !r_input_file; stdlib_dirs = stdlib_dirs; simple_errors = !r_simple_errors }
-
-let stdlib_not_found_err () =
-  DebugMessage.perr @@ sprintf "\n%s\n"
-  ("A path to Scilla stdlib not found. Please set " ^ StdlibTracker.scilla_stdlib_env ^ 
-    " environment variable, or pass through command-line argument for this script.\n" ^
-    "Example:\n" ^ Sys.argv.(0) ^ " list_sort.scilla -libdir ./src/stdlib/\n");
-   exit 1

--- a/src/runners/eval_runner.ml
+++ b/src/runners/eval_runner.ml
@@ -39,20 +39,14 @@ module TCERep = TC.OutputERep
 let gas_limit = 2000
 
 let () =
-  if (Array.length Sys.argv) < 2 || (Array.length Sys.argv) > 3
-  then
-    (printf "%s\n" ("Usage: " ^ Sys.argv.(0) ^ " /path/to/exp.scilla [/path/to/stdlib]");
-    exit 1)
-  else
-  let filename = Sys.argv.(1) in
+  let cli = parse_cli() in
+  let filename = cli.input_file in
   match FrontEndParser.parse_file ScillaParser.exps filename with
   | Some [e] ->
       (* Since this is not a contract, we have no in-contract lib defined. *)
       let clib = { TC.UntypedSyntax.lname = asId "dummy";
                    TC.UntypedSyntax.lentries = [] } in
-      (* This is an auxiliary executable, it's second argument must
-       * have a list of stdlib dirs, so note that down. *)
-      add_cmd_stdlib ();
+      StdlibTracker.add_stdlib_dirs cli.stdlib_dirs;
       let lib_dirs = StdlibTracker.get_stdlib_dirs() in
       if lib_dirs = [] then stdlib_not_found_err ();
       (* Import all libraries in known stdlib paths. *)

--- a/src/runners/type_checker.ml
+++ b/src/runners/type_checker.ml
@@ -71,19 +71,13 @@ let check_typing e elibs =
 let check_patterns e = PM_Checker.pm_check_expr e
     
 let () =
-  if (Array.length Sys.argv) < 2
-  then
-    (perr (sprintf "Usage: %s foo.scilla\n" Sys.argv.(0))
-    )
-  else (
+    let cli = parse_cli () in
     let open GlobalConfig in
+    StdlibTracker.add_stdlib_dirs cli.stdlib_dirs;
     set_debug_level Debug_None;
-    let filename = Sys.argv.(1) in
+    let filename = cli.input_file in
     match FrontEndParser.parse_file ScillaParser.exps filename with
     | Some [e] ->
-        (* This is an auxiliary executable, it's second argument must
-         * have a list of stdlib dirs, so note that down. *)
-        add_cmd_stdlib();
         (* Get list of stdlib dirs. *)
         let lib_dirs = StdlibTracker.get_stdlib_dirs() in
         if lib_dirs = [] then stdlib_not_found_err ();
@@ -97,4 +91,4 @@ let () =
              )
          | Error el -> pout @@ scilla_error_to_jstring el)
     | Some _ | None ->
-        pout @@ scilla_error_to_jstring (mk_error0 "Failed to parse input file"))
+        pout @@ scilla_error_to_jstring (mk_error0 "Failed to parse input file")

--- a/tests/util/TestUtil.ml
+++ b/tests/util/TestUtil.ml
@@ -84,10 +84,10 @@ module DiffBasedTests(Input : TestSuiteInput) = struct
         Printf.printf "Updated gold for test %s\n" input_file);
       in
       let libdir = FilePath.make_relative dir (env.stdlib_dir test_ctxt) in
-      let args = if use_stdlib then [input_file;libdir] else [input_file] in
+      let args = if use_stdlib then ["-libdir";libdir;input_file] else [input_file] in
       (if (env.print_cli test_ctxt) then
         if use_stdlib then
-          (Printf.printf "\nUsing CLI: %s %s %s\n" runner input_file libdir)
+          (Printf.printf "\nUsing CLI: %s %s %s %s\n" runner "-libdir" libdir input_file)
         else
           (Printf.printf "\nUsing CLI: %s %s\n" runner input_file));
       let update_gold = env.update_gold test_ctxt in


### PR DESCRIPTION
This change impacts CLI inputs (to all runners except `scilla-runner`) in the following two ways:

1. Previously, the third argument to the various runners was assumed to be the path to stdlib. This is no more true. This path needs to be specified with `-libdir /path/to/stdlib`. 
2. A new command line option "-simple-errors" has been introduced. This is currently a dummy and I'll, in a while, as a separate PR make this function. The intention of this is to print more human readable errors instead of full JSONs (the flag is off by default, so no IDE / etc is impacted).