### PR TITLE
build: use pkg-config from dune

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -77,7 +77,10 @@ eval `opam config env`
 
 Scilla requires OpenSSL 1.0.2 and if your platform does not have packages for this, you may need to build OpenSSL
 yourself and set `PKG_CONFIG_PATH` environment variable accordingly
-(if you install OpenSSL in a non-default path).
+(if you install OpenSSL in a non-default path):
+```shell
+export PKG_CONFIG_PATH="_OpenSSL_prefix_/lib/pkgconfig:$PKG_CONFIG_PATH"
+```
 
 ### macOS
 
@@ -101,7 +104,7 @@ into `/usr/local` directory, so in case of a non-default version of the package,
 you will need to set up `PKG_CONFIG_PATH` environment variable as Homebrew suggests.
 It should look like
 ```shell
-export PKG_CONFIG_PATH="/usr/local/opt/openssl@_VERSION_/lib/pkgconfig:$PKG_CONFIG_PATH""
+export PKG_CONFIG_PATH="/usr/local/opt/openssl@_Version_/lib/pkgconfig:$PKG_CONFIG_PATH""
 ```
 
 ## Using Ocaml with Emacs

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -76,20 +76,15 @@ eval `opam config env`
 ```
 
 Scilla requires OpenSSL 1.0.2 and if your platform does not have packages for this, you may need to build OpenSSL
-yourself and set $CPLUS_INCLUDE_PATH, $C_INCLUDE_PATH, $LIBRARY_PATH and $LD_LIBRARY_PATH accordingly
+yourself and set `PKG_CONFIG_PATH` environment variable accordingly
 (if you install OpenSSL in a non-default path).
 
 ### macOS
 
 The dependencies can be installed via [Homebrew](https://brew.sh/):
 
-Note: pending PR at https://github.com/DomT4/homebrew-crypto/pull/95/commits/9c62017362aa973afad75616046d14006f31be6a
 ```shell
-brew tap iantanwx/crypto
-```
-
-```shell
-brew install ocaml opam pkg-config libffi openssl@1.1 boost secp256k1
+brew install ocaml opam pkg-config libffi openssl boost secp256k1
 opam init --disable-sandboxing -y --compiler=4.06.1
 opam install ocaml-migrate-parsetree core cryptokit ppx_sexp_conv yojson batteries angstrom hex ppx_deriving menhir oUnit dune stdint fileutils ctypes ctypes-foreign bisect_ppx secp256k1
 ```
@@ -99,14 +94,14 @@ Then run the following command to setup environment on current shell.
 eval `opam config env`
 ```
 
-Homebrew's `openssl` package is keg-only, which means it doesn't get symlinked into `/usr/local` directory,
-so (as mentioned above) you need to setup `LIBRARY_PATH` environment variable as follows
+Normally, by this moment everything should be set up as the [Dune](https://dune.build) build system
+takes care of environment variables for `pkg-config` utility.
+However Homebrew's `openssl` package is keg-only, which means it doesn't get symlinked
+into `/usr/local` directory, so in case of a non-default version of the package,
+you will need to set up `PKG_CONFIG_PATH` environment variable as Homebrew suggests.
+It should look like
 ```shell
-export LIBRARY_PATH=/usr/local/opt/openssl@1.1/lib:$LIBRARY_PATH
-```
-or invoke `make` command like so:
-```shell
-LIBRARY_PATH=/usr/local/opt/openssl@1.1/lib make
+export PKG_CONFIG_PATH="/usr/local/opt/openssl@_VERSION_/lib/pkgconfig:$PKG_CONFIG_PATH""
 ```
 
 ## Using Ocaml with Emacs

--- a/src/cpp/config/discover.ml
+++ b/src/cpp/config/discover.ml
@@ -1,0 +1,21 @@
+module C = Configurator.V1
+
+let () =
+  C.main ~name:"foo" (fun c ->
+  let default : C.Pkg_config.package_conf =
+    { libs   = []
+    ; cflags = []
+    }
+  in
+  let conf =
+    match C.Pkg_config.get c with
+    | None -> default
+    | Some pc ->
+        match (C.Pkg_config.query pc ~package:"openssl") with
+        | None -> default
+        | Some deps -> deps
+  in
+
+
+  C.Flags.write_sexp "c_flags.sexp"         conf.cflags;
+  C.Flags.write_sexp "c_library_flags.sexp" conf.libs)

--- a/src/cpp/config/dune
+++ b/src/cpp/config/dune
@@ -1,0 +1,3 @@
+(executable
+ (name discover)
+ (libraries base stdio dune.configurator))

--- a/src/cpp/dune
+++ b/src/cpp/dune
@@ -5,7 +5,13 @@
   (libraries ctypes ctypes.foreign cryptokit)
   (c_names generate_dsa_nonce)
   (cxx_names c_schnorr DataConversion Schnorr PrivKey PubKey Signature BIGNUMSerialize ECPOINTSerialize)
-  (c_flags -I/usr/local/opt/openssl/include)
-  (cxx_flags -std=c++11 -I/usr/local/opt/openssl/include)
-  (flags (-cclib -lstdc++ -cclib -lcrypto))
+  (c_flags (:include c_flags.sexp))
+  (cxx_flags -std=c++11 (:include c_flags.sexp))
+  ;;; -lstdc++ is not portable, it can be e.g. -lc++
+  (c_library_flags -lstdc++ (:include c_library_flags.sexp))
   )
+
+(rule
+ (targets c_flags.sexp c_library_flags.sexp)
+ (deps    (:discover config/discover.exe))
+ (action  (run %{discover})))

--- a/src/runners/dune
+++ b/src/runners/dune
@@ -11,7 +11,5 @@
               ppx_sexp_conv ppx_deriving
               ppx_let yojson cryptokit
               scilla-base scilla-eval scilla-checkers scilla-cpp-deps)
-  (flags (-cclib -lstdc++ -cclib -lcrypto))
-
   (preprocess (pps ppx_sexp_conv ppx_let ppx_deriving.show bisect_ppx -conditional))
   (package scilla-runner))

--- a/src/runners/eval_runner.ml
+++ b/src/runners/eval_runner.ml
@@ -17,9 +17,7 @@
 *)
 
 
-open Printf
 open Syntax
-open ErrorUtils
 open ParserUtil
 open RunnerUtil
 open GlobalConfig

--- a/src/runners/scilla_checker.ml
+++ b/src/runners/scilla_checker.ml
@@ -139,7 +139,7 @@ let () =
       pure @@ (cmod, tenv, event_info, cf_info_opt)
     ) in
     match r with
-    | Error el -> exit 1 (* we've already printed the error(s). *)
+    | Error _ -> exit 1 (* we've already printed the error(s). *)
     | Ok (cmod, _, event_info, cf_info_opt) ->
         let base_output =
           let warnings_output =

--- a/src/runners/scilla_runner.ml
+++ b/src/runners/scilla_runner.ml
@@ -64,7 +64,7 @@ let check_extract_cstate name res gas_limit =
 (*   Running the simularion and printing results     *)
 (*****************************************************)
 
-let check_after_step _name res gas_limit  =
+let check_after_step res gas_limit  =
   match res Eval.init_gas_kont gas_limit with
   | Error (err, remaining_gas) ->
       perr @@ scilla_error_gas_string remaining_gas err ;
@@ -259,7 +259,7 @@ let () =
         plog (sprintf "In a Blockchain State:\n%s\n" (pp_literal_map bstate));
         let step_result = handle_message ctr cstate bstate m in
         let (cstate', mlist, elist, accepted_b), gas =
-          check_after_step cli.input step_result gas_remaining' in
+          check_after_step step_result gas_remaining' in
       
         let osj = output_state_json cstate' in
         let omj = output_message_json gas mlist in

--- a/src/runners/scilla_runner.ml
+++ b/src/runners/scilla_runner.ml
@@ -20,7 +20,6 @@
 open Syntax
 open Core
 open ErrorUtils
-open EvalUtil
 open Eval
 open DebugMessage
 open ContractUtil
@@ -65,7 +64,7 @@ let check_extract_cstate name res gas_limit =
 (*   Running the simularion and printing results     *)
 (*****************************************************)
 
-let check_after_step name res gas_limit  =
+let check_after_step _name res gas_limit  =
   match res Eval.init_gas_kont gas_limit with
   | Error (err, remaining_gas) ->
       perr @@ scilla_error_gas_string remaining_gas err ;

--- a/src/runners/type_checker.ml
+++ b/src/runners/type_checker.ml
@@ -24,7 +24,6 @@ open TypeUtil
 open Recursion
 open RunnerUtil
 open DebugMessage
-open ErrorUtils
 open MonadUtil
 open Result.Let_syntax
 open PatternChecker
@@ -58,7 +57,7 @@ let check_typing e elibs =
   let open TC.TypeEnv in
   let rec_lib = { ParsedSyntax.lname = asId "rec_lib" ;
                   ParsedSyntax.lentries = recursion_principles } in
-  let%bind (typed_rec_libs, tenv0) = type_library TEnv.mk rec_lib in
+  let%bind (_typed_rec_libs, tenv0) = type_library TEnv.mk rec_lib in
   (* Step 1: Type check external libraries *)
   let%bind (_, tenv1) = MonadUtil.foldM elibs ~init:([], tenv0)
       ~f:(fun (lib_acc, env_acc) elib ->

--- a/tests/dune
+++ b/tests/dune
@@ -8,5 +8,4 @@
              testtypes testtypefail
              testpmfail
              testchecker testinteger256)
-  (flags (-cclib -lstdc++ -cclib -lcrypto))
 )


### PR DESCRIPTION
* We switch to pkg-config-based configuration from within Dune
and eliminate the need for propagating C libraries
linker switches from bottom to top because Dune has a dedicated
construction for this (c_library_flags).
The code is mostly taken from the Dune manual.

* Previously, (flags (-cclib -lstdc++ -cclib -lcrypto)) in src/runners/dune
suppressed some warnings-as-errors flags (-w @a-4-29-40-41-42-44-45-48-58-59-60-40),
hence the need to silence some creeped-in warnings.