### PR TITLE
cpp linker error fix

### DIFF
--- a/src/cpp/dune
+++ b/src/cpp/dune
@@ -6,7 +6,7 @@
   (c_names generate_dsa_nonce)
   (cxx_names c_schnorr DataConversion Schnorr PrivKey PubKey Signature BIGNUMSerialize ECPOINTSerialize)
   (c_flags (:include c_flags.sexp))
-  (cxx_flags -std=c++11 (:include c_flags.sexp))
+  (cxx_flags -std=c++11 -fPIC (:include c_flags.sexp))
   ;;; -lstdc++ is not portable, it can be e.g. -lc++
   (c_library_flags -lstdc++ (:include c_library_flags.sexp))
   )


### PR DESCRIPTION
This is step 1 in fixing the cpp linker error described below.

```
raptorwrangler@raptor3:~/Desktop/Scilla$ make clean; make
dune clean
git clean -dfXq
dune build --profile release @install
      menhir src/lang/base/ScillaParser.{ml,mli}
Warning: 11 states have shift/reduce conflicts.
Warning: 21 shift/reduce conflicts were arbitrarily resolved.
  ocamlmklib src/cpp/dllscilla_cpp_deps_stubs.so,src/cpp/libscilla_cpp_deps_stubs.a (exit 2)
(cd _build/default && /home/raptorwrangler/.opam/4.06.1/bin/ocamlmklib.opt -g -o src/cpp/scilla_cpp_deps_stubs src/cpp/generate_dsa_nonce.o src/cpp/BIGNUMSerialize.o src/cpp/DataConversion.o src/cpp/ECPOINTSerialize.o src/cpp/PrivKey.o src/cpp/PubKey.o src/cpp/Schnorr.o src/cpp/Signature.o src/cpp/c_schnorr.o)
/usr/bin/ld: src/cpp/BIGNUMSerialize.o: relocation R_X86_64_PC32 against symbol `_ZNKSt6vectorIhSaIhEE4sizeEv' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: Bad value
collect2: error: ld returned 1 exit status
```

When in doubt, do as the error message suggests, so I added the `-fPIC` flag to the cpp compiler options.

Step 2 is to run `opam upgrade ctypes`. Then everything compiles and runs, but it does involve a downgrade of the `integers` package, so I don't know if that is what we want.