### PR TITLE
Fix Nix build, use env shell cmd in scripts for portability

### DIFF
--- a/scripts/build_openssl.sh
+++ b/scripts/build_openssl.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 if [ -d ~/openssl/install ]
 then

--- a/scripts/install_opam2_ubuntu.sh
+++ b/scripts/install_opam2_ubuntu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # The -x flag makes sure the script exits as soon as one command returns a non-zero exit code
 # The -v flag makes the shell print all lines in the script before executing them, which helps identify which steps failed

--- a/scripts/libff.sh
+++ b/scripts/libff.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script is expected to be executed from Scilla root
 # $./scripts/libff.sh
 # The script fetches, builds and installs libff in the

--- a/shell.nix
+++ b/shell.nix
@@ -8,8 +8,8 @@ let
   ppx_deriving_rpc = opkgs.callPackage ./scripts/nix/ppx_deriving_rpc.nix { inherit rpclib; };
   ocamlVersion = opkgs.ocaml.version;
   systemPkgs = [
-    ocaml opam gcc dune ncurses boost openssl
-    zlib secp256k1 libffi pkgconfig pcre patdiff
+    m4 ocaml cmake opam gcc dune ncurses boost openssl
+    zlib gmp procps secp256k1 libffi pkgconfig pcre patdiff
   ];
   ocamlPkgs = with opkgs; [
     base core core_bench core_profiler ppx_deriving ppx_tools_versioned


### PR DESCRIPTION
Fixes the broken Nix build.
Adds a couple of missing Nix-related dependencies.
Also, I suggest using the
```
#!/usr/bin/env bash
```
instead of just
```
#!/bin/bash
```
in shell scripts, for [portability](https://en.wikipedia.org/wiki/Shebang_(Unix)#Portability)

I'll add Nix build to the CI as a separate PR.