### PR TITLE
README fix `let` example path. (micro change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Once the project is built you can try the following things:
 From the project root, execute
 
 ```
-./bin/eval-runner -libdir src/stdlib tests/eval/exp/good/let.scilla
+./bin/eval-runner -libdir src/stdlib tests/eval/exp/good/let.scilexp
 ```
 
 Instead of `let.scilla` you might want to try any dfferent file in


### PR DESCRIPTION
Problem:

```
$ docker run zilliqa/scilla ./bin/eval-runner -libdir src/stdlib tests/eval/exp/good/let.scilla
Uncaught exception:
  
  (Sys_error "tests/eval/exp/good/let.scilla: No such file or directory")

Raised by primitive operation at file "pervasives.ml", line 389, characters 28-54
Called from file "src/in_channel.ml", line 22, characters 45-66
Called from file "src/runners/eval_runner.ml", line 41, characters 8-64
```

Fix is change `let.scilla` -> `let.scilexp` :

```
$ docker run zilliqa/scilla ./bin/eval-runner -libdir src/stdlib tests/eval/exp/good/let.scilexp
(Int32 42),
{ [a -> (Int32 42)],
  [y -> (Int32 42)],
  [f -> <closure>],
  [x -> (Int32 42)] }
```
