### PR TITLE
Use the TMPDIR env variable instead of hardcoding /tmp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,6 @@
 
 OCAML_VERSION_RECOMMENDED=4.06.1
 
-# The :- allows for a variable to be assigned a value if another variable is either empty or is undefined
-# (according to gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html)
-TMP=${TMPDIR:-/tmp}
-IPC_SOCK_PATH="$TMP/zilliqa.sock"
-
 .PHONY: default all utop dev clean docker zilliqa-docker
 
 default: all
@@ -49,7 +44,7 @@ gold: dev
 # don't want multiple threads of the testsuite connecting to the same server concurrently.
 test_extipcserver: dev
 	dune exec tests/testsuite.exe -- -print-diff true -runner sequential \
-	-ext-ipc-server $(IPC_SOCK_PATH) \
+	-ext-ipc-server "/tmp/zilliqa.sock" \
 	-only-test "all_tests:0:contract_tests:0:these_tests_must_SUCCEED"
 
 # Clean up

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Invoke `make` to build, `make clean` to clean up, etc.
 
 OCAML_VERSION_RECOMMENDED=4.06.1
+IPC_SOCK_PATH="/tmp/zilliqa.sock"
 
 .PHONY: default all utop dev clean docker zilliqa-docker
 
@@ -44,7 +45,7 @@ gold: dev
 # don't want multiple threads of the testsuite connecting to the same server concurrently.
 test_extipcserver: dev
 	dune exec tests/testsuite.exe -- -print-diff true -runner sequential \
-	-ext-ipc-server "/tmp/zilliqa.sock" \
+	-ext-ipc-server $(IPC_SOCK_PATH) \
 	-only-test "all_tests:0:contract_tests:0:these_tests_must_SUCCEED"
 
 # Clean up

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 OCAML_VERSION_RECOMMENDED=4.06.1
 
+# The :- allows for a variable to be assigned a value if another variable is either empty or is undefined
+# (according to gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html)
 TMP=${TMPDIR:-/tmp}
 IPC_SOCK_PATH="$TMP/zilliqa.sock"
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 
 OCAML_VERSION_RECOMMENDED=4.06.1
 
+TMP=${TMPDIR:-/tmp}
+IPC_SOCK_PATH="$TMP/zilliqa.sock"
+
 .PHONY: default all utop dev clean docker zilliqa-docker
 
 default: all
@@ -44,7 +47,7 @@ gold: dev
 # don't want multiple threads of the testsuite connecting to the same server concurrently.
 test_extipcserver: dev
 	dune exec tests/testsuite.exe -- -print-diff true -runner sequential \
-	-ext-ipc-server "/tmp/zilliqa.sock" \
+	-ext-ipc-server $(IPC_SOCK_PATH) \
 	-only-test "all_tests:0:contract_tests:0:these_tests_must_SUCCEED"
 
 # Clean up

--- a/tests/runner/Testcontracts.ml
+++ b/tests/runner/Testcontracts.ml
@@ -24,7 +24,7 @@ open TestUtil
 open OUnitTest
 
 let testsuit_gas_limit = "8000"
-let ipc_socket_addr = Filename.(concat temp_dir_name "scillaipcsocket")
+let ipc_socket_addr = Filename.temp_dir_name ^/ "scillaipcsocket"
 
 let succ_code : Caml.Unix.process_status = WEXITED 0
 let fail_code : Caml.Unix.process_status = WEXITED 1

--- a/tests/runner/Testcontracts.ml
+++ b/tests/runner/Testcontracts.ml
@@ -2,16 +2,16 @@
   This file is part of scilla.
 
   Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
-  
+
   scilla is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software
   Foundation, either version 3 of the License, or (at your option) any later
   version.
- 
+
   scilla is distributed in the hope that it will be useful, but WITHOUT ANY
   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
   A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
- 
+
   You should have received a copy of the GNU General Public License along with
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
@@ -24,7 +24,7 @@ open TestUtil
 open OUnitTest
 
 let testsuit_gas_limit = "8000"
-let ipc_socket_addr = "/tmp/scillaipcsocket"
+let ipc_socket_addr = Filename.(concat temp_dir_name "scillaipcsocket")
 
 let succ_code : Caml.Unix.process_status = WEXITED 0
 let fail_code : Caml.Unix.process_status = WEXITED 1
@@ -238,4 +238,3 @@ let add_tests env =
     ];
     "misc_tests" >::: build_misc_tests env;
   ]
-


### PR DESCRIPTION
We might want to consider using the `Filename.temp_dir_name` (which relies on the [TMPDIR](https://en.wikipedia.org/wiki/TMPDIR) and defaults to `/tmp`) instead of hardcoding the `/tmp` directory for contract output files and socket files. For example, on NixOS the `$TMPDIR` is set to `/run/user/1000` (not `/tmp`).
