### PR TITLE
Cashflow tags for constructors

### DIFF
--- a/src/lang/base/Datatypes.ml
+++ b/src/lang/base/Datatypes.ml
@@ -166,6 +166,9 @@ module DataTypeDictionary = struct
   (* Get all known ADTs *)
   let get_all_adts () = Caml.Hashtbl.fold (fun _ a acc -> a :: acc) adt_name_dict []
 
+  (* Get all known ADT constructors *)
+  let get_all_ctrs () = Caml.Hashtbl.fold (fun _ c acc -> c :: acc) adt_cons_dict []
+
 end
 
 

--- a/src/lang/base/Datatypes.mli
+++ b/src/lang/base/Datatypes.mli
@@ -47,6 +47,8 @@ module DataTypeDictionary : sig
   val constr_tmap : adt -> string -> (typ list) option
   (* Get all known ADTs *)
   val get_all_adts : unit -> adt list
+  (* Get all known ADT constructors *)
+  val get_all_ctrs : unit -> (adt * constructor) list
 
   val add_adt : adt -> loc -> (unit, scilla_error list) result
     

--- a/src/lang/base/JSON.ml
+++ b/src/lang/base/JSON.ml
@@ -472,7 +472,7 @@ module CashflowInfo = struct
                       `Assoc [(adt,
                                `List (List.map ctrs ~f:(fun (i, ts) ->
                                    `Assoc [("constructor", `String i);
-                                           ("tag",
+                                           ("tags",
                                             `List (List.map ts ~f:(fun t -> `String t)))])))])))]
   
 end

--- a/src/lang/base/JSON.ml
+++ b/src/lang/base/JSON.ml
@@ -457,12 +457,22 @@ end
 
 module CashflowInfo = struct
 
-  let get_json tags =
-    `List
-      (List.map
-         tags
-         ~f:(fun (i, t) ->
-             `Assoc [("field", `String i);
-                     ("tag", `String t)]))
+  let get_json (param_field_tags, ctr_tags) =
+    `Assoc [("State variables",
+             `List
+                (List.map
+                   param_field_tags
+                   ~f:(fun (i, t) ->
+                       `Assoc [("field", `String i);
+                               ("tag", `String t)]))) ;
+            ("ADT constructors",
+             `List
+               (List.map ctr_tags
+                  ~f:(fun (adt, ctrs) ->
+                      `Assoc [(adt,
+                               `List (List.map ctrs ~f:(fun (i, ts) ->
+                                   `Assoc [("constructor", `String i);
+                                           ("tag",
+                                            `List (List.map ts ~f:(fun t -> `String t)))])))])))]
   
 end

--- a/src/lang/base/JSON.mli
+++ b/src/lang/base/JSON.mli
@@ -147,16 +147,31 @@ module Event : sig
 end
 
 module CashflowInfo : sig
-  (* Given a list of pairs with of fields and cashflow tags for a contract, 
-     give a string JSON with these details:
+  (* Given: A pair of lists.
+            The first element is an association list from fields to their tags.
+            The second element is an association list from adts to their contstructor tags.
+            Constructor tags are an association list from constructors to their argument tags.
+            An argument tag is either a normal tag, or "_" if the argument was ignored during the cashflow analysis.
+
+     Output: A string JSON with these details:
 
      {
-       "cashflow_tags" : [
-         { "field" : "owners",
-           "tag" : "NotMoney" },
-         { "field" : "donations",
-           "tag" : "MapMoney" }
-       ]
+       "cashflow_tags" : {
+           "State variables": [
+               { "field" : "owners",
+                 "tag" : "NotMoney" },
+               { "field" : "donations",
+                 "tag" : "MapMoney" }
+           ],
+           "ADT constructors" : [
+               {
+                   "Type1" : [
+                       { "constructor" : "Test1", "tags" : [ "NoInfo", "_", "NotMoney" ] },
+                       { "constructor" : "Test2", "tags" : [ ] }
+                   ]
+               }               
+           ]
+        }
      }
 
   *)

--- a/src/lang/base/JSON.mli
+++ b/src/lang/base/JSON.mli
@@ -161,5 +161,5 @@ module CashflowInfo : sig
 
   *)
 
-  val get_json : (string * string) list -> Yojson.t
+  val get_json : ((string * string) list * (string * ((string * string list) list)) list) -> Yojson.t
 end

--- a/src/lang/checkers/Cashflow.ml
+++ b/src/lang/checkers/Cashflow.ml
@@ -458,7 +458,9 @@ module ScillaCashflowChecker
           | Some targs ->
               let tag_list = List.map targs
                   ~f:(fun t -> if ctr_arg_filter t then Some NoInfo else None) in
-              (ctr.cname, tag_list) :: acc)
+              if List.exists tag_list ~f:Option.is_some
+              then (ctr.cname, tag_list) :: acc
+              else acc)
 
   let update_ctr_tag_map ctr_tag_map ctr_name arg_tags =
     match List.Assoc.find ctr_tag_map ~equal:(=) ctr_name with

--- a/src/lang/checkers/Cashflow.ml
+++ b/src/lang/checkers/Cashflow.ml
@@ -434,7 +434,67 @@ module ScillaCashflowChecker
                    | None -> Inconsistent)
               | _ -> Inconsistent in
             Some (List.map tmap ~f:tag_tmap)
-    
+
+  let ctr_arg_filter targ =
+    match targ with
+    | PrimType _
+    | MapType _
+    | FunType _ -> true
+    | ADT _     (* TODO: Detect induction, and ignore only when inductive *)
+    | TypeVar _ (* TypeVars tagged at type level *)
+    | PolyFun _ (* Ignore *)
+    | Unit ->   (* Ignore *)
+        false
+          
+  let init_ctr_tag_map () =
+    let open DataTypeDictionary in
+    let all_ctrs = get_all_ctrs () in
+    List.fold_left all_ctrs ~init:[]
+      ~f:(fun acc (adt, ctr) ->
+          match constr_tmap adt ctr.cname with
+          | None ->
+              (* No constructor arguments - ignore *)
+              acc
+          | Some targs ->
+              match List.filter targs ~f:ctr_arg_filter with
+              | [] -> (* No interesting arguments - ignore *)
+                  acc
+              | filtered_args ->
+                  let tag_list = List.map filtered_args ~f:(fun _ -> NoInfo) in
+                  (ctr.cname, tag_list) :: acc)
+
+  let update_ctr_tag_map ctr_tag_map ctr_name arg_tags =
+    match List.Assoc.find ctr_tag_map ~equal:(=) ctr_name with
+    | None ->
+        (* Ignored constructor *)
+        None
+    | Some filtered_arg_map_tags ->
+        let open DataTypeDictionary in
+        match lookup_constructor ctr_name with
+        | Error _ ->
+            (* Don't allow failures at this point *)
+            None
+        | Ok (adt, _) ->
+            match constr_tmap adt ctr_name with
+            | None ->
+                None
+            | Some targs ->
+                match List.zip targs arg_tags with
+                | None ->
+                    (* Arity mismatch - ignore *)
+                    None
+                | Some zipped_args ->
+                    let filtered_tags = List.filter_map zipped_args
+                        ~f:(fun (targ, arg_tag) -> if ctr_arg_filter targ then Some arg_tag else None) in
+                    match List.map2 filtered_arg_map_tags filtered_tags ~f:lub_tags with
+                    | Unequal_lengths ->
+                        (* Filter mismatch - ignore *)
+                        None
+                    | Ok new_tags ->
+                        if arg_tags = new_tags
+                        then None (* No changes *)
+                        else Some (List.Assoc.add ctr_tag_map ~equal:(=) ctr_name new_tags)
+              
   (*******************************************************)
   (*      Helper functions for local variables           *)
   (*******************************************************)
@@ -963,21 +1023,27 @@ module ScillaCashflowChecker
     | Constructor (_, ps) ->
         List.fold_left ps ~init:acc ~f:get_pattern_vars
 
-  let update_pattern_vars_tags p local_env =
-    let rec walk p =
+  let update_pattern_vars_tags p local_env ctr_tag_map =
+    let rec walk p ctr_tag_map =
       match p with
-      | Wildcard -> (Wildcard, false)
+      | Wildcard -> (Wildcard, NoInfo, ctr_tag_map, false)
       | Binder x ->
-          let new_x = update_id_tag x (lookup_var_tag x local_env) in
-          (Binder new_x, get_id_tag x <> get_id_tag new_x)
+          let new_x_tag = lookup_var_tag x local_env in
+          let new_x = update_id_tag x new_x_tag in
+          (Binder new_x, new_x_tag, ctr_tag_map, get_id_tag x <> get_id_tag new_x)
       | Constructor (s, ps) ->
-          let (new_ps, ps_changes) =
-            List.fold_right ps ~init:([], false)
-              ~f:(fun p (acc_ps, acc_changes) ->
-                 let (new_p, p_changes) = walk p in
-                 (new_p :: acc_ps, acc_changes || p_changes))in
-          (Constructor (s, new_ps), ps_changes) in
-    walk p
+          let (new_ps, new_ps_tags, ps_ctr_tag_map, ps_changes) =
+            List.fold_right ps ~init:([], [], ctr_tag_map, false)
+              ~f:(fun p (acc_ps, acc_ps_tags, acc_ctr_tag_map, acc_changes) ->
+                 let (new_p, new_p_tag, p_ctr_tag_map, p_changes) = walk p acc_ctr_tag_map in
+                 (new_p :: acc_ps, new_p_tag :: acc_ps_tags, p_ctr_tag_map, acc_changes || p_changes)) in
+          let (new_ctr_tag_map, ctr_tag_map_changes) =
+            update_ctr_tag_map ps_ctr_tag_map s new_ps_tags |>
+            Option.value_map ~default:(ctr_tag_map, false) ~f:(fun map -> (map, true)) in
+          let ctr_tag = ctr_to_adt_tag s new_ps_tags in
+          (Constructor (s, new_ps), ctr_tag, new_ctr_tag_map, ctr_tag_map_changes || ps_changes) in
+    let (new_p, _, new_ctr_tag_map, changes) = walk p ctr_tag_map in
+    (new_p, new_ctr_tag_map, changes)
 
   let insert_pattern_vars_into_env p local_env =
     let pattern_vars = get_pattern_vars [] p in
@@ -1024,22 +1090,22 @@ module ScillaCashflowChecker
         match v with
         | Ident (name, (_, rep)) -> CFSyntax.MVar (Ident (name, (tag, rep)))
 
-  let rec cf_tag_expr erep expected_tag field_env local_env =
+  let rec cf_tag_expr erep expected_tag field_env local_env ctr_tag_map =
     let lub t = lub_tags expected_tag t in
     let (e, (tag, rep)) = erep in
-    let (new_e, new_e_tag, new_field_env, new_local_env, new_changes) = 
+    let (new_e, new_e_tag, new_field_env, new_local_env, new_ctr_tag_map, new_changes) = 
       match e with
       | Literal _ ->
           (* No need to deduce tag from type. 
              If the literal is a number, then nothing can be deduced, 
              and if it is not a number, the tag of relevant variables 
              will be deduced from their usage. *)
-          (e, tag, field_env, local_env, false)
+          (e, tag, field_env, local_env, ctr_tag_map, false)
       | Var i ->
           let new_i_tag = lub (lookup_var_tag2 i local_env field_env) in
           let new_i = update_id_tag i new_i_tag in
           let (new_local_env, new_field_env) = update_var_tag2 i new_i_tag local_env field_env in
-          (Var new_i, new_i_tag, new_field_env, new_local_env, new_i_tag <> (get_id_tag i))
+          (Var new_i, new_i_tag, new_field_env, new_local_env, ctr_tag_map, new_i_tag <> (get_id_tag i))
       | Fun (arg, t, body) ->
           (* Using Map tag to represent functions as well as maps *)
           let body_expected_tag =
@@ -1049,14 +1115,15 @@ module ScillaCashflowChecker
             | _     -> Inconsistent in
           let body_local_env =
             AssocDictionary.insert (get_id arg) (get_id_tag arg) local_env in
-          let ((_, (new_body_tag, _)) as new_body, res_field_env, res_body_local_env, body_changes) =
-            cf_tag_expr body body_expected_tag field_env body_local_env in
+          let ((_, (new_body_tag, _)) as new_body, res_field_env, res_body_local_env, res_ctr_tag_map, body_changes) =
+            cf_tag_expr body body_expected_tag field_env body_local_env ctr_tag_map in
           let res_arg_tag = lookup_var_tag arg res_body_local_env in
           let new_local_env = AssocDictionary.remove (get_id arg) res_body_local_env in
           (Fun (update_id_tag arg res_arg_tag, t, new_body),
            Map new_body_tag,
            res_field_env,
            new_local_env,
+           res_ctr_tag_map,
            body_changes || (get_id_tag arg <> res_arg_tag))
       | App (f, args) ->
           let new_args = List.map ~f:(fun arg -> update_id_tag arg (lookup_var_tag2 arg local_env field_env)) args in
@@ -1077,6 +1144,7 @@ module ScillaCashflowChecker
            new_e_tag,
            new_field_env,
            new_local_env,
+           ctr_tag_map,
            args_changes || f_tag <> get_id_tag f)
       | Builtin (f, args) ->
           let args_tags = List.map ~f:(fun arg -> lookup_var_tag2 arg local_env field_env) args in
@@ -1101,13 +1169,14 @@ module ScillaCashflowChecker
            res_tag,
            final_field_env,
            final_local_env,
+           ctr_tag_map,
            changes || f_tag <> get_id_tag f)
       | Let (i, topt, lhs, rhs) ->
-          let ((_, (new_lhs_tag, _)) as new_lhs, lhs_field_env, lhs_local_env, lhs_changes) =
-            cf_tag_expr lhs (get_id_tag i) field_env local_env in
+          let ((_, (new_lhs_tag, _)) as new_lhs, lhs_field_env, lhs_local_env, lhs_ctr_tag_map, lhs_changes) =
+            cf_tag_expr lhs (get_id_tag i) field_env local_env ctr_tag_map in
           let updated_lhs_local_env = AssocDictionary.insert (get_id i) new_lhs_tag lhs_local_env in
-          let ((_, (new_rhs_tag, _)) as new_rhs, rhs_field_env, rhs_local_env, rhs_changes) =
-            cf_tag_expr rhs expected_tag lhs_field_env updated_lhs_local_env in
+          let ((_, (new_rhs_tag, _)) as new_rhs, rhs_field_env, rhs_local_env, rhs_ctr_tag_map, rhs_changes) =
+            cf_tag_expr rhs expected_tag lhs_field_env updated_lhs_local_env lhs_ctr_tag_map in
           let new_i_tag = lookup_var_tag i rhs_local_env in
           let new_i = update_id_tag i new_i_tag in
           let res_local_env = AssocDictionary.remove (get_id i) rhs_local_env in
@@ -1115,6 +1184,7 @@ module ScillaCashflowChecker
            new_rhs_tag,
            rhs_field_env,
            res_local_env,
+           rhs_ctr_tag_map,
            lhs_changes || rhs_changes || new_i_tag <> get_id_tag i)
       | Constr (cname, ts, args) ->
           let new_args = List.map ~f:(fun arg -> update_id_tag arg (lookup_var_tag2 arg local_env field_env)) args in
@@ -1123,27 +1193,32 @@ module ScillaCashflowChecker
             | Ok res -> res
             | Unequal_lengths -> false
           in
+          let (new_ctr_tag_map, ctr_tag_map_changes) = 
+            update_ctr_tag_map ctr_tag_map cname (List.map new_args ~f:get_id_tag) |>
+            Option.value_map ~default:(ctr_tag_map, false) ~f:(fun map -> (map, true)) in
           let tag = ctr_to_adt_tag cname (List.map new_args ~f:get_id_tag) in
           (Constr (cname, ts, new_args),
            tag,
            field_env,
            local_env,
-           args_changes)
+           new_ctr_tag_map,
+           ctr_tag_map_changes || args_changes)
       | MatchExpr (x, clauses) ->
-          let (res_clauses, res_tag, new_field_env, new_local_env, clause_changes) =
+          let (res_clauses, res_tag, new_field_env, new_local_env, new_ctr_tag_map, clause_changes) =
             List.fold_right clauses
-              ~init:([], expected_tag, field_env, local_env, false) 
-              ~f:(fun (p, ep) (acc_clauses, acc_res_tag, acc_field_env, acc_local_env, acc_changes) ->
+              ~init:([], expected_tag, field_env, local_env, ctr_tag_map, false) 
+              ~f:(fun (p, ep) (acc_clauses, acc_res_tag, acc_field_env, acc_local_env, acc_ctr_tag_map, acc_changes) ->
                  let sub_local_env =
                    insert_pattern_vars_into_env p acc_local_env in
-                 let ((_, (new_e_tag, _)) as new_e, new_field_env, new_local_env, new_changes) =
-                   cf_tag_expr ep expected_tag acc_field_env sub_local_env in
-                 let (new_p, p_changes) = update_pattern_vars_tags p new_local_env in
+                 let ((_, (new_e_tag, _)) as new_e, new_field_env, new_local_env, e_ctr_tag_map, new_changes) =
+                   cf_tag_expr ep expected_tag acc_field_env sub_local_env acc_ctr_tag_map in
+                 let (new_p, new_ctr_tag_map, p_changes) = update_pattern_vars_tags p new_local_env e_ctr_tag_map in
                  let res_local_env = remove_pattern_vars_from_env p new_local_env in
                  ((new_p, new_e) :: acc_clauses,
                   lub_tags acc_res_tag new_e_tag,
                   new_field_env,
                   res_local_env,
+                  new_ctr_tag_map,
                   acc_changes || new_changes || p_changes))
               in
           let x_tag_usage = lub_pattern_tags (List.map ~f:(fun (p, _) -> p) res_clauses) in
@@ -1154,19 +1229,20 @@ module ScillaCashflowChecker
            res_tag,
            new_field_env,
            res_local_env,
+           new_ctr_tag_map,
            clause_changes || (get_id_tag x) <> new_x_tag)
       | Fixpoint (_f, _t, _body) ->
           (* Library functions not handled. *)
-          (e, Inconsistent, field_env, local_env, false)
+          (e, Inconsistent, field_env, local_env, ctr_tag_map, false)
       | TFun (tvar, body) ->
           (* Ignore polymorphism. *)
-          let ((_, (new_body_tag, _)) as new_body, new_field_env, new_local_env, changes) =
-            cf_tag_expr body expected_tag field_env local_env in
-          (TFun (tvar, new_body), new_body_tag, new_field_env, new_local_env, changes)
+          let ((_, (new_body_tag, _)) as new_body, new_field_env, new_local_env, new_ctr_tag_map, changes) =
+            cf_tag_expr body expected_tag field_env local_env ctr_tag_map in
+          (TFun (tvar, new_body), new_body_tag, new_field_env, new_local_env, new_ctr_tag_map, changes)
       | TApp (tf, arg_types) ->
           let new_tf_tag = lookup_var_tag2 tf local_env field_env in
           let new_tf = update_id_tag tf new_tf_tag in
-          (TApp (new_tf, arg_types), new_tf_tag, field_env, local_env, false)
+          (TApp (new_tf, arg_types), new_tf_tag, field_env, local_env, ctr_tag_map, false)
       | Message bs ->
           (* Find initializers and update env as appropriate *)
           let (new_bs, new_field_env, new_local_env, changes) =
@@ -1192,9 +1268,10 @@ module ScillaCashflowChecker
            NotMoney,
            new_field_env,
            new_local_env,
+           ctr_tag_map,
            changes) in
     let e_tag = lub new_e_tag in
-    ((new_e, (e_tag, rep)), new_field_env, new_local_env, new_changes || tag <> e_tag)
+    ((new_e, (e_tag, rep)), new_field_env, new_local_env, new_ctr_tag_map, new_changes || tag <> e_tag)
 
   (* Helper function for Load and Store - ensure field and local have same tag *)
   let cf_update_tag_for_field_assignment f x field_env local_env =
@@ -1207,9 +1284,9 @@ module ScillaCashflowChecker
     let new_local_env = AssocDictionary.update (get_id x) new_tag local_env in
     (new_f, new_x, new_field_env, new_local_env)
 
-  let rec cf_tag_stmt (srep : CFSyntax.stmt_annot) field_env local_env =
+  let rec cf_tag_stmt (srep : CFSyntax.stmt_annot) field_env local_env ctr_tag_map =
     let (s, rep) = srep in
-    let (new_s, new_field_env, new_local_env, changes) =
+    let (new_s, new_field_env, new_local_env, new_ctr_tag_map, changes) =
       match s with
       | Load (x, f) ->
           let (new_f, new_x, new_field_env, tmp_local_env) =
@@ -1219,6 +1296,7 @@ module ScillaCashflowChecker
           (Load (new_x, new_f),
            new_field_env,
            new_local_env,
+           ctr_tag_map,
            (get_id_tag new_x) <> (get_id_tag x) || (get_id_tag new_f) <> (get_id_tag f))
       | Store (f, x) ->
           let (new_f, new_x, new_field_env, new_local_env) =
@@ -1226,17 +1304,19 @@ module ScillaCashflowChecker
           (Store (new_f, new_x),
            new_field_env,
            new_local_env,
+           ctr_tag_map,
            (get_id_tag new_x) <> (get_id_tag x) || (get_id_tag new_f) <> (get_id_tag f))
       | Bind (x, e) ->
           let x_tag = lookup_var_tag x local_env in
           let e_local_env = AssocDictionary.remove (get_id x) local_env in
-          let ((_, (new_e_tag, _)) as new_e, new_field_env, new_local_env, e_changes) =
-            cf_tag_expr e x_tag field_env e_local_env in
+          let ((_, (new_e_tag, _)) as new_e, new_field_env, new_local_env, new_ctr_tag_map, e_changes) =
+            cf_tag_expr e x_tag field_env e_local_env ctr_tag_map in
           let new_x_tag = lub_tags x_tag new_e_tag in
           let new_x = update_id_tag x new_x_tag in
           (Bind (new_x, new_e),
            new_field_env,
            new_local_env,
+           new_ctr_tag_map,
            e_changes || (get_id_tag x) <> new_x_tag)
       | MapUpdate (m, ks, v_opt) ->
           let v_tag =
@@ -1266,6 +1346,7 @@ module ScillaCashflowChecker
           (MapUpdate (new_m, new_ks, new_v_opt),
            new_field_env,
            new_local_env,
+           ctr_tag_map,
            (get_id_tag m) <> m_tag || new_v_opt <> v_opt || new_ks <> ks)
       | MapGet (x, m, ks, fetch) ->
           let x_tag = lookup_var_tag x local_env in
@@ -1295,21 +1376,23 @@ module ScillaCashflowChecker
           (MapGet (new_x, new_m, new_ks, fetch),
            new_field_env,
            new_local_env,
+           ctr_tag_map,
            (get_id_tag x) <> new_x_tag || (get_id_tag m) <> m_tag || new_ks <> ks)
       | MatchStmt (x, clauses) -> 
-          let (res_clauses, new_field_env, new_local_env, clause_changes) =
+          let (res_clauses, new_field_env, new_local_env, new_ctr_tag_map, clause_changes) =
             List.fold_right clauses
-              ~init:([], field_env, local_env, false) 
-              ~f:(fun (p, sp) (acc_clauses, acc_field_env, acc_local_env, acc_changes) ->
+              ~init:([], field_env, local_env, ctr_tag_map, false) 
+              ~f:(fun (p, sp) (acc_clauses, acc_field_env, acc_local_env, acc_ctr_tag_map, acc_changes) ->
                  let sub_local_env =
                    insert_pattern_vars_into_env p acc_local_env in
-                 let (new_stmts, new_field_env, s_local_env, s_changes) =
-                   cf_tag_stmts sp acc_field_env sub_local_env in
-                 let (new_p, p_changes) = update_pattern_vars_tags p s_local_env in
+                 let (new_stmts, new_field_env, s_local_env, s_ctr_tag_map, s_changes) =
+                   cf_tag_stmts sp acc_field_env sub_local_env acc_ctr_tag_map in
+                 let (new_p, new_ctr_tag_map, p_changes) = update_pattern_vars_tags p s_local_env s_ctr_tag_map in
                  let new_local_env = remove_pattern_vars_from_env p s_local_env in
                  ((new_p, new_stmts) :: acc_clauses,
                   new_field_env,
                   new_local_env,
+                  new_ctr_tag_map,
                   acc_changes || s_changes || p_changes))
               in
           let x_tag_usage = lub_pattern_tags (List.map ~f:(fun (p, _) -> p) res_clauses) in
@@ -1319,6 +1402,7 @@ module ScillaCashflowChecker
           (MatchStmt (new_x, res_clauses),
            new_field_env,
            res_local_env,
+           new_ctr_tag_map,
            clause_changes || (get_id_tag x) <> new_x_tag)
       | ReadFromBC (x, s) ->
           let x_tag = lub_tags NotMoney (lookup_var_tag x local_env) in
@@ -1327,8 +1411,9 @@ module ScillaCashflowChecker
           (ReadFromBC (new_x, s),
            field_env,
            new_local_env,
+           ctr_tag_map,
            (get_id_tag x) <> x_tag)
-      | AcceptPayment -> (AcceptPayment, field_env, local_env, false)
+      | AcceptPayment -> (AcceptPayment, field_env, local_env, ctr_tag_map, false)
       | SendMsgs m ->
           let m_tag = lub_tags NotMoney (lookup_var_tag m local_env) in
           let new_m = update_id_tag m m_tag in
@@ -1336,6 +1421,7 @@ module ScillaCashflowChecker
           (SendMsgs new_m,
            field_env,
            new_local_env,
+           ctr_tag_map,
            (get_id_tag m) <> m_tag)
       | CreateEvnt e ->
           let e_tag = lub_tags NotMoney (lookup_var_tag e local_env) in
@@ -1344,6 +1430,7 @@ module ScillaCashflowChecker
           (CreateEvnt new_e,
            field_env,
            new_local_env,
+           ctr_tag_map,
            (get_id_tag e) <> e_tag)
       | Throw x ->
           let x_tag = lub_tags NotMoney (lookup_var_tag x local_env) in
@@ -1352,10 +1439,11 @@ module ScillaCashflowChecker
           (Throw new_x,
            field_env,
            new_local_env,
+           ctr_tag_map,
            (get_id_tag x) <> x_tag) in
-    ((new_s, rep), new_field_env, new_local_env, changes)
+    ((new_s, rep), new_field_env, new_local_env, new_ctr_tag_map, changes)
 
-    and cf_tag_stmts ss field_env local_env =
+    and cf_tag_stmts ss field_env local_env ctr_tag_map =
       let init_local_env =
         List.fold_left ss ~init:local_env
           ~f:(fun acc_env srep ->
@@ -1368,19 +1456,19 @@ module ScillaCashflowChecker
                  AssocDictionary.insert (get_id x) (get_id_tag x) acc_env
              | _ -> acc_env) in
       List.fold_right ss
-        ~init:([], field_env, init_local_env, false)
-        ~f:(fun s (acc_ss, acc_field_env, acc_local_env, acc_changes) ->
-           let (new_s, new_field_env, new_local_env, new_changes) =
-             cf_tag_stmt s acc_field_env acc_local_env in
+        ~init:([], field_env, init_local_env, ctr_tag_map, false)
+        ~f:(fun s (acc_ss, acc_field_env, acc_local_env, acc_ctr_tag_map, acc_changes) ->
+           let (new_s, new_field_env, new_local_env, new_ctr_tag_map, new_changes) =
+             cf_tag_stmt s acc_field_env acc_local_env acc_ctr_tag_map in
            (new_s :: acc_ss,
             new_field_env,
             new_local_env,
+            new_ctr_tag_map,
             new_changes || acc_changes))
         
 
-    let cf_tag_transition t field_env =
+    let cf_tag_transition t field_env ctr_tag_map =
       let { tname ; tparams ; tbody } = t in
-
       let empty_local_env = AssocDictionary.make_dict() in
       let implicit_local_env =
         AssocDictionary.insert "_amount" Money 
@@ -1391,8 +1479,8 @@ module ScillaCashflowChecker
           ~f:(fun acc_env (p, _) ->
              AssocDictionary.insert (get_id p) (get_id_tag p) acc_env)
           in
-      let (new_tbody, new_field_env, new_local_env, body_changes) =
-        cf_tag_stmts tbody field_env param_local_env in
+      let (new_tbody, new_field_env, new_local_env, new_ctr_tag_map, body_changes) =
+        cf_tag_stmts tbody field_env param_local_env ctr_tag_map in
       let (new_params, new_changes) =
         List.fold_right tparams ~init:([], body_changes)
           ~f:(fun (p, typ) (acc_ps, acc_changes) ->
@@ -1402,12 +1490,14 @@ module ScillaCashflowChecker
                in
       ({ tname = tname ; tparams = new_params ; tbody = new_tbody },
        new_field_env,
+       new_ctr_tag_map,
        new_changes)
 
     let cf_tag_contract c =
       let { cname ; cparams ; cfields ; ctrans } = c in
       let empty_field_env = AssocDictionary.make_dict () in
       let implicit_field_env = AssocDictionary.insert "_balance" Money empty_field_env in
+      let ctr_tag_map = init_ctr_tag_map () in
       let param_field_env =
         List.fold_left cparams ~init:implicit_field_env
           ~f:(fun acc_env (p, _) ->
@@ -1416,23 +1506,23 @@ module ScillaCashflowChecker
       let init_field_env =
         List.fold_left cfields ~init:param_field_env
           ~f:(fun acc_env (f, _, e) ->
-             let ((_, (e_tag, _)), _, _, _) =
-                  cf_tag_expr e NoInfo (AssocDictionary.make_dict ()) (AssocDictionary.make_dict ()) in
+             let ((_, (e_tag, _)), _, _, _, _) =
+                  cf_tag_expr e NoInfo (AssocDictionary.make_dict ()) (AssocDictionary.make_dict ()) ctr_tag_map in
              AssocDictionary.insert (get_id f) e_tag acc_env)
           in
-      let rec tagger transitions field_env =
-        let (new_ts, new_field_env, ctrans_changes) =
-          List.fold_right transitions ~init:([], field_env, false) 
-            ~f:(fun t (acc_ts, acc_field_env, acc_changes) ->
-               let (new_t, new_field_env, t_changes) =
-                 cf_tag_transition t acc_field_env in
-               (new_t :: acc_ts, new_field_env, acc_changes || t_changes))
+      let rec tagger transitions field_env ctr_tag_map =
+        let (new_ts, new_field_env, new_ctr_tag_map, ctrans_changes) =
+          List.fold_right transitions ~init:([], field_env, ctr_tag_map, false) 
+            ~f:(fun t (acc_ts, acc_field_env, acc_ctr_tag_map, acc_changes) ->
+               let (new_t, new_field_env, new_ctr_tag_map, t_changes) =
+                 cf_tag_transition t acc_field_env acc_ctr_tag_map in
+               (new_t :: acc_ts, new_field_env, new_ctr_tag_map, acc_changes || t_changes))
             in
         if ctrans_changes
         then
-          tagger new_ts new_field_env
-        else (new_ts, new_field_env) in
-      let (new_ctrans, new_field_env) = tagger ctrans init_field_env in
+          tagger new_ts new_field_env new_ctr_tag_map
+        else (new_ts, new_field_env, new_ctr_tag_map) in
+      let (new_ctrans, new_field_env, new_ctr_tag_map) = tagger ctrans init_field_env ctr_tag_map in
       let new_fields =
         List.fold_right cfields ~init:[] 
           ~f:(fun (f, t, e) acc_fields ->
@@ -1445,19 +1535,21 @@ module ScillaCashflowChecker
              let new_tag = lookup_var_tag p new_field_env in
              (update_id_tag p new_tag, t) :: acc_params)
           in
-      { cname = cname ;
-        cparams = new_params ;
-        cfields = new_fields ;
-        ctrans = new_ctrans }
+      ({ cname = cname ;
+         cparams = new_params ;
+         cfields = new_fields ;
+         ctrans = new_ctrans },
+       new_ctr_tag_map)
 
     let cf_tag_module m =
       let { smver; cname ; libs ; elibs ; contr } = m in
-      let new_contr = cf_tag_contract contr in
-      { smver = smver;
-        cname = cname ;
-        libs = libs ;
-        elibs = elibs ;
-        contr = new_contr }
+      let (new_contr, ctr_tag_map) = cf_tag_contract contr in
+      ({ smver = smver;
+         cname = cname ;
+         libs = libs ;
+         elibs = elibs ;
+         contr = new_contr },
+       ctr_tag_map)
     
   (*******************************************************)
   (*                Main entry function                  *)
@@ -1465,9 +1557,22 @@ module ScillaCashflowChecker
 
   let main cmod =
     let init_mod = cf_init_tag_module cmod in
-    let new_mod = cf_tag_module init_mod in
-    (List.map ~f:(fun (p, _) -> (get_id p, get_id_tag p)) new_mod.contr.cparams)
-    @
-    (List.map ~f:(fun (f, _, _) -> (get_id f, get_id_tag f)) new_mod.contr.cfields)
-
+    let (new_mod, ctr_tag_map) = cf_tag_module init_mod in
+    let param_field_tags = 
+      (List.map ~f:(fun (p, _) -> (get_id p, get_id_tag p)) new_mod.contr.cparams)
+      @
+      (List.map ~f:(fun (f, _, _) -> (get_id f, get_id_tag f)) new_mod.contr.cfields) in
+    let ctr_tags =
+      let all_adts = DataTypeDictionary.get_all_adts () in
+      List.filter_map all_adts
+        ~f:(fun adt ->
+            match List.filter_map adt.tconstr
+                    ~f:(fun ctr ->
+                        List.Assoc.find ctr_tag_map ~equal:(=) ctr.cname |>
+                        Option.map ~f:(fun arg_tags -> (ctr.cname, arg_tags))) with
+            | [] ->
+                (* No interesting constructors found *)
+                None
+            | x -> Some (adt.tname, x)) in
+    (param_field_tags, ctr_tags)
 end

--- a/src/runners/scilla_checker.ml
+++ b/src/runners/scilla_checker.ml
@@ -124,7 +124,7 @@ let check_cashflow typed_cmod =
       ~f:(fun (adt, ctrs) ->
           (adt, List.map ctrs
              ~f:(fun (i, ts) ->
-                 (i, List.map ts ~f:CF.ECFR.money_tag_to_string)))) in
+                 (i, List.map ts ~f:(fun t_opt -> Option.value_map t_opt ~default:"_" ~f:CF.ECFR.money_tag_to_string))))) in
   (param_field_tags_to_string, ctr_tags_to_string)
 
 let check_version vernum =

--- a/src/runners/scilla_checker.ml
+++ b/src/runners/scilla_checker.ml
@@ -167,7 +167,7 @@ let check_cmodule cli =
     let _ = if cli.cf_flag then check_accepts typed_cmod else () in
     let%bind _ = check_sanity typed_cmod typed_rlibs typed_elibs in
     let%bind event_info = check_events_info (EI.event_info pm_checked_cmod)  in
-    let%bind cf_info_opt = if cli.cf_flag then pure @@ Some (check_cashflow typed_cmod) else pure @@ None in
+    let cf_info_opt = if cli.cf_flag then Some (check_cashflow typed_cmod) else None in
     pure @@ (cmod, tenv, event_info, cf_info_opt)
   ) in
   (match r with

--- a/tests/checker/good/TestCheckerSuccess.ml
+++ b/tests/checker/good/TestCheckerSuccess.ml
@@ -36,7 +36,7 @@ module Tests = TestUtil.DiffBasedTests(
       "fungible-token.scilla";
       "helloWorld.scilla";
       "inplace-map.scilla";
-      "map_key_test.scilla";
+        "map_key_test.scilla";
       "mappair.scilla";
       "multiple-msgs.scilla";
       "nonfungible-token.scilla";

--- a/tests/checker/good/gold/adt_test.scilla.gold
+++ b/tests/checker/good/gold/adt_test.scilla.gold
@@ -2,17 +2,7 @@
   "cashflow_tags": {
     "State variables": [],
     "ADT constructors": [
-      {
-        "TestType1": [
-          { "constructor": "Item1", "tag": [ "NoInfo" ] },
-          { "constructor": "Item2", "tag": [] }
-        ]
-      },
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] },
-      { "TestType2": [ { "constructor": "Item3", "tag": [ "_" ] } ] }
+      { "TestType1": [ { "constructor": "Item1", "tags": [ "NoInfo" ] } ] }
     ]
   },
   "contract_info": {

--- a/tests/checker/good/gold/adt_test.scilla.gold
+++ b/tests/checker/good/gold/adt_test.scilla.gold
@@ -1,5 +1,20 @@
 {
-  "cashflow_tags": [],
+  "cashflow_tags": {
+    "State variables": [],
+    "ADT constructors": [
+      {
+        "TestType1": [
+          { "constructor": "Item1", "tag": [ "NoInfo" ] },
+          { "constructor": "Item2", "tag": [] }
+        ]
+      },
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] },
+      { "TestType2": [ { "constructor": "Item3", "tag": [ "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "BadLib",

--- a/tests/checker/good/gold/auction.scilla.gold
+++ b/tests/checker/good/gold/auction.scilla.gold
@@ -9,12 +9,7 @@
       { "field": "highestBid", "tag": "Money" },
       { "field": "pendingReturns", "tag": "(Map Money)" }
     ],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
+    "ADT constructors": []
   },
   "contract_info": {
     "scilla_major_version": "0",

--- a/tests/checker/good/gold/auction.scilla.gold
+++ b/tests/checker/good/gold/auction.scilla.gold
@@ -1,13 +1,21 @@
 {
-  "cashflow_tags": [
-    { "field": "auctionStart", "tag": "NotMoney" },
-    { "field": "biddingTime", "tag": "NotMoney" },
-    { "field": "beneficiary", "tag": "NotMoney" },
-    { "field": "ended", "tag": "NotMoney" },
-    { "field": "highestBidder", "tag": "(Option NotMoney)" },
-    { "field": "highestBid", "tag": "Money" },
-    { "field": "pendingReturns", "tag": "(Map Money)" }
-  ],
+  "cashflow_tags": {
+    "State variables": [
+      { "field": "auctionStart", "tag": "NotMoney" },
+      { "field": "biddingTime", "tag": "NotMoney" },
+      { "field": "beneficiary", "tag": "NotMoney" },
+      { "field": "ended", "tag": "NotMoney" },
+      { "field": "highestBidder", "tag": "(Option NotMoney)" },
+      { "field": "highestBid", "tag": "Money" },
+      { "field": "pendingReturns", "tag": "(Map Money)" }
+    ],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "OpenAuction",

--- a/tests/checker/good/gold/bookstore.scilla.gold
+++ b/tests/checker/good/gold/bookstore.scilla.gold
@@ -7,12 +7,7 @@
       { "field": "lastBookID", "tag": "(Option NotMoney)" },
       { "field": "bookInventory", "tag": "(Map (Pair NoInfo NoInfo))" }
     ],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
+    "ADT constructors": []
   },
   "contract_info": {
     "scilla_major_version": "0",

--- a/tests/checker/good/gold/bookstore.scilla.gold
+++ b/tests/checker/good/gold/bookstore.scilla.gold
@@ -1,11 +1,19 @@
 {
-  "cashflow_tags": [
-    { "field": "owner", "tag": "NotMoney" },
-    { "field": "storeName", "tag": "NoInfo" },
-    { "field": "members", "tag": "(Map (Pair NoInfo NoInfo))" },
-    { "field": "lastBookID", "tag": "(Option NotMoney)" },
-    { "field": "bookInventory", "tag": "(Map (Pair NoInfo NoInfo))" }
-  ],
+  "cashflow_tags": {
+    "State variables": [
+      { "field": "owner", "tag": "NotMoney" },
+      { "field": "storeName", "tag": "NoInfo" },
+      { "field": "members", "tag": "(Map (Pair NoInfo NoInfo))" },
+      { "field": "lastBookID", "tag": "(Option NotMoney)" },
+      { "field": "bookInventory", "tag": "(Map (Pair NoInfo NoInfo))" }
+    ],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "BookStore",

--- a/tests/checker/good/gold/cashflow_test.scilla.gold
+++ b/tests/checker/good/gold/cashflow_test.scilla.gold
@@ -1,7 +1,15 @@
 {
-  "cashflow_tags": [
-    { "field": "transaction_pairs", "tag": "(List (Pair NotMoney Money))" }
-  ],
+  "cashflow_tags": {
+    "State variables": [
+      { "field": "transaction_pairs", "tag": "(List (Pair NotMoney Money))" }
+    ],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "CashflowTest",

--- a/tests/checker/good/gold/cashflow_test.scilla.gold
+++ b/tests/checker/good/gold/cashflow_test.scilla.gold
@@ -3,12 +3,7 @@
     "State variables": [
       { "field": "transaction_pairs", "tag": "(List (Pair NotMoney Money))" }
     ],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
+    "ADT constructors": []
   },
   "contract_info": {
     "scilla_major_version": "0",

--- a/tests/checker/good/gold/cfinvoke.scilla.gold
+++ b/tests/checker/good/gold/cfinvoke.scilla.gold
@@ -4,12 +4,7 @@
       { "field": "cfaddr", "tag": "NotMoney" },
       { "field": "owner", "tag": "NotMoney" }
     ],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
+    "ADT constructors": []
   },
   "contract_info": {
     "scilla_major_version": "0",

--- a/tests/checker/good/gold/cfinvoke.scilla.gold
+++ b/tests/checker/good/gold/cfinvoke.scilla.gold
@@ -1,8 +1,16 @@
 {
-  "cashflow_tags": [
-    { "field": "cfaddr", "tag": "NotMoney" },
-    { "field": "owner", "tag": "NotMoney" }
-  ],
+  "cashflow_tags": {
+    "State variables": [
+      { "field": "cfaddr", "tag": "NotMoney" },
+      { "field": "owner", "tag": "NotMoney" }
+    ],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "CrowdFundingInvoke",

--- a/tests/checker/good/gold/chain-call-balance-1.scilla.gold
+++ b/tests/checker/good/gold/chain-call-balance-1.scilla.gold
@@ -1,5 +1,13 @@
 {
-  "cashflow_tags": [],
+  "cashflow_tags": {
+    "State variables": [],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Test",

--- a/tests/checker/good/gold/chain-call-balance-1.scilla.gold
+++ b/tests/checker/good/gold/chain-call-balance-1.scilla.gold
@@ -1,13 +1,5 @@
 {
-  "cashflow_tags": {
-    "State variables": [],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
-  },
+  "cashflow_tags": { "State variables": [], "ADT constructors": [] },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Test",

--- a/tests/checker/good/gold/chain-call-balance-2.scilla.gold
+++ b/tests/checker/good/gold/chain-call-balance-2.scilla.gold
@@ -1,5 +1,13 @@
 {
-  "cashflow_tags": [],
+  "cashflow_tags": {
+    "State variables": [],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Test",

--- a/tests/checker/good/gold/chain-call-balance-2.scilla.gold
+++ b/tests/checker/good/gold/chain-call-balance-2.scilla.gold
@@ -1,13 +1,5 @@
 {
-  "cashflow_tags": {
-    "State variables": [],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
-  },
+  "cashflow_tags": { "State variables": [], "ADT constructors": [] },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Test",

--- a/tests/checker/good/gold/chain-call-balance-3.scilla.gold
+++ b/tests/checker/good/gold/chain-call-balance-3.scilla.gold
@@ -1,5 +1,13 @@
 {
-  "cashflow_tags": [],
+  "cashflow_tags": {
+    "State variables": [],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Test",

--- a/tests/checker/good/gold/chain-call-balance-3.scilla.gold
+++ b/tests/checker/good/gold/chain-call-balance-3.scilla.gold
@@ -1,13 +1,5 @@
 {
-  "cashflow_tags": {
-    "State variables": [],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
-  },
+  "cashflow_tags": { "State variables": [], "ADT constructors": [] },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Test",

--- a/tests/checker/good/gold/crowdfunding.scilla.gold
+++ b/tests/checker/good/gold/crowdfunding.scilla.gold
@@ -1,11 +1,19 @@
 {
-  "cashflow_tags": [
-    { "field": "owner", "tag": "NotMoney" },
-    { "field": "max_block", "tag": "NotMoney" },
-    { "field": "goal", "tag": "Money" },
-    { "field": "backers", "tag": "(Map Money)" },
-    { "field": "funded", "tag": "NotMoney" }
-  ],
+  "cashflow_tags": {
+    "State variables": [
+      { "field": "owner", "tag": "NotMoney" },
+      { "field": "max_block", "tag": "NotMoney" },
+      { "field": "goal", "tag": "Money" },
+      { "field": "backers", "tag": "(Map Money)" },
+      { "field": "funded", "tag": "NotMoney" }
+    ],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Crowdfunding",

--- a/tests/checker/good/gold/crowdfunding.scilla.gold
+++ b/tests/checker/good/gold/crowdfunding.scilla.gold
@@ -7,12 +7,7 @@
       { "field": "backers", "tag": "(Map Money)" },
       { "field": "funded", "tag": "NotMoney" }
     ],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
+    "ADT constructors": []
   },
   "contract_info": {
     "scilla_major_version": "0",

--- a/tests/checker/good/gold/ecdsa.scilla.gold
+++ b/tests/checker/good/gold/ecdsa.scilla.gold
@@ -3,12 +3,7 @@
     "State variables": [
       { "field": "pub_key", "tag": "(Option Inconsistent)" }
     ],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
+    "ADT constructors": []
   },
   "contract_info": {
     "scilla_major_version": "0",

--- a/tests/checker/good/gold/ecdsa.scilla.gold
+++ b/tests/checker/good/gold/ecdsa.scilla.gold
@@ -1,5 +1,15 @@
 {
-  "cashflow_tags": [ { "field": "pub_key", "tag": "(Option Inconsistent)" } ],
+  "cashflow_tags": {
+    "State variables": [
+      { "field": "pub_key", "tag": "(Option Inconsistent)" }
+    ],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Ecdsa",

--- a/tests/checker/good/gold/empty.scilla.gold
+++ b/tests/checker/good/gold/empty.scilla.gold
@@ -1,5 +1,13 @@
 {
-  "cashflow_tags": [],
+  "cashflow_tags": {
+    "State variables": [],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Empty",

--- a/tests/checker/good/gold/empty.scilla.gold
+++ b/tests/checker/good/gold/empty.scilla.gold
@@ -1,13 +1,5 @@
 {
-  "cashflow_tags": {
-    "State variables": [],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
-  },
+  "cashflow_tags": { "State variables": [], "ADT constructors": [] },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Empty",

--- a/tests/checker/good/gold/fungible-token.scilla.gold
+++ b/tests/checker/good/gold/fungible-token.scilla.gold
@@ -9,12 +9,7 @@
       { "field": "balances", "tag": "(Map NoInfo)" },
       { "field": "allowed", "tag": "(Map (Map NoInfo))" }
     ],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
+    "ADT constructors": []
   },
   "contract_info": {
     "scilla_major_version": "0",

--- a/tests/checker/good/gold/fungible-token.scilla.gold
+++ b/tests/checker/good/gold/fungible-token.scilla.gold
@@ -1,13 +1,21 @@
 {
-  "cashflow_tags": [
-    { "field": "owner", "tag": "NoInfo" },
-    { "field": "total_tokens", "tag": "NoInfo" },
-    { "field": "decimals", "tag": "NoInfo" },
-    { "field": "name", "tag": "NoInfo" },
-    { "field": "symbol", "tag": "NoInfo" },
-    { "field": "balances", "tag": "(Map NoInfo)" },
-    { "field": "allowed", "tag": "(Map (Map NoInfo))" }
-  ],
+  "cashflow_tags": {
+    "State variables": [
+      { "field": "owner", "tag": "NoInfo" },
+      { "field": "total_tokens", "tag": "NoInfo" },
+      { "field": "decimals", "tag": "NoInfo" },
+      { "field": "name", "tag": "NoInfo" },
+      { "field": "symbol", "tag": "NoInfo" },
+      { "field": "balances", "tag": "(Map NoInfo)" },
+      { "field": "allowed", "tag": "(Map (Map NoInfo))" }
+    ],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "FungibleToken",

--- a/tests/checker/good/gold/helloWorld.scilla.gold
+++ b/tests/checker/good/gold/helloWorld.scilla.gold
@@ -4,12 +4,7 @@
       { "field": "owner", "tag": "NotMoney" },
       { "field": "welcome_msg", "tag": "NoInfo" }
     ],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
+    "ADT constructors": []
   },
   "contract_info": {
     "scilla_major_version": "0",

--- a/tests/checker/good/gold/helloWorld.scilla.gold
+++ b/tests/checker/good/gold/helloWorld.scilla.gold
@@ -1,8 +1,16 @@
 {
-  "cashflow_tags": [
-    { "field": "owner", "tag": "NotMoney" },
-    { "field": "welcome_msg", "tag": "NoInfo" }
-  ],
+  "cashflow_tags": {
+    "State variables": [
+      { "field": "owner", "tag": "NotMoney" },
+      { "field": "welcome_msg", "tag": "NoInfo" }
+    ],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "HelloWorld",

--- a/tests/checker/good/gold/inplace-map.scilla.gold
+++ b/tests/checker/good/gold/inplace-map.scilla.gold
@@ -5,12 +5,7 @@
       { "field": "gmap", "tag": "(Map NoInfo)" },
       { "field": "gmap3", "tag": "(Map (Map (Map NoInfo)))" }
     ],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
+    "ADT constructors": []
   },
   "contract_info": {
     "scilla_major_version": "0",

--- a/tests/checker/good/gold/inplace-map.scilla.gold
+++ b/tests/checker/good/gold/inplace-map.scilla.gold
@@ -1,9 +1,17 @@
 {
-  "cashflow_tags": [
-    { "field": "owner", "tag": "NotMoney" },
-    { "field": "gmap", "tag": "(Map NoInfo)" },
-    { "field": "gmap3", "tag": "(Map (Map (Map NoInfo)))" }
-  ],
+  "cashflow_tags": {
+    "State variables": [
+      { "field": "owner", "tag": "NotMoney" },
+      { "field": "gmap", "tag": "(Map NoInfo)" },
+      { "field": "gmap3", "tag": "(Map (Map (Map NoInfo)))" }
+    ],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Test",

--- a/tests/checker/good/gold/libchain1.scilla.gold
+++ b/tests/checker/good/gold/libchain1.scilla.gold
@@ -1,13 +1,5 @@
 {
-  "cashflow_tags": {
-    "State variables": [],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
-  },
+  "cashflow_tags": { "State variables": [], "ADT constructors": [] },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "TestContr1",

--- a/tests/checker/good/gold/libchain1.scilla.gold
+++ b/tests/checker/good/gold/libchain1.scilla.gold
@@ -1,5 +1,13 @@
 {
-  "cashflow_tags": [],
+  "cashflow_tags": {
+    "State variables": [],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "TestContr1",

--- a/tests/checker/good/gold/libchain2.scilla.gold
+++ b/tests/checker/good/gold/libchain2.scilla.gold
@@ -1,5 +1,13 @@
 {
-  "cashflow_tags": [],
+  "cashflow_tags": {
+    "State variables": [],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "TestContr2",

--- a/tests/checker/good/gold/libchain2.scilla.gold
+++ b/tests/checker/good/gold/libchain2.scilla.gold
@@ -1,13 +1,5 @@
 {
-  "cashflow_tags": {
-    "State variables": [],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
-  },
+  "cashflow_tags": { "State variables": [], "ADT constructors": [] },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "TestContr2",

--- a/tests/checker/good/gold/libdiamond.scilla.gold
+++ b/tests/checker/good/gold/libdiamond.scilla.gold
@@ -1,13 +1,5 @@
 {
-  "cashflow_tags": {
-    "State variables": [],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
-  },
+  "cashflow_tags": { "State variables": [], "ADT constructors": [] },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "TestContr1",

--- a/tests/checker/good/gold/libdiamond.scilla.gold
+++ b/tests/checker/good/gold/libdiamond.scilla.gold
@@ -1,5 +1,13 @@
 {
-  "cashflow_tags": [],
+  "cashflow_tags": {
+    "State variables": [],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "TestContr1",

--- a/tests/checker/good/gold/map_key_test.scilla.gold
+++ b/tests/checker/good/gold/map_key_test.scilla.gold
@@ -1,5 +1,14 @@
 {
-  "cashflow_tags": [],
+  "cashflow_tags": {
+    "State variables": [],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "TestType": [ { "constructor": "T", "tag": [ "NoInfo" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Test",

--- a/tests/checker/good/gold/map_key_test.scilla.gold
+++ b/tests/checker/good/gold/map_key_test.scilla.gold
@@ -2,11 +2,7 @@
   "cashflow_tags": {
     "State variables": [],
     "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "TestType": [ { "constructor": "T", "tag": [ "NoInfo" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+      { "TestType": [ { "constructor": "T", "tags": [ "NoInfo" ] } ] }
     ]
   },
   "contract_info": {

--- a/tests/checker/good/gold/mappair.scilla.gold
+++ b/tests/checker/good/gold/mappair.scilla.gold
@@ -8,12 +8,7 @@
       { "field": "plist", "tag": "(List NoInfo)" },
       { "field": "gnat", "tag": "(Nat )" }
     ],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
+    "ADT constructors": []
   },
   "contract_info": {
     "scilla_major_version": "0",

--- a/tests/checker/good/gold/mappair.scilla.gold
+++ b/tests/checker/good/gold/mappair.scilla.gold
@@ -1,12 +1,20 @@
 {
-  "cashflow_tags": [
-    { "field": "owner", "tag": "NotMoney" },
-    { "field": "gmap", "tag": "(Map (Pair NoInfo NoInfo))" },
-    { "field": "gpair", "tag": "(Pair (List NoInfo) (Option NoInfo))" },
-    { "field": "llist", "tag": "(List NoInfo)" },
-    { "field": "plist", "tag": "(List NoInfo)" },
-    { "field": "gnat", "tag": "(Nat )" }
-  ],
+  "cashflow_tags": {
+    "State variables": [
+      { "field": "owner", "tag": "NotMoney" },
+      { "field": "gmap", "tag": "(Map (Pair NoInfo NoInfo))" },
+      { "field": "gpair", "tag": "(Pair (List NoInfo) (Option NoInfo))" },
+      { "field": "llist", "tag": "(List NoInfo)" },
+      { "field": "plist", "tag": "(List NoInfo)" },
+      { "field": "gnat", "tag": "(Nat )" }
+    ],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Test",

--- a/tests/checker/good/gold/missing-accepts.scilla.gold
+++ b/tests/checker/good/gold/missing-accepts.scilla.gold
@@ -1,13 +1,5 @@
 {
-  "cashflow_tags": {
-    "State variables": [],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
-  },
+  "cashflow_tags": { "State variables": [], "ADT constructors": [] },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "MissingAccepts",

--- a/tests/checker/good/gold/missing-accepts.scilla.gold
+++ b/tests/checker/good/gold/missing-accepts.scilla.gold
@@ -1,5 +1,13 @@
 {
-  "cashflow_tags": [],
+  "cashflow_tags": {
+    "State variables": [],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "MissingAccepts",

--- a/tests/checker/good/gold/multiple-accepts.scilla.gold
+++ b/tests/checker/good/gold/multiple-accepts.scilla.gold
@@ -1,13 +1,5 @@
 {
-  "cashflow_tags": {
-    "State variables": [],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
-  },
+  "cashflow_tags": { "State variables": [], "ADT constructors": [] },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "MultipleAccepts",

--- a/tests/checker/good/gold/multiple-accepts.scilla.gold
+++ b/tests/checker/good/gold/multiple-accepts.scilla.gold
@@ -1,5 +1,13 @@
 {
-  "cashflow_tags": [],
+  "cashflow_tags": {
+    "State variables": [],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "MultipleAccepts",

--- a/tests/checker/good/gold/multiple-msgs.scilla.gold
+++ b/tests/checker/good/gold/multiple-msgs.scilla.gold
@@ -1,13 +1,5 @@
 {
-  "cashflow_tags": {
-    "State variables": [],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
-  },
+  "cashflow_tags": { "State variables": [], "ADT constructors": [] },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "HelloWorld",

--- a/tests/checker/good/gold/multiple-msgs.scilla.gold
+++ b/tests/checker/good/gold/multiple-msgs.scilla.gold
@@ -1,5 +1,13 @@
 {
-  "cashflow_tags": [],
+  "cashflow_tags": {
+    "State variables": [],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "HelloWorld",

--- a/tests/checker/good/gold/nonfungible-token.scilla.gold
+++ b/tests/checker/good/gold/nonfungible-token.scilla.gold
@@ -9,12 +9,7 @@
       { "field": "tokenApprovals", "tag": "(Map NoInfo)" },
       { "field": "operatorApprovals", "tag": "(Map (Map NoInfo))" }
     ],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
+    "ADT constructors": []
   },
   "contract_info": {
     "scilla_major_version": "0",

--- a/tests/checker/good/gold/nonfungible-token.scilla.gold
+++ b/tests/checker/good/gold/nonfungible-token.scilla.gold
@@ -1,13 +1,21 @@
 {
-  "cashflow_tags": [
-    { "field": "contractOwner", "tag": "NoInfo" },
-    { "field": "name", "tag": "NoInfo" },
-    { "field": "symbol", "tag": "NoInfo" },
-    { "field": "tokenOwnerMap", "tag": "(Map NoInfo)" },
-    { "field": "ownedTokenCount", "tag": "(Map NoInfo)" },
-    { "field": "tokenApprovals", "tag": "(Map NoInfo)" },
-    { "field": "operatorApprovals", "tag": "(Map (Map NoInfo))" }
-  ],
+  "cashflow_tags": {
+    "State variables": [
+      { "field": "contractOwner", "tag": "NoInfo" },
+      { "field": "name", "tag": "NoInfo" },
+      { "field": "symbol", "tag": "NoInfo" },
+      { "field": "tokenOwnerMap", "tag": "(Map NoInfo)" },
+      { "field": "ownedTokenCount", "tag": "(Map NoInfo)" },
+      { "field": "tokenApprovals", "tag": "(Map NoInfo)" },
+      { "field": "operatorApprovals", "tag": "(Map (Map NoInfo))" }
+    ],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "NonfungibleToken",

--- a/tests/checker/good/gold/one-accept.scilla.gold
+++ b/tests/checker/good/gold/one-accept.scilla.gold
@@ -1,5 +1,13 @@
 {
-  "cashflow_tags": [],
+  "cashflow_tags": {
+    "State variables": [],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "OneAccept",

--- a/tests/checker/good/gold/one-accept.scilla.gold
+++ b/tests/checker/good/gold/one-accept.scilla.gold
@@ -1,13 +1,5 @@
 {
-  "cashflow_tags": {
-    "State variables": [],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
-  },
+  "cashflow_tags": { "State variables": [], "ADT constructors": [] },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "OneAccept",

--- a/tests/checker/good/gold/one-msg.scilla.gold
+++ b/tests/checker/good/gold/one-msg.scilla.gold
@@ -1,13 +1,5 @@
 {
-  "cashflow_tags": {
-    "State variables": [],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
-  },
+  "cashflow_tags": { "State variables": [], "ADT constructors": [] },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "HelloWorld",

--- a/tests/checker/good/gold/one-msg.scilla.gold
+++ b/tests/checker/good/gold/one-msg.scilla.gold
@@ -1,5 +1,13 @@
 {
-  "cashflow_tags": [],
+  "cashflow_tags": {
+    "State variables": [],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "HelloWorld",

--- a/tests/checker/good/gold/one-msg1.scilla.gold
+++ b/tests/checker/good/gold/one-msg1.scilla.gold
@@ -1,13 +1,5 @@
 {
-  "cashflow_tags": {
-    "State variables": [],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
-  },
+  "cashflow_tags": { "State variables": [], "ADT constructors": [] },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "HelloWorld",

--- a/tests/checker/good/gold/one-msg1.scilla.gold
+++ b/tests/checker/good/gold/one-msg1.scilla.gold
@@ -1,5 +1,13 @@
 {
-  "cashflow_tags": [],
+  "cashflow_tags": {
+    "State variables": [],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "HelloWorld",

--- a/tests/checker/good/gold/one-transition-accepts.scilla.gold
+++ b/tests/checker/good/gold/one-transition-accepts.scilla.gold
@@ -1,5 +1,13 @@
 {
-  "cashflow_tags": [],
+  "cashflow_tags": {
+    "State variables": [],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "OneTransitionAccepts",

--- a/tests/checker/good/gold/one-transition-accepts.scilla.gold
+++ b/tests/checker/good/gold/one-transition-accepts.scilla.gold
@@ -1,13 +1,5 @@
 {
-  "cashflow_tags": {
-    "State variables": [],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
-  },
+  "cashflow_tags": { "State variables": [], "ADT constructors": [] },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "OneTransitionAccepts",

--- a/tests/checker/good/gold/one-transition-might-accept.scilla.gold
+++ b/tests/checker/good/gold/one-transition-might-accept.scilla.gold
@@ -1,13 +1,5 @@
 {
-  "cashflow_tags": {
-    "State variables": [],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
-  },
+  "cashflow_tags": { "State variables": [], "ADT constructors": [] },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "OneTransitionMightAccept",

--- a/tests/checker/good/gold/one-transition-might-accept.scilla.gold
+++ b/tests/checker/good/gold/one-transition-might-accept.scilla.gold
@@ -1,5 +1,13 @@
 {
-  "cashflow_tags": [],
+  "cashflow_tags": {
+    "State variables": [],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "OneTransitionMightAccept",

--- a/tests/checker/good/gold/ping.scilla.gold
+++ b/tests/checker/good/gold/ping.scilla.gold
@@ -1,8 +1,16 @@
 {
-  "cashflow_tags": [
-    { "field": "count", "tag": "NoInfo" },
-    { "field": "pong_addr", "tag": "(Option NotMoney)" }
-  ],
+  "cashflow_tags": {
+    "State variables": [
+      { "field": "count", "tag": "NoInfo" },
+      { "field": "pong_addr", "tag": "(Option NotMoney)" }
+    ],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Ping",

--- a/tests/checker/good/gold/ping.scilla.gold
+++ b/tests/checker/good/gold/ping.scilla.gold
@@ -4,12 +4,7 @@
       { "field": "count", "tag": "NoInfo" },
       { "field": "pong_addr", "tag": "(Option NotMoney)" }
     ],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
+    "ADT constructors": []
   },
   "contract_info": {
     "scilla_major_version": "0",

--- a/tests/checker/good/gold/pong.scilla.gold
+++ b/tests/checker/good/gold/pong.scilla.gold
@@ -4,12 +4,7 @@
       { "field": "count", "tag": "NoInfo" },
       { "field": "ping_addr", "tag": "(Option NotMoney)" }
     ],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
+    "ADT constructors": []
   },
   "contract_info": {
     "scilla_major_version": "0",

--- a/tests/checker/good/gold/pong.scilla.gold
+++ b/tests/checker/good/gold/pong.scilla.gold
@@ -1,8 +1,16 @@
 {
-  "cashflow_tags": [
-    { "field": "count", "tag": "NoInfo" },
-    { "field": "ping_addr", "tag": "(Option NotMoney)" }
-  ],
+  "cashflow_tags": {
+    "State variables": [
+      { "field": "count", "tag": "NoInfo" },
+      { "field": "ping_addr", "tag": "(Option NotMoney)" }
+    ],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Pong",

--- a/tests/checker/good/gold/schnorr.scilla.gold
+++ b/tests/checker/good/gold/schnorr.scilla.gold
@@ -1,12 +1,7 @@
 {
   "cashflow_tags": {
     "State variables": [ { "field": "pub_key", "tag": "(Option NotMoney)" } ],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
+    "ADT constructors": []
   },
   "contract_info": {
     "scilla_major_version": "0",

--- a/tests/checker/good/gold/schnorr.scilla.gold
+++ b/tests/checker/good/gold/schnorr.scilla.gold
@@ -1,5 +1,13 @@
 {
-  "cashflow_tags": [ { "field": "pub_key", "tag": "(Option NotMoney)" } ],
+  "cashflow_tags": {
+    "State variables": [ { "field": "pub_key", "tag": "(Option NotMoney)" } ],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Schnorr",

--- a/tests/checker/good/gold/shogi.scilla.gold
+++ b/tests/checker/good/gold/shogi.scilla.gold
@@ -1,12 +1,76 @@
 {
-  "cashflow_tags": [
-    { "field": "player1", "tag": "NotMoney" },
-    { "field": "player2", "tag": "NoInfo" },
-    { "field": "board", "tag": "(Map (Map (SquareContents )))" },
-    { "field": "captured_pieces", "tag": "(Map (Map NoInfo))" },
-    { "field": "player_in_turn", "tag": "(Option NotMoney)" },
-    { "field": "winner", "tag": "(Option NotMoney)" }
-  ],
+  "cashflow_tags": {
+    "State variables": [
+      { "field": "player1", "tag": "NotMoney" },
+      { "field": "player2", "tag": "NoInfo" },
+      { "field": "board", "tag": "(Map (Map (SquareContents )))" },
+      { "field": "captured_pieces", "tag": "(Map (Map NoInfo))" },
+      { "field": "player_in_turn", "tag": "(Option NotMoney)" },
+      { "field": "winner", "tag": "(Option NotMoney)" }
+    ],
+    "ADT constructors": [
+      {
+        "Piece": [
+          { "constructor": "King", "tag": [] },
+          { "constructor": "GoldGeneral", "tag": [] },
+          { "constructor": "SilverGeneral", "tag": [] },
+          { "constructor": "Knight", "tag": [] },
+          { "constructor": "Lance", "tag": [] },
+          { "constructor": "Pawn", "tag": [] },
+          { "constructor": "Rook", "tag": [] },
+          { "constructor": "Bishop", "tag": [] }
+        ]
+      },
+      {
+        "Error": [
+          { "constructor": "GameOver", "tag": [] },
+          { "constructor": "PlayingOutOfTurn", "tag": [] },
+          { "constructor": "IllegalAction", "tag": [] },
+          { "constructor": "InternalError", "tag": [] }
+        ]
+      },
+      {
+        "SquareContents": [
+          { "constructor": "Occupied", "tag": [ "_", "_", "NotMoney" ] },
+          { "constructor": "Free", "tag": [] }
+        ]
+      },
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      {
+        "Action": [
+          { "constructor": "Move", "tag": [ "_", "_", "NoInfo", "_" ] },
+          { "constructor": "Place", "tag": [ "_", "_" ] },
+          { "constructor": "Resign", "tag": [] }
+        ]
+      },
+      {
+        "Direction": [
+          { "constructor": "East", "tag": [] },
+          { "constructor": "SouthEast", "tag": [] },
+          { "constructor": "South", "tag": [] },
+          { "constructor": "SouthWest", "tag": [] },
+          { "constructor": "West", "tag": [] },
+          { "constructor": "NorthWest", "tag": [] },
+          { "constructor": "North", "tag": [] },
+          { "constructor": "NorthEast", "tag": [] }
+        ]
+      },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] },
+      {
+        "PromotionStatus": [
+          { "constructor": "NotPromoted", "tag": [] },
+          { "constructor": "Promoted", "tag": [] }
+        ]
+      },
+      {
+        "Square": [
+          { "constructor": "Square", "tag": [ "NotMoney", "NotMoney" ] }
+        ]
+      }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Shogi",

--- a/tests/checker/good/gold/shogi.scilla.gold
+++ b/tests/checker/good/gold/shogi.scilla.gold
@@ -10,63 +10,18 @@
     ],
     "ADT constructors": [
       {
-        "Piece": [
-          { "constructor": "King", "tag": [] },
-          { "constructor": "GoldGeneral", "tag": [] },
-          { "constructor": "SilverGeneral", "tag": [] },
-          { "constructor": "Knight", "tag": [] },
-          { "constructor": "Lance", "tag": [] },
-          { "constructor": "Pawn", "tag": [] },
-          { "constructor": "Rook", "tag": [] },
-          { "constructor": "Bishop", "tag": [] }
-        ]
-      },
-      {
-        "Error": [
-          { "constructor": "GameOver", "tag": [] },
-          { "constructor": "PlayingOutOfTurn", "tag": [] },
-          { "constructor": "IllegalAction", "tag": [] },
-          { "constructor": "InternalError", "tag": [] }
-        ]
-      },
-      {
         "SquareContents": [
-          { "constructor": "Occupied", "tag": [ "_", "_", "NotMoney" ] },
-          { "constructor": "Free", "tag": [] }
+          { "constructor": "Occupied", "tags": [ "_", "_", "NotMoney" ] }
         ]
       },
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
       {
         "Action": [
-          { "constructor": "Move", "tag": [ "_", "_", "NoInfo", "_" ] },
-          { "constructor": "Place", "tag": [ "_", "_" ] },
-          { "constructor": "Resign", "tag": [] }
-        ]
-      },
-      {
-        "Direction": [
-          { "constructor": "East", "tag": [] },
-          { "constructor": "SouthEast", "tag": [] },
-          { "constructor": "South", "tag": [] },
-          { "constructor": "SouthWest", "tag": [] },
-          { "constructor": "West", "tag": [] },
-          { "constructor": "NorthWest", "tag": [] },
-          { "constructor": "North", "tag": [] },
-          { "constructor": "NorthEast", "tag": [] }
-        ]
-      },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] },
-      {
-        "PromotionStatus": [
-          { "constructor": "NotPromoted", "tag": [] },
-          { "constructor": "Promoted", "tag": [] }
+          { "constructor": "Move", "tags": [ "_", "_", "NoInfo", "_" ] }
         ]
       },
       {
         "Square": [
-          { "constructor": "Square", "tag": [ "NotMoney", "NotMoney" ] }
+          { "constructor": "Square", "tags": [ "NotMoney", "NotMoney" ] }
         ]
       }
     ]

--- a/tests/checker/good/gold/simple-dex.scilla.gold
+++ b/tests/checker/good/gold/simple-dex.scilla.gold
@@ -11,14 +11,10 @@
         "Order": [
           {
             "constructor": "Order",
-            "tag": [ "NoInfo", "NoInfo", "NoInfo", "NoInfo" ]
+            "tags": [ "NoInfo", "NoInfo", "NoInfo", "NoInfo" ]
           }
         ]
-      },
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+      }
     ]
   },
   "contract_info": {

--- a/tests/checker/good/gold/simple-dex.scilla.gold
+++ b/tests/checker/good/gold/simple-dex.scilla.gold
@@ -1,10 +1,26 @@
 {
-  "cashflow_tags": [
-    { "field": "contractOwner", "tag": "NoInfo" },
-    { "field": "orderbook", "tag": "(Map (Order ))" },
-    { "field": "orderInfo", "tag": "(Map (Pair NotMoney NotMoney))" },
-    { "field": "pendingReturns", "tag": "(Map (Map NoInfo))" }
-  ],
+  "cashflow_tags": {
+    "State variables": [
+      { "field": "contractOwner", "tag": "NoInfo" },
+      { "field": "orderbook", "tag": "(Map (Order ))" },
+      { "field": "orderInfo", "tag": "(Map (Pair NotMoney NotMoney))" },
+      { "field": "pendingReturns", "tag": "(Map (Map NoInfo))" }
+    ],
+    "ADT constructors": [
+      {
+        "Order": [
+          {
+            "constructor": "Order",
+            "tag": [ "NoInfo", "NoInfo", "NoInfo", "NoInfo" ]
+          }
+        ]
+      },
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "SimpleDex",

--- a/tests/checker/good/gold/wallet.scilla.gold
+++ b/tests/checker/good/gold/wallet.scilla.gold
@@ -1,15 +1,45 @@
 {
-  "cashflow_tags": [
-    { "field": "initial_owners", "tag": "NoInfo" },
-    { "field": "required_signatures", "tag": "NotMoney" },
-    { "field": "validity_checked", "tag": "NotMoney" },
-    { "field": "contract_valid", "tag": "NotMoney" },
-    { "field": "owners", "tag": "(Map NotMoney)" },
-    { "field": "transactionCount", "tag": "NotMoney" },
-    { "field": "signatures", "tag": "(Map (Map NotMoney))" },
-    { "field": "transactions", "tag": "(Map (Transaction ))" },
-    { "field": "owner_signatures", "tag": "(Map (Map NotMoney))" }
-  ],
+  "cashflow_tags": {
+    "State variables": [
+      { "field": "initial_owners", "tag": "NoInfo" },
+      { "field": "required_signatures", "tag": "NotMoney" },
+      { "field": "validity_checked", "tag": "NotMoney" },
+      { "field": "contract_valid", "tag": "NotMoney" },
+      { "field": "owners", "tag": "(Map NotMoney)" },
+      { "field": "transactionCount", "tag": "NotMoney" },
+      { "field": "signatures", "tag": "(Map (Map NotMoney))" },
+      { "field": "transactions", "tag": "(Map (Transaction ))" },
+      { "field": "owner_signatures", "tag": "(Map (Map NotMoney))" }
+    ],
+    "ADT constructors": [
+      {
+        "Error": [
+          { "constructor": "NonOwnerCannotSign", "tag": [] },
+          { "constructor": "UnknownTransactionId", "tag": [] },
+          { "constructor": "InsufficientFunds", "tag": [] },
+          { "constructor": "NoSignatureListFound", "tag": [] },
+          { "constructor": "AlreadySigned", "tag": [] },
+          { "constructor": "NotAlreadySigned", "tag": [] },
+          { "constructor": "InvalidContract", "tag": [] },
+          { "constructor": "InvalidAmount", "tag": [] },
+          { "constructor": "NotEnoughSignatures", "tag": [] },
+          { "constructor": "SenderIsNotRecipient", "tag": [] },
+          { "constructor": "CandidateAlreadyAdded", "tag": [] },
+          { "constructor": "UnknownCandidate", "tag": [] },
+          { "constructor": "CandidateAlreadyOwner", "tag": [] }
+        ]
+      },
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      {
+        "Transaction": [
+          { "constructor": "Trans", "tag": [ "NotMoney", "Money" ] }
+        ]
+      },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Wallet",

--- a/tests/checker/good/gold/wallet.scilla.gold
+++ b/tests/checker/good/gold/wallet.scilla.gold
@@ -13,31 +13,10 @@
     ],
     "ADT constructors": [
       {
-        "Error": [
-          { "constructor": "NonOwnerCannotSign", "tag": [] },
-          { "constructor": "UnknownTransactionId", "tag": [] },
-          { "constructor": "InsufficientFunds", "tag": [] },
-          { "constructor": "NoSignatureListFound", "tag": [] },
-          { "constructor": "AlreadySigned", "tag": [] },
-          { "constructor": "NotAlreadySigned", "tag": [] },
-          { "constructor": "InvalidContract", "tag": [] },
-          { "constructor": "InvalidAmount", "tag": [] },
-          { "constructor": "NotEnoughSignatures", "tag": [] },
-          { "constructor": "SenderIsNotRecipient", "tag": [] },
-          { "constructor": "CandidateAlreadyAdded", "tag": [] },
-          { "constructor": "UnknownCandidate", "tag": [] },
-          { "constructor": "CandidateAlreadyOwner", "tag": [] }
-        ]
-      },
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      {
         "Transaction": [
-          { "constructor": "Trans", "tag": [ "NotMoney", "Money" ] }
+          { "constructor": "Trans", "tags": [ "NotMoney", "Money" ] }
         ]
-      },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+      }
     ]
   },
   "contract_info": {

--- a/tests/checker/good/gold/zil-game.scilla.gold
+++ b/tests/checker/good/gold/zil-game.scilla.gold
@@ -1,13 +1,21 @@
 {
-  "cashflow_tags": [
-    { "field": "owner", "tag": "NotMoney" },
-    { "field": "player_a", "tag": "NotMoney" },
-    { "field": "player_b", "tag": "NotMoney" },
-    { "field": "puzzle", "tag": "NoInfo" },
-    { "field": "player_a_hash", "tag": "(Option NoInfo)" },
-    { "field": "player_b_hash", "tag": "(Option NoInfo)" },
-    { "field": "timer", "tag": "(Option NoInfo)" }
-  ],
+  "cashflow_tags": {
+    "State variables": [
+      { "field": "owner", "tag": "NotMoney" },
+      { "field": "player_a", "tag": "NotMoney" },
+      { "field": "player_b", "tag": "NotMoney" },
+      { "field": "puzzle", "tag": "NoInfo" },
+      { "field": "player_a_hash", "tag": "(Option NoInfo)" },
+      { "field": "player_b_hash", "tag": "(Option NoInfo)" },
+      { "field": "timer", "tag": "(Option NoInfo)" }
+    ],
+    "ADT constructors": [
+      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
+      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
+      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
+      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
+    ]
+  },
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "ZilGame",

--- a/tests/checker/good/gold/zil-game.scilla.gold
+++ b/tests/checker/good/gold/zil-game.scilla.gold
@@ -9,12 +9,7 @@
       { "field": "player_b_hash", "tag": "(Option NoInfo)" },
       { "field": "timer", "tag": "(Option NoInfo)" }
     ],
-    "ADT constructors": [
-      { "Option": [ { "constructor": "Some", "tag": [ "_" ] } ] },
-      { "Nat": [ { "constructor": "Succ", "tag": [ "_" ] } ] },
-      { "List": [ { "constructor": "Cons", "tag": [ "_", "_" ] } ] },
-      { "Pair": [ { "constructor": "Pair", "tag": [ "_", "_" ] } ] }
-    ]
+    "ADT constructors": []
   },
   "contract_info": {
     "scilla_major_version": "0",


### PR DESCRIPTION
Fixes #484.

The Cashflow checker now tags ADT constructor arguments as well.

A global map from "interesting" constructors to argument tags is maintained throughout the analysis, and updated every time a constructor is applied or pattern-matched against.

An "interesting" constructor is one that has at least one "interesting" argument. An "interesting" argument is defined using the function `ctr_arg_filter`, and is currently defined as an argument of primitive type, map type, or function type. We exclude ADT types because they may be inductive. We exclude the Unit type because it is degenerate. We exclude type containing type variables since they are tagged at variable level rather than at constructor level.

Surprisingly, we get pretty good results even though library functions are still not analysed...