### PR TITLE
Upgrade travis os to 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   - OCAML_VERSION=4.07.1
 os:
   - linux
+    dist: xenial
 # TODO: enable macOS builds
 # `brew update` downloads too many packages for the provided macOS image
 # and that sometimes causes build breaks because of time-outs.


### PR DESCRIPTION
Scilla currently runs on Ubuntu 14.04 in Travis-CI tests. Upgrade this to Ubuntu 16.04.