### PR TITLE
Fix parsing of type of Map value

### DIFF
--- a/src/lang/base/ScillaParser.mly
+++ b/src/lang/base/ScillaParser.mly
@@ -127,13 +127,18 @@ t_map_key :
 | LPAREN; kt = CID; RPAREN; { to_map_key_type kt }
 
 (* TODO: This is a temporary fix of issue #261 *)
+t_map_value_args:
+| LPAREN; t = t_map_value_args; RPAREN; { t }
+| d = CID; { to_type d }
+| MAP; k=t_map_key; v = t_map_value; { MapType (k, v) }
+
 t_map_value :
-| LPAREN; d = CID; targs=list(t_map_value); RPAREN;
+| LPAREN; d = CID; targs=list(t_map_value_args); RPAREN;
     { match targs with
       | [] -> to_type d                       
       | _ -> ADT (d, targs) }
-| LPAREN; MAP; k=t_map_key; v = t_map_value; RPAREN; { MapType (k, v) }
-| d = CID; targs=list(t_map_value)
+| LPAREN; MAP; k=t_map_key; v = t_map_value_args; RPAREN; { MapType (k, v) }
+| d = CID; targs=list(t_map_value_args)
     { match targs with
       | [] -> to_type d                       
       | _ -> ADT (d, targs) }

--- a/tests/typecheck/good/Testtypes.ml
+++ b/tests/typecheck/good/Testtypes.ml
@@ -77,6 +77,7 @@ module Tests = TestUtil.DiffBasedTests(
       "pm2.scilla";
       "pm3.scilla";
       "pm4.scilla";
+      "pair.scilla";
       "subst.scilla";
       "nat_to_int.scilla";
       "to_int.scilla";

--- a/tests/typecheck/good/gold/pair.scilla.gold
+++ b/tests/typecheck/good/gold/pair.scilla.gold
@@ -1,0 +1,1 @@
+Map (Int32) (Pair (BNum) (Uint128)) -> Uint128

--- a/tests/typecheck/good/pair.scilla
+++ b/tests/typecheck/good/pair.scilla
@@ -1,0 +1,6 @@
+
+let f =
+  fun (a : Map Int32 (Pair BNum Uint128)) =>
+    Uint128 0
+in
+f


### PR DESCRIPTION
The type expression `Map Int32 (Pair BNum Uint128)` does not get parsed by our parser while `(Pair BNum Uint128)` does get parsed. This is because of the difference b/w how types for `Map` values are parsed and how all other types are parsed. Fix this.

