### PR TITLE
Allow multiple libdirs in tests

### DIFF
--- a/tests/checker/bad/TestCheckerFail.ml
+++ b/tests/checker/bad/TestCheckerFail.ml
@@ -25,7 +25,7 @@ module Tests = TestUtil.DiffBasedTests(
     let test_path f = ["checker"; "bad"; f]
     let runner = "scilla-checker"
     let custom_args = ["-cf"]
-    let lib_override = None
+    let additional_libdirs = []
     let tests = [
       "bad_fields1.scilla";
       "bad_fields2.scilla";
@@ -68,7 +68,7 @@ module LibTests = TestUtil.DiffBasedTests(
     let test_path f = ["checker"; "bad"; f]
     let runner = "scilla-checker"
     let custom_args = ["-cf"]
-    let lib_override = Some ["checker"; "bad"; "lib"]
+    let additional_libdirs = [["checker"; "bad"; "lib"]]
     let tests = [
       "bad_adt_lib_1.scilla";
       "bad_adt_lib_2.scilla";

--- a/tests/checker/good/TestCheckerSuccess.ml
+++ b/tests/checker/good/TestCheckerSuccess.ml
@@ -25,7 +25,7 @@ module Tests = TestUtil.DiffBasedTests(
     let test_path f = ["checker"; "good"; f]
     let runner = "scilla-checker"
     let custom_args = ["-cf"]
-    let lib_override = None
+    let additional_libdirs = []
     let tests = [
       "crowdfunding.scilla"; "zil-game.scilla"; "fungible-token.scilla"; "auction.scilla";
       "empty.scilla"; "schnorr.scilla"; "ecdsa.scilla"; "inplace-map.scilla";

--- a/tests/eval/exp/bad/TestExpsFail.ml
+++ b/tests/eval/exp/bad/TestExpsFail.ml
@@ -55,7 +55,7 @@ module Tests = TestUtil.DiffBasedTests(
     let test_path f = ["eval"; "exp"; "bad"; f]
     let runner = "eval-runner"
     let custom_args = []
-    let lib_override = None
+    let additional_libdirs = []
     let tests = explist
     let exit_code : Unix.process_status = WEXITED 1
 

--- a/tests/eval/exp/good/TestExps.ml
+++ b/tests/eval/exp/good/TestExps.ml
@@ -122,7 +122,7 @@ module Tests = TestUtil.DiffBasedTests(
     let test_path f = ["eval"; "exp"; "good"; f]
     let runner = "eval-runner"
     let custom_args = []
-    let lib_override = None
+    let additional_libdirs = []
     let tests = explist
     let exit_code : Unix.process_status = WEXITED 0
 

--- a/tests/pm_check/bad/TestPMFail.ml
+++ b/tests/pm_check/bad/TestPMFail.ml
@@ -25,7 +25,7 @@ module Tests = TestUtil.DiffBasedTests(
     let test_path f = ["pm_check"; "bad"; f]
     let runner = "type-checker"      
     let custom_args = []
-    let lib_override = None
+    let additional_libdirs = []
     let tests = [
       "pm1.scilla";
       "pm2.scilla";

--- a/tests/typecheck/bad/TestTypeFail.ml
+++ b/tests/typecheck/bad/TestTypeFail.ml
@@ -139,7 +139,7 @@ module Tests = TestUtil.DiffBasedTests(
     let test_path f = ["typecheck"; "bad"; f]
     let runner = "type-checker"      
     let custom_args = []
-    let lib_override = None
+    let additional_libdirs = []
     let tests = [
       "adt-error1.scilla";
       "branch-mismatch.scilla";

--- a/tests/typecheck/good/Testtypes.ml
+++ b/tests/typecheck/good/Testtypes.ml
@@ -63,7 +63,7 @@ module Tests = TestUtil.DiffBasedTests(
     let test_path f = ["typecheck"; "good"; f]
     let runner = "type-checker"
     let custom_args = []
-    let lib_override = None
+    let additional_libdirs = []
     let tests = [
       "branch-match.scilla";
       "builtin-strings.scilla";


### PR DESCRIPTION
Fixes #394.

Each instantiation of the TestUtil.DiffBasedTests functor can now specify a list of directories of additional external libraries.

TestUtil concatenates all external libraries (including the standard library), and supplies them to the command-line test runner.