### PR TITLE
Fix ping pong contracts

### DIFF
--- a/tests/contracts/ping/contract.scilla
+++ b/tests/contracts/ping/contract.scilla
@@ -7,10 +7,6 @@ let one_msg =
     let nil_msg = Nil {Message} in
       Cons {Message} msg nil_msg
 
-let game_over = Int32 0
-let calling_pong = Int32 1
-let addr_not_set = Int32 2
-
 (***************************************************)
 (*             The contract definition             *)
 (***************************************************)
@@ -32,20 +28,20 @@ transition Ping ()
     is_game_over = builtin lt cnt one;
     match is_game_over with
     | True =>
-      msg = {_tag : Main; _recipient : _sender; _amount : Uint128 0; code : game_over};
-      msgs = one_msg msg;
-      send msgs
+      msg = {_eventname : "GameOver"};
+      event msg
     | False =>
       deccount = builtin sub cnt one;
       count := deccount;
-      msg = {_tag : Pong; _recipient : pongAddr; _amount : Uint128 0; code : calling_pong};
+      msg = {_tag : Pong; _recipient : pongAddr; _amount : Uint128 0};
       msgs = one_msg msg;
-      send msgs
+      send msgs;
+      e = {_eventname : "CallingPong"};
+      event e
     end
   | None =>
-    msg = {_tag : Main; _recipient : _sender; _amount : Uint128 0; code : addr_not_set};
-    msgs = one_msg msg;
-    send msgs
+    msg = {_eventname : "AddressNotSet"};
+    event msg
   end
 end
 

--- a/tests/contracts/ping/output_0.json
+++ b/tests/contracts/ping/output_0.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7601",
+  "gas_remaining": "7607",
   "_accepted": "false",
   "message": null,
   "states": [

--- a/tests/contracts/ping/output_1.json
+++ b/tests/contracts/ping/output_1.json
@@ -1,12 +1,12 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7579",
+  "gas_remaining": "7567",
   "_accepted": "false",
   "message": {
     "_tag": "Pong",
     "_amount": "0",
     "_recipient": "0x2992d4dfafd282e8a8b3c776eb9fc907d321e21a",
-    "params": [ { "vname": "code", "type": "Int32", "value": "1" } ]
+    "params": []
   },
   "states": [
     { "vname": "_balance", "type": "Uint128", "value": "0" },
@@ -21,5 +21,5 @@
       }
     }
   ],
-  "events": []
+  "events": [ { "_eventname": "CallingPong", "params": [] } ]
 }

--- a/tests/contracts/ping/output_2.json
+++ b/tests/contracts/ping/output_2.json
@@ -1,12 +1,12 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7579",
+  "gas_remaining": "7567",
   "_accepted": "false",
   "message": {
     "_tag": "Pong",
     "_amount": "0",
     "_recipient": "0x2992d4dfafd282e8a8b3c776eb9fc907d321e21a",
-    "params": [ { "vname": "code", "type": "Int32", "value": "1" } ]
+    "params": []
   },
   "states": [
     { "vname": "_balance", "type": "Uint128", "value": "0" },
@@ -21,5 +21,5 @@
       }
     }
   ],
-  "events": []
+  "events": [ { "_eventname": "CallingPong", "params": [] } ]
 }

--- a/tests/contracts/ping/output_3.json
+++ b/tests/contracts/ping/output_3.json
@@ -1,13 +1,8 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7588",
+  "gas_remaining": "7699",
   "_accepted": "false",
-  "message": {
-    "_tag": "Main",
-    "_amount": "0",
-    "_recipient": "0x2992d4dfafd282e8a8b3c776eb9fc907d321e21a",
-    "params": [ { "vname": "code", "type": "Int32", "value": "0" } ]
-  },
+  "message": null,
   "states": [
     { "vname": "_balance", "type": "Uint128", "value": "0" },
     { "vname": "count", "type": "Int32", "value": "0" },
@@ -21,5 +16,5 @@
       }
     }
   ],
-  "events": []
+  "events": [ { "_eventname": "GameOver", "params": [] } ]
 }

--- a/tests/contracts/pong/contract.scilla
+++ b/tests/contracts/pong/contract.scilla
@@ -7,10 +7,6 @@ let one_msg =
     let nil_msg = Nil {Message} in
       Cons {Message} msg nil_msg
 
-let game_over = Int32 0
-let calling_ping = Int32 1
-let addr_not_set = Int32 2
-
 (***************************************************)
 (*             The contract definition             *)
 (***************************************************)
@@ -32,20 +28,20 @@ transition Pong ()
     is_game_over = builtin lt cnt one;
     match is_game_over with
     | True =>
-      msg = {_tag : Main; _recipient : _sender; _amount : Uint128 0; code : game_over};
-      msgs = one_msg msg;
-      send msgs
+      msg = {_eventname : "GameOver"};
+      event msg
     | False =>
       deccount = builtin sub cnt one;
       count := deccount;
-      msg = {_tag : Ping; _recipient : pingAddr; _amount : Uint128 0; code : calling_ping};
+      msg = {_tag : Ping; _recipient : pingAddr; _amount : Uint128 0};
       msgs = one_msg msg;
-      send msgs
+      send msgs;
+      e = {_eventname : "CallingPing"};
+      event e
     end
   | None =>
-    msg = {_tag : Main; _recipient : _sender; _amount : Uint128 0; code : addr_not_set};
-    msgs = one_msg msg;
-    send msgs
+    msg = {_eventname : "AddressNotSet"};
+    event msg
   end
 end
 

--- a/tests/contracts/pong/output_0.json
+++ b/tests/contracts/pong/output_0.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7602",
+  "gas_remaining": "7608",
   "_accepted": "false",
   "message": null,
   "states": [

--- a/tests/contracts/pong/output_1.json
+++ b/tests/contracts/pong/output_1.json
@@ -1,12 +1,12 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7579",
+  "gas_remaining": "7567",
   "_accepted": "false",
   "message": {
     "_tag": "Ping",
     "_amount": "0",
     "_recipient": "0x1992d4dfafd282e8a8b3c776eb9fc907d321e21a",
-    "params": [ { "vname": "code", "type": "Int32", "value": "1" } ]
+    "params": []
   },
   "states": [
     { "vname": "_balance", "type": "Uint128", "value": "0" },
@@ -21,5 +21,5 @@
       }
     }
   ],
-  "events": []
+  "events": [ { "_eventname": "CallingPing", "params": [] } ]
 }

--- a/tests/contracts/pong/output_2.json
+++ b/tests/contracts/pong/output_2.json
@@ -1,12 +1,12 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7579",
+  "gas_remaining": "7567",
   "_accepted": "false",
   "message": {
     "_tag": "Ping",
     "_amount": "0",
     "_recipient": "0x1992d4dfafd282e8a8b3c776eb9fc907d321e21a",
-    "params": [ { "vname": "code", "type": "Int32", "value": "1" } ]
+    "params": []
   },
   "states": [
     { "vname": "_balance", "type": "Uint128", "value": "0" },
@@ -21,5 +21,5 @@
       }
     }
   ],
-  "events": []
+  "events": [ { "_eventname": "CallingPing", "params": [] } ]
 }

--- a/tests/contracts/pong/output_3.json
+++ b/tests/contracts/pong/output_3.json
@@ -1,13 +1,8 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7637",
+  "gas_remaining": "7748",
   "_accepted": "false",
-  "message": {
-    "_tag": "Main",
-    "_amount": "0",
-    "_recipient": "0x1992d4dfafd282e8a8b3c776eb9fc907d321e21a",
-    "params": [ { "vname": "code", "type": "Int32", "value": "2" } ]
-  },
+  "message": null,
   "states": [
     { "vname": "_balance", "type": "Uint128", "value": "0" },
     {
@@ -21,5 +16,5 @@
     },
     { "vname": "count", "type": "Int32", "value": "2" }
   ],
-  "events": []
+  "events": [ { "_eventname": "AddressNotSet", "params": [] } ]
 }


### PR DESCRIPTION
Messages shouldn't contain fields other than target transition
paramters. Convert extra info to events.