### PR TITLE
Fix mismatched ocaml version in docker building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN apt-get update \
     libpcre3-dev \
     && rm -rf /var/lib/apt/lists/*
 
+ENV OCAML_VERSION 4.06.1
+
 RUN cd /scilla/${MAJOR_VERSION} && make opamdep-ci \
     && echo '. ~/.opam/opam-init/init.sh > /dev/null 2> /dev/null || true ' >> ~/.bashrc \
     && eval $(opam env) && \

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -29,6 +29,8 @@ RUN apt-get update \
     libpcre3-dev \
     && rm -rf /var/lib/apt/lists/*
 
+ENV OCAML_VERSION 4.06.1
+
 RUN cd /scilla/${MAJOR_VERSION} && make opamdep-ci \
     && echo '. ~/.opam/opam-init/init.sh > /dev/null 2> /dev/null || true ' >> ~/.bashrc \
     && eval $(opam env) && \


### PR DESCRIPTION
Since the latest version of OCaml in Ubuntu source is 4.05 (see https://ocaml.org/docs/install.html), it is better to switch to 4.06.1 manually. It can fixes the docker building error.