### PR TITLE
Check contracts for payment acceptances

### DIFF
--- a/src/lang/checkers/Accept.ml
+++ b/src/lang/checkers/Accept.ml
@@ -1,0 +1,154 @@
+(*
+  This file is part of scilla.
+
+  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+
+  scilla is free software: you can redistribute it and/or modify it under the
+  terms of the GNU General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option) any later
+  version.
+
+  scilla is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along with
+*)
+
+(* Check each transition for code paths which may have more than one
+   accept statement.  We can't be sure of duplicates through static
+   analysis alone, since the code path chosen can depend on run-time
+   state.  Therefore we only warn, rather than error, when there is
+   the *possibility* of duplicates.
+
+   Also check for contracts which have no transitions with accept
+   statements.  There might be valid reasons for writing such contracts,
+   so again we only generate warnings not errors. *)
+
+open TypeUtil
+open ErrorUtils
+open Syntax
+
+module ScillaAcceptChecker
+         (SR : Rep)
+         (ER : sig
+            include Rep
+            val get_type : rep -> PlainTypes.t inferred_type
+          end) = struct
+
+  module EISyntax = ScillaSyntax (SR) (ER)
+
+  open EISyntax
+
+  (* Warning level to use when contract has code paths with potentially
+   * no accept statement. *)
+  let warning_level_missing_accept = 1
+
+  (* Warning level to use when contract has code paths with potentially
+   * multiple accept statements. *)
+  let warning_level_duplicate_accepts = 1
+
+  let find_accept_groups (stmts : stmt_annot list) : loc list list =
+    let rec walk (seen : loc list list) (stmts : stmt_annot list) : loc list list =
+      (* Walk the syntax tree looking for code paths containing one
+         or more accept statements.
+
+         seen is a List with an item for each code path which has
+         already seen at least one accept statement before reaching
+         the point in the syntax tree just before stmts.  Each item
+         in the List is List of all the accepts seen along that path
+         to this point.
+
+         Returns an updated version of the List of Lists which
+         includes any accepts seen in stmts.
+
+         Note that any given code path remains untracked until an
+         accept is discovered in it.  This keeps the seen data
+         nested List to a minimal size. *)
+      List.fold_left
+        (fun (seen2 : loc list list) (stmt : stmt_annot) ->
+          let loc = (stmt_loc stmt) in
+          match fst stmt with
+          | AcceptPayment ->
+             (match seen2 with
+              (* If we didn't see any accept statements before reaching
+               * this point, register this as the first one. *)
+              | [] -> [[loc]]
+              (* Otherwise add this accept statement to the list of accepts
+               * already seen on each code path reaching this point. *)
+              | _ -> List.map (fun accepts -> loc :: accepts) seen2)
+          | MatchStmt (_ident, branches) ->
+             (* For each branch in the match statement we have a
+                  new code path to "multiply" with the code paths
+                  which already reached this point, so walk each
+                  branch and build all the results into a new list.
+              *)
+             List.fold_left
+               (fun seen3 (_pattern, branchstmts) ->
+                 match walk seen2 branchstmts with
+                 | [] -> seen3
+                 | seen4 -> seen3 @ seen4)
+               [] branches
+          | _ -> seen2
+        ) seen stmts
+    in
+    walk [] stmts
+
+  let check_accepts (contr : contract) =
+    let check_transition_accepts (transition : transition) =
+      let transition_accept_groups =
+        List.map List.rev (find_accept_groups transition.tbody)
+      in
+
+      let accept_loc_end (l : loc) =
+        match l with
+        | { fname=fname; lnum=lnum; cnum=cnum } ->
+           { fname=fname; lnum=lnum; cnum= cnum + 6 }
+
+      in
+
+      let dup_accept_warning (group : loc list) : unit =
+        (warn2
+           (Core.sprintf
+              "transition %s had a potential code path with duplicate accept statements:\n"
+              (get_id transition.tname) ^
+              String.concat ""
+                (List.map
+                   (fun loc -> Core.sprintf "  Accept at %s\n" (get_loc_str loc))
+                   group))
+           warning_level_duplicate_accepts
+           (List.hd group)
+           (accept_loc_end @@ BatList.last group))
+      in
+
+      List.iter
+        (fun group ->
+          match group with
+          | _ :: _ :: _ -> dup_accept_warning group
+          | _ -> ())
+        transition_accept_groups;
+
+      transition_accept_groups
+    in
+
+    let all_accept_groups =
+      (List.fold_left
+         (fun acc t -> acc @ check_transition_accepts t)
+         [] contr.ctrans)
+    in
+
+    (match all_accept_groups with
+     | [] ->
+        (warn0
+           (Core.sprintf "Contract %s had no transitions with accept statement\n"
+              (get_id contr.cname))
+           warning_level_missing_accept)
+     | _ -> ())
+
+  (* ************************************** *)
+  (* ******** Interface to Accept ********* *)
+  (* ************************************** *)
+
+  let contr_sanity (cmod : cmodule) = check_accepts cmod.contr
+
+end

--- a/src/runners/scilla_checker.ml
+++ b/src/runners/scilla_checker.ml
@@ -31,6 +31,7 @@ open SanityChecker
 open Recursion
 open EventInfo
 open Cashflow
+open Accept
 
 module ParsedSyntax = ParserUtil.ParsedSyntax
 module PSRep = ParserRep
@@ -51,6 +52,7 @@ module PMCERep = PMC.EPR
 module SC = ScillaSanityChecker (TCSRep) (TCERep)
 module EI = ScillaEventInfo (PMCSRep) (PMCERep)
 module CF = ScillaCashflowChecker (TCSRep) (TCERep)
+module AC = ScillaAcceptChecker (TCSRep) (TCERep)
 
 (* Check that the module parses *)
 let check_parsing ctr  = 
@@ -91,6 +93,8 @@ let check_sanity m rlibs elibs =
   | Error msg -> pout @@ scilla_error_to_string msg ; res
   | Ok _ -> pure ()
 
+let check_accepts m =AC.contr_sanity m
+
 let check_events_info einfo  =
   match einfo with
   | Error msg -> pout @@ scilla_error_to_string msg ; einfo
@@ -128,6 +132,7 @@ let () =
       let%bind (recursion_cmod, recursion_rec_principles, recursion_elibs) = check_recursion cmod elibs in
       let%bind (typed_cmod, tenv, typed_elibs, typed_rlibs) = check_typing recursion_cmod recursion_rec_principles recursion_elibs  in
       let%bind pm_checked_cmod = check_patterns typed_cmod  in
+      let _ = if cli.cf_flag then check_accepts typed_cmod else () in
       let%bind _ = check_sanity typed_cmod typed_rlibs typed_elibs in
       let%bind event_info = check_events_info (EI.event_info pm_checked_cmod)  in
       let cf_info_opt = if cli.cf_flag then Some (check_cashflow typed_cmod) else None in

--- a/tests/checker/bad/gold/bad_version.scilla.gold
+++ b/tests/checker/bad/gold/bad_version.scilla.gold
@@ -7,5 +7,13 @@
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ],
-  "warnings": []
+  "warnings": [
+    {
+      "warning_message":
+        "Contract Empty had no transitions with accept statement\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 1
+    }
+  ]
 }

--- a/tests/checker/bad/gold/mappair2.scilla.gold
+++ b/tests/checker/bad/gold/mappair2.scilla.gold
@@ -97,6 +97,13 @@
       },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
+    },
+    {
+      "warning_message":
+        "Contract Test had no transitions with accept statement\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 1
     }
   ]
 }

--- a/tests/checker/good/TestCheckerSuccess.ml
+++ b/tests/checker/good/TestCheckerSuccess.ml
@@ -31,6 +31,9 @@ module Tests = TestUtil.DiffBasedTests(
       "empty.scilla"; "schnorr.scilla"; "ecdsa.scilla"; "inplace-map.scilla";
       "wallet.scilla"; "adt_test.scilla"; "one-msg.scilla"; "one-msg1.scilla";
       "multiple-msgs.scilla"; "map_key_test.scilla";
+      "one-accept.scilla"; "multiple-accepts.scilla";
+      "one-transition-accepts.scilla"; "one-transition-might-accept.scilla";
+      "missing-accepts.scilla";
     ]
     let exit_code : Unix.process_status = WEXITED 0
   end)

--- a/tests/checker/good/gold/adt_test.scilla.gold
+++ b/tests/checker/good/gold/adt_test.scilla.gold
@@ -8,5 +8,13 @@
     "transitions": [],
     "events": []
   },
-  "warnings": []
+  "warnings": [
+    {
+      "warning_message":
+        "Contract BadLib had no transitions with accept statement\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 1
+    }
+  ]
 }

--- a/tests/checker/good/gold/ecdsa.scilla.gold
+++ b/tests/checker/good/gold/ecdsa.scilla.gold
@@ -16,5 +16,13 @@
     ],
     "events": []
   },
-  "warnings": []
+  "warnings": [
+    {
+      "warning_message":
+        "Contract Ecdsa had no transitions with accept statement\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 1
+    }
+  ]
 }

--- a/tests/checker/good/gold/empty.scilla.gold
+++ b/tests/checker/good/gold/empty.scilla.gold
@@ -8,5 +8,13 @@
     "transitions": [],
     "events": []
   },
-  "warnings": []
+  "warnings": [
+    {
+      "warning_message":
+        "Contract Empty had no transitions with accept statement\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 1
+    }
+  ]
 }

--- a/tests/checker/good/gold/fungible-token.scilla.gold
+++ b/tests/checker/good/gold/fungible-token.scilla.gold
@@ -197,6 +197,13 @@
       },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
+    },
+    {
+      "warning_message":
+        "Contract FungibleToken had no transitions with accept statement\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 1
     }
   ]
 }

--- a/tests/checker/good/gold/inplace-map.scilla.gold
+++ b/tests/checker/good/gold/inplace-map.scilla.gold
@@ -28,5 +28,13 @@
     ],
     "events": []
   },
-  "warnings": []
+  "warnings": [
+    {
+      "warning_message":
+        "Contract Test had no transitions with accept statement\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 1
+    }
+  ]
 }

--- a/tests/checker/good/gold/map_key_test.scilla.gold
+++ b/tests/checker/good/gold/map_key_test.scilla.gold
@@ -11,5 +11,13 @@
     ],
     "events": []
   },
-  "warnings": []
+  "warnings": [
+    {
+      "warning_message":
+        "Contract Test had no transitions with accept statement\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 1
+    }
+  ]
 }

--- a/tests/checker/good/gold/missing-accepts.scilla.gold
+++ b/tests/checker/good/gold/missing-accepts.scilla.gold
@@ -1,0 +1,26 @@
+{
+  "cashflow_tags": [],
+  "contract_info": {
+    "scilla_major_version": "0",
+    "vname": "MissingAccepts",
+    "params": [],
+    "fields": [],
+    "transitions": [
+      { "vname": "foo", "params": [ { "vname": "cond", "type": "Bool" } ] },
+      { "vname": "bar", "params": [ { "vname": "cond", "type": "Bool" } ] }
+    ],
+    "events": [
+      { "vname": "bar", "params": [] },
+      { "vname": "foo", "params": [] }
+    ]
+  },
+  "warnings": [
+    {
+      "warning_message":
+        "Contract MissingAccepts had no transitions with accept statement\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 1
+    }
+  ]
+}

--- a/tests/checker/good/gold/multiple-accepts.scilla.gold
+++ b/tests/checker/good/gold/multiple-accepts.scilla.gold
@@ -21,8 +21,8 @@
         "params": [ { "vname": "switch", "type": "Bool" } ]
       },
       {
-        "vname": "donate_twice_non_obvious",
-        "params": [ { "vname": "switch", "type": "Bool" } ]
+        "vname": "donate_variable",
+        "params": [ { "vname": "times", "type": "Uint32" } ]
       }
     ],
     "events": [ { "vname": "Thanks", "params": [] } ]
@@ -30,82 +30,232 @@
   "warnings": [
     {
       "warning_message":
-        "transition donate_twice_non_obvious had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:58:13\n  Accept at checker/good/multiple-accepts.scilla:63:3\n  Accept at checker/good/multiple-accepts.scilla:70:3\n",
+        "transition donate_variable had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:70:13\n  Accept at checker/good/multiple-accepts.scilla:78:13\n",
       "start_location": {
-        "file": "checker/good/multiple-accepts.scilla",
-        "line": 58,
-        "column": 13
-      },
-      "end_location": {
         "file": "checker/good/multiple-accepts.scilla",
         "line": 70,
-        "column": 9
-      },
-      "warning_id": 1
-    },
-    {
-      "warning_message":
-        "transition donate_twice_non_obvious had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:58:13\n  Accept at checker/good/multiple-accepts.scilla:63:3\n  Accept at checker/good/multiple-accepts.scilla:65:14\n  Accept at checker/good/multiple-accepts.scilla:70:3\n",
-      "start_location": {
-        "file": "checker/good/multiple-accepts.scilla",
-        "line": 58,
         "column": 13
       },
       "end_location": {
         "file": "checker/good/multiple-accepts.scilla",
-        "line": 70,
-        "column": 9
-      },
-      "warning_id": 1
-    },
-    {
-      "warning_message":
-        "transition donate_once_non_obvious had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:43:13\n  Accept at checker/good/multiple-accepts.scilla:49:14\n",
-      "start_location": {
-        "file": "checker/good/multiple-accepts.scilla",
-        "line": 43,
-        "column": 13
-      },
-      "end_location": {
-        "file": "checker/good/multiple-accepts.scilla",
-        "line": 49,
-        "column": 20
-      },
-      "warning_id": 1
-    },
-    {
-      "warning_message":
-        "transition donate_once_or_twice_reversed had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:29:13\n  Accept at checker/good/multiple-accepts.scilla:34:3\n",
-      "start_location": {
-        "file": "checker/good/multiple-accepts.scilla",
-        "line": 29,
-        "column": 13
-      },
-      "end_location": {
-        "file": "checker/good/multiple-accepts.scilla",
-        "line": 34,
-        "column": 9
-      },
-      "warning_id": 1
-    },
-    {
-      "warning_message":
-        "transition donate_once_or_twice had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:18:3\n  Accept at checker/good/multiple-accepts.scilla:20:13\n",
-      "start_location": {
-        "file": "checker/good/multiple-accepts.scilla",
-        "line": 18,
-        "column": 3
-      },
-      "end_location": {
-        "file": "checker/good/multiple-accepts.scilla",
-        "line": 20,
+        "line": 78,
         "column": 19
       },
       "warning_id": 1
     },
     {
       "warning_message":
-        "transition donate_thrice had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:12:3\n  Accept at checker/good/multiple-accepts.scilla:13:3\n  Accept at checker/good/multiple-accepts.scilla:14:3\n",
+        "transition donate_variable had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:70:13\n  Accept at checker/good/multiple-accepts.scilla:86:13\n",
+      "start_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 70,
+        "column": 13
+      },
+      "end_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 86,
+        "column": 19
+      },
+      "warning_id": 1
+    },
+    {
+      "warning_message":
+        "transition donate_variable had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:78:13\n  Accept at checker/good/multiple-accepts.scilla:86:13\n",
+      "start_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 78,
+        "column": 13
+      },
+      "end_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 86,
+        "column": 19
+      },
+      "warning_id": 1
+    },
+    {
+      "warning_message":
+        "transition donate_variable had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:70:13\n  Accept at checker/good/multiple-accepts.scilla:78:13\n  Accept at checker/good/multiple-accepts.scilla:86:13\n",
+      "start_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 70,
+        "column": 13
+      },
+      "end_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 86,
+        "column": 19
+      },
+      "warning_id": 1
+    },
+    {
+      "warning_message":
+        "transition donate_variable had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:70:13\n  Accept at checker/good/multiple-accepts.scilla:94:13\n",
+      "start_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 70,
+        "column": 13
+      },
+      "end_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 94,
+        "column": 19
+      },
+      "warning_id": 1
+    },
+    {
+      "warning_message":
+        "transition donate_variable had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:78:13\n  Accept at checker/good/multiple-accepts.scilla:94:13\n",
+      "start_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 78,
+        "column": 13
+      },
+      "end_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 94,
+        "column": 19
+      },
+      "warning_id": 1
+    },
+    {
+      "warning_message":
+        "transition donate_variable had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:70:13\n  Accept at checker/good/multiple-accepts.scilla:78:13\n  Accept at checker/good/multiple-accepts.scilla:94:13\n",
+      "start_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 70,
+        "column": 13
+      },
+      "end_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 94,
+        "column": 19
+      },
+      "warning_id": 1
+    },
+    {
+      "warning_message":
+        "transition donate_variable had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:86:13\n  Accept at checker/good/multiple-accepts.scilla:94:13\n",
+      "start_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 86,
+        "column": 13
+      },
+      "end_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 94,
+        "column": 19
+      },
+      "warning_id": 1
+    },
+    {
+      "warning_message":
+        "transition donate_variable had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:70:13\n  Accept at checker/good/multiple-accepts.scilla:86:13\n  Accept at checker/good/multiple-accepts.scilla:94:13\n",
+      "start_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 70,
+        "column": 13
+      },
+      "end_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 94,
+        "column": 19
+      },
+      "warning_id": 1
+    },
+    {
+      "warning_message":
+        "transition donate_variable had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:78:13\n  Accept at checker/good/multiple-accepts.scilla:86:13\n  Accept at checker/good/multiple-accepts.scilla:94:13\n",
+      "start_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 78,
+        "column": 13
+      },
+      "end_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 94,
+        "column": 19
+      },
+      "warning_id": 1
+    },
+    {
+      "warning_message":
+        "transition donate_variable had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:70:13\n  Accept at checker/good/multiple-accepts.scilla:78:13\n  Accept at checker/good/multiple-accepts.scilla:86:13\n  Accept at checker/good/multiple-accepts.scilla:94:13\n",
+      "start_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 70,
+        "column": 13
+      },
+      "end_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 94,
+        "column": 19
+      },
+      "warning_id": 1
+    },
+    {
+      "warning_message":
+        "transition donate_once_non_obvious had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:48:13\n  Accept at checker/good/multiple-accepts.scilla:54:14\n",
+      "start_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 48,
+        "column": 13
+      },
+      "end_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 54,
+        "column": 20
+      },
+      "warning_id": 1
+    },
+    {
+      "warning_message":
+        "transition donate_once_or_twice_reversed had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:34:13\n  Accept at checker/good/multiple-accepts.scilla:39:3\n",
+      "start_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 34,
+        "column": 13
+      },
+      "end_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 39,
+        "column": 9
+      },
+      "warning_id": 1
+    },
+    {
+      "warning_message":
+        "transition donate_once_or_twice had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:23:3\n  Accept at checker/good/multiple-accepts.scilla:25:13\n",
+      "start_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 23,
+        "column": 3
+      },
+      "end_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 25,
+        "column": 19
+      },
+      "warning_id": 1
+    },
+    {
+      "warning_message":
+        "transition donate_thrice had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:17:3\n  Accept at checker/good/multiple-accepts.scilla:18:3\n  Accept at checker/good/multiple-accepts.scilla:19:3\n",
+      "start_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 17,
+        "column": 3
+      },
+      "end_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 19,
+        "column": 9
+      },
+      "warning_id": 1
+    },
+    {
+      "warning_message":
+        "transition donate_twice had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:12:3\n  Accept at checker/good/multiple-accepts.scilla:13:3\n",
       "start_location": {
         "file": "checker/good/multiple-accepts.scilla",
         "line": 12,
@@ -113,22 +263,7 @@
       },
       "end_location": {
         "file": "checker/good/multiple-accepts.scilla",
-        "line": 14,
-        "column": 9
-      },
-      "warning_id": 1
-    },
-    {
-      "warning_message":
-        "transition donate_twice had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:7:3\n  Accept at checker/good/multiple-accepts.scilla:8:3\n",
-      "start_location": {
-        "file": "checker/good/multiple-accepts.scilla",
-        "line": 7,
-        "column": 3
-      },
-      "end_location": {
-        "file": "checker/good/multiple-accepts.scilla",
-        "line": 8,
+        "line": 13,
         "column": 9
       },
       "warning_id": 1

--- a/tests/checker/good/gold/multiple-accepts.scilla.gold
+++ b/tests/checker/good/gold/multiple-accepts.scilla.gold
@@ -1,0 +1,137 @@
+{
+  "cashflow_tags": [],
+  "contract_info": {
+    "scilla_major_version": "0",
+    "vname": "MultipleAccepts",
+    "params": [],
+    "fields": [],
+    "transitions": [
+      { "vname": "donate_twice", "params": [] },
+      { "vname": "donate_thrice", "params": [] },
+      {
+        "vname": "donate_once_or_twice",
+        "params": [ { "vname": "twice", "type": "Bool" } ]
+      },
+      {
+        "vname": "donate_once_or_twice_reversed",
+        "params": [ { "vname": "twice", "type": "Bool" } ]
+      },
+      {
+        "vname": "donate_once_non_obvious",
+        "params": [ { "vname": "switch", "type": "Bool" } ]
+      },
+      {
+        "vname": "donate_twice_non_obvious",
+        "params": [ { "vname": "switch", "type": "Bool" } ]
+      }
+    ],
+    "events": [ { "vname": "Thanks", "params": [] } ]
+  },
+  "warnings": [
+    {
+      "warning_message":
+        "transition donate_twice_non_obvious had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:58:13\n  Accept at checker/good/multiple-accepts.scilla:63:3\n  Accept at checker/good/multiple-accepts.scilla:70:3\n",
+      "start_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 58,
+        "column": 13
+      },
+      "end_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 70,
+        "column": 9
+      },
+      "warning_id": 1
+    },
+    {
+      "warning_message":
+        "transition donate_twice_non_obvious had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:58:13\n  Accept at checker/good/multiple-accepts.scilla:63:3\n  Accept at checker/good/multiple-accepts.scilla:65:14\n  Accept at checker/good/multiple-accepts.scilla:70:3\n",
+      "start_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 58,
+        "column": 13
+      },
+      "end_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 70,
+        "column": 9
+      },
+      "warning_id": 1
+    },
+    {
+      "warning_message":
+        "transition donate_once_non_obvious had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:43:13\n  Accept at checker/good/multiple-accepts.scilla:49:14\n",
+      "start_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 43,
+        "column": 13
+      },
+      "end_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 49,
+        "column": 20
+      },
+      "warning_id": 1
+    },
+    {
+      "warning_message":
+        "transition donate_once_or_twice_reversed had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:29:13\n  Accept at checker/good/multiple-accepts.scilla:34:3\n",
+      "start_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 29,
+        "column": 13
+      },
+      "end_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 34,
+        "column": 9
+      },
+      "warning_id": 1
+    },
+    {
+      "warning_message":
+        "transition donate_once_or_twice had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:18:3\n  Accept at checker/good/multiple-accepts.scilla:20:13\n",
+      "start_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 18,
+        "column": 3
+      },
+      "end_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 20,
+        "column": 19
+      },
+      "warning_id": 1
+    },
+    {
+      "warning_message":
+        "transition donate_thrice had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:12:3\n  Accept at checker/good/multiple-accepts.scilla:13:3\n  Accept at checker/good/multiple-accepts.scilla:14:3\n",
+      "start_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 12,
+        "column": 3
+      },
+      "end_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 14,
+        "column": 9
+      },
+      "warning_id": 1
+    },
+    {
+      "warning_message":
+        "transition donate_twice had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:7:3\n  Accept at checker/good/multiple-accepts.scilla:8:3\n",
+      "start_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 7,
+        "column": 3
+      },
+      "end_location": {
+        "file": "checker/good/multiple-accepts.scilla",
+        "line": 8,
+        "column": 9
+      },
+      "warning_id": 1
+    }
+  ]
+}

--- a/tests/checker/good/gold/multiple-msgs.scilla.gold
+++ b/tests/checker/good/gold/multiple-msgs.scilla.gold
@@ -19,6 +19,13 @@
       },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
+    },
+    {
+      "warning_message":
+        "Contract HelloWorld had no transitions with accept statement\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 1
     }
   ]
 }

--- a/tests/checker/good/gold/one-accept.scilla.gold
+++ b/tests/checker/good/gold/one-accept.scilla.gold
@@ -1,0 +1,28 @@
+{
+  "cashflow_tags": [],
+  "contract_info": {
+    "scilla_major_version": "0",
+    "vname": "OneAccept",
+    "params": [],
+    "fields": [],
+    "transitions": [
+      { "vname": "simple_donate1", "params": [] },
+      { "vname": "simple_donate2", "params": [] },
+      { "vname": "simple_donate3", "params": [] },
+      {
+        "vname": "branched_donate1",
+        "params": [ { "vname": "cond", "type": "Bool" } ]
+      },
+      {
+        "vname": "branched_donate2",
+        "params": [ { "vname": "cond", "type": "Bool" } ]
+      }
+    ],
+    "events": [
+      { "vname": "Donation accepted in branch 2", "params": [] },
+      { "vname": "Donation accepted in branch 1", "params": [] },
+      { "vname": "Donation accepted", "params": [] }
+    ]
+  },
+  "warnings": []
+}

--- a/tests/checker/good/gold/one-msg.scilla.gold
+++ b/tests/checker/good/gold/one-msg.scilla.gold
@@ -8,5 +8,13 @@
     "transitions": [ { "vname": "onemsg", "params": [] } ],
     "events": []
   },
-  "warnings": []
+  "warnings": [
+    {
+      "warning_message":
+        "Contract HelloWorld had no transitions with accept statement\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 1
+    }
+  ]
 }

--- a/tests/checker/good/gold/one-msg1.scilla.gold
+++ b/tests/checker/good/gold/one-msg1.scilla.gold
@@ -19,6 +19,13 @@
       },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
+    },
+    {
+      "warning_message":
+        "Contract HelloWorld had no transitions with accept statement\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 1
     }
   ]
 }

--- a/tests/checker/good/gold/one-transition-accepts.scilla.gold
+++ b/tests/checker/good/gold/one-transition-accepts.scilla.gold
@@ -1,0 +1,18 @@
+{
+  "cashflow_tags": [],
+  "contract_info": {
+    "scilla_major_version": "0",
+    "vname": "OneTransitionAccepts",
+    "params": [],
+    "fields": [],
+    "transitions": [
+      {
+        "vname": "donate",
+        "params": [ { "vname": "cond", "type": "Bool" } ]
+      },
+      { "vname": "foo", "params": [ { "vname": "cond", "type": "Bool" } ] }
+    ],
+    "events": [ { "vname": "foo", "params": [] } ]
+  },
+  "warnings": []
+}

--- a/tests/checker/good/gold/one-transition-might-accept.scilla.gold
+++ b/tests/checker/good/gold/one-transition-might-accept.scilla.gold
@@ -1,0 +1,21 @@
+{
+  "cashflow_tags": [],
+  "contract_info": {
+    "scilla_major_version": "0",
+    "vname": "OneTransitionMightAccept",
+    "params": [],
+    "fields": [],
+    "transitions": [
+      {
+        "vname": "maybe_donate1",
+        "params": [ { "vname": "cond", "type": "Bool" } ]
+      },
+      { "vname": "foo", "params": [ { "vname": "cond", "type": "Bool" } ] }
+    ],
+    "events": [
+      { "vname": "foo", "params": [] },
+      { "vname": "Donation rejected", "params": [] }
+    ]
+  },
+  "warnings": []
+}

--- a/tests/checker/good/gold/schnorr.scilla.gold
+++ b/tests/checker/good/gold/schnorr.scilla.gold
@@ -16,5 +16,13 @@
     ],
     "events": []
   },
-  "warnings": []
+  "warnings": [
+    {
+      "warning_message":
+        "Contract Schnorr had no transitions with accept statement\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 1
+    }
+  ]
 }

--- a/tests/checker/good/gold/zil-game.scilla.gold
+++ b/tests/checker/good/gold/zil-game.scilla.gold
@@ -35,5 +35,13 @@
     ],
     "events": [ { "vname": "GameOver", "params": [] } ]
   },
-  "warnings": []
+  "warnings": [
+    {
+      "warning_message":
+        "Contract ZilGame had no transitions with accept statement\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 1
+    }
+  ]
 }

--- a/tests/checker/good/missing-accepts.scilla
+++ b/tests/checker/good/missing-accepts.scilla
@@ -1,0 +1,14 @@
+scilla_version 0
+
+contract MissingAccepts
+()
+
+transition foo(cond : Bool)
+  e = { _eventname : "foo" };
+  event e
+end
+
+transition bar(cond : Bool)
+  e = { _eventname : "bar" };
+  event e
+end

--- a/tests/checker/good/multiple-accepts.scilla
+++ b/tests/checker/good/multiple-accepts.scilla
@@ -1,0 +1,72 @@
+scilla_version 0
+
+contract MultipleAccepts
+()
+
+transition donate_twice()
+  accept;
+  accept
+end
+
+transition donate_thrice()
+  accept;
+  accept;
+  accept
+end
+
+transition donate_once_or_twice(twice : Bool)
+  accept;
+  match twice with
+  | True => accept
+  | False =>
+    e = { _eventname : "Thanks" };
+    event e
+  end
+end
+
+transition donate_once_or_twice_reversed(twice : Bool)
+  match twice with
+  | True => accept
+  | False =>
+    e = { _eventname : "Thanks" };
+    event e
+  end;
+  accept
+end
+
+(* This is guaranteed to only accept once, but static analysis won't let *)
+(* us figure that out in full generality (because the result of the      *)
+(* expression being matched on won't be known until runtime.  So this    *)
+(* needs to trigger a warning, not an error.                             *)
+transition donate_once_non_obvious(switch : Bool)
+  match switch with
+  | True => accept
+  | False =>
+    e = { _eventname : "Thanks" };
+    event e
+  end;
+  match switch with
+  | False => accept
+  | True =>
+    e = { _eventname : "Thanks" };
+    event e
+  end
+end
+
+transition donate_twice_non_obvious(switch : Bool)
+  match switch with
+  | True => accept
+  | False =>
+    e = { _eventname : "Thanks" };
+    event e
+  end;
+  accept;
+  match switch with
+  | False => accept
+  | True =>
+    e = { _eventname : "Thanks" };
+    event e
+  end;
+  accept
+end
+

--- a/tests/checker/good/multiple-accepts.scilla
+++ b/tests/checker/good/multiple-accepts.scilla
@@ -1,5 +1,10 @@
 scilla_version 0
 
+import IntUtils
+
+(* Need this in order for the above import to work *)
+library MultipleAcceptLib
+
 contract MultipleAccepts
 ()
 
@@ -53,20 +58,43 @@ transition donate_once_non_obvious(switch : Bool)
   end
 end
 
-transition donate_twice_non_obvious(switch : Bool)
-  match switch with
+(* Attempt to accept payment a variable number of times, up to a max of 4 *)
+transition donate_variable(times : Uint32)
+  one = Uint32 1;
+  two = Uint32 2;
+  three = Uint32 3;
+  four = Uint32 4;
+
+  sw = uint32_ge times one;
+  match sw with
   | True => accept
   | False =>
     e = { _eventname : "Thanks" };
     event e
   end;
-  accept;
-  match switch with
-  | False => accept
-  | True =>
+
+  sw = uint32_ge times two;
+  match sw with
+  | True => accept
+  | False =>
     e = { _eventname : "Thanks" };
     event e
   end;
-  accept
+
+  sw = uint32_ge times three;
+  match sw with
+  | True => accept
+  | False =>
+    e = { _eventname : "Thanks" };
+    event e
+  end;
+
+  sw = uint32_ge times four;
+  match sw with
+  | True => accept
+  | False =>
+    e = { _eventname : "Thanks" };
+    event e
+  end
 end
 

--- a/tests/checker/good/one-accept.scilla
+++ b/tests/checker/good/one-accept.scilla
@@ -1,0 +1,41 @@
+scilla_version 0
+
+contract OneAccept
+()
+
+transition simple_donate1()
+  accept
+end
+
+transition simple_donate2()
+  e = { _eventname : "Donation accepted" };
+  event e;
+  accept
+end
+
+transition simple_donate3()
+  accept;
+  e = { _eventname : "Donation accepted" };
+  event e
+end
+
+transition branched_donate1 (cond : Bool)
+  match cond with
+  | True => accept
+  | False => accept
+  end
+end
+
+transition branched_donate2 (cond : Bool)
+  match cond with
+  | True =>
+    e = { _eventname : "Donation accepted in branch 1" };
+    event e;
+    accept
+  | False =>
+    e = { _eventname : "Donation accepted in branch 2" };
+    event e;
+    accept
+  end
+end
+

--- a/tests/checker/good/one-transition-accepts.scilla
+++ b/tests/checker/good/one-transition-accepts.scilla
@@ -1,0 +1,13 @@
+scilla_version 0
+
+contract OneTransitionAccepts
+()
+
+transition donate(cond : Bool)
+  accept
+end
+
+transition foo(cond : Bool)
+  e = { _eventname : "foo" };
+  event e
+end

--- a/tests/checker/good/one-transition-might-accept.scilla
+++ b/tests/checker/good/one-transition-might-accept.scilla
@@ -1,0 +1,18 @@
+scilla_version 0
+
+contract OneTransitionMightAccept
+()
+
+transition maybe_donate1(cond : Bool)
+  match cond with
+  | True => accept
+  | False =>
+    e = { _eventname : "Donation rejected" };
+    event e
+  end
+end
+
+transition foo(cond : Bool)
+  e = { _eventname : "foo" };
+  event e
+end


### PR DESCRIPTION
If a contract has no transitions which accept payment, raise a warning.  **Unfortunately this introduces a lot of new warnings for existing test cases, therefore most likely the usefulness of this feature, or at least its UI, will need to be reconsidered.  Guidance from Zilliqa is needed on this point.**

Also if a transition has any code path with potentially multiple `accept` statements in it, raise a warning.  We do not raise an error since it is not possible via static analysis to know for sure in all cases whether multiple `accept` statements would be reached if present, since this can be dependent on conditions which are only known at run-time.  As a silly example, this transition may or may not attempt to accept twice:

    transition donate_once_or_twice(twice : Bool)
      accept;
      match twice with
      | True => accept
      | False =>
        e = { _eventname : "Thanks" };
        event e
      end
    end

In contrast, this transition is guaranteed to accept only once:

    transition donate_once(switch : Bool)
      match switch with
      | True => accept
      | False =>
        e = { _eventname : "Thanks" };
        event e
      end;
      match switch with
      | False => accept
      | True =>
        e = { _eventname : "Thanks" };
        event e
      end
    end

however it would be very difficult to implement analysis which catches cases like this.