### PR TITLE
Do not incentivize stores that reduce storage.

### DIFF
--- a/src/lang/base/Gas.ml
+++ b/src/lang/base/Gas.ml
@@ -101,18 +101,10 @@ module ScillaGas
     | Builtin _ -> pure 0 (* this is a dynamic cost. *)
 
   let stmt_cost scon = match scon with
-    | G_Load l -> literal_cost l
-    | G_Store (old_l, new_l) -> 
-        let%bind old_cost =  literal_cost(old_l) in 
-        let%bind new_cost = literal_cost(new_l) in
-        let storage_cost = new_cost - old_cost in
-        let op_cost = Int.max old_cost new_cost in
-        pure @@ op_cost + storage_cost
+    | G_Load l | G_Store l -> literal_cost l
     | G_MapUpdate (n, lopt)
     | G_MapGet (n, lopt) ->
       let%bind l_cost = 
-        (* Deleting a key only has the cost of indexing 
-           (to incentivice removal of data). *)
         (match lopt with | Some l -> (literal_cost l) | None -> pure 0) in
       pure @@ n + l_cost
     | G_Bind -> pure 1

--- a/src/lang/base/Syntax.ml
+++ b/src/lang/base/Syntax.ml
@@ -632,8 +632,8 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
   type stmt_eval_context =
     (* literal being loaded *)
     | G_Load of literal
-    (* old value of stored literal, new value *)
-    | G_Store of (literal * literal)
+    (* literal being stored *)
+    | G_Store of literal
     (* none *)
     | G_Bind
     (* nesting depth, new value *)

--- a/src/lang/eval/StateService.ml
+++ b/src/lang/eval/StateService.ml
@@ -164,11 +164,11 @@ let update_local ~fname ~keys vopt fields =
       )
     in
       recurser mlit keys vt
-  | Some {fname = f; ftyp =  t; fval = Some l} ->
+  | Some {fname = f; ftyp =  t; fval = Some _} ->
     (match vopt with
     | Some fval' ->
       let fields' = List.filter fields ~f:(fun f -> f.fname <> (get_id fname)) in
-      pure ({fname = f; ftyp = t; fval = Some fval'} :: fields', G_Store (l, fval'))
+      pure ({fname = f; ftyp = t; fval = Some fval'} :: fields', G_Store fval')
     | None ->
       fail1 (sprintf "StateService: Cannot remove non-map value %s from state" (get_id fname))
         (ER.get_loc (get_rep fname))

--- a/tests/runner/auction/output_1.json
+++ b/tests/runner/auction/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7374",
+  "gas_remaining": "7393",
   "_accepted": "true",
   "message": null,
   "states": [

--- a/tests/runner/crowdfunding/output_1.json
+++ b/tests/runner/crowdfunding/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7524",
+  "gas_remaining": "7560",
   "_accepted": "true",
   "message": null,
   "states": [

--- a/tests/runner/crowdfunding/output_2.json
+++ b/tests/runner/crowdfunding/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7452",
+  "gas_remaining": "7488",
   "_accepted": "true",
   "message": null,
   "states": [

--- a/tests/runner/crowdfunding/output_6.json
+++ b/tests/runner/crowdfunding/output_6.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7454",
+  "gas_remaining": "7490",
   "_accepted": "true",
   "message": null,
   "states": [

--- a/tests/runner/mappair/output_2.json
+++ b/tests/runner/mappair/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7433",
+  "gas_remaining": "7441",
   "_accepted": "false",
   "message": {
     "_tag": "",

--- a/tests/runner/mappair/output_3.json
+++ b/tests/runner/mappair/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7403",
+  "gas_remaining": "7411",
   "_accepted": "false",
   "message": {
     "_tag": "",

--- a/tests/runner/ping/output_0.json
+++ b/tests/runner/ping/output_0.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7676",
+  "gas_remaining": "7695",
   "_accepted": "false",
   "message": null,
   "states": [

--- a/tests/runner/pong/output_0.json
+++ b/tests/runner/pong/output_0.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7677",
+  "gas_remaining": "7696",
   "_accepted": "false",
   "message": null,
   "states": [

--- a/tests/runner/wallet/output_1.json
+++ b/tests/runner/wallet/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7179",
+  "gas_remaining": "7242",
   "_accepted": "true",
   "message": null,
   "states": [

--- a/tests/runner/wallet/output_11.json
+++ b/tests/runner/wallet/output_11.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7064",
+  "gas_remaining": "7085",
   "_accepted": "false",
   "message": null,
   "states": [

--- a/tests/runner/wallet/output_2.json
+++ b/tests/runner/wallet/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6935",
+  "gas_remaining": "6979",
   "_accepted": "false",
   "message": null,
   "states": [

--- a/tests/runner/wallet/output_3.json
+++ b/tests/runner/wallet/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7080",
+  "gas_remaining": "7101",
   "_accepted": "false",
   "message": null,
   "states": [

--- a/tests/runner/wallet/output_4.json
+++ b/tests/runner/wallet/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7037",
+  "gas_remaining": "7058",
   "_accepted": "false",
   "message": null,
   "states": [

--- a/tests/runner/wallet/output_8.json
+++ b/tests/runner/wallet/output_8.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7110",
+  "gas_remaining": "7130",
   "_accepted": "false",
   "message": null,
   "states": [

--- a/tests/runner/wallet/output_9.json
+++ b/tests/runner/wallet/output_9.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6896",
+  "gas_remaining": "6917",
   "_accepted": "false",
   "message": null,
   "states": [

--- a/tests/runner/zil-game/output_1.json
+++ b/tests/runner/zil-game/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7234",
+  "gas_remaining": "7328",
   "_accepted": "false",
   "message": {
     "_tag": "",


### PR DESCRIPTION
Incentivising stores that reduce the on-disk storage aren't
really useful because they are only a discount on the current
transaction and not pay back. For every transaction involving
a large stored data object, computation proportional to the
size is still charged. On the long run, it is better that we
move to a different model that charges correctly for persistant
storage.

On a side note: The current model does not work with the new
IPC based state accesses, since the previous size of a data
being stored is not available at all (to compute old_size - new_size)
to decide the incentive.