### PR TITLE
Upgrade travis os to 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ matrix:
 # and that sometimes causes build breaks because of time-outs.
 # Without this command we get an old opam version (1.x) which is not satisfactory.
 
-#  - osx
-
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,14 @@ sudo: required
 env:
   - OCAML_VERSION=4.06.1
   - OCAML_VERSION=4.07.1
-os:
-  - linux
-    dist: xenial
+
+matrix:
+  include:
+    - os: linux
+      dist: xenial
+    # - os: osx
+    #  osx_image: xcode10.1
+
 # TODO: enable macOS builds
 # `brew update` downloads too many packages for the provided macOS image
 # and that sometimes causes build breaks because of time-outs.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: generic
 sudo: required
-env:
-  - OCAML_VERSION=4.06.1
-  - OCAML_VERSION=4.07.1
 
 matrix:
   include:
     - os: linux
       dist: xenial
+      env: OCAML_VERSION=4.07.1
+    - os: linux
+      dist: xenial
+      env: OCAML_VERSION=4.06.1
     # - os: osx
     #  osx_image: xcode10.1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   - OCAML_VERSION=4.07.1
 os:
   - linux
+    dist: xenial
 # TODO: enable macOS builds
 # `brew update` downloads too many packages for the provided macOS image
 # and that sometimes causes build breaks because of time-outs.


### PR DESCRIPTION
Now using a build matrix as described in https://docs.travis-ci.com/user/build-matrix/ to have two builds with 16.04 Ubuntu and two versions of OCaml tested.

Related: #592 #593 