### PR TITLE
Use Uint64 instead of native int for tracking gas use

### DIFF
--- a/src/lang/base/MonadUtil.ml
+++ b/src/lang/base/MonadUtil.ml
@@ -19,6 +19,7 @@
 open Core
 open Result.Let_syntax
 open ErrorUtils
+open Stdint
 
 (* [Evaluation in CPS]
 
@@ -149,17 +150,17 @@ module EvalMonad = struct
   *)
   let checkwrap_opR op_thunk cost =
     (fun k remaining_gas ->
-       if (remaining_gas >= cost)
+       if (Uint64.compare remaining_gas cost) >= 0
        then 
          let res = op_thunk () in
-         k res (remaining_gas - cost)
+         k res (Uint64.sub remaining_gas cost)
        else 
          k (Error (mk_error0 "Ran out of gas")) remaining_gas)
 
   let checkwrap_op op_thunk cost emsg =
     (fun k remaining_gas ->
-       if remaining_gas >= cost then
-          op_thunk () k (remaining_gas - cost)
+       if (Uint64.compare remaining_gas cost) >= 0 then
+          op_thunk () k (Uint64.sub remaining_gas cost)
        else
          k (Error emsg) remaining_gas)
 

--- a/src/lang/base/PrettyPrinters.ml
+++ b/src/lang/base/PrettyPrinters.ml
@@ -22,6 +22,7 @@ open Syntax
 open Yojson
 open PrimTypes
 open ErrorUtils
+open Stdint
 
 (****************************************************************)
 (*                    Exception wrappers                        *)
@@ -158,7 +159,7 @@ let scilla_error_gas_jstring ?(pp = true) gas_remaining elist =
   let j' = scilla_error_to_json elist in
   let k' = scilla_warning_to_json (get_warnings ()) in
   let j = `Assoc [
-    ("gas_remaining", `Int gas_remaining);
+    ("gas_remaining", `String (Uint64.to_string gas_remaining));
     ("errors", j');
     ("warnings", k');
   ] in
@@ -171,7 +172,7 @@ let scilla_error_gas_string gas_remaining elist  =
   else
   (scilla_error_to_sstring elist) ^
   (scilla_warning_to_sstring (get_warnings())) ^
-  (sprintf "Gas remaining: %d\n" gas_remaining)
+  (sprintf "Gas remaining: %s\n" (Uint64.to_string gas_remaining))
 
 (*****************************************************)
 (*                Pretty Printers                    *)

--- a/src/lang/base/Syntax.ml
+++ b/src/lang/base/Syntax.ml
@@ -21,6 +21,7 @@ open Core
 open Sexplib.Std
 open MonadUtil
 open ErrorUtils
+open Stdint
 
 exception SyntaxError of string
 
@@ -84,25 +85,25 @@ let address_length = 20
 let hash_length = 32
 
 type int_lit =
-  | Int32L of int32 | Int64L of int64 | Int128L of Stdint.int128 | Int256L of Integer256.int256
+  | Int32L of int32 | Int64L of int64 | Int128L of int128 | Int256L of Integer256.int256
 
 let sexp_of_int_lit i = 
   match i with 
   | Int32L i' -> Sexp.Atom ("Int32 " ^ Int32.to_string i')
   | Int64L i' -> Sexp.Atom ("Int64 " ^ Int64.to_string i')
-  | Int128L i' -> Sexp.Atom ("Int128 " ^ Stdint.Int128.to_string i')
+  | Int128L i' -> Sexp.Atom ("Int128 " ^ Int128.to_string i')
   | Int256L i' -> Sexp.Atom ("Int256 " ^ Integer256.Int256.to_string i')
 
 let int_lit_of_sexp _ = raise (SyntaxError "int_lit_of_sexp not implemented")
 
 type uint_lit =
-  | Uint32L of Stdint.uint32 | Uint64L of Stdint.uint64 | Uint128L of Stdint.uint128 | Uint256L of Integer256.uint256
+  | Uint32L of uint32 | Uint64L of uint64 | Uint128L of uint128 | Uint256L of Integer256.uint256
 
 let sexp_of_uint_lit i = 
   match i with 
-  | Uint32L i' -> Sexp.Atom ("Uint32 " ^ Stdint.Uint32.to_string i')
-  | Uint64L i' -> Sexp.Atom ("Uint64 " ^ Stdint.Uint64.to_string i')
-  | Uint128L i' -> Sexp.Atom ("Uint128 " ^ Stdint.Uint128.to_string i')
+  | Uint32L i' -> Sexp.Atom ("Uint32 " ^ Uint32.to_string i')
+  | Uint64L i' -> Sexp.Atom ("Uint64 " ^ Uint64.to_string i')
+  | Uint128L i' -> Sexp.Atom ("Uint128 " ^ Uint128.to_string i')
   | Uint256L i' -> Sexp.Atom ("Uint256 " ^ Integer256.Uint256.to_string i')
 
 let uint_lit_of_sexp _ = raise (SyntaxError "uint_lit_of_sexp not implemented")
@@ -142,12 +143,12 @@ type literal =
   (* An embedded closure *)
   | Clo of (literal -> 
             (literal, scilla_error list, 
-             int -> ((literal * (string * literal) list) * int, scilla_error list * int) result) 
+             uint64 -> ((literal * (string * literal) list) * uint64, scilla_error list * uint64) result) 
               CPSMonad.t)
   (* A type abstraction *)
   | TAbs of (typ -> 
              (literal, scilla_error list, 
-              int -> ((literal * (string * literal) list) * int, scilla_error list * int) result) 
+              uint64 -> ((literal * (string * literal) list) * uint64, scilla_error list * uint64) result) 
                CPSMonad.t)
 [@@deriving sexp]
 

--- a/src/lang/eval/Eval.ml
+++ b/src/lang/eval/Eval.ml
@@ -85,7 +85,7 @@ let sanitize_literal l =
    type as described in [Specialising the Return Type of Closures].
  *)
 
-let rec exp_eval erep env =
+let rec exp_eval erep env  =
   let (e, _) = erep in
   match e with
   | Literal l ->
@@ -206,7 +206,7 @@ and exp_eval_wrapper expr env =
   let%bind cost = fromR @@ EvalGas.expr_static_cost expr in
   let emsg = sprintf "Ran out of gas.\n" in
   (* Add end location too: https://github.com/Zilliqa/scilla/issues/134 *)
-  checkwrap_op thunk cost (mk_error1 emsg eloc)
+  checkwrap_op thunk (Uint64.of_int cost) (mk_error1 emsg eloc)
 
 (* [Initial Gas-Passing Continuation]
 
@@ -444,7 +444,7 @@ let literal_list_gas llit =
   mapM ~f:(fun (name, lit) ->
       let%bind c = fromR @@ EvalGas.literal_cost lit in
       let dummy () = pure () in (* the literal is already created. *)
-      checkwrap_op dummy c (mk_error0("Ran out of gas initializing " ^ name))
+      checkwrap_op dummy (Uint64.of_int c) (mk_error0("Ran out of gas initializing " ^ name))
     ) llit
 
 (* Initialize a module with given arguments and initial balance *)

--- a/src/lang/eval/EvalUtil.ml
+++ b/src/lang/eval/EvalUtil.ml
@@ -45,14 +45,14 @@ let builtin_executor i arg_tps arg_lits =
     fromR @@ EvalBuiltIns.BuiltInDictionary.find_builtin_op i arg_tps in
   let%bind cost = fromR @@ EvalGas.builtin_cost i arg_lits in
   let res () = op arg_lits ret_typ in
-  checkwrap_opR res cost
+  checkwrap_opR res (Uint64.of_int cost)
 
 (* Add a check that the just evaluated statement was in our gas limit. *)
 let stmt_gas_wrap scon sloc =
   let%bind cost = fromR @@ EvalGas.stmt_cost scon in
   let err = (mk_error1 "Ran out of gas evaluating statement" sloc) in 
   let dummy () = pure () in (* the operation is already executed unfortunately *)
-    checkwrap_op dummy cost err
+    checkwrap_op dummy (Uint64.of_int cost) err
 
 (*****************************************************)
 (* Update-only execution environment for expressions *)

--- a/src/runners/cli.mli
+++ b/src/runners/cli.mli
@@ -24,7 +24,7 @@ type ioFiles = {
     output : string;
     input : string;
     libdirs : string list;
-    gas_limit : int;
+    gas_limit : Stdint.uint64;
     pp_json : bool;
 }
 

--- a/src/runners/eval_runner.ml
+++ b/src/runners/eval_runner.ml
@@ -36,7 +36,7 @@ module TCSRep = TC.OutputSRep
 module TCERep = TC.OutputERep
 
 
-let gas_limit = 2000
+let gas_limit = Stdint.Uint64.of_int 2000
 
 let () =
   let cli = parse_cli() in

--- a/src/runners/scilla_runner.ml
+++ b/src/runners/scilla_runner.ml
@@ -74,7 +74,7 @@ let check_after_step name res gas_limit  =
       plog (sprintf "Success! Here's what we got:\n" ^
             (* sprintf "%s" (ContractState.pp cstate) ^ *)
             sprintf "Emitted messages:\n%s\n\n" (pp_literal_list outs) ^
-            sprintf"Gas remaining:%s\n" (Int.to_string remaining_gas) ^
+            sprintf"Gas remaining:%s\n" (Uint64.to_string remaining_gas) ^
             sprintf "Emitted events:\n%s\n\n" (pp_literal_list events));
        (cstate, outs, events, accepted_b), remaining_gas
 
@@ -135,23 +135,22 @@ let () =
     let open Unix in
     (* Subtract gas based on (contract+init) size / message size. *)
     if is_deployment then
-      let cost = Int64.add (stat cli.input).st_size (stat cli.input_init).st_size in
-      let rem = Int64.sub (Int64.of_int cli.gas_limit) cost in
-      if Int64.compare rem Int64.zero < 0 then
-        (perr @@ scilla_error_gas_jstring 0 @@ 
+      let cost' = Int64.add (stat cli.input).st_size (stat cli.input_init).st_size in
+      let cost = Uint64.of_int64 cost' in
+      if (Uint64.compare cli.gas_limit cost) < 0 then
+        (perr @@ scilla_error_gas_jstring Uint64.zero @@ 
               mk_error0 (sprintf "Ran out of gas when parsing contract/init files.\n");
         exit 1)
       else
-        Int64.to_int rem
+        Uint64.sub cli.gas_limit cost
     else
-      let cost = (stat cli.input_message).st_size in
-      let rem = Int64.sub (Int64.of_int cli.gas_limit) cost in
-      if Int64.compare rem Int64.zero < 0 then
-        (perr @@ scilla_error_gas_jstring 0 @@ 
+      let cost = Uint64.of_int64 (stat cli.input_message).st_size in
+      if (Uint64.compare cli.gas_limit cost) < 0 then
+        (perr @@ scilla_error_gas_jstring Uint64.zero @@ 
               mk_error0 (sprintf "Ran out of gas when parsing message.\n");
         exit 1)
       else
-        Int64.to_int rem
+        Uint64.sub cli.gas_limit cost
   in
   let parse_module =
     FrontEndParser.parse_file ScillaParser.cmodule cli.input in
@@ -186,7 +185,7 @@ let () =
 
       (* Check for version mismatch. Subtract penalty for mist-match. *)
       let emsg = scilla_error_gas_string
-        (gas_remaining - Gas.version_mismatch_penalty)
+        (Uint64.sub gas_remaining (Uint64.of_int Gas.version_mismatch_penalty))
         (mk_error0 ("Scilla version mismatch\n"))
       in
       let init_json_scilla_version = List.fold_left initargs ~init:None ~f:(fun found (name, lit) ->
@@ -271,7 +270,7 @@ let () =
       in
       let output_json = `Assoc [
         ("scilla_major_version", `String (Int.to_string cmod.smver));
-        "gas_remaining", `String (Int.to_string gas);
+        "gas_remaining", `String (Uint64.to_string gas);
         ContractUtil.accepted_label, `String (Bool.to_string accepted_b);
         ("message", output_msg_json); 
         ("states", output_state_json);

--- a/tests/contracts/helloWorld/output_4.json
+++ b/tests/contracts/helloWorld/output_4.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 7847,
+  "gas_remaining": "7847",
   "errors": [
     {
       "error_message": "_balance field missing",

--- a/tests/contracts/helloWorld/output_5.json
+++ b/tests/contracts/helloWorld/output_5.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 7820,
+  "gas_remaining": "7820",
   "errors": [
     {
       "error_message": "Field Unknown : Int32 not defined in the contract\n",

--- a/tests/contracts/helloWorld/output_6.json
+++ b/tests/contracts/helloWorld/output_6.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 7578,
+  "gas_remaining": "7578",
   "errors": [
     {
       "error_message":

--- a/tests/contracts/helloWorld/output_7.json
+++ b/tests/contracts/helloWorld/output_7.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 7700,
+  "gas_remaining": "7700",
   "errors": [
     {
       "error_message": "Field welcome_msg occurs more than once in input.\n",

--- a/tests/contracts/helloWorld/output_8.json
+++ b/tests/contracts/helloWorld/output_8.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 7692,
+  "gas_remaining": "7692",
   "errors": [
     {
       "error_message":

--- a/tests/contracts/helloWorld/output_9.json
+++ b/tests/contracts/helloWorld/output_9.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 7445,
+  "gas_remaining": "7445",
   "errors": [
     {
       "error_message":

--- a/tests/contracts/mappair/output_10.json
+++ b/tests/contracts/mappair/output_10.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 7607,
+  "gas_remaining": "7607",
   "errors": [
     {
       "error_message":

--- a/tests/contracts/mappair/output_11.json
+++ b/tests/contracts/mappair/output_11.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 7454,
+  "gas_remaining": "7454",
   "errors": [
     {
       "error_message":

--- a/tests/contracts/mappair/output_12.json
+++ b/tests/contracts/mappair/output_12.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 7714,
+  "gas_remaining": "7714",
   "errors": [
     {
       "error_message":

--- a/tests/contracts/mappair/output_13.json
+++ b/tests/contracts/mappair/output_13.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 7830,
+  "gas_remaining": "7830",
   "errors": [
     {
       "error_message":

--- a/tests/contracts/mappair/output_14.json
+++ b/tests/contracts/mappair/output_14.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 7771,
+  "gas_remaining": "7771",
   "errors": [
     {
       "error_message":

--- a/tests/contracts/mappair/output_8.json
+++ b/tests/contracts/mappair/output_8.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 7830,
+  "gas_remaining": "7830",
   "errors": [
     {
       "error_message":

--- a/tests/contracts/mappair/output_9.json
+++ b/tests/contracts/mappair/output_9.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 7607,
+  "gas_remaining": "7607",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/app_error1.scilla.gold
+++ b/tests/eval/exp/bad/gold/app_error1.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1749,
+  "gas_remaining": "1749",
   "errors": [
     {
       "error_message": "Not a functional value: (Int32 2).",

--- a/tests/eval/exp/bad/gold/app_error2.scilla.gold
+++ b/tests/eval/exp/bad/gold/app_error2.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1753,
+  "gas_remaining": "1753",
   "errors": [
     {
       "error_message": "Not a functional value: (Int64 1).",

--- a/tests/eval/exp/bad/gold/builtin-divzero.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-divzero.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1736,
+  "gas_remaining": "1736",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-divzero2.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-divzero2.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1736,
+  "gas_remaining": "1736",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-divzero3.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-divzero3.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1676,
+  "gas_remaining": "1676",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-divzero4.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-divzero4.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1676,
+  "gas_remaining": "1676",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow1.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow1.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1745,
+  "gas_remaining": "1745",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow10.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow10.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1740,
+  "gas_remaining": "1740",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow11.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow11.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1740,
+  "gas_remaining": "1740",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow12.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow12.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1740,
+  "gas_remaining": "1740",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow2.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow2.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1732,
+  "gas_remaining": "1732",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow3.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow3.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1732,
+  "gas_remaining": "1732",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow5.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow5.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1736,
+  "gas_remaining": "1736",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow6.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow6.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1736,
+  "gas_remaining": "1736",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow7.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow7.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1752,
+  "gas_remaining": "1752",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow8.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow8.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1752,
+  "gas_remaining": "1752",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow9.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow9.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1752,
+  "gas_remaining": "1752",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-pow.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-pow.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1760,
+  "gas_remaining": "1760",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-pow2.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-pow2.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 960,
+  "gas_remaining": "960",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-remzero.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin-remzero.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1736,
+  "gas_remaining": "1736",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin4.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin4.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1749,
+  "gas_remaining": "1749",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin_error1.scilla.gold
+++ b/tests/eval/exp/bad/gold/builtin_error1.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1746,
+  "gas_remaining": "1746",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/let-error.scilla.gold
+++ b/tests/eval/exp/bad/gold/let-error.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1756,
+  "gas_remaining": "1756",
   "errors": [
     {
       "error_message": "Identifier \"oops\" is not bound in environment:\n",

--- a/tests/eval/exp/bad/gold/msg_error.scilla.gold
+++ b/tests/eval/exp/bad/gold/msg_error.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1754,
+  "gas_remaining": "1754",
   "errors": [
     {
       "error_message": "Cannot serialize literal <closure>",

--- a/tests/eval/exp/bad/gold/msg_error2.scilla.gold
+++ b/tests/eval/exp/bad/gold/msg_error2.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1752,
+  "gas_remaining": "1752",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/msg_error3.scilla.gold
+++ b/tests/eval/exp/bad/gold/msg_error3.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": 1752,
+  "gas_remaining": "1752",
   "errors": [
     {
       "error_message": "Identifier \"o\" is not bound in environment:\n",


### PR DESCRIPTION
While this PR modified gas tracking to use Uint64 globally, the actual cost functions in `Gas.ml` continue to use native `int`s to keep the code simple. The computations can get syntactically ugly if we switch to `Uint64`.

Fixes #308 