### PR TITLE
Cleanup error reporting

### DIFF
--- a/easyrun.sh
+++ b/easyrun.sh
@@ -39,6 +39,13 @@ fi
 
 ./bin/scilla-runner -init ${cdir}/init.json -istate ${cdir}/state_${i}.json -imessage ${cdir}/message_${i}.json -o ${cdir}/output_${i}.json -iblockchain ${cdir}/blockchain_${i}.json -i ${cdir}/contract.scilla -libdir src/stdlib -gaslimit 2000
 
-echo "output.json emitted by interpreter:"
-cat ${cdir}/output_${i}.json
-echo ""
+status=$?
+
+if test $status -eq 0
+then
+    echo "output.json emitted by interpreter:"
+    cat ${cdir}/output_${i}.json
+    echo ""
+else
+    echo "scilla-runner failed"
+fi

--- a/src/lang/base/GlobalConfig.ml
+++ b/src/lang/base/GlobalConfig.ml
@@ -98,6 +98,13 @@ let set_pp_lit b =
 
 let get_pp_lit () = !pp_lit
 
+let json_errors = ref false
+
+let set_use_json_errors b =
+  json_errors := b
+
+let use_json_errors () = !json_errors
+
 module StdlibTracker = struct
 
 (* Environment variable: where to look for stdlib.

--- a/src/lang/base/GlobalConfig.mli
+++ b/src/lang/base/GlobalConfig.mli
@@ -41,6 +41,10 @@ val set_trace_file : string -> unit
 val set_pp_lit : bool -> unit
 val get_pp_lit : unit -> bool
 
+(* Should error reporting be in JSON format? *)
+val set_use_json_errors : bool -> unit
+val use_json_errors : unit -> bool
+
 module StdlibTracker : sig
 
   (* Environment variable: where to look for stdlib.

--- a/src/lang/base/PrettyPrinters.ml
+++ b/src/lang/base/PrettyPrinters.ml
@@ -102,8 +102,8 @@ let scilla_error_to_sstring elist =
   in
     (List.fold elist ~init:"" ~f:(fun acc e -> acc ^ "\n" ^ (pp e))) ^ "\n"
 
-let scilla_error_to_string elist pp_json =
-  if pp_json
+let scilla_error_to_string elist  =
+  if GlobalConfig.use_json_errors()
   then scilla_error_to_jstring elist
   else scilla_error_to_sstring elist
 
@@ -113,8 +113,8 @@ let scilla_error_gas_jstring ?(pp = true) gas_remaining elist =
   if pp then Basic.pretty_to_string j
   else Basic.to_string j
 
-let scilla_error_gas_string gas_remaining elist pp_json =
-  if pp_json
+let scilla_error_gas_string gas_remaining elist  =
+  if GlobalConfig.use_json_errors()
   then scilla_error_gas_jstring gas_remaining elist
   else
   (scilla_error_to_sstring elist) ^ (sprintf "Gas remaining: %d\n" gas_remaining)

--- a/src/lang/base/ScillaParser.mly
+++ b/src/lang/base/ScillaParser.mly
@@ -227,6 +227,9 @@ builtin_args :
 ident :
 | i = ID { Ident(i, toLoc $startpos) }
 
+cident :
+| c = CID { Ident(c, toLoc $startpos) }
+
 type_annot:
 | COLON; t = typ { t }
 
@@ -309,7 +312,7 @@ lmodule :
 | l = library; EOF { l }
 
 imports :
-| IMPORT; els = list(CID) { List.map (fun c -> asIdL c (toLoc $startpos)) els }
+| IMPORT; els = list(cident) { els }
 | { [] }
 
 cmodule:

--- a/src/runners/RunnerUtil.ml
+++ b/src/runners/RunnerUtil.ml
@@ -21,40 +21,48 @@
 open Printf
 open Syntax
 open GlobalConfig
+open ErrorUtils
+open PrettyPrinters
 open DebugMessage
 
 (* Parse external libraries "names" (by looking for in StdlibTracker). *)
 let import_libs names =
   List.map (fun id -> 
     let name = get_id id in
+    let sloc = get_rep id in
     let errmsg = (sprintf "%s. " ("Failed to import library " ^ name)) in
     let dir = StdlibTracker.find_lib_dir name in
     let open Core in 
     let f = match dir with
-      | None -> perr (errmsg ^ "Not found.\n") ; exit 1
+      | None -> perr @@ scilla_error_to_string
+         (mk_error1 (errmsg ^ "Not found.\n") sloc); exit 1
       | Some d -> d ^ Filename.dir_sep ^ name ^ ".scilla" in
     try
-      let parse_lib = FrontEndParser.parse_file ScillaParser.lmodule f in
+      let parse_lib = FrontEndParser.parse_file ScillaParser.lmodule f  in
       match parse_lib with
-      | None -> perr (errmsg ^ "Failed to parse.\n"); exit 1
+      | None -> perr @@ scilla_error_to_string
+          (mk_error1 (errmsg ^ "Failed to parse.\n") sloc); exit 1
       | Some lib ->
         plog (sprintf "%s\n" "Successfully imported external library " ^ name);
         lib
-    with | _ -> perr (errmsg ^ "Failed to parse.\n"); exit 1
+    with | _ -> perr @@ scilla_error_to_string 
+          (mk_error1 (errmsg ^ "Failed to parse.\n") sloc); exit 1
     ) names 
 
 let stdlib_not_found_err () =
-  DebugMessage.perr @@ sprintf "\n%s\n"
-  ("A path to Scilla stdlib not found. Please set " ^ StdlibTracker.scilla_stdlib_env ^ 
-    " environment variable, or pass through command-line argument for this script.\n" ^
-    "Example:\n" ^ Sys.argv.(0) ^ " list_sort.scilla -libdir ./src/stdlib/\n");
-   exit 1
+  (perr @@ scilla_error_to_string (mk_error0 
+    ("A path to Scilla stdlib not found. Please set " ^ StdlibTracker.scilla_stdlib_env ^ 
+     " environment variable, or pass through command-line argument for this script.\n" ^
+     "Example:\n" ^ Sys.argv.(0) ^ " list_sort.scilla -libdir ./src/stdlib/\n"));
+   exit 1)
 
 (* Parse all libraries that can be found in ldirs. *)
-let import_all_libs ldirs =
+let import_all_libs ldirs  =
   (* Get list of scilla libraries in dir *)
   let get_lib_list dir =
-    if not (Sys.file_exists dir) then stdlib_not_found_err ();
+    if not (Sys.file_exists dir) then
+      (perr @@ scilla_error_to_string (mk_error0 "Invalid stdlib director provided");
+       exit 1);
     let files = Array.to_list (Sys.readdir dir) in
     List.fold_right (fun file names ->
       if Filename.extension file = ".scilla"
@@ -69,12 +77,11 @@ let import_all_libs ldirs =
     let names' = get_lib_list dir in
       List.append names names') ldirs []
   in
-    import_libs names
+    import_libs names 
 
 type runner_cli = {
   input_file : string;
   stdlib_dirs : string list;
-  json_errors : bool;
 }
 
 let parse_cli () =
@@ -84,12 +91,13 @@ let parse_cli () =
   let r_json_errors = ref false in
   let speclist = [
     ("-libdir", Arg.String (fun x -> r_stdlib_dir := x), "Path to stdlib");
-    ("-jsonerrors", Arg.Unit (fun () -> r_json_errors := true), "Print human readable errors instead of in JSONs");
+    ("-jsonerrors", Arg.Unit (fun () -> r_json_errors := true), "Print errors in JSON format");
   ] in 
   (* Only one input file allowed, so the last anonymous argument will be *it*. *)
   let anon_handler s = r_input_file := s in
   let () = Arg.parse speclist anon_handler ("Usage:\n" ^ usage) in
   if !r_input_file = "" then
     (DebugMessage.perr @@ "Usage:\n" ^ Sys.argv.(0) ^ usage ^ "\n"; exit 1);
+  GlobalConfig.set_use_json_errors !r_json_errors;
   let stdlib_dirs = if !r_stdlib_dir = "" then [] else String.split_on_char ';' !r_stdlib_dir in
-  { input_file = !r_input_file; stdlib_dirs = stdlib_dirs; json_errors = !r_json_errors }
+  { input_file = !r_input_file; stdlib_dirs = stdlib_dirs; }

--- a/src/runners/cli.ml
+++ b/src/runners/cli.ml
@@ -48,6 +48,9 @@ let process_trace () =
 let process_pplit () =
   if !b_pp_lit then GlobalConfig.set_pp_lit true else GlobalConfig.set_pp_lit false
 
+let process_json_errors () =
+  GlobalConfig.set_use_json_errors !b_json_errors
+
 let validate_main () =
   let msg = 
     (* init.json is mandatory *)
@@ -97,7 +100,6 @@ type ioFiles = {
     input : string;
     libdirs : string list;
     gas_limit : int;
-    json_errors : bool;
 }
 
 let parse () =
@@ -119,7 +121,8 @@ let parse () =
   let () = Arg.parse speclist ignore_anon ("Usage:\n" ^ usage) in
   let () = process_trace() in
   let () = process_pplit() in
+  let () = process_json_errors() in
   let () = validate_main () in
     {input_init = !f_input_init; input_state = !f_input_state; input_message = !f_input_message;
      input_blockchain = !f_input_blockchain; output = !f_output; input = !f_input;
-     libdirs = !d_libs; gas_limit = !v_gas_limit; json_errors = !b_json_errors}
+     libdirs = !d_libs; gas_limit = !v_gas_limit;}

--- a/src/runners/cli.mli
+++ b/src/runners/cli.mli
@@ -25,7 +25,6 @@ type ioFiles = {
     input : string;
     libdirs : string list;
     gas_limit : int;
-    json_errors : bool;
 }
 
 val parse : unit -> ioFiles

--- a/src/runners/eval_runner.ml
+++ b/src/runners/eval_runner.ml
@@ -56,7 +56,7 @@ let () =
         (match envres gas_limit with
         | Ok (env', gas_remaining) -> env', gas_remaining
         | Error (err, gas_remaining) ->
-          pout @@ scilla_error_gas_jstring gas_remaining err;
+          pout @@ scilla_error_gas_string gas_remaining err;
           exit 1;) in
       let lib_fnames = List.map (fun (name, _) -> name) env in
       let res' = Eval.exp_eval_wrapper e env in
@@ -64,7 +64,6 @@ let () =
       (match res with
       | Ok _ ->
           printf "%s\n" (Eval.pp_result res lib_fnames)
-      | Error (el, gas_remaining) -> (pout @@ scilla_error_gas_jstring gas_remaining el); exit 1)
-  | Some _ | None ->
-      (pout @@ scilla_error_gas_jstring gas_limit (mk_error0 ("Failed to parse input file." ^ filename));
-      exit 1)
+      | Error (el, gas_remaining) -> (pout @@ scilla_error_gas_string gas_remaining el ); exit 1)
+  | Some _ | None -> (* Error is printed by the parser. *)
+      exit 1

--- a/src/runners/scilla_runner.ml
+++ b/src/runners/scilla_runner.ml
@@ -34,7 +34,7 @@ open MonadUtil.EvalMonad
 (*          Checking initialized libraries          *)
 (****************************************************)
 
-let check_libs clibs elibs name gas_limit pp_json =
+let check_libs clibs elibs name gas_limit =
    let ls = init_libraries clibs elibs in
    (* Are libraries ok? *)
    match ls gas_limit with
@@ -46,16 +46,16 @@ let check_libs clibs elibs name gas_limit pp_json =
          name);
       gas_remaining
    | Error (err, gas_remaining) ->
-      perr @@ scilla_error_gas_string gas_remaining err pp_json;
+      perr @@ scilla_error_gas_string gas_remaining err ;
       exit 1
 
 (****************************************************)
 (*     Checking initialized contract state          *)
 (****************************************************)
-let check_extract_cstate name res gas_limit pp_json = 
+let check_extract_cstate name res gas_limit = 
   match res gas_limit with
   | Error (err, remaining_gas) ->
-      perr @@ scilla_error_gas_string remaining_gas err pp_json;
+      perr @@ scilla_error_gas_string remaining_gas err ;
       exit 1
   | Ok ((_, cstate), remaining_gas) ->
       plog (sprintf "[Initializing %s's fields]\nSuccess!\n"
@@ -66,10 +66,10 @@ let check_extract_cstate name res gas_limit pp_json =
 (*   Running the simularion and printing results     *)
 (*****************************************************)
 
-let check_after_step name res gas_limit pp_json =
+let check_after_step name res gas_limit  =
   match res gas_limit with
   | Error (err, remaining_gas) ->
-      perr @@ scilla_error_gas_string remaining_gas err pp_json;
+      perr @@ scilla_error_gas_string remaining_gas err ;
       exit 1
   | Ok ((cstate, outs, events), remaining_gas) ->
       plog (sprintf "Success! Here's what we got:\n" ^
@@ -130,7 +130,9 @@ let () =
   let parse_module =
     FrontEndParser.parse_file ScillaParser.cmodule cli.input in
   match parse_module with
-  | None -> plog (sprintf "%s\n" "Failed to parse input file.")
+  | None -> 
+    (* Error is printed by the parser. *)
+    plog (sprintf "%s\n" "Failed to parse input file.")
   | Some cmod ->
       plog (sprintf "\n[Parsing]:\nContract module [%s] is successfully parsed.\n" cli.input);
 
@@ -142,7 +144,7 @@ let () =
       let clibs = cmod.libs in
   
       (* Checking initialized libraries! *)
-      let gas_remaining = check_libs clibs elibs cli.input cli.gas_limit cli.json_errors in
+      let gas_remaining = check_libs clibs elibs cli.input cli.gas_limit in
  
       (* Retrieve initial parameters *)
       let initargs = 
@@ -151,8 +153,7 @@ let () =
         with
         | JSON.Invalid_json s -> 
             perr @@ scilla_error_gas_string gas_remaining 
-                (mk_error0 (sprintf "Failed to parse json %s:\n" cli.input_init))
-                 cli.json_errors;
+                (mk_error0 (sprintf "Failed to parse json %s:\n" cli.input_init));
             exit 1
       in
       (* Retrieve block chain state  *)
@@ -162,8 +163,7 @@ let () =
       with
         | JSON.Invalid_json s -> 
             perr @@ scilla_error_gas_string gas_remaining 
-              (mk_error0 (sprintf "Failed to parse json %s:\n" cli.input_blockchain))
-              cli.json_errors;
+              (mk_error0 (sprintf "Failed to parse json %s:\n" cli.input_blockchain));
             exit 1
       in
       let (output_msg_json, output_state_json, output_events_json), gas = 
@@ -173,7 +173,7 @@ let () =
         let init_res = init_module cmod initargs [] Uint128.zero bstate elibs in
         (* Prints stats after the initialization and returns the initial state *)
         (* Will throw an exception if unsuccessful. *)
-        let (_, remaining_gas') = check_extract_cstate cli.input init_res gas_remaining cli.json_errors in
+        let (_, remaining_gas') = check_extract_cstate cli.input init_res gas_remaining in
         (plog (sprintf "\nContract initialized successfully\n");
           (`Null, `List [], `List []), remaining_gas')
       else
@@ -184,8 +184,7 @@ let () =
         with
         | JSON.Invalid_json s ->
             perr @@ scilla_error_gas_string gas_remaining 
-              (mk_error0 (sprintf "Failed to parse json %s:\n" cli.input_message))
-               cli.json_errors;
+              (mk_error0 (sprintf "Failed to parse json %s:\n" cli.input_message));
             exit 1
         in
         let m = Msg mmsg in
@@ -197,8 +196,7 @@ let () =
         with
         | JSON.Invalid_json s ->
             perr @@ scilla_error_gas_string gas_remaining 
-              (mk_error0 (sprintf "Failed to parse json %s:\n" cli.input_state))
-               cli.json_errors;
+              (mk_error0 (sprintf "Failed to parse json %s:\n" cli.input_state));
             exit 1
         in
 
@@ -206,7 +204,7 @@ let () =
         let init_res = init_module cmod initargs curargs cur_bal bstate elibs in
         (* Prints stats after the initialization and returns the initial state *)
         (* Will throw an exception if unsuccessful. *)
-        let cstate, gas_remaining' = check_extract_cstate cli.input init_res gas_remaining cli.json_errors in
+        let cstate, gas_remaining' = check_extract_cstate cli.input init_res gas_remaining in
         (* Contract code *)
         let ctr = cmod.contr in
 
@@ -214,7 +212,7 @@ let () =
         plog (sprintf "In a Blockchain State:\n%s\n" (pp_literal_map bstate));
         let step_result = handle_message ctr cstate bstate m in
         let (cstate', mlist, elist), gas =
-          check_after_step cli.input step_result gas_remaining' cli.json_errors in
+          check_after_step cli.input step_result gas_remaining' in
       
         let osj = output_state_json cstate' in
         let omj = output_message_json mlist in

--- a/src/runners/type_checker.ml
+++ b/src/runners/type_checker.ml
@@ -75,22 +75,20 @@ let () =
     let open GlobalConfig in
     StdlibTracker.add_stdlib_dirs cli.stdlib_dirs;
     set_debug_level Debug_None;
-    let pp_json = cli.json_errors in
     let filename = cli.input_file in
-    match FrontEndParser.parse_file ScillaParser.exps filename with
+    match FrontEndParser.parse_file ScillaParser.exps filename  with
     | Some [e] ->
         (* Get list of stdlib dirs. *)
         let lib_dirs = StdlibTracker.get_stdlib_dirs() in
         if lib_dirs = [] then stdlib_not_found_err ();
         (* Import all libs. *)
-        let std_lib = import_all_libs lib_dirs in
+        let std_lib = import_all_libs lib_dirs  in
         (match check_typing e std_lib with
          | Ok ((_, (e_typ, _)) as typed_erep) ->
              (match check_patterns typed_erep with
               | Ok _ -> printf "%s\n" (pp_typ e_typ.tp)
-              | Error el -> (pout @@ scilla_error_to_string el pp_json; exit 1)
+              | Error el -> (pout @@ scilla_error_to_string el ; exit 1)
              )
-         | Error el -> (pout @@ scilla_error_to_string el pp_json); exit 1)
-    | Some _ | None ->
-        (pout @@ scilla_error_to_string (mk_error0 "Failed to parse input file") pp_json;
-        exit 1)
+         | Error el -> (pout @@ scilla_error_to_string el ); exit 1)
+    | Some _ | None -> (* Error is printed by the parser. *)
+        exit 1

--- a/tests/eval/exp/bad/gold/builtin-overflow4.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow4.scilla.gold
@@ -1,11 +1,13 @@
 {
-  "gas_remaining": 2000,
   "errors": [
     {
-      "error_message":
-        "Failed to parse input file.eval/exp/bad/builtin-overflow4.scilla",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "error_message": "Syntax error: Invalid Int32 literal -2147483649",
+      "start_location": {
+        "file": "eval/exp/bad/builtin-overflow4.scilla",
+        "line": 8,
+        "column": 29
+      },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]
-}Syntax error in file eval/exp/bad/builtin-overflow4.scilla: line 8, position 29.: Invalid Int32 literal -2147483649
+}

--- a/tests/eval/exp/bad/gold/string_error1.scilla.gold
+++ b/tests/eval/exp/bad/gold/string_error1.scilla.gold
@@ -1,11 +1,13 @@
 {
-  "gas_remaining": 2000,
   "errors": [
     {
-      "error_message":
-        "Failed to parse input file.eval/exp/bad/string_error1.scilla",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "error_message": "Syntax error: String is not terminated",
+      "start_location": {
+        "file": "eval/exp/bad/string_error1.scilla",
+        "line": 2,
+        "column": 19
+      },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ]
-}Syntax error in file eval/exp/bad/string_error1.scilla: line 2, position 19.: String is not terminated
+}


### PR DESCRIPTION
1. Make `-jsonerrors` a part of `GlobalConfig` so that we don't need to pass it around everywhere.
2. `FrontEndParser` reports it's own errors, so make it compliant to our standard error format. In addition, when the parser fails, the runners calling it shouldn't re-report parser errors (as they are already printed by `FrontEndParser` itself).
3. `easyrun.sh` now checks for exit status of `scilla-runner`.

With this, all errors printed by any of our runners are in the two possible formats:
1. Default: human readable format `filename:line:column: error: message`
2. When `-jsonerrors` is provided, errors are printed in a JSON format (#214).