### PR TITLE
Increase the max. number of open file descriptors when making gold files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test: dev
 	ulimit -s 128 -n 1024; dune exec tests/testsuite.exe -- -print-diff true
 
 gold: dev
-	dune exec tests/testsuite.exe -- -update-gold true
+	ulimit -s 128 -n 1024; dune exec tests/testsuite.exe -- -update-gold true
 
 # Clean up
 clean:


### PR DESCRIPTION
A follow-up of PR #619