### PR TITLE
Add a Makefile target to build only scilla-checker and scilla-runner

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,0 +1,26 @@
+# escape=\
+ARG BASE_IMAGE=ubuntu:16.04
+
+FROM ${BASE_IMAGE}
+
+COPY . /scilla
+
+WORKDIR /scilla
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    build-essential \
+    m4 \
+    ocaml \
+    opam \
+    pkg-config \
+    zlib1g-dev \
+    libgmp-dev \
+    libffi-dev \
+    libssl-dev \
+    libboost-system-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN make opamdep && echo \
+    ". ~/.opam/opam-init/init.sh > /dev/null 2> /dev/null || true " >> ~/.bashrc && \
+    eval `opam config env` && make slim

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,12 @@ all:
 	dune build @install
 	@test -L bin || ln -s _build/install/default/bin .
 
+# Build only scilla-checker and scilla-runner
+blockchain:
+	dune build src/runners/scilla_runner.exe
+	dune build src/runners/scilla_checker.exe
+	@test -L bin || mkdir bin; ln -s _build/default/src/runners/*.exe bin/
+
 # Launch utop such that it finds the libraroes.
 utop: all
 	OCAMLPATH=_build/install/default/lib:$(OCAMLPATH) utop

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ all:
 	@test -L bin || ln -s _build/install/default/bin .
 
 # Build only scilla-checker and scilla-runner
-blockchain:
+slim:
 	dune build src/runners/scilla_runner.exe
 	dune build src/runners/scilla_checker.exe
 	@test -L bin || mkdir bin; ln -s _build/default/src/runners/*.exe bin/


### PR DESCRIPTION
@Gnnng Can you check this and also add a docker target (is that what it's called) to use `make blockchain` instead of the default `make`?