### PR TITLE
Update .gitignore to ignore only root /bin directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ _opam/*
 # oasis generated files
 setup.data
 setup.log
-bin
+/bin
 scilla
 *.install
 .merlin


### PR DESCRIPTION
A couple of days ago the `git clean -dfXq --exclude=\!_opam/**` from the `Makefile` deleted my `bin/mock_server_runner.ml` when I ran the `make clean`, so I thought it may be a good idea to update the `.gitignore` to only exclude the root `/bin` directory instead of every `bin` directory