### PR TITLE
Make local opam switch installation more robust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,5 +56,6 @@ before_install:
 - rm $HOME/.opam/log/*
 script:
 - if [ $TRAVIS_OS_NAME = osx ]; then ulimit -n 1024; fi
+- eval $(opam env)
 - make test
 - make coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,9 +52,7 @@ branches:
     - /^release-v.*$/
 before_install:
 - if [ $TRAVIS_OS_NAME = linux ]; then ./scripts/install_opam2_ubuntu.sh; fi
-- opam init --disable-sandboxing --compiler=$OCAML_VERSION -y
-- eval $(opam env)
-- opam install ./scilla.opam --deps-only --with-test -y
+- make opamdep-ci
 - rm $HOME/.opam/log/*
 script:
 - if [ $TRAVIS_OS_NAME = osx ]; then ulimit -n 1024; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
     libpcre3-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN cd /scilla/${MAJOR_VERSION} && make opamdep \
+RUN cd /scilla/${MAJOR_VERSION} && make opamdep-ci \
     && echo '. ~/.opam/opam-init/init.sh > /dev/null 2> /dev/null || true ' >> ~/.bashrc \
     && eval `opam config env` && \
     make

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,5 @@ RUN apt-get update \
 
 RUN cd /scilla/${MAJOR_VERSION} && make opamdep-ci \
     && echo '. ~/.opam/opam-init/init.sh > /dev/null 2> /dev/null || true ' >> ~/.bashrc \
-    && eval `opam config env` && \
+    && eval $(opam env) && \
     make

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -29,7 +29,6 @@ RUN apt-get update \
     libpcre3-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN cd /scilla/${MAJOR_VERSION} && make opamdep \
+RUN cd /scilla/${MAJOR_VERSION} && make opamdep-ci \
     && echo '. ~/.opam/opam-init/init.sh > /dev/null 2> /dev/null || true ' >> ~/.bashrc \
-    && eval `opam config env` && \
-    make slim
+    && make slim

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -31,4 +31,5 @@ RUN apt-get update \
 
 RUN cd /scilla/${MAJOR_VERSION} && make opamdep-ci \
     && echo '. ~/.opam/opam-init/init.sh > /dev/null 2> /dev/null || true ' >> ~/.bashrc \
-    && make slim
+    && eval $(opam env) && \
+    make slim

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -83,7 +83,7 @@ ulimit -n 1024
 
 #### Initialize opam
 ```shell
-opam init --disable-sandboxing --compiler=4.06.1 --yes
+opam init --compiler=4.06.1 --yes
 ```
 Note: the initializer will change your shell configuration to setup the environment opam needs to work.
 You can remove `--yes` from the above command to manually control that process.
@@ -112,7 +112,7 @@ This is like a standard opam switch but instead of `$HOME/.opam`, it will reside
 This lets us to avoid dependency conflict and changing our switches back and forth when working on different projects.
 To create a local opam switch and install all the Scilla dependencies, `cd` into project root and execute:
 ```shell
-opam switch create . --deps-only --with-test --yes
+opam switch create ./ --deps-only --with-test --yes ocaml-base-compiler.4.06.1
 ```
 Now, whenever you are inside the project directory, opam will prefer the local switch to any globally installed switches,
 unless being told explicitly which one to use.

--- a/Makefile
+++ b/Makefile
@@ -73,13 +73,13 @@ zilliqa-docker:
 .PHONY : opamdep
 opamdep:
 	opam init --compiler=$(OCAML_VERSION_RECOMMENDED) --yes
-	eval $(opam env)
+	eval $$(opam env)
 	opam install ./scilla.opam --deps-only --with-test --yes
 
 .PHONY : opamdep-ci
 opamdep-ci:
 	opam init --disable-sandboxing --compiler=$(OCAML_VERSION) --yes
-	eval $(opam env)
+	eval $$(opam env)
 	opam install ./scilla.opam --deps-only --with-test --yes
 
 .PHONY : coverage

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 # Invoke `make` to build, `make clean` to clean up, etc.
 
+OCAML_VERSION_RECOMMENDED=4.06.1
+
 .PHONY: default all utop dev clean docker zilliqa-docker
 
 default: all
@@ -68,10 +70,17 @@ zilliqa-docker:
 	fi
 	docker build --build-arg BASE_IMAGE=$(ZILLIQA_IMAGE) .
 
+.PHONY : opamdep
 opamdep:
-	opam init --disable-sandboxing -y --compiler=4.06.1
+	opam init --compiler=$(OCAML_VERSION_RECOMMENDED) --yes
+	eval $(opam env)
 	opam install ./scilla.opam --deps-only --with-test --yes
 
+.PHONY : opamdep-ci
+opamdep-ci:
+	opam init --disable-sandboxing --compiler=$(OCAML_VERSION) --yes
+	eval $(opam env)
+	opam install ./scilla.opam --deps-only --with-test --yes
 
 .PHONY : coverage
 coverage :


### PR DESCRIPTION
Also, avoid `--disable-sandboxing` option for user setup as it's not secure.
Installation scripts may bypass sandboxing and potentially execute something
like `rm -rf /`