### PR TITLE
Remove block keyword since BNum does the same thing

### DIFF
--- a/src/lang/base/ScillaLexer.mll
+++ b/src/lang/base/ScillaLexer.mll
@@ -60,7 +60,6 @@ rule read =
   (* Keywords *)          
   | "forall"      { FORALL }      
   | "builtin"     { BUILTIN }      
-  | "block"       { BLOCK }      
   | "library"     { LIBRARY }
   | "import"      { IMPORT }
   | "let"         { LET }

--- a/src/lang/base/ScillaParser.mly
+++ b/src/lang/base/ScillaParser.mly
@@ -71,7 +71,6 @@
 (* Keywords *)    
 %token BUILTIN
 %token FORALL
-%token BLOCK
 %token EMP
 %token LIBRARY
 %token IMPORT
@@ -183,8 +182,6 @@ simple_exp :
 | l = lit      { (Literal l, toLoc $startpos) } 
                
 lit :        
-| BLOCK;
-  n = NUMLIT   { build_prim_literal_exn PrimTypes.bnum_typ (Big_int.string_of_big_int n) }
 | i = CID;
   n = NUMLIT   {
     let string_of_n = Big_int.string_of_big_int n in


### PR DESCRIPTION
Fixes issue #375.

`block` keyword removed, since using `BNum` achieves the same thing.

No tests were using the `block` keyword, so all tests are still green.