### PR TITLE
Increase the max. number of open file descriptors when running tests

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -70,7 +70,8 @@ It should look like
 export PKG_CONFIG_PATH="/usr/local/opt/openssl@_Version_/lib/pkgconfig:$PKG_CONFIG_PATH"
 ```
 
-To run tests with `make test` you might need to increase the maximum number of open file descriptors:
+To run tests using Dune (`dune exec tests/testsuite.exe`), you may need to increase
+the maximum number of open file descriptors as `Makefile`'s `test` target does:
 ```shell
 ulimit -n 1024
 ```

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ utop: all
 # (e.g. on macOS 10.14.5 make sets the limit to 65532kB, but the standard
 # value is 8192kB)
 test: dev
-	ulimit -s 128; dune exec tests/testsuite.exe -- -print-diff true
+	ulimit -s 128 -n 1024; dune exec tests/testsuite.exe -- -print-diff true
 
 gold: dev
 	dune exec tests/testsuite.exe -- -update-gold true


### PR DESCRIPTION
This change makes it easier for macOS users who missed the relevant section in INSTALL.md