### PR TITLE
Add test case to show absence of location info for ADTs

### DIFF
--- a/tests/checker/bad/TestCheckerFail.ml
+++ b/tests/checker/bad/TestCheckerFail.ml
@@ -59,6 +59,7 @@ module Tests = TestUtil.DiffBasedTests(
       "bad_adt_2.scilla";
       "bad_adt_3.scilla";
       "bad_adt_4.scilla";
+      "bad_adt_7.scilla";
       "unserializable_param.scilla";
       "unstorable_adt.scilla";
       "bad_version.scilla";

--- a/tests/checker/bad/bad_adt_7.scilla
+++ b/tests/checker/bad/bad_adt_7.scilla
@@ -1,0 +1,11 @@
+scilla_version 0
+
+library Test
+
+let bn = BNum 100
+let i32 = Int32 10
+
+contract Test ()
+
+field badpair : Pair (BNum Int32) = bn i32
+

--- a/tests/checker/bad/gold/bad_adt_7.scilla.gold
+++ b/tests/checker/bad/gold/bad_adt_7.scilla.gold
@@ -1,0 +1,19 @@
+{
+  "errors": [
+    {
+      "error_message": "Type error(s) in contract Test:\n",
+      "start_location": {
+        "file": "checker/bad/bad_adt_7.scilla",
+        "line": 8,
+        "column": 10
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "ADT BNum not found",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": []
+}


### PR DESCRIPTION
This is only a test case for #456 and does *not* resolve it.

It looks like the absence of location info is only when the type error is in a field declaration. Otherwise we approximate the location with the location of the expression itself.