### PR TITLE
Fix stackoverflow for to_nat builtin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,12 @@ utop: all
 	OCAMLPATH=_build/install/default/lib:$(OCAMLPATH) utop
 
 # Build and run tests
+# the make utility increases the maximum stack limit, this allows our tests
+# to pass but analogous programs might break when run on users' machines
+# (e.g. on macOS 10.14.5 make sets the limit to 65532kB, but the standard
+# value is 8192kB)
 test: dev
-	dune exec tests/testsuite.exe -- -print-diff true
+	ulimit -s 128; dune exec tests/testsuite.exe -- -print-diff true
 
 gold: dev
 	dune exec tests/testsuite.exe -- -update-gold true

--- a/src/lang/base/BuiltIns.ml
+++ b/src/lang/base/BuiltIns.ml
@@ -528,14 +528,12 @@ module ScillaBuiltIns
 
     let to_nat ls _ = match ls with
       | [UintLit (Uint32L n)] ->
-        let zero = ADTValue ("Zero", [], []) in
-        let rec nat_builder (i : Uint32.t) =
-          if i = Uint32.zero then zero
-          else
-            let prev = nat_builder (Uint32.sub i Uint32.one) in
-            ADTValue ("Succ", [], [prev])
+        let rec nat_builder (i : Uint32.t) (acc : Syntax.literal) =
+          if i = Uint32.zero then acc
+          else nat_builder (Uint32.pred i) (ADTValue ("Succ", [], [acc]))
         in
-        pure (nat_builder n)
+        let zero = ADTValue ("Zero", [], []) in
+        pure @@ nat_builder n zero
       (* Other integer widths can be in the library, using integer conversions. *)
       | _ -> builtin_fail "Uint.to_nat only supported for Uint32" ls
 

--- a/src/lang/base/PrettyPrinters.ml
+++ b/src/lang/base/PrettyPrinters.ml
@@ -225,18 +225,17 @@ let rec pp_literal_simplified l =
         (match cn with
         | "Cons" ->
           (* Print non-empty lists in a readable way. *)
-          let rec pcons largs =
-            if List.length largs = 0 then "(Nil)" else
-            let this = (pp_literal_simplified (List.nth_exn largs 0)) ^ ", " in
-            let next =
-              if List.length largs <> 2 then "(Malformed List)" else
-              (match (List.nth_exn largs 1) with
-              | ADTValue(_, _, al') ->
-                pcons al'
-              | _ -> "(Malformed List") in
-            (this ^ next)
+          let list_buffer = Buffer.create 1024 in
+          let rec plist = function
+            | ADTValue ("Nil", _, []) -> Buffer.add_string list_buffer "(Nil)"
+            | ADTValue ("Cons", _, [head; tail]) ->
+                let head_str = (pp_literal_simplified head) ^ ", " in
+                Buffer.add_string list_buffer head_str;
+                plist tail
+            | _ -> Buffer.clear list_buffer; Buffer.add_string list_buffer "(Malformed List)"
           in
-            "(List " ^ pcons al ^ ")"
+          plist l;
+          "(List " ^ Buffer.contents list_buffer ^ ")"
         | "Zero" | "Succ" ->
             let rec counter nat acc =
               match nat with

--- a/src/lang/base/PrettyPrinters.ml
+++ b/src/lang/base/PrettyPrinters.ml
@@ -238,15 +238,14 @@ let rec pp_literal_simplified l =
           in
             "(List " ^ pcons al ^ ")"
         | "Zero" | "Succ" ->
-            let rec counter largs =
-              if List.length largs = 0 then "0" else
-              if List.length largs <> 1 then "(Malformed Nat)" else
-              (match (List.nth_exn largs 0) with
-              | ADTValue (_, _, al') ->
-                Int.to_string ((Int.of_string (counter al')) + 1)
-              | _ -> "(Malformed Nat)")
+            let rec counter nat acc =
+              match nat with
+              | ADTValue ("Zero", _, []) -> Some acc
+              | ADTValue ("Succ", _, [pred]) -> counter pred (Uint32.succ acc)
+              | _ -> None
             in
-              "(Nat "^ (counter al) ^ ")"
+            let res = Option.map (counter l Uint32.zero) ~f:Uint32.to_string in
+            "(Nat " ^ Option.value res ~default:"(Malformed Nat)" ^ ")"
         | _ ->
           (* Generic printing for other ADTs. *)
           "(" ^ cn ^

--- a/tests/eval/exp/bad/gold/app_error1.scilexp.gold
+++ b/tests/eval/exp/bad/gold/app_error1.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1750",
+  "gas_remaining": "4001750",
   "errors": [
     {
       "error_message": "Not a functional value: (Int32 2).",

--- a/tests/eval/exp/bad/gold/app_error2.scilexp.gold
+++ b/tests/eval/exp/bad/gold/app_error2.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1754",
+  "gas_remaining": "4001754",
   "errors": [
     {
       "error_message": "Not a functional value: (Int64 1).",

--- a/tests/eval/exp/bad/gold/builtin-bech32-1.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin-bech32-1.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1489",
+  "gas_remaining": "4001489",
   "errors": [
     {
       "error_message": "Only zil and tzil bech32 addresses are supported",

--- a/tests/eval/exp/bad/gold/builtin-bech32-2.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin-bech32-2.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1493",
+  "gas_remaining": "4001493",
   "errors": [
     {
       "error_message": "Only zil and tzil bech32 addresses are supported",

--- a/tests/eval/exp/bad/gold/builtin-bech32-3.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin-bech32-3.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1493",
+  "gas_remaining": "4001493",
   "errors": [
     {
       "error_message": "bech32 decoding failed",

--- a/tests/eval/exp/bad/gold/builtin-divzero.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin-divzero.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1737",
+  "gas_remaining": "4001737",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-divzero2.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin-divzero2.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1737",
+  "gas_remaining": "4001737",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-divzero3.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin-divzero3.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1677",
+  "gas_remaining": "4001677",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-divzero4.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin-divzero4.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1677",
+  "gas_remaining": "4001677",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow1.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow1.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1746",
+  "gas_remaining": "4001746",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow10.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow10.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1741",
+  "gas_remaining": "4001741",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow11.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow11.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1741",
+  "gas_remaining": "4001741",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow12.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow12.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1741",
+  "gas_remaining": "4001741",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow13.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow13.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1747",
+  "gas_remaining": "4001747",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow14.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow14.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1745",
+  "gas_remaining": "4001745",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow2.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow2.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1733",
+  "gas_remaining": "4001733",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow3.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow3.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1733",
+  "gas_remaining": "4001733",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow5.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow5.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1737",
+  "gas_remaining": "4001737",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow6.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow6.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1737",
+  "gas_remaining": "4001737",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow7.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow7.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1753",
+  "gas_remaining": "4001753",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow8.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow8.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1753",
+  "gas_remaining": "4001753",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-overflow9.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin-overflow9.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1753",
+  "gas_remaining": "4001753",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-pow.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin-pow.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1761",
+  "gas_remaining": "4001761",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-pow2.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin-pow2.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "961",
+  "gas_remaining": "4000961",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin-remzero.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin-remzero.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1737",
+  "gas_remaining": "4001737",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/builtin4.scilexp.gold
+++ b/tests/eval/exp/bad/gold/builtin4.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1750",
+  "gas_remaining": "4001750",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/let-error.scilexp.gold
+++ b/tests/eval/exp/bad/gold/let-error.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1757",
+  "gas_remaining": "4001757",
   "errors": [
     {
       "error_message": "Identifier \"oops\" is not bound in environment:\n",

--- a/tests/eval/exp/bad/gold/msg_error.scilexp.gold
+++ b/tests/eval/exp/bad/gold/msg_error.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1755",
+  "gas_remaining": "4001755",
   "errors": [
     {
       "error_message": "Cannot type runtime closure.",

--- a/tests/eval/exp/bad/gold/msg_error2.scilexp.gold
+++ b/tests/eval/exp/bad/gold/msg_error2.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1753",
+  "gas_remaining": "4001753",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/bad/gold/msg_error3.scilexp.gold
+++ b/tests/eval/exp/bad/gold/msg_error3.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1753",
+  "gas_remaining": "4001753",
   "errors": [
     {
       "error_message": "Identifier \"o\" is not bound in environment:\n",

--- a/tests/eval/exp/bad/gold/substr_err1.scilexp.gold
+++ b/tests/eval/exp/bad/gold/substr_err1.scilexp.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "1754",
+  "gas_remaining": "4001754",
   "errors": [
     {
       "error_message":

--- a/tests/eval/exp/good/gold/int_to_nat.scilexp.gold
+++ b/tests/eval/exp/good/gold/int_to_nat.scilexp.gold
@@ -10,6 +10,8 @@
   [three_nat2 -> (Nat 3)],
   [two_nat2 -> (Nat 2)],
   [one_nat2 -> (Nat 1)],
+  [stress_test_nat -> (Nat 1000000)],
+  [stress_test_uint -> (Uint32 1000000)],
   [three_nat1 -> (Nat 3)],
   [three_uint -> (Uint32 3)],
   [zero_nat2 -> (Nat 0)],

--- a/tests/eval/exp/good/int_to_nat.scilexp
+++ b/tests/eval/exp/good/int_to_nat.scilexp
@@ -5,6 +5,8 @@ let zero_nat2 = Zero in
 
 let three_uint = Uint32 3 in
 let three_nat1 = builtin to_nat three_uint in
+let stress_test_uint = Uint32 1000000 in
+let stress_test_nat = builtin to_nat stress_test_uint in
 let one_nat2 = Succ zero_nat2 in
 let two_nat2 = Succ one_nat2 in
 let three_nat2 = Succ two_nat2 in

--- a/tests/util/TestUtil.ml
+++ b/tests/util/TestUtil.ml
@@ -93,7 +93,7 @@ module DiffBasedTests(Input : TestSuiteInput) = struct
       let additional_dirs = List.map ~f:make_filename additional_libdirs in
       let stdlib = env.stdlib_dir test_ctxt in
       let path = string_of_path @@ stdlib :: additional_dirs in
-      let args = custom_args @ ["-libdir";path;"-jsonerrors";input_file] in
+      let args = custom_args @ ["-libdir";path;"-jsonerrors";input_file;"-gaslimit";"4002000"] in
       let msg = cli_usage_on_err evalbin args in
       print_cli_usage (env.print_cli test_ctxt) evalbin args;
       assert_command


### PR DESCRIPTION
The following fails
```
let stress_test_uint = Uint32 1000000 in
builtin to_nat stress_test_uint
```
with a stackoverflow error provided the caller has enough gas.

This PR fixes it for the `to_nat` builtin and for pretty-printing of nats.

There is a not strictly relevant change in the pretty-printing function for lists. This has been done to make pretty-printing for nats and lists more uniform.