### PR TITLE
Restrict substr arguments to uint32

### DIFF
--- a/src/lang/base/BuiltIns.ml
+++ b/src/lang/base/BuiltIns.ml
@@ -125,18 +125,7 @@ module ScillaBuiltIns
       | _ -> builtin_fail "String.concat" ls
 
     let substr_arity = 3    
-    let substr_type =
-      tfun_typ "'A" @@ tfun_typ "'B" @@ tfun_typ "'C" @@
-      (fun_typ (tvar "'A") @@ fun_typ (tvar "'B") @@ fun_typ (tvar "'C") string_typ)
-    (* Elaborator to run with arbitrary uints *)
-    let substr_elab _ ts = match ts with
-      | [s; u1; u2]
-        when s = string_typ &&
-             is_uint_type u1 &&
-             is_uint_type u2 ->
-          elab_tfun_with_args substr_type ts
-      | _ -> fail0 "Failed to elaborate"
-
+    let substr_type = fun_typ string_typ @@ fun_typ uint32_typ @@ fun_typ uint32_typ string_typ
     let substr ls _ = match ls with
       | [StringLit x; UintLit (Uint32L s); UintLit (Uint32L e)] ->
           pure @@ StringLit (Core.String.sub x ~pos:(Uint32.to_int s) ~len:(Uint32.to_int e))
@@ -1094,7 +1083,7 @@ module ScillaBuiltIns
       (* Strings *)
       ("eq", String.eq_arity, String.eq_type, elab_id, String.eq);
       ("concat", String.concat_arity, String.concat_type, elab_id, String.concat);
-      ("substr", String.substr_arity, String.substr_type, String.substr_elab, String.substr);
+      ("substr", String.substr_arity, String.substr_type, elab_id, String.substr);
       ("strlen", String.strlen_arity, String.strlen_type, elab_id, String.strlen);
       ("to_string", String.to_string_arity, String.to_string_type, String.to_string_elab, String.to_string);
 

--- a/tests/typecheck/bad/TestTypeFail.ml
+++ b/tests/typecheck/bad/TestTypeFail.ml
@@ -159,6 +159,7 @@ module Tests = TestUtil.DiffBasedTests(
       "nth-error.scilla";
       "folder-error.scilla";
       "some.scilla";
+      "substr.scilla";
     ]
     let exit_code : Unix.process_status = WEXITED 1
   end)

--- a/tests/typecheck/bad/gold/substr.scilla.gold
+++ b/tests/typecheck/bad/gold/substr.scilla.gold
@@ -1,0 +1,15 @@
+{
+  "errors": [
+    {
+      "error_message":
+        "Type error in built-in application of `substr`:\nCannot find built-in with name \"substr\" and argument types [String; Uint128; Uint256].",
+      "start_location": {
+        "file": "typecheck/bad/substr.scilla",
+        "line": 5,
+        "column": 9
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": []
+}

--- a/tests/typecheck/bad/substr.scilla
+++ b/tests/typecheck/bad/substr.scilla
@@ -1,0 +1,5 @@
+(* substr_test.scilla *)
+let s = "Foo42" in
+let start = Uint128 0 in
+let len = Uint256 3 in
+builtin substr s start len

--- a/tests/typecheck/bad/substr.scilla
+++ b/tests/typecheck/bad/substr.scilla
@@ -1,4 +1,4 @@
-(* substr_test.scilla *)
+(* fails type check as substr only accepts Uint32 as the 2nd and 3rd arguments. *)
 let s = "Foo42" in
 let start = Uint128 0 in
 let len = Uint256 3 in


### PR DESCRIPTION
This PR raises the question of backwards compatibility. However, note that we never supported `substr` arguments other than `Uint32`, but it is just that the checker did not flag that as an error (while the runners did). So this is better treated as a bug fix than a new restriction.

Also, both the official [docs](https://scilla.readthedocs.io/en/latest/scilla-in-depth.html?highlight=builtins#strings) and the Wiki [page](https://github.com/Zilliqa/scilla/wiki/Scilla-Built-Ins#strings) have always only specified `Uint32` as the allowed type.  