### PR TITLE
Allow `map_access_type` to be called with non-map types and 0 indices

### DIFF
--- a/src/lang/base/TypeUtil.ml
+++ b/src/lang/base/TypeUtil.ml
@@ -313,10 +313,10 @@ module TypeUtilities = struct
 
   (* Given a map type and a list of key types, what is the type of the accessed value? *)
   let rec map_access_type mt nindices = match mt, nindices with
-      | MapType (_, _), 0 -> pure mt
-      | MapType (_, vt'), 1 -> pure vt'
-      | MapType (_, vt'), nkeys' when nkeys' > 1 -> map_access_type vt' (nindices-1)
-      | _, _ -> fail0 "Cannot index into map %s: Too many index keys or non-map type"
+    | _ , 0 -> pure mt
+    | MapType (_, vt'), 1 -> pure vt'
+    | MapType (_, vt'), nkeys' when nkeys' > 1 -> map_access_type vt' (nindices-1)
+    | _, _ -> fail0 "Cannot index into map: Too many index keys."
 
   (* The depth of a nested map. *)
   let rec map_depth mt = match mt with

--- a/tests/typecheck/good/Testtypes.ml
+++ b/tests/typecheck/good/Testtypes.ml
@@ -105,6 +105,7 @@ let map_access_type_tests = [
   ("Map (Uint32) (Map (Uint32) (Int32))", "Map (Uint32) (Map (Uint32) (Int32))", 0);
   ("Map (Uint32) (Map (Uint32) (Int32))", "Map (Uint32) (Int32)", 1);
   ("Map (Uint32) (Map (Uint32) (Int32))", "Int32", 2);
+  ("Int32", "Int32", 0);
 ]
 
 let make_map_access_type_tests tlist =


### PR DESCRIPTION
- This change makes `map_access_type` consistent with `map_depth`
- It also makes it easier to use (otherwise we need to check if something is map type before calling the function, even when the number of indices is 0)