### PR TITLE
Fix for parallel build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,3 +103,14 @@ coveralls:
 	curl -L -F json_file=@./coverage.json https://coveralls.io/api/v1/jobs
 	make clean
 	-find . -name 'bisect*.out' | xargs rm
+
+
+# Diagnostic builds
+
+verbose:
+	dune build --profile dev @install --verbose
+
+# sequential build
+verbose-j1:
+	dune build -j1 --profile dev @install --verbose
+

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.0)
+(lang dune 1.5)
 (using menhir 2.0)

--- a/src/lang/base/dune
+++ b/src/lang/base/dune
@@ -1,30 +1,31 @@
-(rule
-  (deps ParserFaults.messages)
-  (targets ParserFaults.ml)
-  (action
-    (with-stdout-to ParserFaults.ml
-      (run menhir --compile-errors ParserFaults.messages ScillaParser.mly)))
-)
-
 (ocamllex
-  (modules ScillaLexer))
+ (modules ScillaLexer))
 
 (menhir
  (flags "--table")
  (modules ScillaParser))
 
+;; Generate ParserFaults module (to make parsing messages more user-friendly)
+(rule
+ (targets ParserFaults.ml)
+ (deps ParserFaults.messages ScillaParser.mly)
+ (action
+  (with-stdout-to ParserFaults.ml
+   (run %{bin:menhir} --compile-errors ParserFaults.messages ScillaParser.mly))))
+
+
 (library
  (name scilla_base)
-  (wrapped false)
-  (libraries core ppx_sexp_conv
-              num hex stdint batteries
-              ppx_deriving.show
-              cryptokit secp256k1 bitstring
-              yojson scilla_cpp_deps scilla_util
-              menhirLib)
-  (preprocess (pps ppx_sexp_conv
-                    ppx_let 
-                    ppx_deriving.show
-                    bisect_ppx -exclude-file=../../bisect.exclude -conditional
-                    ))
-  (synopsis "Scilla workbench implementation."))
+ (wrapped false)
+ (libraries core ppx_sexp_conv
+            num hex stdint batteries
+            ppx_deriving.show
+            cryptokit secp256k1 bitstring
+            yojson scilla_cpp_deps scilla_util
+            menhirLib)
+ (preprocess
+  (pps ppx_sexp_conv
+       ppx_let
+       ppx_deriving.show
+       bisect_ppx -exclude-file=../../bisect.exclude -conditional))
+ (synopsis "Scilla workbench implementation."))


### PR DESCRIPTION
Also, add diagnostic make targets and some indentation fixes (sorry)
The actual fix is to add `ScillaParser.mly` to `ParserFaults.ml`'s dependencies