### PR TITLE
Warn when important names are shadowed by re-definitions

### DIFF
--- a/src/lang/checkers/SanityChecker.ml
+++ b/src/lang/checkers/SanityChecker.ml
@@ -434,6 +434,8 @@ module ScillaSanityChecker
         | Fun (i, _, e_body)
         | Fixpoint (i, _, e_body)
         | TFun (i, e_body) ->
+          (* "i" being a type variable shouldn't be shadowing contract parameters,
+            fields or transition parameters. This is just a conservative check. *)
           check_warn_redef cparams cfields pnames i;
           expr_iter e_body
         | MatchExpr (_, clauses) ->

--- a/src/lang/checkers/SanityChecker.ml
+++ b/src/lang/checkers/SanityChecker.ml
@@ -42,6 +42,8 @@ module ScillaSanityChecker
 
   (* Warning level to use when contract loads/stores entire Maps. *)
   let warning_level_map_load_store = 1
+  (* Warning level to use when warning about shadowing of contract parameters and fields. *)
+  let warning_level_name_shadowing = 2
 
   (* ************************************** *)
   (* ******** Basic Sanity Checker ******** *)
@@ -374,11 +376,103 @@ module ScillaSanityChecker
     ) ~init:() cmod.contr.ctrans
 
   (* ************************************** *)
+  (* ********* Warn name shadowing ******** *)
+  (* ************************************** *)
+
+  let warn_shadowing cmod =
+
+    (* A utility function that checks if "id" is shadowing cparams, cfields or pnames. *)
+    let check_warn_redef cparams cfields pnames id =
+      if List.mem (get_id id) cparams
+      then (
+        warn1 (Printf.sprintf "Name %s shadows a contract parameter." (get_id id))
+        warning_level_name_shadowing
+        (ER.get_loc (get_rep id));
+      ) else if List.mem (get_id id) cfields
+      then (
+        warn1 (Printf.sprintf "Name %s shadows a field declaration." (get_id id))
+        warning_level_name_shadowing
+        (ER.get_loc (get_rep id));
+      ) else if List.mem (get_id id) pnames
+      then (
+        warn1 (Printf.sprintf "Name %s shadows a transition parameter." (get_id id))
+        warning_level_name_shadowing
+        (ER.get_loc (get_rep id));
+      )
+    in
+
+    let cparams = List.map (fun (p, _) -> get_id p) cmod.contr.cparams in
+    (* Check if a field shadows any contract parameter. *)
+    List.iter (fun (f, _, _) -> check_warn_redef cparams [] [] f) cmod.contr.cfields;
+  
+    let cfields = List.map (fun (f, _, _) -> get_id f) cmod.contr.cfields in
+
+    (* Go through each transition. *)
+    List.iter (fun t ->
+
+    (* 1. If a parameter name shadows one of cparams or cfields, warn. *)
+      List.iter (fun (p, _) -> check_warn_redef cparams cfields [] p) t.tparams;
+      let pnames = List.map (fun (p, _) -> get_id p) t.tparams in
+
+      (* Check for shadowing in patterns. *)
+      let rec pattern_iter = function
+        | Wildcard -> ()
+        | Binder i -> check_warn_redef cparams cfields pnames i
+        | Constructor (_, plist) ->
+          List.iter (fun pat -> pattern_iter pat) plist
+      in
+
+      (* Check for shadowing in expressions. *)
+      let rec expr_iter (e, _) =
+        match e with
+        | Literal _ | Builtin _ | Constr _ | App _ | Message _ 
+        | Var _ | TApp _ -> ()
+        | Let (i, _, e_lhs, e_rhs) ->
+          check_warn_redef cparams cfields pnames i;
+          expr_iter e_lhs;
+          expr_iter e_rhs
+        | Fun (i, _, e_body)
+        | Fixpoint (i, _, e_body)
+        | TFun (i, e_body) ->
+          check_warn_redef cparams cfields pnames i;
+          expr_iter e_body
+        | MatchExpr (_, clauses) ->
+          List.iter (fun (pat, mbody) ->
+            pattern_iter pat;
+            expr_iter mbody
+          ) clauses
+      in
+
+      (* Check for shadowing in statements. *)
+      let rec stmt_iter stmts =
+        List.iter (fun (s, _) ->
+          match s with
+          | Load (x, _) | MapGet (x, _, _, _) | ReadFromBC (x, _) ->
+            check_warn_redef cparams cfields pnames x;
+          | Store _ | MapUpdate _ | SendMsgs _
+          | AcceptPayment | CreateEvnt _ | Throw _ ->
+            ()
+          | Bind (x, e) ->
+            check_warn_redef cparams cfields pnames x;
+            expr_iter e
+          | MatchStmt (_, clauses) ->
+            List.iter (fun (pat, mbody) ->
+              pattern_iter pat;
+              stmt_iter mbody
+            ) clauses
+        ) stmts
+      in
+      (* Go through all statements and see if any of cparams, cfields or pnames are redefined. *)
+      stmt_iter t.tbody
+    ) cmod.contr.ctrans
+
+  (* ************************************** *)
   (* ******** Interface to Checker ******** *)
   (* ************************************** *)
 
   let contr_sanity (cmod : cmodule) (rlibs : lib_entry list) (elibs : libtree list) =
     let%bind _ = basic_sanity cmod in
+    warn_shadowing cmod;
     one_msg_checker cmod rlibs elibs
 
 end

--- a/tests/checker/good/TestCheckerSuccess.ml
+++ b/tests/checker/good/TestCheckerSuccess.ml
@@ -72,6 +72,8 @@ module CheckerTests = TestUtil.DiffBasedTests(
       "libdiamond.scilla";
       "InstantiatedListUtils.scillib";
       "map_no_inplace_warn.scilla";
+      "shadowwarn1.scilla";
+      "shadowwarn2.scilla"
     ]
     let exit_code : Unix.process_status = WEXITED 0
   end)

--- a/tests/checker/good/TestCheckerSuccess.ml
+++ b/tests/checker/good/TestCheckerSuccess.ml
@@ -73,7 +73,8 @@ module CheckerTests = TestUtil.DiffBasedTests(
       "InstantiatedListUtils.scillib";
       "map_no_inplace_warn.scilla";
       "shadowwarn1.scilla";
-      "shadowwarn2.scilla"
+      "shadowwarn2.scilla";
+      "simple-dex-shadowwarn.scilla";
     ]
     let exit_code : Unix.process_status = WEXITED 0
   end)

--- a/tests/checker/good/gold/schnorr.scilla.gold
+++ b/tests/checker/good/gold/schnorr.scilla.gold
@@ -60,6 +60,16 @@
   },
   "warnings": [
     {
+      "warning_message": "Name sig shadows a transition parameter.",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 24,
+        "column": 9
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 2
+    },
+    {
       "warning_message":
         "No transition in contract Schnorr contains an accept statement\n",
       "start_location": { "file": "", "line": 0, "column": 0 },

--- a/tests/checker/good/gold/shadowwarn1.scilla.gold
+++ b/tests/checker/good/gold/shadowwarn1.scilla.gold
@@ -1,23 +1,15 @@
 {
   "cashflow_tags": {
-    "State variables": [
-      { "field": "pub_key", "tag": "(Option Inconsistent)" }
-    ],
+    "State variables": [ { "field": "p1", "tag": "NoInfo" } ],
     "ADT constructors": []
   },
   "contract_info": {
     "scilla_major_version": "0",
-    "vname": "Ecdsa",
-    "params": [],
-    "fields": [ { "vname": "pub_key", "type": "Option (ByStr33)" } ],
+    "vname": "ShadowWarn1",
+    "params": [ { "vname": "p1", "type": "Uint32" } ],
+    "fields": [],
     "transitions": [
-      {
-        "vname": "verify",
-        "params": [
-          { "vname": "msg", "type": "ByStr" },
-          { "vname": "sig", "type": "ByStr64" }
-        ]
-      }
+      { "vname": "Foo", "params": [ { "vname": "p1", "type": "String" } ] }
     ],
     "events": [],
     "ADTs": [
@@ -62,18 +54,18 @@
   },
   "warnings": [
     {
-      "warning_message": "Name sig shadows a transition parameter.",
+      "warning_message": "Name p1 shadows a contract parameter.",
       "start_location": {
-        "file": "contracts/ecdsa.scilla",
-        "line": 24,
-        "column": 9
+        "file": "checker/good/shadowwarn1.scilla",
+        "line": 5,
+        "column": 17
       },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 2
     },
     {
       "warning_message":
-        "No transition in contract Ecdsa contains an accept statement\n",
+        "No transition in contract ShadowWarn1 contains an accept statement\n",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1

--- a/tests/checker/good/gold/shadowwarn2.scilla.gold
+++ b/tests/checker/good/gold/shadowwarn2.scilla.gold
@@ -1,23 +1,22 @@
 {
   "cashflow_tags": {
     "State variables": [
-      { "field": "pub_key", "tag": "(Option Inconsistent)" }
+      { "field": "p1", "tag": "NoInfo" },
+      { "field": "p1", "tag": "NoInfo" },
+      { "field": "p2", "tag": "NoInfo" }
     ],
     "ADT constructors": []
   },
   "contract_info": {
     "scilla_major_version": "0",
-    "vname": "Ecdsa",
-    "params": [],
-    "fields": [ { "vname": "pub_key", "type": "Option (ByStr33)" } ],
+    "vname": "ShadowWarn2",
+    "params": [ { "vname": "p1", "type": "Uint32" } ],
+    "fields": [
+      { "vname": "p1", "type": "ByStr1" },
+      { "vname": "p2", "type": "ByStr1" }
+    ],
     "transitions": [
-      {
-        "vname": "verify",
-        "params": [
-          { "vname": "msg", "type": "ByStr" },
-          { "vname": "sig", "type": "ByStr64" }
-        ]
-      }
+      { "vname": "Foo", "params": [ { "vname": "p2", "type": "String" } ] }
     ],
     "events": [],
     "ADTs": [
@@ -62,18 +61,28 @@
   },
   "warnings": [
     {
-      "warning_message": "Name sig shadows a transition parameter.",
+      "warning_message": "Name p2 shadows a field declaration.",
       "start_location": {
-        "file": "contracts/ecdsa.scilla",
-        "line": 24,
-        "column": 9
+        "file": "checker/good/shadowwarn2.scilla",
+        "line": 8,
+        "column": 17
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 2
+    },
+    {
+      "warning_message": "Name p1 shadows a contract parameter.",
+      "start_location": {
+        "file": "checker/good/shadowwarn2.scilla",
+        "line": 5,
+        "column": 7
       },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 2
     },
     {
       "warning_message":
-        "No transition in contract Ecdsa contains an accept statement\n",
+        "No transition in contract ShadowWarn2 contains an accept statement\n",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1

--- a/tests/checker/good/gold/simple-dex-shadowwarn.scilla.gold
+++ b/tests/checker/good/gold/simple-dex-shadowwarn.scilla.gold
@@ -137,6 +137,16 @@
   },
   "warnings": [
     {
+      "warning_message": "Name orderInfo shadows a field declaration.",
+      "start_location": {
+        "file": "checker/good/simple-dex-shadowwarn.scilla",
+        "line": 204,
+        "column": 10
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 2
+    },
+    {
       "warning_message":
         "No transition in contract SimpleDex contains an accept statement\n",
       "start_location": { "file": "", "line": 0, "column": 0 },

--- a/tests/checker/good/gold/simple-dex.scilla.gold
+++ b/tests/checker/good/gold/simple-dex.scilla.gold
@@ -137,6 +137,16 @@
   },
   "warnings": [
     {
+      "warning_message": "Name orderInfo shadows a field declaration.",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 204,
+        "column": 10
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 2
+    },
+    {
       "warning_message":
         "No transition in contract SimpleDex contains an accept statement\n",
       "start_location": { "file": "", "line": 0, "column": 0 },

--- a/tests/checker/good/shadowwarn1.scilla
+++ b/tests/checker/good/shadowwarn1.scilla
@@ -1,0 +1,7 @@
+scilla_version 0
+
+contract ShadowWarn1 (p1 : Uint32)
+
+transition Foo (p1 : String)
+
+end

--- a/tests/checker/good/shadowwarn2.scilla
+++ b/tests/checker/good/shadowwarn2.scilla
@@ -1,0 +1,10 @@
+scilla_version 0
+
+contract ShadowWarn2 (p1 : Uint32)
+
+field p1 : ByStr1 = 0xff
+field p2 : ByStr1 = 0xfe
+
+transition Foo (p2 : String)
+
+end

--- a/tests/checker/good/simple-dex-shadowwarn.scilla
+++ b/tests/checker/good/simple-dex-shadowwarn.scilla
@@ -201,9 +201,9 @@ end
 transition cancelOrder(orderId: ByStr32)
   getOrderInfo <- orderInfo[orderId];
   match getOrderInfo with
-  | Some orderInfoForId => 
+  | Some orderInfo => 
       makerAddr = let getMakerAddr = @fst (ByStr20)(BNum) in
-                  getMakerAddr orderInfoForId;
+                  getMakerAddr orderInfo;
       checkSender = builtin eq makerAddr _sender;
       match checkSender with
       | True =>


### PR DESCRIPTION
In the order of importance:
 *  contract parameters,
  * fields,
  * transition parameters,
  * definitions in a transition

When any of these shadows a name that is of more importance, warn.

This resolves the second part of #522.