### PR TITLE
Move computations into library functions

### DIFF
--- a/tests/checker/good/gold/crowdfunding_proc.scilla.gold
+++ b/tests/checker/good/gold/crowdfunding_proc.scilla.gold
@@ -3,7 +3,7 @@
     "State variables": [
       { "field": "owner", "tag": "NotMoney" },
       { "field": "max_block", "tag": "NotMoney" },
-      { "field": "goal", "tag": "Money" },
+      { "field": "goal", "tag": "NoInfo" },
       { "field": "backers", "tag": "(Map Money)" },
       { "field": "funded", "tag": "NotMoney" }
     ],

--- a/tests/contracts/crowdfunding_proc.scilla
+++ b/tests/contracts/crowdfunding_proc.scilla
@@ -124,15 +124,15 @@ transition GetFunds ()
   | False =>
     GetFundsFailure not_owner_code
   | True => 
-  	blk <- & BLOCKNUMBER;
-  	bal <- _balance;
+    blk <- & BLOCKNUMBER;
+    bal <- _balance;
     allowed = get_funds_allowed blk max_block bal goal;
     match allowed with 
-  	| False =>  
+    | False =>  
       GetFundsFailure cannot_get_funds
-  	| True =>
+    | True =>
       PerformGetFunds
-  	end
+    end
   end   
 end
 
@@ -159,13 +159,13 @@ transition ClaimBack ()
   | False =>
     ClaimBackFailure too_early_code
   | True =>
-  	bal <- _balance;
-  	f <- funded;
+    bal <- _balance;
+    f <- funded;
     allowed = claimback_allowed bal goal f;
-  	match allowed with
-  	| False =>
+    match allowed with
+    | False =>
       ClaimBackFailure cannot_reclaim_code
-  	| True =>
+    | True =>
       res <- backers[_sender];
       match res with
       | None =>
@@ -174,6 +174,6 @@ transition ClaimBack ()
       | Some v =>
         PerformClaimBack v
       end
-  	end
+    end
   end  
 end

--- a/tests/contracts/crowdfunding_proc.scilla
+++ b/tests/contracts/crowdfunding_proc.scilla
@@ -22,7 +22,26 @@ let blk_leq =
   	let bc1 = builtin blt blk1 blk2 in 
   	let bc2 = builtin eq blk1 blk2 in 
   	orb bc1 bc2
-    
+
+let get_funds_allowed =
+  fun (cur_block : BNum) =>
+  fun (max_block : BNum) =>
+  fun (balance : Uint128) =>
+  fun (goal : Uint128) =>
+    let in_time = blk_leq cur_block max_block in
+    let deadline_passed = negb in_time in
+    let target_not_reached = builtin lt balance goal in
+    let target_reached = negb target_not_reached in
+    andb deadline_passed target_reached
+
+let claimback_allowed =
+  fun (balance : Uint128) =>
+  fun (goal : Uint128) =>
+  fun (already_funded : Bool) =>
+    let target_not_reached = builtin lt balance goal in
+    let not_already_funded = negb already_funded in
+    andb target_not_reached not_already_funded
+
 let accepted_code = Int32 1
 let missed_deadline_code = Int32 2
 let already_backed_code  = Int32 3
@@ -106,13 +125,9 @@ transition GetFunds ()
     GetFundsFailure not_owner_code
   | True => 
   	blk <- & BLOCKNUMBER;
-  	in_time = blk_leq blk max_block;
-  	c1 = negb in_time;
   	bal <- _balance;
-  	c2 = builtin lt bal goal;
-  	c3 = negb c2;
-  	c4 = andb c1 c3;
-  	match c4 with 
+    allowed = get_funds_allowed blk max_block bal goal;
+    match allowed with 
   	| False =>  
       GetFundsFailure cannot_get_funds
   	| True =>
@@ -146,11 +161,8 @@ transition ClaimBack ()
   | True =>
   	bal <- _balance;
   	f <- funded;
-  	c1 = builtin lt bal goal;
-    c2 = negb f;
-    (* Target has not been reached *)
-  	c3 = andb c1 c2;
-  	match c3 with
+    allowed = claimback_allowed bal goal f;
+  	match allowed with
   	| False =>
       ClaimBackFailure cannot_reclaim_code
   	| True =>

--- a/tests/contracts/crowdfunding_proc.scilla
+++ b/tests/contracts/crowdfunding_proc.scilla
@@ -13,15 +13,15 @@ library Crowdfunding
 
 let one_msg = 
   fun (msg : Message) => 
-  	let nil_msg = Nil {Message} in
-  	Cons {Message} msg nil_msg
+    let nil_msg = Nil {Message} in
+    Cons {Message} msg nil_msg
 
 let blk_leq =
   fun (blk1 : BNum) =>
   fun (blk2 : BNum) =>
-  	let bc1 = builtin blt blk1 blk2 in 
-  	let bc2 = builtin eq blk1 blk2 in 
-  	orb bc1 bc2
+    let bc1 = builtin blt blk1 blk2 in 
+    let bc2 = builtin eq blk1 blk2 in 
+    orb bc1 bc2
 
 let get_funds_allowed =
   fun (cur_block : BNum) =>

--- a/tests/runner/crowdfunding_proc/output_1.json
+++ b/tests/runner/crowdfunding_proc/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7590",
+  "gas_remaining": "7586",
   "_accepted": "true",
   "message": null,
   "states": [

--- a/tests/runner/crowdfunding_proc/output_2.json
+++ b/tests/runner/crowdfunding_proc/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7591",
+  "gas_remaining": "7587",
   "_accepted": "true",
   "message": null,
   "states": [

--- a/tests/runner/crowdfunding_proc/output_3.json
+++ b/tests/runner/crowdfunding_proc/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7609",
+  "gas_remaining": "7605",
   "_accepted": "false",
   "message": null,
   "states": [

--- a/tests/runner/crowdfunding_proc/output_4.json
+++ b/tests/runner/crowdfunding_proc/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7670",
+  "gas_remaining": "7666",
   "_accepted": "false",
   "message": null,
   "states": [

--- a/tests/runner/crowdfunding_proc/output_5.json
+++ b/tests/runner/crowdfunding_proc/output_5.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7448",
+  "gas_remaining": "7441",
   "_accepted": "false",
   "message": {
     "_tag": "",

--- a/tests/runner/crowdfunding_proc/output_6.json
+++ b/tests/runner/crowdfunding_proc/output_6.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7593",
+  "gas_remaining": "7589",
   "_accepted": "true",
   "message": null,
   "states": [


### PR DESCRIPTION
I have moved some pure computation into some newly created library functions in the crowdfunding contract.

I need the crowdfunding contract for our documentation of procedures, but introducing procedures means that there is no longer a need for the library function `check_update`, we lose the illustration of library functions. I have therefore moved the permission criteria into library functions.