### PR TITLE
Fix reference to non-existent font-lock-variable-face

### DIFF
--- a/misc/emacs-mode/scilla-mode.el
+++ b/misc/emacs-mode/scilla-mode.el
@@ -55,7 +55,7 @@
     ;; Numerical constants. Decimal or Hexadecimal integers.
     ("\\(\\b[0-9]+\\b\\|\\b0x[0-9a-fA-F]+\\b\\)" . font-lock-constant-face)
     ;; Math any other identifier
-    ("[a-zA-Z_]+[a-zA-Z0-9]*" . font-lock-variable-face)
+    ("[a-zA-Z_]+[a-zA-Z0-9]*" . font-lock-variable-name-face)
     ))
 
 ;;; Indentation


### PR DESCRIPTION
This must have been a simple typo; there is no such variable in emacs, and never has been, according to a run of

    git log -G font-lock-variable-face

on the emacs source.  Google returns a few results, but they all appear to be similar typos.  So rename it to `font-lock-variable-name-face` in order to avoid errors like this:

    Debugger entered--Lisp error: (void-variable font-lock-variable-face)
      eval(font-lock-variable-face)
      font-lock-fontify-keywords-region(514 1094 nil)
      font-lock-default-fontify-region(517 1017 nil)
      font-lock-fontify-region(517 1017)
      #f(compiled-function (fun) #<bytecode 0x1d4e705>)(font-lock-fontify-region)
      run-hook-wrapped(#f(compiled-function (fun) #<bytecode 0x1d4e705>) font-lock-fontify-region)
      jit-lock--run-functions(517 1017)
      jit-lock-fontify-now(517 1017)
      jit-lock-stealth-fontify()
      apply(jit-lock-stealth-fontify nil)
      timer-event-handler([t 0 1 0 t jit-lock-stealth-fontify nil idle 0])