### PR TITLE
Use `import as` syntax for qualified imports

### DIFF
--- a/src/lang/base/ScillaLexer.mll
+++ b/src/lang/base/ScillaLexer.mll
@@ -85,6 +85,9 @@ rule read =
   | "scilla_version" { SCILLA_VERSION }
   | "type"        { TYPE }
   | "of"          { OF }
+  | "as"          { AS }
+  | "procedure"   { PROCEDURE }
+  | "throw"       { THROW }
 
 
   (* Separators *)    
@@ -99,7 +102,6 @@ rule read =
   | "{"           { LBRACE }
   | "}"           { RBRACE }
   | ","           { COMMA }
-  | ">>"          { IMPORTAS }
   | "=>"          { ARROW }                  
   | "->"          { TARROW }                  
   | "="           { EQ }                  

--- a/src/lang/base/ScillaParser.mly
+++ b/src/lang/base/ScillaParser.mly
@@ -83,7 +83,6 @@
 %token RSQB
 %token LPAREN
 %token RPAREN
-%token IMPORTAS
 %token ARROW
 %token TARROW
 %token AT
@@ -105,6 +104,9 @@
 %token EMP
 %token LIBRARY
 %token IMPORT
+%token AS
+%token PROCEDURE
+%token THROW
 %token FIELD
 %token LET
 %token IN
@@ -393,7 +395,7 @@ lmodule :
 
 importname :
 | c = CID { Ident(c, toLoc $startpos), None }
-| c1 = CID IMPORTAS c2 = CID { Ident(c1, toLoc $startpos(c1)), Some (Ident(c2, toLoc $startpos(c2)))}
+| c1 = CID AS c2 = CID { Ident(c1, toLoc $startpos(c1)), Some (Ident(c2, toLoc $startpos(c2)))}
 
 imports :
 | IMPORT; els = list(importname) { els }

--- a/tests/checker/bad/TestLibNS1.scillib
+++ b/tests/checker/bad/TestLibNS1.scillib
@@ -1,6 +1,6 @@
 (* importing the a (non-empty) library into same namespace is a name conflict *)
-import TestLibNS1 >> Foo
-       TestLibNS1 >> Foo
+import TestLibNS1 as Foo
+       TestLibNS1 as Foo
 
 library TestLibNS1
 

--- a/tests/checker/bad/namespace1.scilla
+++ b/tests/checker/bad/namespace1.scilla
@@ -1,7 +1,7 @@
 scilla_version 0
 
 (* Importing as "Barr" but using as "Bar" *)
-import TestLib1 >> Barr
+import TestLib1 as Barr
 
 library NS
 

--- a/tests/checker/good/TestLibNS1.scillib
+++ b/tests/checker/good/TestLibNS1.scillib
@@ -1,4 +1,4 @@
-import BoolUtils >> Foo
+import BoolUtils as Foo
 
 library TestLibNS1
 

--- a/tests/checker/good/TestLibNS2.scillib
+++ b/tests/checker/good/TestLibNS2.scillib
@@ -1,4 +1,4 @@
-import TestLibNS1 >> Foo
+import TestLibNS1 as Foo
 
 library TestLibNS2
 

--- a/tests/checker/good/TestLibNS3.scillib
+++ b/tests/checker/good/TestLibNS3.scillib
@@ -1,6 +1,6 @@
 (* importing the same library into two different namespaces should be fine *)
-import BoolUtils >> Foo
-       BoolUtils >> Bar
+import BoolUtils as Foo
+       BoolUtils as Bar
 
 library TestLibNS3
 

--- a/tests/checker/good/TestLibNS4.scillib
+++ b/tests/checker/good/TestLibNS4.scillib
@@ -1,6 +1,6 @@
 (* importing two disjoint libraries into the same namespace is fine *)
-import TestLibNS2 >> Foo
-       BoolUtils  >> Foo
+import TestLibNS2 as Foo
+       BoolUtils  as Foo
 
 library TestLibNS4
 

--- a/tests/checker/good/lib/TestLibDiamondTop.scillib
+++ b/tests/checker/good/lib/TestLibDiamondTop.scillib
@@ -1,4 +1,4 @@
-import TestLibDiamondLeft >> LeftFoo
-       TestLibDiamondRight >> RightFoo
+import TestLibDiamondLeft as LeftFoo
+       TestLibDiamondRight as RightFoo
 
 library TestLibDiamondTop

--- a/tests/checker/good/lib/TestLibNS1.scillib
+++ b/tests/checker/good/lib/TestLibNS1.scillib
@@ -1,4 +1,4 @@
-import BoolUtils >> Foo
+import BoolUtils as Foo
 
 library TestLibNS1
 

--- a/tests/checker/good/libdiamond2.scilla
+++ b/tests/checker/good/libdiamond2.scilla
@@ -1,7 +1,7 @@
 scilla_version 0
 
 import TestLibDiamondTop
-       TestLibDiamondBottom >> FooBot
+       TestLibDiamondBottom as FooBot
 
 library LibDiamond
 

--- a/tests/checker/good/namespace1.scilla
+++ b/tests/checker/good/namespace1.scilla
@@ -1,6 +1,6 @@
 scilla_version 0
 
-import TestLib1 >> Bar
+import TestLib1 as Bar
 
 library NS
 

--- a/tests/checker/good/namespace2.scilla
+++ b/tests/checker/good/namespace2.scilla
@@ -1,6 +1,6 @@
 scilla_version 0
 
-import ListUtils >> LU
+import ListUtils as LU
 
 library NS
 

--- a/tests/checker/good/namespace3.scilla
+++ b/tests/checker/good/namespace3.scilla
@@ -1,6 +1,6 @@
 scilla_version 0
 
-import TestLib1 >> TL
+import TestLib1 as TL
 
 library NS
 


### PR DESCRIPTION
Since we're adding a new keyword, also reserve two keywords `procedure` and `throw` for future use.