### PR TITLE
Messages/Events cannot be stored

### DIFF
--- a/src/lang/base/TypeUtil.ml
+++ b/src/lang/base/TypeUtil.ml
@@ -250,7 +250,13 @@ module TypeUtilities
     | ADT (_, ts) -> List.for_all ~f:(fun t -> is_storable_type t) ts
     | PolyFun _ -> false
     | Unit -> false
-    | _ -> true
+    | PrimType _ ->
+      (* Messages/Events when stored or passed in messages cannot be analyzed,
+       * leading to potential badly constructed Messages/Events. So we disallow. *)
+      if t = PrimTypes.msg_typ || t = PrimTypes.event_typ then
+        false
+      else
+        true
 
   let get_msgevnt_type m =
     if (List.exists ~f:(fun (s, _) -> s = ContractUtil.MessagePayload.tag_label) m)

--- a/src/lang/base/TypeUtil.ml
+++ b/src/lang/base/TypeUtil.ml
@@ -253,10 +253,7 @@ module TypeUtilities
     | PrimType _ ->
       (* Messages/Events when stored or passed in messages cannot be analyzed,
        * leading to potential badly constructed Messages/Events. So we disallow. *)
-      if t = PrimTypes.msg_typ || t = PrimTypes.event_typ then
-        false
-      else
-        true
+      not (t = PrimTypes.msg_typ || t = PrimTypes.event_typ)
 
   let get_msgevnt_type m =
     if (List.exists ~f:(fun (s, _) -> s = ContractUtil.MessagePayload.tag_label) m)

--- a/tests/checker/bad/TestCheckerFail.ml
+++ b/tests/checker/bad/TestCheckerFail.ml
@@ -29,7 +29,9 @@ module Tests = TestUtil.DiffBasedTests(
     let tests = [
       "bad_fields1.scilla";
       "bad_fields2.scilla";
-      "bad_fields2.scilla";
+      "bad_fields3.scilla";
+      "bad_fields4.scilla";
+      "bad_message1.scilla";
       "send_event1.scilla";
       "send_event2.scilla";
       "unbound.scilla";

--- a/tests/checker/bad/bad_fields4.scilla
+++ b/tests/checker/bad/bad_fields4.scilla
@@ -1,0 +1,10 @@
+scilla_version 0
+
+contract Empty
+()
+
+field bad_bar : Message = { _tag : "Main"; _amount : Uint128 0 }
+
+transition dummy()
+
+end

--- a/tests/checker/bad/bad_message1.scilla
+++ b/tests/checker/bad/bad_message1.scilla
@@ -1,0 +1,11 @@
+scilla_version 0
+
+contract Empty
+()
+
+
+transition dummy()
+  m1 = { _tag : "Main"; _amount : Uint128 0; _recipient : _sender };
+  (* Bad: Nested message *)
+  m2 = { _tag : "Main"; _amount : Uint128 0;  _recipient : _sender; subm : m1 }
+end

--- a/tests/checker/bad/gold/bad_fields4.scilla.gold
+++ b/tests/checker/bad/gold/bad_fields4.scilla.gold
@@ -3,7 +3,7 @@
     {
       "error_message": "Type error(s) in contract Empty:\n",
       "start_location": {
-        "file": "checker/bad/bad_fields3.scilla",
+        "file": "checker/bad/bad_fields4.scilla",
         "line": 3,
         "column": 10
       },
@@ -12,15 +12,14 @@
     {
       "error_message": "Type error in field bad_bar:\n",
       "start_location": {
-        "file": "checker/bad/bad_fields3.scilla",
+        "file": "checker/bad/bad_fields4.scilla",
         "line": 6,
         "column": 7
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message":
-        "Values of the type \"List (String -> Int32)\" cannot be stored.",
+      "error_message": "Values of the type \"Message\" cannot be stored.",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/checker/bad/gold/bad_message1.scilla.gold
+++ b/tests/checker/bad/gold/bad_message1.scilla.gold
@@ -3,25 +3,29 @@
     {
       "error_message": "Type error(s) in contract Empty:\n",
       "start_location": {
-        "file": "checker/bad/bad_fields3.scilla",
+        "file": "checker/bad/bad_message1.scilla",
         "line": 3,
         "column": 10
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message": "Type error in field bad_bar:\n",
+      "error_message": "Type error(s) in transition dummy:\n",
       "start_location": {
-        "file": "checker/bad/bad_fields3.scilla",
-        "line": 6,
-        "column": 7
+        "file": "checker/bad/bad_message1.scilla",
+        "line": 7,
+        "column": 12
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
       "error_message":
-        "Values of the type \"List (String -> Int32)\" cannot be stored.",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+        "Type error in the binding to into `m2`:\nCannot send values of type Message.",
+      "start_location": {
+        "file": "checker/bad/bad_message1.scilla",
+        "line": 10,
+        "column": 76
+      },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ],


### PR DESCRIPTION
Add a static check to ensure that Message and Event constructs cannot be stored in the state or passed as parameters in messages/events.

Related to #142 