### PR TITLE
Transition_executed event added, and removed unused transaction_signed

### DIFF
--- a/tests/checker/good/gold/wallet_2.scilla.gold
+++ b/tests/checker/good/gold/wallet_2.scilla.gold
@@ -91,7 +91,7 @@
         "vname": "WalletError",
         "params": [ { "vname": "err_code", "type": "Int32" } ]
       },
-      { "vname": "Transaction signed", "params": [] },
+      { "vname": "Transaction executed", "params": [] },
       {
         "vname": "Transaction created",
         "params": [ { "vname": "transactionId", "type": "Uint32" } ]
@@ -180,7 +180,7 @@
       "warning_message": "Consider using in-place Map access",
       "start_location": {
         "file": "contracts/wallet_2.scilla",
-        "line": 424,
+        "line": 426,
         "column": 14
       },
       "end_location": { "file": "", "line": 0, "column": 0 },

--- a/tests/contracts/wallet_2.scilla
+++ b/tests/contracts/wallet_2.scilla
@@ -17,8 +17,8 @@ let mk_transaction_added_event =
     { _eventname : "Transaction created" ; transactionId : tc }
 
 (* Event for communicating the signing of a transaction *)
-let mk_transaction_signed_event =
-    { _eventname : "Transaction signed" }
+let mk_transaction_executed_event =
+    { _eventname : "Transaction executed" }
 
 type Error =
 | NonOwnerCannotSign
@@ -374,7 +374,9 @@ transition ExecuteTransaction (transactionId : Uint32)
             (* Remove transaction and signatures, and execute. *)
             DeleteTransaction transactionId;
             msgs = transaction_msg_as_list recipient amount tag;
-            send msgs
+            send msgs;
+            e = mk_transaction_executed_event;
+            event e
           end
         end
       end

--- a/tests/runner/wallet_2/output_28.json
+++ b/tests/runner/wallet_2/output_28.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6993",
+  "gas_remaining": "6951",
   "_accepted": "false",
   "message": {
     "_tag": "",
@@ -50,5 +50,5 @@
       ]
     }
   ],
-  "events": []
+  "events": [ { "_eventname": "Transaction executed", "params": [] } ]
 }

--- a/tests/runner/wallet_2/output_29.json
+++ b/tests/runner/wallet_2/output_29.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6993",
+  "gas_remaining": "6951",
   "_accepted": "false",
   "message": {
     "_tag": "",
@@ -50,5 +50,5 @@
       ]
     }
   ],
-  "events": []
+  "events": [ { "_eventname": "Transaction executed", "params": [] } ]
 }

--- a/tests/runner/wallet_2/output_30.json
+++ b/tests/runner/wallet_2/output_30.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6993",
+  "gas_remaining": "6951",
   "_accepted": "false",
   "message": {
     "_tag": "AddFunds",
@@ -50,5 +50,5 @@
       ]
     }
   ],
-  "events": []
+  "events": [ { "_eventname": "Transaction executed", "params": [] } ]
 }

--- a/tests/runner/wallet_2/output_31.json
+++ b/tests/runner/wallet_2/output_31.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6993",
+  "gas_remaining": "6951",
   "_accepted": "false",
   "message": {
     "_tag": "",
@@ -50,5 +50,5 @@
       ]
     }
   ],
-  "events": []
+  "events": [ { "_eventname": "Transaction executed", "params": [] } ]
 }

--- a/tests/runner/wallet_2/output_32.json
+++ b/tests/runner/wallet_2/output_32.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6993",
+  "gas_remaining": "6951",
   "_accepted": "false",
   "message": {
     "_tag": "",
@@ -50,5 +50,5 @@
       ]
     }
   ],
-  "events": []
+  "events": [ { "_eventname": "Transaction executed", "params": [] } ]
 }

--- a/tests/runner/wallet_2/output_42.json
+++ b/tests/runner/wallet_2/output_42.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6993",
+  "gas_remaining": "6951",
   "_accepted": "false",
   "message": {
     "_tag": "",
@@ -72,5 +72,5 @@
       ]
     }
   ],
-  "events": []
+  "events": [ { "_eventname": "Transaction executed", "params": [] } ]
 }


### PR DESCRIPTION
As discussed on the call with @AmritKumar, @vaivaswatha and Gareth Mensah.

`transaction_signed` was removed when the `AddSignature` procedure was introduced. `AddSignature` is called both from the `SubmitTransaction` and `SignTransaction` transitions, but the `transaction_signed` event should only occur when `SignTransaction` calls `AddSignature` successfully. However, there is no way for `SignTransaction` to know whether the call to `AddSignature` succeeded, so the event cannot be issued as is.

I can't think of a nice way to fix this. Maybe it's possible to split `AddSignature` up so that the event can be issued correctly, but I can't see it off the top of my head.