### PR TITLE
Update Makefile rule for opam 2.0.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ zilliqa-docker:
 
 opamdep:
 	opam init -y
+	opam switch create 4.06.1
 	opam switch -y 4.06.1
 	opam install -y ocaml-migrate-parsetree core cryptokit ppx_sexp_conv yojson batteries angstrom hex ppx_deriving ppx_deriving_yojson menhir oUnit dune stdint fileutils ctypes ctypes-foreign bisect_ppx secp256k1
 


### PR DESCRIPTION
The rule seemed to work for opam 1.2 but with the newer version of opam, it complains:
```bash
$ opam switch -y 4.06.1
[ERROR] No switch 4.06.1 is currently installed. Did you mean 'opam switch
        create 4.06.1'?
        Installed switches are:
          - default
```
Note this was on Ubuntu 18.04 with the avsm ppa.