### PR TITLE
Implement nested multi-line comments

### DIFF
--- a/tests/checker/good/gold/nested-comments.scilla.gold
+++ b/tests/checker/good/gold/nested-comments.scilla.gold
@@ -1,0 +1,59 @@
+{
+  "cashflow_tags": { "State variables": [], "ADT constructors": [] },
+  "contract_info": {
+    "scilla_major_version": "0",
+    "vname": "NestedComments",
+    "params": [],
+    "fields": [],
+    "transitions": [ { "vname": "dummy", "params": [] } ],
+    "events": [],
+    "ADTs": [
+      {
+        "tname": "Option",
+        "tparams": [ "'A" ],
+        "tmap": [
+          { "cname": "Some", "argtypes": [ "'A" ] },
+          { "cname": "None", "argtypes": [] }
+        ]
+      },
+      {
+        "tname": "Bool",
+        "tparams": [],
+        "tmap": [
+          { "cname": "True", "argtypes": [] },
+          { "cname": "False", "argtypes": [] }
+        ]
+      },
+      {
+        "tname": "Nat",
+        "tparams": [],
+        "tmap": [
+          { "cname": "Zero", "argtypes": [] },
+          { "cname": "Succ", "argtypes": [ "Nat" ] }
+        ]
+      },
+      {
+        "tname": "List",
+        "tparams": [ "'A" ],
+        "tmap": [
+          { "cname": "Cons", "argtypes": [ "'A", "List ('A)" ] },
+          { "cname": "Nil", "argtypes": [] }
+        ]
+      },
+      {
+        "tname": "Pair",
+        "tparams": [ "'A", "'B" ],
+        "tmap": [ { "cname": "Pair", "argtypes": [ "'A", "'B" ] } ]
+      }
+    ]
+  },
+  "warnings": [
+    {
+      "warning_message":
+        "No transition in contract NestedComments contains an accept statement\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 1
+    }
+  ]
+}

--- a/tests/checker/good/nested-comments.scilla
+++ b/tests/checker/good/nested-comments.scilla
@@ -1,0 +1,20 @@
+scilla_version 0
+
+(* This
+is a (* nested
+comment
+* that looks very
+    strange. *) *)
+
+library NestedComments
+
+(* Line comment *)
+
+contract NestedComments ()
+
+(* Block
+ * comment
+ *)
+
+transition dummy( (* inner comment *) )
+end


### PR DESCRIPTION
This pull request implements nested multi-line comments and removes the previous code for single line comments.

The issue 580 (Feature Request: Block comment) should be resolved following this pull request.
 #580 