### PR TITLE
MultiVersion should put scilla to /scilla/majorVersion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 # escape=\
 ARG BASE_IMAGE=ubuntu:16.04
-ARG MAJOR_VERSION=0
 
 FROM ${BASE_IMAGE}
 
+ARG MAJOR_VERSION=0
+
 COPY . /scilla/${MAJOR_VERSION}
 
-WORKDIR /scilla
+WORKDIR /scilla/${MAJOR_VERSION}
 
 RUN apt-get update \
     && apt-get install -y software-properties-common \
@@ -26,7 +27,7 @@ RUN apt-get update \
     libboost-system-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN cd /scilla && make opamdep \
+RUN cd /scilla/${MAJOR_VERSION} && make opamdep \
     && echo '. ~/.opam/opam-init/init.sh > /dev/null 2> /dev/null || true ' >> ~/.bashrc \
     && eval `opam config env` && \
     make

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # escape=\
 ARG BASE_IMAGE=ubuntu:16.04
+ARG MAJOR_VERSION=0
 
 FROM ${BASE_IMAGE}
 
-COPY . /scilla
+COPY . /scilla/${MAJOR_VERSION}
 
 WORKDIR /scilla
 

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,9 +1,10 @@
 # escape=\
 ARG BASE_IMAGE=ubuntu:16.04
+ARG MAJOR_VERSION=0
 
 FROM ${BASE_IMAGE}
 
-COPY . /scilla
+COPY . /scilla/${MAJOR_VERSION}
 
 WORKDIR /scilla
 

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,12 +1,13 @@
 # escape=\
 ARG BASE_IMAGE=ubuntu:16.04
-ARG MAJOR_VERSION=0
 
 FROM ${BASE_IMAGE}
 
+ARG MAJOR_VERSION=0
+
 COPY . /scilla/${MAJOR_VERSION}
 
-WORKDIR /scilla
+WORKDIR /scilla/${MAJOR_VERSION}
 
 RUN apt-get update \
     && apt-get install -y software-properties-common \
@@ -26,7 +27,7 @@ RUN apt-get update \
     libboost-system-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN cd /scilla && make opamdep \
+RUN cd /scilla/${MAJOR_VERSION} && make opamdep \
     && echo '. ~/.opam/opam-init/init.sh > /dev/null 2> /dev/null || true ' >> ~/.bashrc \
     && eval `opam config env` && \
     make slim

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,7 @@ clean:
 
 # Build a standalone scilla docker
 docker:
-	MAJOR_VERSION=$$(grep -r scilla_version src/lang/base/Syntax.ml|cut -d ',' -f1|cut -d '(' -f2); \
-	docker build --build-arg MAJOR_VERSION=$${MAJOR_VERSION} .
+	docker build .
 
 # Build a zilliqa-plus-scilla docker based on from zilliqa image ZILLIQA_IMAGE
 zilliqa-docker:
@@ -46,8 +45,7 @@ zilliqa-docker:
 		echo "" && \
 		exit 1; \
 	fi
-	MAJOR_VERSION=$$(grep -r scilla_version src/lang/base/Syntax.ml|cut -d ',' -f1|cut -d '(' -f2); \
-	docker build --build-arg BASE_IMAGE=$(ZILLIQA_IMAGE) --build-arg MAJOR_VERSION=$${MAJOR_VERSION} .
+	docker build --build-arg BASE_IMAGE=$(ZILLIQA_IMAGE) .
 
 opamdep:
 	opam init -y

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ clean:
 
 # Build a standalone scilla docker
 docker:
-	docker build .
+	MAJOR_VERSION=$$(grep -r scilla_version src/lang/base/Syntax.ml|cut -d ',' -f1|cut -d '(' -f2); \
+	docker build --build-arg MAJOR_VERSION=$${MAJOR_VERSION} .
 
 # Build a zilliqa-plus-scilla docker based on from zilliqa image ZILLIQA_IMAGE
 zilliqa-docker:
@@ -45,7 +46,8 @@ zilliqa-docker:
 		echo "" && \
 		exit 1; \
 	fi
-	docker build --build-arg BASE_IMAGE=$(ZILLIQA_IMAGE) .
+	MAJOR_VERSION=$$(grep -r scilla_version src/lang/base/Syntax.ml|cut -d ',' -f1|cut -d '(' -f2); \
+	docker build --build-arg BASE_IMAGE=$(ZILLIQA_IMAGE) --build-arg MAJOR_VERSION=$${MAJOR_VERSION} .
 
 opamdep:
 	opam init -y


### PR DESCRIPTION
Since multi version supporting, the scilla executable files should be put under /scilla/majorVersion/xxx.