### PR TITLE
Make Scilla available for Nix users

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -54,7 +54,7 @@ sudo apt-get install -y curl build-essential m4 ocaml opam pkg-config zlib1g-dev
 ### macOS
 
 The dependencies (listed in [Brewfile](Brewfile)) can be installed via [Homebrew](https://brew.sh/) as follows.
-Run 
+Run
 ```shell
 brew bundle
 ```
@@ -75,6 +75,12 @@ the maximum number of open file descriptors as `Makefile`'s `test` target does:
 ```shell
 ulimit -n 1024
 ```
+
+### Nix and NixOS
+
+There is a `shell.nix` for Nix users, so running the `nix-shell`
+should drop you into and isolated environment with all the
+necessary dependencies available.
 
 
 ## Installing opam packages
@@ -105,7 +111,7 @@ make opamdep
 
 ### If you have opam package manager already installed
 You can try installing the Scilla dependencies using the instructions above, but skipping the initialization step.
-If `opam` reports a dependency conflict, one way out might be creating yet another opam switch and 
+If `opam` reports a dependency conflict, one way out might be creating yet another opam switch and
 managing your switches when doing Scilla- and non-Scilla- related hacking.
 Another way is to use opam's feature called "local switch".
 This is like a standard opam switch but instead of `$HOME/.opam`, it will reside in the project root directory in `_opam` subdirectory.

--- a/scripts/nix/ocaml-protoc.nix
+++ b/scripts/nix/ocaml-protoc.nix
@@ -1,0 +1,38 @@
+{ stdenv, ocaml, fetchFromGitHub, ocamlbuild, findlib, ppx_deriving_protobuf }:
+
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-ocaml-protoc-${version}";
+  version = "1.2.0";
+
+  minimumOCamlVersion = "4.02";
+
+  src = fetchFromGitHub {
+    owner = "mransan";
+    repo = "ocaml-protoc";
+    rev = "60d2d4dd55f73830e1bed603cc44d3420430632c";
+    sha256 = "1d1p8ch723z2qa9azmmnhbcpwxbpzk3imh1cgkjjq4p5jwzj8amj";
+  };
+
+  installPhase = ''
+    mkdir -p tmp/bin
+    export PREFIX=`pwd`/tmp
+    make all.install.build
+    make check_install
+    make lib.install
+    make bin.install
+  '';
+
+  buildInputs = [ ocaml findlib ocamlbuild ];
+  propagatedBuildInputs = [ ppx_deriving_protobuf ];
+
+  createFindlibDestdir = true;
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/mransan/ocaml-protoc";
+    description = "A Protobuf Compiler for OCaml";
+    license = licenses.mit;
+    maintainers = [ maintainers.vyorkin ];
+  };
+}

--- a/scripts/nix/ppx_deriving_protobuf.nix
+++ b/scripts/nix/ppx_deriving_protobuf.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, buildDunePackage, cppo, ppx_tools, ppx_deriving
+, ppxfind }:
+
+buildDunePackage rec {
+  pname = "ppx_deriving_protobuf";
+  version = "2.7";
+
+  src = fetchFromGitHub {
+    owner = "ocaml-ppx";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0aq4f3gbkhhai0c8i5mcw2kpqy8l610f4dknwkrxh0nsizwbwryn";
+  };
+
+  buildInputs = [ cppo ppx_tools ppxfind ppx_deriving ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/ocaml-ppx/ppx_deriving_protobuf";
+    description = "A Protocol Buffers codec generator for OCaml";
+    license = licenses.mit;
+    maintainers = [ maintainers.vyorkin ];
+  };
+}

--- a/scripts/nix/ppx_deriving_rpc.nix
+++ b/scripts/nix/ppx_deriving_rpc.nix
@@ -1,0 +1,18 @@
+{ lib, buildDunePackage, rpclib, ppxfind, ppx_deriving, cppo }:
+
+buildDunePackage rec {
+  pname = "ppx_deriving_rpc";
+
+  inherit (rpclib) version src;
+
+  buildInputs = [ ppxfind cppo ];
+
+  propagatedBuildInputs = [ rpclib ppx_deriving ];
+
+  meta = with lib; {
+    homepage = "https://github.com/mirage/ocaml-rpc";
+    description = "Ppx deriver for ocaml-rpc";
+    license = licenses.isc;
+    maintainers = [ maintainers.vyorkin ];
+  };
+}

--- a/scripts/nix/rpclib.nix
+++ b/scripts/nix/rpclib.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, buildDunePackage, alcotest, cmdliner, rresult, result, xmlm, yojson }:
+
+buildDunePackage rec {
+  pname = "rpclib";
+  version = "5.9.0";
+
+  minimumOCamlVersion = "4.04";
+
+  src = fetchFromGitHub {
+    owner = "mirage";
+    repo = "ocaml-rpc";
+    rev = "v${version}";
+    sha256 = "1swnnmmnkn53mxqpckdnd1j8bz0wksqznjbv0zamspxyqybmancq";
+  };
+
+  buildInputs = [ alcotest cmdliner yojson ];
+  propagatedBuildInputs = [ rresult result xmlm ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/mirage/ocaml-rpc";
+    description = "Light library to deal with RPCs in OCaml";
+    license = licenses.isc;
+    maintainers = [ maintainers.vyorkin ];
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,30 @@
+with import <nixpkgs> { };
+
+let
+  opkgs = pkgs.ocamlPackages;
+  ppx_deriving_protobuf = opkgs.callPackage ./scripts/nix/ppx_deriving_protobuf.nix { };
+  ocaml-protoc = opkgs.callPackage ./scripts/nix/ocaml-protoc.nix { inherit ppx_deriving_protobuf; };
+  rpclib = opkgs.callPackage ./scripts/nix/rpclib.nix { };
+  ppx_deriving_rpc = opkgs.callPackage ./scripts/nix/ppx_deriving_rpc.nix { inherit rpclib; };
+  ocamlVersion = opkgs.ocaml.version;
+  systemPkgs = [
+    ocaml opam gcc dune ncurses boost openssl
+    zlib secp256k1 libffi pkgconfig pcre patdiff
+  ];
+  ocamlPkgs = with opkgs; [
+    base core core_bench core_profiler ppx_deriving ppx_tools_versioned
+    ppx_sexp_conv bisect_ppx fileutils hex stdint batteries cryptokit
+    bitstring ctypes findlib utop angstrom ounit expect_test_helpers patience_diff
+    ocaml_pcre merlin ocp-indent ocp-index yojson menhir secp256k1 rpclib
+    ppx_deriving_protobuf ocaml-protoc ppx_deriving_rpc result rresult xmlm
+  ];
+  packages = systemPkgs ++ ocamlPkgs;
+  mkpath = p: "${p}/lib/ocaml/${ocamlVersion}/site-lib";
+  paths = builtins.concatStringsSep ":" (map mkpath ocamlPkgs);
+  siteLisp = "share/emacs/site-lisp";
+in pkgs.mkShell {
+  buildInputs = packages;
+  shellHook = with opkgs; ''
+    export OCAML_TOPLEVEL_PATH="${mkpath findlib}"
+  '';
+}

--- a/shell.nix
+++ b/shell.nix
@@ -13,7 +13,7 @@ let
   ];
   ocamlPkgs = with opkgs; [
     base core core_bench core_profiler ppx_deriving ppx_tools_versioned
-    ppx_sexp_conv bisect_ppx fileutils hex stdint batteries cryptokit
+    ppx_sexp_conv bisect_ppx fileutils hex stdint batteries zarith cryptokit
     bitstring ctypes findlib utop angstrom ounit expect_test_helpers patience_diff
     ocaml_pcre merlin ocp-indent ocp-index yojson menhir secp256k1 rpclib
     ppx_deriving_protobuf ocaml-protoc ppx_deriving_rpc result rresult xmlm


### PR DESCRIPTION
For now, I've added a few missing rpc and protobuf-related nix-derivations to the `./nix` directory. Later they should be removed in favor of those I've contributed to the `nixpkgs`:
* https://github.com/NixOS/nixpkgs/pull/68962
* https://github.com/NixOS/nixpkgs/pull/68958

resolves #616 