### PR TITLE
remove dependence on ppx_deriving_yojson

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
 - sudo mv opam-2.0.0-x86_64-linux /usr/local/bin/opam
 - sudo chmod a+x /usr/local/bin/opam
 - opam init --disable-sandboxing -y --compiler=4.06.1
-- opam install -y ocaml-migrate-parsetree core cryptokit ppx_sexp_conv yojson batteries angstrom hex ppx_deriving ppx_deriving_yojson menhir oUnit dune stdint fileutils ctypes ctypes-foreign bisect_ppx secp256k1
+- opam install -y ocaml-migrate-parsetree core cryptokit ppx_sexp_conv yojson batteries angstrom hex ppx_deriving menhir oUnit dune stdint fileutils ctypes ctypes-foreign bisect_ppx secp256k1
 - eval `opam config env`
 - rm $HOME/.opam/log/*
 script:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -52,7 +52,7 @@ opam packages using the commands listed below:
 
 ```
 opam init --disable-sandboxing -y --compiler=4.06.1
-opam install ocaml-migrate-parsetree core cryptokit ppx_sexp_conv yojson batteries angstrom hex ppx_deriving ppx_deriving_yojson menhir oUnit dune stdint fileutils ctypes ctypes-foreign bisect_ppx secp256k1
+opam install ocaml-migrate-parsetree core cryptokit ppx_sexp_conv yojson batteries angstrom hex ppx_deriving menhir oUnit dune stdint fileutils ctypes ctypes-foreign bisect_ppx secp256k1
 ```
 
 The above three commands can, alternatively, be run using the make target `opamdep`
@@ -91,7 +91,7 @@ brew tap iantanwx/crypto
 ```
 brew install ocaml opam pkg-config libffi openssl@1.1 boost secp256k1
 opam init --disable-sandboxing -y --compiler=4.06.1
-opam install ocaml-migrate-parsetree core cryptokit ppx_sexp_conv yojson batteries angstrom hex ppx_deriving ppx_deriving_yojson menhir oUnit dune stdint fileutils ctypes ctypes-foreign bisect_ppx secp256k1
+opam install ocaml-migrate-parsetree core cryptokit ppx_sexp_conv yojson batteries angstrom hex ppx_deriving menhir oUnit dune stdint fileutils ctypes ctypes-foreign bisect_ppx secp256k1
 
 ```
 Then run the following command to setup environment on current shell. 

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ zilliqa-docker:
 
 opamdep:
 	opam init --disable-sandboxing -y --compiler=4.06.1
-	opam install -y ocaml-migrate-parsetree core cryptokit ppx_sexp_conv yojson batteries angstrom hex ppx_deriving ppx_deriving_yojson menhir oUnit dune stdint fileutils ctypes ctypes-foreign bisect_ppx secp256k1
+	opam install -y ocaml-migrate-parsetree core cryptokit ppx_sexp_conv yojson batteries angstrom hex ppx_deriving menhir oUnit dune stdint fileutils ctypes ctypes-foreign bisect_ppx secp256k1
 
 
 .PHONY : coverage

--- a/src/lang/base/dune
+++ b/src/lang/base/dune
@@ -11,12 +11,11 @@
   (libraries core ppx_sexp_conv
               num hex stdint batteries
               ppx_deriving.show
-              ppx_deriving_yojson.runtime
               cryptokit secp256k1
               yojson scilla-cpp-deps)
   (preprocess (pps ppx_sexp_conv
                     ppx_let 
                     ppx_deriving.show
                     bisect_ppx -exclude-file=../../bisect.exclude -conditional
-                    ppx_deriving_yojson))
+                    ))
   (synopsis "Scilla workbench implementation."))


### PR DESCRIPTION
On my system, I had an issue with compability b/w yojson and this package that I'm removing. Turns out this one wasn't required, so I'm removing it.

Reviewers, please test this locally. 