### PR TITLE
rename scilla.el to scilla-mode.el

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,15 +131,15 @@ that has been used to run the test.
 ## Developer Tools
 ### Emacs mode for Scilla
 
-An emacs major mode for editing Scilla contracts is [provided](./misc/emacs-mode/scilla.el).
-Add the following line to your ~/.emacs file to load this mode for files ending with .scilla.
+An emacs major mode for editing Scilla contracts is [provided](./misc/emacs-mode/scilla-mode.el).
+Add the following line to your `~/.emacs` file to load this mode for files ending with `.scilla`.
 For enabling flycheck mode for Scilla (see [INSTALL.md](./INSTALL.md)).
 
 ```
 ;; For enabling flycheck mode for Scilla.
 (setq scilla-root "/path/to/scilla/root")
 ;; Scilla mode
-(load-file "/path/to/scilla.el")
+(load-file "/path/to/scilla-mode.el")
 ```
 ### Vim plugin for Scilla
 

--- a/misc/emacs-mode/scilla-mode.el
+++ b/misc/emacs-mode/scilla-mode.el
@@ -1,6 +1,12 @@
 ;; This is an Emacs major mode for the Scilla language.
 ;; Include the below line (with path set properly) in ~/.emacs
-;;   (load-file "/path/to/scilla.el")
+;;   (load-file "/path/to/scilla-mode.el")
+;;
+;; or via use-package, e.g.:
+;;
+;; (use-package scilla
+;;   :require flycheck
+;;   :load-path (lambda () (concat scilla-root "/misc/emacs-mode")))
 
 (defvar scilla-mode-map
   (let ((map (make-sparse-keymap)))
@@ -226,7 +232,7 @@
 (add-to-list 'auto-mode-alist '("\\.scilla\\'" . scilla-mode))
 
 ;; Set scilla-root in your ~/.emacs file as "setq scilla-root /path/to/scilla".
-;;  Note: make sure to set scilla-root *before* loading this file (scilla.el)
+;;  Note: make sure to set scilla-root *before* loading this file (scilla-mode.el)
 ;; If scilla-root has been set and flycheck is available, enable flycheck.
 (if (and (boundp 'scilla-root) (require 'flycheck nil t))
     (progn
@@ -255,5 +261,5 @@
       )
   (message "Scilla-FlyCheck: scilla-root not set or flycheck not available.")
   )
-     
- ;;; scilla.el ends here
+
+ ;;; scilla-mode.el ends here

--- a/misc/emacs-mode/scilla-mode.el
+++ b/misc/emacs-mode/scilla-mode.el
@@ -1,5 +1,5 @@
 ;; This is an Emacs major mode for the Scilla language.
-;; Include the below line (with path set properly) in ~/.emacs
+;; Include the below line (with path set properly) in `~/.emacs`
 ;;   (load-file "/path/to/scilla-mode.el")
 ;;
 ;; or via use-package, e.g.:

--- a/misc/emacs-mode/scilla-mode.el
+++ b/misc/emacs-mode/scilla-mode.el
@@ -1,5 +1,5 @@
 ;; This is an Emacs major mode for the Scilla language.
-;; Include the below line (with path set properly) in `~/.emacs`
+;; Include the below line (with path set properly) in ~/.emacs
 ;;   (load-file "/path/to/scilla-mode.el")
 ;;
 ;; or via use-package, e.g.:


### PR DESCRIPTION
In order to enable compatibility with emacs' named features[0] (which is very commonly used, especially by the `use-package` ecosystem), the provided feature needs to match the filename which provides it.  However the `'scilla-mode` symbol is currently provided by `scilla.el`, not `scilla-mode.el`.  This results in an error like:

   Lisp error: (error "Loading file /path/to/scilla/misc/emacs-mode/scilla.el failed to provide feature ‘scilla’")

So rename the file to match the feature symbol.  This allows it to be loaded via

    (use-package scilla
      :require flycheck
      :load-path (lambda () (concat scilla-root "/misc/emacs-mode")))

or similar, and brings it in line with many other major modes, e.g.

    $ find /usr/share/emacs | egrep -c -- '-mode\.el(\.gz)?$'
    56

[0] https://www.gnu.org/software/emacs/manual/html_node/elisp/Named-Features.html