### PR TITLE
testsuite: input state json must contain all fields

### DIFF
--- a/src/lang/eval/EvalUtil.ml
+++ b/src/lang/eval/EvalUtil.ml
@@ -204,11 +204,11 @@ module Configuration = struct
     else 
       let%bind (is_member, g) = fromR @@ StateService.is_member ~fname:m ~keys:klist in
       match (is_member, g) with
-      | true, G_MapGet(i, Some _) ->
+      | true, G_MapGet(i, _) ->
         let scillit = ADTValue ("True", [], []) in
         let g' = G_MapGet(i, Some scillit) in
         pure (scillit, g')
-      | false, G_MapGet(i, None) ->
+      | false, G_MapGet(i, _) ->
         let scillit = ADTValue ("False", [], []) in
         let g' = G_MapGet(i, Some scillit) in
          pure (scillit, g')

--- a/tests/runner/auction/state_1.json
+++ b/tests/runner/auction/state_1.json
@@ -1,7 +1,23 @@
 [
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
   {
-    "vname": "_balance",
-    "type": "Uint128",
-    "value": "0"
+    "vname": "ended",
+    "type": "Bool",
+    "value": { "constructor": "False", "argtypes": [], "arguments": [] }
+  },
+  {
+    "vname": "highestBidder",
+    "type": "Option (ByStr20)",
+    "value": {
+      "constructor": "None",
+      "argtypes": [ "ByStr20" ],
+      "arguments": []
+    }
+  },
+  { "vname": "highestBid", "type": "Uint128", "value": "0" },
+  {
+    "vname": "pendingReturns",
+    "type": "Map (ByStr20) (Uint128)",
+    "value": []
   }
 ]

--- a/tests/runner/auction/state_5.json
+++ b/tests/runner/auction/state_5.json
@@ -1,3 +1,23 @@
 [
-    { "vname": "_balance", "type": "Uint128", "value": "0" }
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  {
+    "vname": "ended",
+    "type": "Bool",
+    "value": { "constructor": "False", "argtypes": [], "arguments": [] }
+  },
+  {
+    "vname": "highestBidder",
+    "type": "Option (ByStr20)",
+    "value": {
+      "constructor": "None",
+      "argtypes": [ "ByStr20" ],
+      "arguments": []
+    }
+  },
+  { "vname": "highestBid", "type": "Uint128", "value": "0" },
+  {
+    "vname": "pendingReturns",
+    "type": "Map (ByStr20) (Uint128)",
+    "value": []
+  }
 ]

--- a/tests/runner/bookstore/state_1.json
+++ b/tests/runner/bookstore/state_1.json
@@ -1,3 +1,10 @@
 [
-  { "vname": "_balance", "type": "Uint128", "value": "0" }
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  { "vname": "members", "type": "Map (ByStr20) (Member)", "value": [] },
+  {
+    "vname": "is_store_open",
+    "type": "Bool",
+    "value": { "constructor": "True", "argtypes": [], "arguments": [] }
+  },
+  { "vname": "bookInventory", "type": "Map (Uint32) (Book)", "value": [] }
 ]

--- a/tests/runner/fungible-token/state_0.json
+++ b/tests/runner/fungible-token/state_0.json
@@ -1,3 +1,15 @@
 [
-    { "vname": "_balance", "type": "Uint128", "value": "0" }
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  {
+    "vname": "balances",
+    "type": "Map (ByStr20) (Uint128)",
+    "value": [
+      { "key": "0x1234567890123456789012345678901234567890", "val": "10000" }
+    ]
+  },
+  {
+    "vname": "allowed",
+    "type": "Map (ByStr20) (Map (ByStr20) (Uint128))",
+    "value": []
+  }
 ]

--- a/tests/runner/helloWorld/state_1.json
+++ b/tests/runner/helloWorld/state_1.json
@@ -1,7 +1,4 @@
 [
-  {
-    "vname": "_balance",
-    "type" : "Uint128",
-    "value": "0"
-  }
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  { "vname": "welcome_msg", "type": "String", "value": "" }
 ]

--- a/tests/runner/helloWorld/state_2.json
+++ b/tests/runner/helloWorld/state_2.json
@@ -1,7 +1,4 @@
 [
-  {
-    "vname": "_balance",
-    "type": "Uint128",
-    "value": "0"
-  }
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  { "vname": "welcome_msg", "type": "String", "value": "" }
 ]

--- a/tests/runner/inplace-map/state_1.json
+++ b/tests/runner/inplace-map/state_1.json
@@ -1,3 +1,9 @@
 [
-    { "vname": "_balance", "type": "Uint128", "value": "0" }
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  { "vname": "gmap", "type": "Map (String) (Int32)", "value": [] },
+  {
+    "vname": "gmap3",
+    "type": "Map (String) (Map (Int32) (Map (Int64) (String)))",
+    "value": []
+  }
 ]

--- a/tests/runner/inplace-map/state_10.json
+++ b/tests/runner/inplace-map/state_10.json
@@ -1,8 +1,13 @@
 [
-    { "vname": "_balance", "type": "Uint128", "value": "0" },
-    {
-      "vname": "gmap",
-      "type": "Map (String) (Int32)",
-      "value": [ { "key": "Hello", "val": "1" } ]
-    }
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  {
+    "vname": "gmap3",
+    "type": "Map (String) (Map (Int32) (Map (Int64) (String)))",
+    "value": []
+  },
+  {
+    "vname": "gmap",
+    "type": "Map (String) (Int32)",
+    "value": [ { "key": "Hello", "val": "1" } ]
+  }
 ]

--- a/tests/runner/inplace-map/state_2.json
+++ b/tests/runner/inplace-map/state_2.json
@@ -1,3 +1,9 @@
 [
-    { "vname": "_balance", "type": "Uint128", "value": "0" }
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  { "vname": "gmap", "type": "Map (String) (Int32)", "value": [] },
+  {
+    "vname": "gmap3",
+    "type": "Map (String) (Map (Int32) (Map (Int64) (String)))",
+    "value": []
+  }
 ]

--- a/tests/runner/inplace-map/state_3.json
+++ b/tests/runner/inplace-map/state_3.json
@@ -1,8 +1,13 @@
 [
-    { "vname": "_balance", "type": "Uint128", "value": "0" },
-    {
-      "vname": "gmap",
-      "type": "Map (String) (Int32)",
-      "value": [ { "key": "Hello", "val": "1" } ]
-    }
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  {
+    "vname": "gmap3",
+    "type": "Map (String) (Map (Int32) (Map (Int64) (String)))",
+    "value": []
+  },
+  {
+    "vname": "gmap",
+    "type": "Map (String) (Int32)",
+    "value": [ { "key": "Hello", "val": "1" } ]
+  }
 ]

--- a/tests/runner/inplace-map/state_4.json
+++ b/tests/runner/inplace-map/state_4.json
@@ -1,8 +1,13 @@
 [
-    { "vname": "_balance", "type": "Uint128", "value": "0" },
-    {
-      "vname": "gmap",
-      "type": "Map (String) (Int32)",
-      "value": [ { "key": "Hello", "val": "1" } ]
-    }
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  {
+    "vname": "gmap3",
+    "type": "Map (String) (Map (Int32) (Map (Int64) (String)))",
+    "value": []
+  },
+  {
+    "vname": "gmap",
+    "type": "Map (String) (Int32)",
+    "value": [ { "key": "Hello", "val": "1" } ]
+  }
 ]

--- a/tests/runner/inplace-map/state_5.json
+++ b/tests/runner/inplace-map/state_5.json
@@ -1,8 +1,13 @@
 [
-    { "vname": "_balance", "type": "Uint128", "value": "0" },
-    {
-      "vname": "gmap",
-      "type": "Map (String) (Int32)",
-      "value": [ { "key": "Hello", "val": "1" } ]
-    }
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  {
+    "vname": "gmap3",
+    "type": "Map (String) (Map (Int32) (Map (Int64) (String)))",
+    "value": []
+  },
+  {
+    "vname": "gmap",
+    "type": "Map (String) (Int32)",
+    "value": [ { "key": "Hello", "val": "1" } ]
+  }
 ]

--- a/tests/runner/mappair/state_1.json
+++ b/tests/runner/mappair/state_1.json
@@ -1,17 +1,36 @@
 [
-    { "vname": "_balance", "type": "Uint128", "value": "0" },
-    {
-        "vname": "gmap",
-        "type": "Map (ByStr20) (Pair (Int32) (Int32))",
-        "value": [
-            {
-                "key": "0x12345678901234567890123456789012345678AB",
-                "val": {
-                    "constructor": "Pair",
-                    "argtypes": [ "Int32", "Int32" ],
-                    "arguments": [ "1", "2" ]
-                }
-            }
-        ]
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  {
+    "vname": "gpair",
+    "type": "Pair (List (Int64)) (Option (Bool))",
+    "value": {
+      "constructor": "Pair",
+      "argtypes": [ "List (Int64)", "Option (Bool)" ],
+      "arguments": [
+        [],
+        { "constructor": "None", "argtypes": [ "Bool" ], "arguments": [] }
+      ]
     }
+  },
+  { "vname": "llist", "type": "List (List (Int64))", "value": [] },
+  { "vname": "plist", "type": "List (Option (Int32))", "value": [] },
+  {
+    "vname": "gnat",
+    "type": "Nat",
+    "value": { "constructor": "Zero", "argtypes": [], "arguments": [] }
+  },
+  {
+    "vname": "gmap",
+    "type": "Map (ByStr20) (Pair (Int32) (Int32))",
+    "value": [
+      {
+        "key": "0x12345678901234567890123456789012345678ab",
+        "val": {
+          "constructor": "Pair",
+          "argtypes": [ "Int32", "Int32" ],
+          "arguments": [ "1", "2" ]
+        }
+      }
+    ]
+  }
 ]

--- a/tests/runner/mappair/state_2.json
+++ b/tests/runner/mappair/state_2.json
@@ -1,17 +1,36 @@
 [
-    { "vname": "_balance", "type": "Uint128", "value": "0" },
-    {
-        "vname": "gmap",
-        "type": "Map (ByStr20) (Pair (Int32) (Int32))",
-        "value": [
-            {
-                "key": "0x12345678901234567890123456789012345678ab",
-                "val": {
-                    "constructor": "Pair",
-                    "argtypes": [ "Int32", "Int32" ],
-                    "arguments": [ "1", "2" ]
-                }
-            }
-        ]
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  {
+    "vname": "gpair",
+    "type": "Pair (List (Int64)) (Option (Bool))",
+    "value": {
+      "constructor": "Pair",
+      "argtypes": [ "List (Int64)", "Option (Bool)" ],
+      "arguments": [
+        [],
+        { "constructor": "None", "argtypes": [ "Bool" ], "arguments": [] }
+      ]
     }
+  },
+  { "vname": "llist", "type": "List (List (Int64))", "value": [] },
+  { "vname": "plist", "type": "List (Option (Int32))", "value": [] },
+  {
+    "vname": "gnat",
+    "type": "Nat",
+    "value": { "constructor": "Zero", "argtypes": [], "arguments": [] }
+  },
+  {
+    "vname": "gmap",
+    "type": "Map (ByStr20) (Pair (Int32) (Int32))",
+    "value": [
+      {
+        "key": "0x12345678901234567890123456789012345678ab",
+        "val": {
+          "constructor": "Pair",
+          "argtypes": [ "Int32", "Int32" ],
+          "arguments": [ "1", "2" ]
+        }
+      }
+    ]
+  }
 ]

--- a/tests/runner/mappair/state_3.json
+++ b/tests/runner/mappair/state_3.json
@@ -1,35 +1,42 @@
 [
-    { "vname": "_balance", "type": "Uint128", "value": "0" },
-    {
-      "vname": "gpair",
-      "type": "Pair (List (Int64)) (Option (Bool))",
-      "value": {
-        "constructor": "Pair",
-        "argtypes": [ "List (Int64)", "Option (Bool)" ],
-        "arguments": [
-          ["2"],
-          {
-            "constructor": "Some",
-            "argtypes": [ "Bool" ],
-            "arguments": [
-              { "constructor": "True", "argtypes": [], "arguments": [] }
-            ]
-          }
-        ]
-      }
-    },
-    {
-        "vname": "gmap",
-        "type": "Map (ByStr20) (Pair (Int32) (Int32))",
-        "value": [
-            {
-                "key": "0x12345678901234567890123456789012345678ab",
-                "val": {
-                    "constructor": "Pair",
-                    "argtypes": [ "Int32", "Int32" ],
-                    "arguments": [ "1", "2" ]
-                }
-            }
-        ]
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  { "vname": "llist", "type": "List (List (Int64))", "value": [] },
+  { "vname": "plist", "type": "List (Option (Int32))", "value": [] },
+  {
+    "vname": "gnat",
+    "type": "Nat",
+    "value": { "constructor": "Zero", "argtypes": [], "arguments": [] }
+  },
+  {
+    "vname": "gpair",
+    "type": "Pair (List (Int64)) (Option (Bool))",
+    "value": {
+      "constructor": "Pair",
+      "argtypes": [ "List (Int64)", "Option (Bool)" ],
+      "arguments": [
+        [ "2" ],
+        {
+          "constructor": "Some",
+          "argtypes": [ "Bool" ],
+          "arguments": [
+            { "constructor": "True", "argtypes": [], "arguments": [] }
+          ]
+        }
+      ]
     }
+  },
+  {
+    "vname": "gmap",
+    "type": "Map (ByStr20) (Pair (Int32) (Int32))",
+    "value": [
+      {
+        "key": "0x12345678901234567890123456789012345678ab",
+        "val": {
+          "constructor": "Pair",
+          "argtypes": [ "Int32", "Int32" ],
+          "arguments": [ "1", "2" ]
+        }
+      }
+    ]
+  }
 ]

--- a/tests/runner/mappair/state_4.json
+++ b/tests/runner/mappair/state_4.json
@@ -1,35 +1,42 @@
 [
-    { "vname": "_balance", "type": "Uint128", "value": "0" },
-    {
-        "vname": "gpair",
-        "type": "Pair (List (Int64)) (Option (Bool))",
-        "value": {
-            "constructor": "Pair",
-            "argtypes": [ "List (Int64)", "Option (Bool)" ],
-            "arguments": [
-                ["3", "2"],
-                {
-                    "constructor": "Some",
-                    "argtypes": [ "Bool" ],
-                    "arguments": [
-                        { "constructor": "False", "argtypes": [], "arguments": [] }
-                    ]
-                }
-            ]
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  { "vname": "llist", "type": "List (List (Int64))", "value": [] },
+  { "vname": "plist", "type": "List (Option (Int32))", "value": [] },
+  {
+    "vname": "gnat",
+    "type": "Nat",
+    "value": { "constructor": "Zero", "argtypes": [], "arguments": [] }
+  },
+  {
+    "vname": "gpair",
+    "type": "Pair (List (Int64)) (Option (Bool))",
+    "value": {
+      "constructor": "Pair",
+      "argtypes": [ "List (Int64)", "Option (Bool)" ],
+      "arguments": [
+        [ "3", "2" ],
+        {
+          "constructor": "Some",
+          "argtypes": [ "Bool" ],
+          "arguments": [
+            { "constructor": "False", "argtypes": [], "arguments": [] }
+          ]
         }
-    },
-    {
-        "vname": "gmap",
-        "type": "Map (ByStr20) (Pair (Int32) (Int32))",
-        "value": [
-            {
-                "key": "0x12345678901234567890123456789012345678ab",
-                "val": {
-                    "constructor": "Pair",
-                    "argtypes": [ "Int32", "Int32" ],
-                    "arguments": [ "1", "2" ]
-                }
-            }
-        ]
+      ]
     }
+  },
+  {
+    "vname": "gmap",
+    "type": "Map (ByStr20) (Pair (Int32) (Int32))",
+    "value": [
+      {
+        "key": "0x12345678901234567890123456789012345678ab",
+        "val": {
+          "constructor": "Pair",
+          "argtypes": [ "Int32", "Int32" ],
+          "arguments": [ "1", "2" ]
+        }
+      }
+    ]
+  }
 ]

--- a/tests/runner/mappair/state_5.json
+++ b/tests/runner/mappair/state_5.json
@@ -1,46 +1,48 @@
 [
-    { "vname": "_balance", "type": "Uint128", "value": "0" },
-    {
-        "vname": "gnat",
-        "type": "Nat ",
-        "value": {
-            "constructor": "Succ",
-            "argtypes": [],
-            "arguments": [
-                { "constructor": "Zero", "argtypes": [], "arguments": [] }
-            ]
-        }
-    },
-    {
-        "vname": "gpair",
-        "type": "Pair (List (Int64)) (Option (Bool))",
-        "value": {
-            "constructor": "Pair",
-            "argtypes": [ "List (Int64)", "Option (Bool)" ],
-            "arguments": [
-                ["3", "2"],
-                {
-                    "constructor": "Some",
-                    "argtypes": [ "Bool" ],
-                    "arguments": [
-                        { "constructor": "False", "argtypes": [], "arguments": [] }
-                    ]
-                }
-            ]
-        }
-    },
-    {
-        "vname": "gmap",
-        "type": "Map (ByStr20) (Pair (Int32) (Int32))",
-        "value": [
-            {
-                "key": "0x12345678901234567890123456789012345678ab",
-                "val": {
-                    "constructor": "Pair",
-                    "argtypes": [ "Int32", "Int32" ],
-                    "arguments": [ "1", "2" ]
-                }
-            }
-        ]
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  { "vname": "llist", "type": "List (List (Int64))", "value": [] },
+  { "vname": "plist", "type": "List (Option (Int32))", "value": [] },
+  {
+    "vname": "gnat",
+    "type": "Nat",
+    "value": {
+      "constructor": "Succ",
+      "argtypes": [],
+      "arguments": [
+        { "constructor": "Zero", "argtypes": [], "arguments": [] }
+      ]
     }
+  },
+  {
+    "vname": "gpair",
+    "type": "Pair (List (Int64)) (Option (Bool))",
+    "value": {
+      "constructor": "Pair",
+      "argtypes": [ "List (Int64)", "Option (Bool)" ],
+      "arguments": [
+        [ "3", "2" ],
+        {
+          "constructor": "Some",
+          "argtypes": [ "Bool" ],
+          "arguments": [
+            { "constructor": "False", "argtypes": [], "arguments": [] }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "vname": "gmap",
+    "type": "Map (ByStr20) (Pair (Int32) (Int32))",
+    "value": [
+      {
+        "key": "0x12345678901234567890123456789012345678ab",
+        "val": {
+          "constructor": "Pair",
+          "argtypes": [ "Int32", "Int32" ],
+          "arguments": [ "1", "2" ]
+        }
+      }
+    ]
+  }
 ]

--- a/tests/runner/mappair/state_6.json
+++ b/tests/runner/mappair/state_6.json
@@ -1,22 +1,37 @@
 [
-    { "vname": "_balance", "type": "Uint128", "value": "0" },
-    {
-        "vname": "gnat",
-        "type": "Nat ",
-        "value": {
-            "constructor": "Succ",
-            "argtypes": [],
-            "arguments": [
-                { "constructor": "Zero", "argtypes": [], "arguments": [] }
-            ]
-        }
-    },
-    {
-        "vname" : "llist",
-        "type" : "List(List(Int64))",
-        "value" : [
-            ["1","2","3"],
-            ["4","5","6"]
-        ]
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  {
+    "vname": "gmap",
+    "type": "Map (ByStr20) (Pair (Int32) (Int32))",
+    "value": []
+  },
+  {
+    "vname": "gpair",
+    "type": "Pair (List (Int64)) (Option (Bool))",
+    "value": {
+      "constructor": "Pair",
+      "argtypes": [ "List (Int64)", "Option (Bool)" ],
+      "arguments": [
+        [],
+        { "constructor": "None", "argtypes": [ "Bool" ], "arguments": [] }
+      ]
     }
+  },
+  { "vname": "plist", "type": "List (Option (Int32))", "value": [] },
+  {
+    "vname": "gnat",
+    "type": "Nat",
+    "value": {
+      "constructor": "Succ",
+      "argtypes": [],
+      "arguments": [
+        { "constructor": "Zero", "argtypes": [], "arguments": [] }
+      ]
+    }
+  },
+  {
+    "vname": "llist",
+    "type": "List (List (Int64))",
+    "value": [ [ "1", "2", "3" ], [ "4", "5", "6" ] ]
+  }
 ]

--- a/tests/runner/mappair/state_7.json
+++ b/tests/runner/mappair/state_7.json
@@ -1,30 +1,44 @@
 [
-    { "vname": "_balance", "type": "Uint128", "value": "0" },
-    {
-        "vname": "gnat",
-        "type": "Nat ",
-        "value": {
-            "constructor": "Succ",
-            "argtypes": [],
-            "arguments": [
-                { "constructor": "Zero", "argtypes": [], "arguments": [] }
-            ]
-        }
-    },
-    {
-        "vname" : "plist",
-        "type" : "List(Option(Int32))",
-        "value" : [
-            {
-                "constructor": "Some",
-                "argtypes": ["Int32"],
-                "arguments": ["2"]
-            },
-            {
-                "constructor": "None",
-                "argtypes": ["Int32"],
-                "arguments": []
-            }
-        ]
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  {
+    "vname": "gmap",
+    "type": "Map (ByStr20) (Pair (Int32) (Int32))",
+    "value": []
+  },
+  {
+    "vname": "gpair",
+    "type": "Pair (List (Int64)) (Option (Bool))",
+    "value": {
+      "constructor": "Pair",
+      "argtypes": [ "List (Int64)", "Option (Bool)" ],
+      "arguments": [
+        [],
+        { "constructor": "None", "argtypes": [ "Bool" ], "arguments": [] }
+      ]
     }
+  },
+  { "vname": "llist", "type": "List (List (Int64))", "value": [] },
+  {
+    "vname": "gnat",
+    "type": "Nat",
+    "value": {
+      "constructor": "Succ",
+      "argtypes": [],
+      "arguments": [
+        { "constructor": "Zero", "argtypes": [], "arguments": [] }
+      ]
+    }
+  },
+  {
+    "vname": "plist",
+    "type": "List (Option (Int32))",
+    "value": [
+      {
+        "constructor": "Some",
+        "argtypes": [ "Int32" ],
+        "arguments": [ "2" ]
+      },
+      { "constructor": "None", "argtypes": [ "Int32" ], "arguments": [] }
+    ]
+  }
 ]

--- a/tests/runner/nonfungible-token/state_1.json
+++ b/tests/runner/nonfungible-token/state_1.json
@@ -1,13 +1,23 @@
 [
-    {
-        "vname": "_balance",
-        "type": "Uint128",
-        "value": "0"
-    },
-    {
-        "vname": "tokenOwnerMap",
-        "type": "Map (Uint256) (ByStr20)",
-        "value": [
-        ]
-    }
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  {
+    "vname": "ownedTokenCount",
+    "type": "Map (ByStr20) (Uint256)",
+    "value": []
+  },
+  {
+    "vname": "tokenApprovals",
+    "type": "Map (Uint256) (ByStr20)",
+    "value": []
+  },
+  {
+    "vname": "operatorApprovals",
+    "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+    "value": []
+  },
+  {
+    "vname": "tokenOwnerMap",
+    "type": "Map (Uint256) (ByStr20)",
+    "value": []
+  }
 ]

--- a/tests/runner/nonfungible-token/state_2.json
+++ b/tests/runner/nonfungible-token/state_2.json
@@ -1,22 +1,27 @@
 [
-    { "vname": "_balance", "type": "Uint128", "value": "0" },
-    {
-        "vname": "tokenApprovals",
-        "type": "Map (Uint256) (ByStr20)",
-        "value": []
-      },
-    {
-      "vname": "ownedTokenCount",
-      "type": "Map (ByStr20) (Uint256)",
-      "value": [
-        { "key": "0x1234567890123456789012345678901234567892", "val": "1" }
-      ]
-    },
-    {
-      "vname": "tokenOwnerMap",
-      "type": "Map (Uint256) (ByStr20)",
-      "value": [
-        { "key": "1", "val": "0x1234567890123456789012345678901234567892" }
-      ]
-    }
-  ]
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  {
+    "vname": "operatorApprovals",
+    "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+    "value": []
+  },
+  {
+    "vname": "tokenApprovals",
+    "type": "Map (Uint256) (ByStr20)",
+    "value": []
+  },
+  {
+    "vname": "ownedTokenCount",
+    "type": "Map (ByStr20) (Uint256)",
+    "value": [
+      { "key": "0x1234567890123456789012345678901234567892", "val": "1" }
+    ]
+  },
+  {
+    "vname": "tokenOwnerMap",
+    "type": "Map (Uint256) (ByStr20)",
+    "value": [
+      { "key": "1", "val": "0x1234567890123456789012345678901234567892" }
+    ]
+  }
+]

--- a/tests/runner/nonfungible-token/state_21.json
+++ b/tests/runner/nonfungible-token/state_21.json
@@ -1,13 +1,23 @@
 [
-    {
-        "vname": "_balance",
-        "type": "Uint128",
-        "value": "0"
-    },
-    {
-        "vname": "tokenOwnerMap",
-        "type": "Map (Uint256) (ByStr20)",
-        "value": [
-        ]
-    }
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  {
+    "vname": "ownedTokenCount",
+    "type": "Map (ByStr20) (Uint256)",
+    "value": []
+  },
+  {
+    "vname": "tokenApprovals",
+    "type": "Map (Uint256) (ByStr20)",
+    "value": []
+  },
+  {
+    "vname": "operatorApprovals",
+    "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+    "value": []
+  },
+  {
+    "vname": "tokenOwnerMap",
+    "type": "Map (Uint256) (ByStr20)",
+    "value": []
+  }
 ]

--- a/tests/runner/nonfungible-token/state_22.json
+++ b/tests/runner/nonfungible-token/state_22.json
@@ -1,22 +1,27 @@
 [
-    { "vname": "_balance", "type": "Uint128", "value": "0" },
-    {
-        "vname": "tokenApprovals",
-        "type": "Map (Uint256) (ByStr20)",
-        "value": []
-      },
-    {
-      "vname": "ownedTokenCount",
-      "type": "Map (ByStr20) (Uint256)",
-      "value": [
-        { "key": "0x1234567890123456789012345678901234567892", "val": "1" }
-      ]
-    },
-    {
-      "vname": "tokenOwnerMap",
-      "type": "Map (Uint256) (ByStr20)",
-      "value": [
-        { "key": "1", "val": "0x1234567890123456789012345678901234567892" }
-      ]
-    }
-  ]
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  {
+    "vname": "operatorApprovals",
+    "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+    "value": []
+  },
+  {
+    "vname": "tokenApprovals",
+    "type": "Map (Uint256) (ByStr20)",
+    "value": []
+  },
+  {
+    "vname": "ownedTokenCount",
+    "type": "Map (ByStr20) (Uint256)",
+    "value": [
+      { "key": "0x1234567890123456789012345678901234567892", "val": "1" }
+    ]
+  },
+  {
+    "vname": "tokenOwnerMap",
+    "type": "Map (Uint256) (ByStr20)",
+    "value": [
+      { "key": "1", "val": "0x1234567890123456789012345678901234567892" }
+    ]
+  }
+]

--- a/tests/runner/nonfungible-token/state_23.json
+++ b/tests/runner/nonfungible-token/state_23.json
@@ -1,6 +1,11 @@
 [
   { "vname": "_balance", "type": "Uint128", "value": "0" },
   {
+    "vname": "operatorApprovals",
+    "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+    "value": []
+  },
+  {
     "vname": "tokenApprovals",
     "type": "Map (Uint256) (ByStr20)",
     "value": []

--- a/tests/runner/nonfungible-token/state_24.json
+++ b/tests/runner/nonfungible-token/state_24.json
@@ -1,6 +1,11 @@
 [
   { "vname": "_balance", "type": "Uint128", "value": "0" },
   {
+    "vname": "operatorApprovals",
+    "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+    "value": []
+  },
+  {
     "vname": "tokenApprovals",
     "type": "Map (Uint256) (ByStr20)",
     "value": []

--- a/tests/runner/nonfungible-token/state_25.json
+++ b/tests/runner/nonfungible-token/state_25.json
@@ -1,6 +1,11 @@
 [
   { "vname": "_balance", "type": "Uint128", "value": "0" },
   {
+    "vname": "operatorApprovals",
+    "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+    "value": []
+  },
+  {
     "vname": "tokenApprovals",
     "type": "Map (Uint256) (ByStr20)",
     "value": []

--- a/tests/runner/nonfungible-token/state_26.json
+++ b/tests/runner/nonfungible-token/state_26.json
@@ -1,6 +1,11 @@
 [
   { "vname": "_balance", "type": "Uint128", "value": "0" },
   {
+    "vname": "operatorApprovals",
+    "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+    "value": []
+  },
+  {
     "vname": "tokenApprovals",
     "type": "Map (Uint256) (ByStr20)",
     "value": []

--- a/tests/runner/nonfungible-token/state_3.json
+++ b/tests/runner/nonfungible-token/state_3.json
@@ -1,6 +1,11 @@
 [
   { "vname": "_balance", "type": "Uint128", "value": "0" },
   {
+    "vname": "operatorApprovals",
+    "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+    "value": []
+  },
+  {
     "vname": "tokenApprovals",
     "type": "Map (Uint256) (ByStr20)",
     "value": []

--- a/tests/runner/nonfungible-token/state_4.json
+++ b/tests/runner/nonfungible-token/state_4.json
@@ -1,6 +1,11 @@
 [
   { "vname": "_balance", "type": "Uint128", "value": "0" },
   {
+    "vname": "operatorApprovals",
+    "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+    "value": []
+  },
+  {
     "vname": "tokenApprovals",
     "type": "Map (Uint256) (ByStr20)",
     "value": []

--- a/tests/runner/nonfungible-token/state_5.json
+++ b/tests/runner/nonfungible-token/state_5.json
@@ -1,6 +1,11 @@
 [
   { "vname": "_balance", "type": "Uint128", "value": "0" },
   {
+    "vname": "operatorApprovals",
+    "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+    "value": []
+  },
+  {
     "vname": "tokenApprovals",
     "type": "Map (Uint256) (ByStr20)",
     "value": []

--- a/tests/runner/nonfungible-token/state_6.json
+++ b/tests/runner/nonfungible-token/state_6.json
@@ -1,6 +1,11 @@
 [
   { "vname": "_balance", "type": "Uint128", "value": "0" },
   {
+    "vname": "operatorApprovals",
+    "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+    "value": []
+  },
+  {
     "vname": "tokenApprovals",
     "type": "Map (Uint256) (ByStr20)",
     "value": []

--- a/tests/runner/nonfungible-token/state_7.json
+++ b/tests/runner/nonfungible-token/state_7.json
@@ -1,6 +1,11 @@
 [
   { "vname": "_balance", "type": "Uint128", "value": "0" },
   {
+    "vname": "operatorApprovals",
+    "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+    "value": []
+  },
+  {
     "vname": "tokenApprovals",
     "type": "Map (Uint256) (ByStr20)",
     "value": []

--- a/tests/runner/ping/state_0.json
+++ b/tests/runner/ping/state_0.json
@@ -1,12 +1,13 @@
 [
-    {
-        "vname" : "count",
-        "type" : "Int32",
-        "value" : "2"
-    },
-    {
-        "vname": "_balance",
-        "type": "Uint128",
-        "value": "0"
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  {
+    "vname": "pong_addr",
+    "type": "Option (ByStr20)",
+    "value": {
+      "constructor": "None",
+      "argtypes": [ "ByStr20" ],
+      "arguments": []
     }
+  },
+  { "vname": "count", "type": "Int32", "value": "2" }
 ]

--- a/tests/runner/pong/state_0.json
+++ b/tests/runner/pong/state_0.json
@@ -1,12 +1,13 @@
 [
-    {
-        "vname" : "count",
-        "type" : "Int32",
-        "value" : "2"
-    },
-    {
-        "vname": "_balance",
-        "type": "Uint128",
-        "value": "0"
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  {
+    "vname": "ping_addr",
+    "type": "Option (ByStr20)",
+    "value": {
+      "constructor": "None",
+      "argtypes": [ "ByStr20" ],
+      "arguments": []
     }
+  },
+  { "vname": "count", "type": "Int32", "value": "2" }
 ]

--- a/tests/runner/pong/state_3.json
+++ b/tests/runner/pong/state_3.json
@@ -1,12 +1,13 @@
 [
-    {
-        "vname" : "count",
-        "type" : "Int32",
-        "value" : "2"
-    },
-    {
-        "vname": "_balance",
-        "type": "Uint128",
-        "value": "0"
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  {
+    "vname": "ping_addr",
+    "type": "Option (ByStr20)",
+    "value": {
+      "constructor": "None",
+      "argtypes": [ "ByStr20" ],
+      "arguments": []
     }
+  },
+  { "vname": "count", "type": "Int32", "value": "2" }
 ]

--- a/tests/runner/simple-dex/state_1.json
+++ b/tests/runner/simple-dex/state_1.json
@@ -1,3 +1,14 @@
 [
-    { "vname": "_balance", "type": "Uint128", "value": "0" }
+  { "vname": "_balance", "type": "Uint128", "value": "0" },
+  { "vname": "orderbook", "type": "Map (ByStr32) (Order)", "value": [] },
+  {
+    "vname": "orderInfo",
+    "type": "Map (ByStr32) (Pair (ByStr20) (BNum))",
+    "value": []
+  },
+  {
+    "vname": "pendingReturns",
+    "type": "Map (ByStr20) (Map (ByStr20) (Uint128))",
+    "value": []
+  }
 ]


### PR DESCRIPTION
When we have IPC mode state access, to test the framework, we need to initialize the IPC server with a state, and that state can be obtained from our state.json files. For this to work, the state.json must have all fields present, so that all the fields can be updated to the server to being IPC state access based execution.