### PR TITLE
Use Yojson.Basic.t instead of Yojson.t

### DIFF
--- a/src/lang/base/JSON.mli
+++ b/src/lang/base/JSON.mli
@@ -37,7 +37,7 @@ module ContractState : sig
   val state_to_string : ?pp:bool -> ((string * Syntax.literal) list) -> string
 
   (* Get a json object from given states *)
-  val state_to_json : ((string * Syntax.literal) list) -> Yojson.t
+  val state_to_json : ((string * Syntax.literal) list) -> Yojson.Basic.t
 
   (* Given an init.json filename, return extlib fields *)
   val get_init_extlibs : string -> (string * string) list
@@ -83,7 +83,7 @@ module Message : sig
    **)
   val message_to_jstring : ?pp:bool -> ((string * Syntax.literal) list) -> string
   (* Same as message_to_jstring, but instead gives out raw json, not it's string *)
-  val message_to_json : ((string * Syntax.literal) list) -> Yojson.t
+  val message_to_json : ((string * Syntax.literal) list) -> Yojson.Basic.t
 
 end
 
@@ -133,7 +133,7 @@ open ParserUtil.ParsedSyntax
         }
   *)
   val get_string : int -> contract -> (string * (string * Syntax.typ) list) list -> string
-  val get_json : int -> contract -> (string * (string * Syntax.typ) list) list -> Yojson.t
+  val get_json : int -> contract -> (string * (string * Syntax.typ) list) list -> Yojson.Basic.t
 
 end
 
@@ -145,7 +145,7 @@ module Event : sig
    **)
   val event_to_jstring : ?pp:bool -> (string * Syntax.literal) list -> string
   (* Same as Event_to_jstring, but instead gives out raw json, not it's string *)
-  val event_to_json : (string * Syntax.literal) list -> Yojson.t
+  val event_to_json : (string * Syntax.literal) list -> Yojson.Basic.t
 
 end
 
@@ -179,5 +179,5 @@ module CashflowInfo : sig
 
   *)
 
-  val get_json : ((string * string) list * (string * ((string * string list) list)) list) -> Yojson.t
+  val get_json : ((string * string) list * (string * ((string * string list) list)) list) -> Yojson.Basic.t
 end

--- a/src/runners/scilla_checker.ml
+++ b/src/runners/scilla_checker.ml
@@ -193,7 +193,7 @@ let check_cmodule cli =
         | Some cf_info -> ("cashflow_tags", JSON.CashflowInfo.get_json cf_info) :: base_output in
       let j = `Assoc output_with_cf in
       check_version cmod.smver;
-      pout (sprintf "%s\n" (Yojson.pretty_to_string j));)
+      pout (sprintf "%s\n" (Yojson.Basic.pretty_to_string j));)
 
 let () =
     let cli = parse_cli () in

--- a/src/runners/scilla_runner.ml
+++ b/src/runners/scilla_runner.ml
@@ -373,7 +373,7 @@ let () =
       ] in
         Out_channel.with_file cli.output ~f:(fun channel -> 
           if cli.pp_json then
-            Yojson.pretty_to_string output_json |> Out_channel.output_string channel
+            Yojson.Basic.pretty_to_string output_json |> Out_channel.output_string channel
           else
-            Yojson.to_string output_json |> Out_channel.output_string channel
+            Yojson.Basic.to_string output_json |> Out_channel.output_string channel
           )


### PR DESCRIPTION
This conversion is necessary if we have to parse JSONs and compare / inter-operate with JSONs built by our JSON.ml library.