### PR TITLE
Report type info for variables under a flag. Update the Emacs mode

### DIFF
--- a/misc/emacs-mode/scilla-mode.el
+++ b/misc/emacs-mode/scilla-mode.el
@@ -281,7 +281,7 @@
 ;; Set scilla-root in your ~/.emacs file as "setq scilla-root /path/to/scilla".
 ;;  Note: make sure to set scilla-root *before* loading this file (scilla-mode.el)
 ;; If scilla-root has been set and flycheck is available, enable flycheck.
-(if (and (boundp 'scilla-root) (require 'json nil t))
+(if (boundp 'scilla-root)
     (progn
       ;; derive stdlib and scilla-checker paths from scilla-root.
       (setq lib-dir (concat scilla-root "/src/stdlib"))

--- a/misc/emacs-mode/scilla-mode.el
+++ b/misc/emacs-mode/scilla-mode.el
@@ -270,16 +270,43 @@
        (json-key-type 'string)
        (json (json-read-from-string checker-output)))
       (progn
-        (setq val (gethash "type_info" json))
-        (if val
-            (progn
-              (message "type_info size: %d" (length val))
+        (setq tilist (gethash "type_info" json))
+        (if tilist
+            (catch 'vtype               ;; If the loop finds an appropriate entry, it'll throw.
+              (progn
+                (dolist (vari tilist)
+                  (progn
+                    (setq startloc (gethash "start_location" vari))
+                    (setq endloc (gethash "end_location" vari))
+                    (if (and startloc endloc)
+                        (progn
+                          (setq startline (gethash "line" startloc))
+                          (setq startcol (gethash "column" startloc))
+                          (setq endline (gethash "line" endloc))
+                          (setq endcol (gethash "column" endloc))
+                          (if (and startline startcol endline endcol)
+                              (when (and (= startline linn) (>= coln startcol) (< coln endcol))
+                                (message "hello")
+                                (setq type (gethash "type" vari))
+                                (if type
+                                    (throw 'vtype type)
+                                  "field type missing in checker output"
+                                  )
+                                )
+                            "start/end line/column not found"
+                            )
+                          )
+                      "(start/end)_location not found"
+                      )
+                    )
+                  )
+                "type not found for variable"
+                )
               )
-          (message "%s" "Warning: type_info not found in checker output")
+          "type_info not found in checker output"
           )
         )
       )
-    "Unit"
     )
   )
 

--- a/misc/emacs-mode/scilla-mode.el
+++ b/misc/emacs-mode/scilla-mode.el
@@ -255,7 +255,8 @@
   (save-excursion
     (goto-char point)
     (beginning-of-line)
-    (- point (point))))
+    ;; count columns from 1 instead of emacs default 0.
+    (+ 1 (- point (point)))))
 
 (defun get-scilla-type (checker-bin filename pos)
   "Given a checker and a filename, Run and extract from the checker output the type of the current variable."

--- a/src/lang/base/JSON.ml
+++ b/src/lang/base/JSON.ml
@@ -502,6 +502,29 @@ module Event = struct
 
 end
 
+module TypeInfo = struct
+
+  let type_info_to_json til =
+    `List (List.map til ~f:(fun (name, t, sloc, eloc) ->
+        `Assoc [
+          ("vname", `String name);
+          ("type", `String (pp_typ t));
+          ("start_location", loc_to_json sloc);
+          ("end_location", loc_to_json eloc);
+        ]
+      )
+    )
+
+  let type_info_to_jstring ?(pp = false) til =
+    let j = type_info_to_json til in
+      if pp
+      then
+        Basic.pretty_to_string j
+      else
+        Basic.to_string j
+
+end
+
 module CashflowInfo = struct
 
   let get_json (param_field_tags, ctr_tags) =

--- a/src/lang/base/JSON.mli
+++ b/src/lang/base/JSON.mli
@@ -152,6 +152,15 @@ module Event : sig
 
 end
 
+module TypeInfo : sig
+
+  val type_info_to_json :
+    (string * Syntax.typ * ErrorUtils.loc * ErrorUtils.loc) list -> Yojson.Basic.t
+
+  val type_info_to_jstring : ?pp:bool -> 
+    (string * Syntax.typ * ErrorUtils.loc * ErrorUtils.loc) list -> string
+end
+
 module CashflowInfo : sig
   (* Given: A pair of lists.
             The first element is an association list from fields to their tags.

--- a/src/lang/base/ScillaParser.mly
+++ b/src/lang/base/ScillaParser.mly
@@ -313,10 +313,10 @@ type_term :
 (***********************************************)
 
 stmt:
-| l = ID; BIND; r = sid   { (Load (asIdL l (toLoc $startpos($2)), asIdL r (toLoc $startpos(r))), toLoc $startpos) }
-| l = ID; ASSIGN; r = sid { (Store (asIdL l (toLoc $startpos($2)), asIdL r (toLoc $startpos(r))), toLoc $startpos) }
-| l = ID; EQ; r = exp    { (Bind (asIdL l (toLoc $startpos($2)), r), toLoc $startpos) }
-| l = ID; BIND; AND; c = CID { (ReadFromBC (asIdL l (toLoc $startpos($2)), c), toLoc $startpos) }
+| l = ID; BIND; r = sid   { (Load (asIdL l (toLoc $startpos(l)), asIdL r (toLoc $startpos(r))), toLoc $startpos) }
+| l = ID; ASSIGN; r = sid { (Store (asIdL l (toLoc $startpos(l)), asIdL r (toLoc $startpos(r))), toLoc $startpos) }
+| l = ID; EQ; r = exp    { (Bind (asIdL l (toLoc $startpos(l)), r), toLoc $startpos) }
+| l = ID; BIND; AND; c = CID { (ReadFromBC (asIdL l (toLoc $startpos(l)), c), toLoc $startpos) }
 | l = ID; BIND; r = ID; keys = nonempty_list(map_access)
   { MapGet(asIdL l (toLoc $startpos(l)), asIdL r (toLoc $startpos(r)), keys, true), toLoc $startpos }
 | l = ID; BIND; EXISTS; r = ID; keys = nonempty_list(map_access)
@@ -326,8 +326,8 @@ stmt:
 | DELETE; l = ID; keys = nonempty_list(map_access)
   { MapUpdate(asIdL l (toLoc $startpos(l)), keys, None), toLoc $startpos }
 | ACCEPT                 { (AcceptPayment, toLoc $startpos) }
-| SEND; m = sid;          { (SendMsgs (asIdL m (toLoc $startpos)), toLoc $startpos) }
-| EVENT; m = sid; { (CreateEvnt (asIdL m (toLoc $startpos)), toLoc $startpos) }
+| SEND; m = sid;          { (SendMsgs (asIdL m (toLoc $startpos(m))), toLoc $startpos) }
+| EVENT; m = sid; { (CreateEvnt (asIdL m (toLoc $startpos(m))), toLoc $startpos) }
 | THROW; mopt = option(sid); { Throw (BatOption.map (fun m -> (asIdL m (toLoc $startpos))) mopt), toLoc $startpos }
 | MATCH; x = sid; WITH; cs=list(stmt_pm_clause); END
   { (MatchStmt (Ident (x, toLoc $startpos(x)), cs), toLoc $startpos)  }

--- a/src/lang/base/ScillaParser.mly
+++ b/src/lang/base/ScillaParser.mly
@@ -216,14 +216,14 @@ simple_exp :
 | LET; x = ID;
   t = ioption(type_annot)
   EQ; f = simple_exp; IN; e = exp
-  {(Let ((Ident (x, toLoc $startpos)), t, f, e), toLoc $startpos) }
+  {(Let ((Ident (x, toLoc $startpos(x))), t, f, e), toLoc $startpos(f)) }
 (* Function *)
 | FUN; LPAREN; i = ID; COLON; t = typ; RPAREN; ARROW; e = exp
-  { (Fun (Ident (i, toLoc $startpos), t, e), toLoc $startpos ) }
+  { (Fun (Ident (i, toLoc $startpos(i)), t, e), toLoc $startpos(e) ) }
 (* Application *)
 | f = sid;
   args = nonempty_list(sident)
-  { (App ((Ident (f, toLoc $startpos)), args), toLoc $startpos ) }
+  { (App ((Ident (f, toLoc $startpos(f))), args), toLoc $startpos ) }
 (* Atomic expression *)
 | a = atomic_exp {a}
 (* Built-in call *)
@@ -246,13 +246,13 @@ simple_exp :
   { (MatchExpr (Ident (x, toLoc $startpos(x)), cs), toLoc $startpos) }
 (* Type function *)
 | TFUN; i = TID ARROW; e = exp
-  { (TFun (Ident (i, toLoc $startpos), e), toLoc $startpos) }
+  { (TFun (Ident (i, toLoc $startpos(i)), e), toLoc $startpos) }
 (* Type application *)
 | AT; f = sid; targs = nonempty_list(targ)
-  { (TApp ((Ident (f, toLoc $startpos)), targs), toLoc $startpos) }
+  { (TApp ((Ident (f, toLoc $startpos(f))), targs), toLoc $startpos) }
 
 atomic_exp :
-| i = sid       { (Var (Ident (i, toLoc $startpos)), toLoc $startpos) }
+| i = sid       { (Var (Ident (i, toLoc $startpos(i))), toLoc $startpos) }
 | l = lit      { (Literal l, toLoc $startpos) }
 
 lit :
@@ -280,12 +280,12 @@ map_access:
 
 pattern:
 | UNDERSCORE { Wildcard }
-| x = ID { Binder (Ident (x, toLoc $startpos)) }
+| x = ID { Binder (Ident (x, toLoc $startpos(x))) }
 | c = scid; ps = list(arg_pattern) { Constructor (c, ps) }
 
 arg_pattern:
 | UNDERSCORE { Wildcard }
-| x = ID { Binder (Ident (x, toLoc $startpos)) }
+| x = ID { Binder (Ident (x, toLoc $startpos(x))) }
 | c = scid;  { Constructor (c, []) }
 | LPAREN; p = pattern RPAREN; { p }
 

--- a/src/lang/checkers/TypeInfo.ml
+++ b/src/lang/checkers/TypeInfo.ml
@@ -1,0 +1,164 @@
+(*
+  This file is part of scilla.
+
+  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+  
+  scilla is free software: you can redistribute it and/or modify it under the
+  terms of the GNU General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option) any later
+  version.
+ 
+  scilla is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License along with
+  scilla.  If not, see <http://www.gnu.org/licenses/>.
+*)
+
+open Core
+open TypeUtil
+open Syntax
+open ErrorUtils
+
+(* This pass computes a list of all entities in the module for which
+ * type information can be reported, along with their start and end locations.
+ * Objects computed look like: "(name, type, start_loc, end_loc) list".
+ * "name" may be empty if the entity being reported is an expression other than
+ * a simple variable.
+ * TODO: Until Issues #134, we cannot report types for expressions.
+ * The alternate strategy is to have the client query for a particular variable
+ * and we search through our AST for that location and report back its type.
+ * We choose our current strategy for the following reasons:
+    1. The client now has an option of caching the results and reusing based
+      on what parts of the code were edited.
+    2. Features such as code lens are easier to implement for the client. i.e.
+      it can display the types of all entities (say in small / mild fonts) for
+      the user to always see.
+    3. It is simpler for us to fit this in our existing testsuite (selfish motive).
+ *)
+
+module ScillaTypeInfo
+    (SR : Rep)
+    (ER : sig
+       include Rep
+       val get_type : rep -> PlainTypes.t inferred_type
+     end) = struct
+
+  module SER = SR
+  module EER = ER
+  module EISyntax = ScillaSyntax (SR) (ER)
+  
+  open EISyntax
+  
+  (* Given an identifier, compute its type info. *)
+  let calc_ident_locs i =
+    let name = get_id i in
+    let sloc = ER.get_loc (get_rep i) in
+    (* Once Issue #134 is solved, this calculation can be avoided. *) 
+    let eloc = { sloc with cnum = sloc.cnum + (String.length name) } in
+    let t = (ER.get_type (get_rep i)).tp in
+    (name, t, sloc, eloc)
+
+  let rec type_info_expr (e, _erep) = match e with
+    | Literal _ -> []
+    | Var a | TApp (a, _) -> [calc_ident_locs a]
+    | Let (x, _, lhs, rhs) ->
+      let lhs_l = type_info_expr lhs in
+      let rhs_l = type_info_expr rhs in
+      (calc_ident_locs x) :: (lhs_l @ rhs_l)
+     | Message spl ->
+      List.fold_right spl ~init:[] ~f:(fun (_, pl) acc ->
+        match pl with
+        | MLit _ -> acc
+        | MVar v -> calc_ident_locs v :: acc
+      )
+    | Fun (f, _, body) | Fixpoint (f, _, body) -> (calc_ident_locs f) :: (type_info_expr body)
+    | App (i, il) -> List.map (i::il) ~f:calc_ident_locs
+    | Constr (_, _, il) ->
+      (* Issue #456 prevents us form having a location for the constructor name. *)
+      List.map il ~f:calc_ident_locs
+    | MatchExpr (o, clauses) ->
+      let ots = calc_ident_locs o in
+      let clausets = List.map clauses ~f:(fun (p, branch) ->
+        let patternvars = get_pattern_bounds p in
+        let patternsts = List.map patternvars ~f:calc_ident_locs in
+        let branchts = type_info_expr branch in
+        patternsts @ branchts
+      ) in
+      ots :: (List.concat clausets)
+    | Builtin (_, il) -> List.map il ~f:calc_ident_locs
+    | TFun (i, e) -> (calc_ident_locs i) :: type_info_expr e
+
+  let rec type_info_stmts stmts =
+    List.fold_right stmts ~init:[] ~f:(fun (stmt, _srep) acc ->
+      (match stmt with
+      | Load (x, f) | Store (f, x) ->
+        [(calc_ident_locs x); (calc_ident_locs f)]
+      | Bind (x, e) ->
+        (calc_ident_locs x) :: (type_info_expr e)
+      (* m[k1][k2][..] := v OR delete m[k1][k2][...] *)
+      | MapUpdate (m, il, vopt) ->
+        [calc_ident_locs m] @ (List.map il ~f:calc_ident_locs) @
+        (match vopt with | Some v -> [calc_ident_locs v] | None -> [])
+      (* v <- m[k1][k2][...] OR b <- exists m[k1][k2][...] *)
+      | MapGet (x, m, il, _) ->
+        [calc_ident_locs x; calc_ident_locs m] @
+        List.map il ~f:calc_ident_locs
+      | MatchStmt (o, clauses) ->
+        let ots = calc_ident_locs o in
+        let clausets = List.map clauses ~f:(fun (p, branch) ->
+          let patternvars = get_pattern_bounds p in
+          let patternsts = List.map patternvars ~f:calc_ident_locs in
+          let branchts = type_info_stmts branch in
+          patternsts @ branchts
+        ) in
+        ots :: (List.concat clausets)
+      | ReadFromBC (v, _) | SendMsgs v | CreateEvnt v -> [calc_ident_locs v]
+      | AcceptPayment -> []
+      | CallProc (_, il) -> (List.map il ~f:calc_ident_locs)
+      | Throw iopt -> match iopt with | Some i -> [calc_ident_locs i] | None -> []
+      ) @ acc
+    )
+
+  let type_info_libentries lentries =
+    List.fold_right lentries ~init:[] ~f:(fun lentry acc ->
+      (match lentry with
+      | LibVar (i, _, e) -> (calc_ident_locs i) :: (type_info_expr e)
+      | LibTyp (i, cdl) -> (calc_ident_locs i) ::
+        (List.map cdl ~f:(fun cd -> calc_ident_locs cd.cname))
+      ) @ acc
+    )
+
+  let type_info_library l = type_info_libentries l.lentries
+
+  (* Given a library module, return a list of variables, their locations and types *)
+  let type_info_lmod (lmod : lmodule) =
+    type_info_library lmod.libs
+
+  (* Given a contract, return a list of variables, their locations and types *)
+  let type_info_cmod (cmod : cmodule) =
+    (* If there's an internal library, provide info for it. *)
+    (match cmod.libs with
+    | Some l -> type_info_library l
+    | None -> []
+    ) @
+
+    (* Contract parameters *)
+    (List.map cmod.contr.cparams ~f:(fun (i, _) -> calc_ident_locs i)) @
+
+    (* Contract fields *)
+    (List.concat @@ List.map cmod.contr.cfields ~f:(fun (i, _, e) ->
+        calc_ident_locs i :: (type_info_expr e)
+      )
+    ) @
+
+    (* Components *)
+    (List.concat @@
+      List.map cmod.contr.ccomps ~f:(fun comp ->
+        (List.map comp.comp_params ~f:(fun (i, _) -> calc_ident_locs i)) @
+        type_info_stmts comp.comp_body
+      )
+    )
+
+end

--- a/src/runners/RunnerUtil.ml
+++ b/src/runners/RunnerUtil.ml
@@ -301,6 +301,7 @@ type runner_cli = {
   cf_flag : bool;
   cf_token_fields : string list;
   p_contract_info : bool;
+  p_type_info : bool
 }
 
 
@@ -312,6 +313,7 @@ let parse_cli () =
   let r_json_errors = ref false in
   let r_gua = ref false in
   let r_contract_info = ref false in
+  let r_type_info = ref false in
   let r_cf = ref false in
   let r_cf_token_fields = ref [] in
   let speclist = [
@@ -340,6 +342,7 @@ let parse_cli () =
     ("-cf-token-field", Arg.String (fun s -> r_cf_token_fields := s :: !r_cf_token_fields), "Make the cashflow checker consider a field to be money (implicitly sets -cf)");
     ("-jsonerrors", Arg.Unit (fun () -> r_json_errors := true), "Print errors in JSON format");
     ("-contractinfo", Arg.Unit (fun () -> r_contract_info := true), "Print various contract information");
+    ("-typeinfo", Arg.Unit (fun () -> r_type_info := true), "Print types of variables with location");
   ] in 
 
   let mandatory_usage = "Usage:\n" ^ Sys.argv.(0) ^ " -gaslimit <limit> -libdir /path/to/stdlib input.scilla\n" in
@@ -361,4 +364,4 @@ let parse_cli () =
   { input_file = !r_input_file; stdlib_dirs = !r_stdlib_dir; gas_limit = gas_limit;
     gua_flag = !r_gua; p_contract_info = !r_contract_info;
     cf_flag = !r_cf; cf_token_fields = !r_cf_token_fields;
-    init_file = !r_init_file }
+    init_file = !r_init_file; p_type_info = !r_type_info}

--- a/src/runners/scilla_checker.ml
+++ b/src/runners/scilla_checker.ml
@@ -31,6 +31,7 @@ open SanityChecker
 open GasUseAnalysis
 open RecursionPrinciples
 open EventInfo
+open TypeInfo
 open Cashflow
 open Accept
 
@@ -56,6 +57,7 @@ module EI = ScillaEventInfo (PMCSRep) (PMCERep)
 module GUA = ScillaGUA (TCSRep) (TCERep)
 module CF = ScillaCashflowChecker (TCSRep) (TCERep)
 module AC = ScillaAcceptChecker (TCSRep) (TCERep)
+module TI = ScillaTypeInfo (TCSRep) (TCERep)
 
 (* Check that the module parses *)
 let check_parsing ctr syn = 
@@ -195,24 +197,33 @@ let check_cmodule cli =
     let%bind (pm_checked_cmod, _pm_checked_rlibs, _pm_checked_elibs) =
       wrap_error_with_gas remaining_gas @@ check_patterns typed_cmod typed_rlibs typed_elibs in
     let _ = if cli.cf_flag then check_accepts typed_cmod else () in
+    let type_info = if cli.p_type_info then TI.type_info_cmod typed_cmod else [] in
     let%bind _ = wrap_error_with_gas remaining_gas @@ check_sanity typed_cmod typed_rlibs typed_elibs in
     let%bind event_info = wrap_error_with_gas remaining_gas @@ EI.event_info pm_checked_cmod in
     let%bind _ = if cli.gua_flag then wrap_error_with_gas remaining_gas @@ analyze_print_gas typed_cmod typed_elibs else pure [] in
     let cf_info_opt = if cli.cf_flag then Some (check_cashflow typed_cmod cli.cf_token_fields) else None in
-    pure @@ (cmod, tenv, event_info, cf_info_opt, remaining_gas)
+    pure @@ (cmod, tenv, event_info, type_info, cf_info_opt, remaining_gas)
   ) in
   (match r with
   | Error (s, g) -> fatal_error_gas s g
-  | Ok (cmod, _, event_info, cf_info_opt, g) ->
+  | Ok (cmod, _, event_info, type_info, cf_info_opt, g) ->
       let base_output =
         let warnings_and_gas_output =
           [ ("warnings", scilla_warning_to_json (get_warnings()));
             ("gas_remaining", `String (Stdint.Uint64.to_string g));
           ]
         in
-        if cli.p_contract_info then
-          ("contract_info", (JSON.ContractInfo.get_json cmod.smver cmod.contr event_info)) :: warnings_and_gas_output
-        else warnings_and_gas_output
+        let ci_output =
+          if cli.p_contract_info then
+            ("contract_info", (JSON.ContractInfo.get_json cmod.smver cmod.contr event_info)) :: warnings_and_gas_output
+          else warnings_and_gas_output
+        in
+        let ti_output =
+          if cli.p_type_info then
+            ("type_info", (JSON.TypeInfo.type_info_to_json type_info)) :: ci_output
+          else ci_output
+        in
+        ti_output
       in
       let output_with_cf =
         match cf_info_opt with

--- a/tests/checker/good/TestCheckerSuccess.ml
+++ b/tests/checker/good/TestCheckerSuccess.ml
@@ -22,7 +22,7 @@ module Tests = TestUtil.DiffBasedTests(
     let test_path f = ["contracts"; f]
     let runner = "scilla-checker"
     let gas_limit = Stdint.Uint64.of_int 8000
-    let custom_args = ["-cf"; "-contractinfo";]
+    let custom_args = ["-cf"; "-contractinfo"; "-typeinfo"]
     let additional_libdirs = []
     let tests = [
       "auction.scilla";

--- a/tests/checker/good/gold/auction.scilla.gold
+++ b/tests/checker/good/gold/auction.scilla.gold
@@ -11,6 +11,2682 @@
     ],
     "ADT constructors": []
   },
+  "type_info": [
+    {
+      "vname": "blk_leq",
+      "type": "BNum -> BNum -> Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 11,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 11,
+        "column": 12
+      }
+    },
+    {
+      "vname": "blk1",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 12,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 12,
+        "column": 7
+      }
+    },
+    {
+      "vname": "blk2",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 13,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 13,
+        "column": 7
+      }
+    },
+    {
+      "vname": "bc1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 14,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 14,
+        "column": 8
+      }
+    },
+    {
+      "vname": "blk1",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 14,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 14,
+        "column": 31
+      }
+    },
+    {
+      "vname": "blk2",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 14,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 14,
+        "column": 36
+      }
+    },
+    {
+      "vname": "bc2",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 15,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 15,
+        "column": 8
+      }
+    },
+    {
+      "vname": "blk1",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 15,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 15,
+        "column": 30
+      }
+    },
+    {
+      "vname": "blk2",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 15,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 15,
+        "column": 35
+      }
+    },
+    {
+      "vname": "orb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 16,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 16,
+        "column": 8
+      }
+    },
+    {
+      "vname": "bc1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 16,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 16,
+        "column": 12
+      }
+    },
+    {
+      "vname": "bc2",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 16,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 16,
+        "column": 16
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 19,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 19,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 20,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 20,
+        "column": 6
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 21,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 21,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 22,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 22,
+        "column": 23
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 22,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 22,
+        "column": 31
+      }
+    },
+    {
+      "vname": "late_to_bid_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 25,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 25,
+        "column": 21
+      }
+    },
+    {
+      "vname": "too_early_to_bid_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 26,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 26,
+        "column": 26
+      }
+    },
+    {
+      "vname": "bid_too_low_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 27,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 27,
+        "column": 21
+      }
+    },
+    {
+      "vname": "first_bid_accepted_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 28,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 28,
+        "column": 28
+      }
+    },
+    {
+      "vname": "bid_accepted_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 29,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 29,
+        "column": 22
+      }
+    },
+    {
+      "vname": "money_sent_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 30,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 30,
+        "column": 20
+      }
+    },
+    {
+      "vname": "nothing_to_withdraw_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 31,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 31,
+        "column": 29
+      }
+    },
+    {
+      "vname": "auction_is_still_on_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 32,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 32,
+        "column": 29
+      }
+    },
+    {
+      "vname": "auction_end_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 33,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 33,
+        "column": 21
+      }
+    },
+    {
+      "vname": "auctionStart",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 44,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 44,
+        "column": 14
+      }
+    },
+    {
+      "vname": "biddingTime",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 45,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 45,
+        "column": 13
+      }
+    },
+    {
+      "vname": "beneficiary",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 46,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 46,
+        "column": 13
+      }
+    },
+    {
+      "vname": "ended",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 51,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 51,
+        "column": 12
+      }
+    },
+    {
+      "vname": "highestBidder",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 52,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 52,
+        "column": 20
+      }
+    },
+    {
+      "vname": "highestBid",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 53,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 53,
+        "column": 17
+      }
+    },
+    {
+      "vname": "pendingReturns",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 54,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 54,
+        "column": 21
+      }
+    },
+    {
+      "vname": "blk",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 59,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 59,
+        "column": 10
+      }
+    },
+    {
+      "vname": "endtime",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 60,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 60,
+        "column": 18
+      }
+    },
+    {
+      "vname": "auctionStart",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 60,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 60,
+        "column": 38
+      }
+    },
+    {
+      "vname": "biddingTime",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 60,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 60,
+        "column": 50
+      }
+    },
+    {
+      "vname": "after_end",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 61,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 61,
+        "column": 22
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 61,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 61,
+        "column": 18
+      }
+    },
+    {
+      "vname": "endtime",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 62,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 62,
+        "column": 28
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 62,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 62,
+        "column": 32
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 63,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 63,
+        "column": 6
+      }
+    },
+    {
+      "vname": "ended",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 63,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 63,
+        "column": 13
+      }
+    },
+    {
+      "vname": "in_time",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 64,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 64,
+        "column": 18
+      }
+    },
+    {
+      "vname": "blk_leq",
+      "type": "BNum -> BNum -> Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 64,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 64,
+        "column": 20
+      }
+    },
+    {
+      "vname": "after_end",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 64,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 64,
+        "column": 30
+      }
+    },
+    {
+      "vname": "blk",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 64,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 64,
+        "column": 34
+      }
+    },
+    {
+      "vname": "flag1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 65,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 65,
+        "column": 14
+      }
+    },
+    {
+      "vname": "orb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 65,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 65,
+        "column": 14
+      }
+    },
+    {
+      "vname": "in_time",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 65,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 65,
+        "column": 22
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 65,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 65,
+        "column": 24
+      }
+    },
+    {
+      "vname": "early",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 66,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 66,
+        "column": 14
+      }
+    },
+    {
+      "vname": "blk_leq",
+      "type": "BNum -> BNum -> Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 66,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 66,
+        "column": 18
+      }
+    },
+    {
+      "vname": "blk",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 66,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 66,
+        "column": 22
+      }
+    },
+    {
+      "vname": "auctionStart",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 66,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 66,
+        "column": 35
+      }
+    },
+    {
+      "vname": "early",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 67,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 67,
+        "column": 14
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 69,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 69,
+        "column": 13
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 69,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 69,
+        "column": 44
+      }
+    },
+    {
+      "vname": "too_early_to_bid_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 69,
+        "column": 74
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 69,
+        "column": 95
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 70,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 70,
+        "column": 14
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 70,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 70,
+        "column": 19
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 70,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 70,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 71,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 71,
+        "column": 9
+      }
+    },
+    {
+      "vname": "flag1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 73,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 73,
+        "column": 16
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 75,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 75,
+        "column": 15
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 75,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 75,
+        "column": 46
+      }
+    },
+    {
+      "vname": "late_to_bid_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 75,
+        "column": 76
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 75,
+        "column": 92
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 76,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 76,
+        "column": 16
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 76,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 76,
+        "column": 21
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 76,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 76,
+        "column": 25
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 77,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 77,
+        "column": 11
+      }
+    },
+    {
+      "vname": "hb",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 79,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 79,
+        "column": 12
+      }
+    },
+    {
+      "vname": "highestBid",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 79,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 79,
+        "column": 23
+      }
+    },
+    {
+      "vname": "sufficientBid",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 82,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 82,
+        "column": 34
+      }
+    },
+    {
+      "vname": "hb",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 82,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 82,
+        "column": 36
+      }
+    },
+    {
+      "vname": "_amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 82,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 82,
+        "column": 44
+      }
+    },
+    {
+      "vname": "sufficientBid",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 83,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 83,
+        "column": 26
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 85,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 85,
+        "column": 17
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 85,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 85,
+        "column": 48
+      }
+    },
+    {
+      "vname": "bid_too_low_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 85,
+        "column": 78
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 85,
+        "column": 94
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 86,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 86,
+        "column": 18
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 86,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 86,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 86,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 86,
+        "column": 27
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 87,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 87,
+        "column": 13
+      }
+    },
+    {
+      "vname": "hbPrev",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 90,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 90,
+        "column": 22
+      }
+    },
+    {
+      "vname": "highestBidder",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 90,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 90,
+        "column": 32
+      }
+    },
+    {
+      "vname": "hbPrev",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 92,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 92,
+        "column": 21
+      }
+    },
+    {
+      "vname": "prevHighestBidder",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 93,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 93,
+        "column": 33
+      }
+    },
+    {
+      "vname": "option_pendingReturnsForPrevHB",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 95,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 95,
+        "column": 41
+      }
+    },
+    {
+      "vname": "pendingReturns",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 95,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 95,
+        "column": 59
+      }
+    },
+    {
+      "vname": "prevHighestBidder",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 95,
+        "column": 60
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 95,
+        "column": 77
+      }
+    },
+    {
+      "vname": "getPRForPrevHighestBidder",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 97,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 97,
+        "column": 62
+      }
+    },
+    {
+      "vname": "option_pendingReturnsForPrevHB",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 97,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 97,
+        "column": 75
+      }
+    },
+    {
+      "vname": "pendingReturnsForPrevHB",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 98,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 98,
+        "column": 39
+      }
+    },
+    {
+      "vname": "hb",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 100,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 100,
+        "column": 25
+      }
+    },
+    {
+      "vname": "pendingReturnsForPrevHB",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 100,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 100,
+        "column": 49
+      }
+    },
+    {
+      "vname": "hb",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 101,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 101,
+        "column": 21
+      }
+    },
+    {
+      "vname": "pendingReturns",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 104,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 104,
+        "column": 21
+      }
+    },
+    {
+      "vname": "prevHighestBidder",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 104,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 104,
+        "column": 39
+      }
+    },
+    {
+      "vname": "getPRForPrevHighestBidder",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 104,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 104,
+        "column": 69
+      }
+    },
+    {
+      "vname": "bidder",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 107,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 107,
+        "column": 20
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 107,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 107,
+        "column": 38
+      }
+    },
+    {
+      "vname": "bidder",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 108,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 108,
+        "column": 30
+      }
+    },
+    {
+      "vname": "highestBidder",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 108,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 108,
+        "column": 34
+      }
+    },
+    {
+      "vname": "_amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 109,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 109,
+        "column": 28
+      }
+    },
+    {
+      "vname": "highestBid",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 109,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 109,
+        "column": 28
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 110,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 110,
+        "column": 10
+      }
+    },
+    {
+      "vname": "bid_accepted_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 110,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 110,
+        "column": 54
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 110,
+        "column": 62
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 110,
+        "column": 69
+      }
+    },
+    {
+      "vname": "_amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 110,
+        "column": 79
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 110,
+        "column": 86
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 111,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 111,
+        "column": 8
+      }
+    },
+    {
+      "vname": "first_bidder",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 114,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 114,
+        "column": 34
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 114,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 114,
+        "column": 46
+      }
+    },
+    {
+      "vname": "first_bidder",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 115,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 115,
+        "column": 38
+      }
+    },
+    {
+      "vname": "highestBidder",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 115,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 115,
+        "column": 36
+      }
+    },
+    {
+      "vname": "_amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 116,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 116,
+        "column": 30
+      }
+    },
+    {
+      "vname": "highestBid",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 116,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 116,
+        "column": 30
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 117,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 117,
+        "column": 12
+      }
+    },
+    {
+      "vname": "first_bid_accepted_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 117,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 117,
+        "column": 62
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 117,
+        "column": 70
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 117,
+        "column": 77
+      }
+    },
+    {
+      "vname": "_amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 117,
+        "column": 87
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 117,
+        "column": 94
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 118,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 118,
+        "column": 10
+      }
+    },
+    {
+      "vname": "prs",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 128,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 128,
+        "column": 10
+      }
+    },
+    {
+      "vname": "pendingReturns",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 128,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 128,
+        "column": 24
+      }
+    },
+    {
+      "vname": "pr",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 129,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 129,
+        "column": 8
+      }
+    },
+    {
+      "vname": "prs",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 129,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 129,
+        "column": 23
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 129,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 129,
+        "column": 31
+      }
+    },
+    {
+      "vname": "pr",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 130,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 130,
+        "column": 11
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 132,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 132,
+        "column": 13
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 132,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 132,
+        "column": 44
+      }
+    },
+    {
+      "vname": "nothing_to_withdraw_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 132,
+        "column": 74
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 132,
+        "column": 98
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 133,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 133,
+        "column": 14
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 133,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 133,
+        "column": 19
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 133,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 133,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 134,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 134,
+        "column": 9
+      }
+    },
+    {
+      "vname": "v",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 135,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 135,
+        "column": 11
+      }
+    },
+    {
+      "vname": "pendingReturns",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 136,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 136,
+        "column": 26
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 136,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 136,
+        "column": 34
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 137,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 137,
+        "column": 8
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 137,
+        "column": 51
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 137,
+        "column": 58
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 138,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 138,
+        "column": 6
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 139,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 139,
+        "column": 13
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 139,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 139,
+        "column": 44
+      }
+    },
+    {
+      "vname": "v",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 139,
+        "column": 56
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 139,
+        "column": 57
+      }
+    },
+    {
+      "vname": "money_sent_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 139,
+        "column": 66
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 139,
+        "column": 81
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 140,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 140,
+        "column": 14
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 140,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 140,
+        "column": 19
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 140,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 140,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 141,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 141,
+        "column": 9
+      }
+    },
+    {
+      "vname": "blk",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 148,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 148,
+        "column": 10
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 149,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 149,
+        "column": 6
+      }
+    },
+    {
+      "vname": "ended",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 149,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 149,
+        "column": 13
+      }
+    },
+    {
+      "vname": "t1",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 150,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 150,
+        "column": 8
+      }
+    },
+    {
+      "vname": "auctionStart",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 150,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 150,
+        "column": 33
+      }
+    },
+    {
+      "vname": "biddingTime",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 150,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 150,
+        "column": 45
+      }
+    },
+    {
+      "vname": "t2",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 151,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 151,
+        "column": 8
+      }
+    },
+    {
+      "vname": "blk_leq",
+      "type": "BNum -> BNum -> Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 151,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 151,
+        "column": 15
+      }
+    },
+    {
+      "vname": "t1",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 151,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 151,
+        "column": 18
+      }
+    },
+    {
+      "vname": "blk",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 151,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 151,
+        "column": 22
+      }
+    },
+    {
+      "vname": "t3",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 152,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 152,
+        "column": 8
+      }
+    },
+    {
+      "vname": "negb",
+      "type": "Bool -> Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 152,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 152,
+        "column": 12
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 152,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 152,
+        "column": 14
+      }
+    },
+    {
+      "vname": "t4",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 153,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 153,
+        "column": 8
+      }
+    },
+    {
+      "vname": "andb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 153,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 153,
+        "column": 12
+      }
+    },
+    {
+      "vname": "t2",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 153,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 153,
+        "column": 15
+      }
+    },
+    {
+      "vname": "t3",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 153,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 153,
+        "column": 18
+      }
+    },
+    {
+      "vname": "t4",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 154,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 154,
+        "column": 11
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 156,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 156,
+        "column": 13
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 156,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 156,
+        "column": 44
+      }
+    },
+    {
+      "vname": "auction_is_still_on_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 156,
+        "column": 74
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 156,
+        "column": 98
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 157,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 157,
+        "column": 14
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 157,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 157,
+        "column": 19
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 157,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 157,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 158,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 158,
+        "column": 9
+      }
+    },
+    {
+      "vname": "val",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 160,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 160,
+        "column": 12
+      }
+    },
+    {
+      "vname": "val",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 161,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 161,
+        "column": 17
+      }
+    },
+    {
+      "vname": "ended",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 161,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 161,
+        "column": 16
+      }
+    },
+    {
+      "vname": "hb",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 162,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 162,
+        "column": 10
+      }
+    },
+    {
+      "vname": "highestBid",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 162,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 162,
+        "column": 21
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 163,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 163,
+        "column": 8
+      }
+    },
+    {
+      "vname": "hb",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 163,
+        "column": 52
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 163,
+        "column": 54
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 164,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 164,
+        "column": 6
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 165,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 165,
+        "column": 13
+      }
+    },
+    {
+      "vname": "beneficiary",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 165,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 165,
+        "column": 48
+      }
+    },
+    {
+      "vname": "hb",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 165,
+        "column": 60
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 165,
+        "column": 62
+      }
+    },
+    {
+      "vname": "auction_end_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 165,
+        "column": 71
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 165,
+        "column": 87
+      }
+    },
+    {
+      "vname": "hb",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 165,
+        "column": 103
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 165,
+        "column": 105
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 166,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 166,
+        "column": 14
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 166,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 166,
+        "column": 19
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 166,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 166,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/auction.scilla",
+        "line": 167,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/auction.scilla",
+        "line": 167,
+        "column": 9
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "OpenAuction",

--- a/tests/checker/good/gold/bookstore.scilla.gold
+++ b/tests/checker/good/gold/bookstore.scilla.gold
@@ -18,6 +18,2514 @@
       }
     ]
   },
+  "type_info": [
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 23,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 23,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 24,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 24,
+        "column": 6
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 25,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 25,
+        "column": 10
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 26,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 26,
+        "column": 21
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 26,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 26,
+        "column": 29
+      }
+    },
+    {
+      "vname": "code_success",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 29,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 29,
+        "column": 17
+      }
+    },
+    {
+      "vname": "code_book_not_found",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 30,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 30,
+        "column": 24
+      }
+    },
+    {
+      "vname": "code_not_authorized",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 31,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 31,
+        "column": 24
+      }
+    },
+    {
+      "vname": "code_invalid_params",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 32,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 32,
+        "column": 24
+      }
+    },
+    {
+      "vname": "code_bookid_exist",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 33,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 33,
+        "column": 22
+      }
+    },
+    {
+      "vname": "code_store_not_open",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 34,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 34,
+        "column": 24
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 55,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 55,
+        "column": 7
+      }
+    },
+    {
+      "vname": "store_name",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 56,
+        "column": 1
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 56,
+        "column": 11
+      }
+    },
+    {
+      "vname": "members",
+      "type": "Map (ByStr20) (Member)",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 70,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 70,
+        "column": 14
+      }
+    },
+    {
+      "vname": "is_store_open",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 74,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 74,
+        "column": 20
+      }
+    },
+    {
+      "vname": "bookInventory",
+      "type": "Map (Uint32) (Book)",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 77,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 77,
+        "column": 20
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 89,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 89,
+        "column": 34
+      }
+    },
+    {
+      "vname": "status_code",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 89,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 89,
+        "column": 53
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 89,
+        "column": 64
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 89,
+        "column": 67
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 90,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 90,
+        "column": 15
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 92,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 92,
+        "column": 8
+      }
+    },
+    {
+      "vname": "status_code",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 92,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 92,
+        "column": 59
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 92,
+        "column": 71
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 92,
+        "column": 74
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 93,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 93,
+        "column": 6
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 95,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 95,
+        "column": 8
+      }
+    },
+    {
+      "vname": "status_code",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 95,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 95,
+        "column": 59
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 95,
+        "column": 70
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 95,
+        "column": 73
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 96,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 96,
+        "column": 6
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 102,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 102,
+        "column": 9
+      }
+    },
+    {
+      "vname": "status_code",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 103,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 103,
+        "column": 14
+      }
+    },
+    {
+      "vname": "event_action",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 104,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 104,
+        "column": 15
+      }
+    },
+    {
+      "vname": "book_id",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 105,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 105,
+        "column": 10
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 107,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 107,
+        "column": 15
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 109,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 109,
+        "column": 8
+      }
+    },
+    {
+      "vname": "status_code",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 111,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 111,
+        "column": 24
+      }
+    },
+    {
+      "vname": "event_action",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 112,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 112,
+        "column": 27
+      }
+    },
+    {
+      "vname": "book_id",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 113,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 113,
+        "column": 18
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 114,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 114,
+        "column": 6
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 116,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 116,
+        "column": 8
+      }
+    },
+    {
+      "vname": "status_code",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 118,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 118,
+        "column": 24
+      }
+    },
+    {
+      "vname": "event_action",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 119,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 119,
+        "column": 27
+      }
+    },
+    {
+      "vname": "book_id",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 120,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 120,
+        "column": 18
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 121,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 121,
+        "column": 6
+      }
+    },
+    {
+      "vname": "is_open",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 135,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 135,
+        "column": 29
+      }
+    },
+    {
+      "vname": "is_authorized",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 138,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 138,
+        "column": 32
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 138,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 138,
+        "column": 39
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 138,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 138,
+        "column": 45
+      }
+    },
+    {
+      "vname": "is_authorized",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 139,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 139,
+        "column": 24
+      }
+    },
+    {
+      "vname": "is_open",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 141,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 141,
+        "column": 31
+      }
+    },
+    {
+      "vname": "is_store_open",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 141,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 141,
+        "column": 34
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 142,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 142,
+        "column": 10
+      }
+    },
+    {
+      "vname": "is_open",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 142,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 142,
+        "column": 52
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 143,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 143,
+        "column": 8
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 146,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 146,
+        "column": 20
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 147,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 147,
+        "column": 14
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 148,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 148,
+        "column": 29
+      }
+    },
+    {
+      "vname": "code_not_authorized",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 148,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 148,
+        "column": 49
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 148,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 148,
+        "column": 53
+      }
+    },
+    {
+      "vname": "name",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 159,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 159,
+        "column": 26
+      }
+    },
+    {
+      "vname": "member_address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 159,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 159,
+        "column": 50
+      }
+    },
+    {
+      "vname": "member_type",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 159,
+        "column": 61
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 159,
+        "column": 72
+      }
+    },
+    {
+      "vname": "is_authorized",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 162,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 162,
+        "column": 32
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 162,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 162,
+        "column": 39
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 162,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 162,
+        "column": 45
+      }
+    },
+    {
+      "vname": "is_authorized",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 163,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 163,
+        "column": 24
+      }
+    },
+    {
+      "vname": "valid_type",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 167,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 167,
+        "column": 30
+      }
+    },
+    {
+      "vname": "three",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 167,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 167,
+        "column": 27
+      }
+    },
+    {
+      "vname": "member_type",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 168,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 168,
+        "column": 47
+      }
+    },
+    {
+      "vname": "three",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 168,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 168,
+        "column": 53
+      }
+    },
+    {
+      "vname": "valid_type",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 169,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 169,
+        "column": 25
+      }
+    },
+    {
+      "vname": "new_member",
+      "type": "Member",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 172,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 172,
+        "column": 34
+      }
+    },
+    {
+      "vname": "name",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 172,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 172,
+        "column": 37
+      }
+    },
+    {
+      "vname": "member_type",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 172,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 172,
+        "column": 49
+      }
+    },
+    {
+      "vname": "members",
+      "type": "Map (ByStr20) (Member)",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 173,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 173,
+        "column": 20
+      }
+    },
+    {
+      "vname": "member_address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 173,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 173,
+        "column": 35
+      }
+    },
+    {
+      "vname": "new_member",
+      "type": "Member",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 173,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 173,
+        "column": 50
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 174,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 174,
+        "column": 26
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 175,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 175,
+        "column": 35
+      }
+    },
+    {
+      "vname": "code_success",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 175,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 175,
+        "column": 48
+      }
+    },
+    {
+      "vname": "name",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 175,
+        "column": 49
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 175,
+        "column": 53
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 178,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 178,
+        "column": 26
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 179,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 179,
+        "column": 20
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 180,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 180,
+        "column": 35
+      }
+    },
+    {
+      "vname": "code_invalid_params",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 180,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 180,
+        "column": 55
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 180,
+        "column": 56
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 180,
+        "column": 59
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 184,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 184,
+        "column": 24
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 185,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 185,
+        "column": 18
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 186,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 186,
+        "column": 33
+      }
+    },
+    {
+      "vname": "code_not_authorized",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 186,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 186,
+        "column": 53
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 186,
+        "column": 54
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 186,
+        "column": 57
+      }
+    },
+    {
+      "vname": "book_title",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 195,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 195,
+        "column": 30
+      }
+    },
+    {
+      "vname": "author",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 195,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 195,
+        "column": 46
+      }
+    },
+    {
+      "vname": "book_id",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 195,
+        "column": 56
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 195,
+        "column": 63
+      }
+    },
+    {
+      "vname": "is_open",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 200,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 200,
+        "column": 20
+      }
+    },
+    {
+      "vname": "is_store_open",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 200,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 200,
+        "column": 29
+      }
+    },
+    {
+      "vname": "is_open",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 201,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 201,
+        "column": 18
+      }
+    },
+    {
+      "vname": "does_book_exist",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 203,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 203,
+        "column": 22
+      }
+    },
+    {
+      "vname": "bookInventory",
+      "type": "Map (Uint32) (Book)",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 203,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 203,
+        "column": 46
+      }
+    },
+    {
+      "vname": "book_id",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 203,
+        "column": 47
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 203,
+        "column": 54
+      }
+    },
+    {
+      "vname": "does_book_exist",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 204,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 204,
+        "column": 28
+      }
+    },
+    {
+      "vname": "action",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 206,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 206,
+        "column": 22
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 207,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 207,
+        "column": 22
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 208,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 208,
+        "column": 29
+      }
+    },
+    {
+      "vname": "code_bookid_exist",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 208,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 208,
+        "column": 47
+      }
+    },
+    {
+      "vname": "action",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 208,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 208,
+        "column": 54
+      }
+    },
+    {
+      "vname": "book_id",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 208,
+        "column": 55
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 208,
+        "column": 62
+      }
+    },
+    {
+      "vname": "new_book",
+      "type": "Book",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 213,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 213,
+        "column": 26
+      }
+    },
+    {
+      "vname": "book_title",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 213,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 213,
+        "column": 35
+      }
+    },
+    {
+      "vname": "author",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 213,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 213,
+        "column": 42
+      }
+    },
+    {
+      "vname": "bookInventory",
+      "type": "Map (Uint32) (Book)",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 216,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 216,
+        "column": 22
+      }
+    },
+    {
+      "vname": "book_id",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 216,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 216,
+        "column": 30
+      }
+    },
+    {
+      "vname": "new_book",
+      "type": "Book",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 216,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 216,
+        "column": 43
+      }
+    },
+    {
+      "vname": "action",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 218,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 218,
+        "column": 22
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 219,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 219,
+        "column": 22
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 220,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 220,
+        "column": 29
+      }
+    },
+    {
+      "vname": "code_success",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 220,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 220,
+        "column": 42
+      }
+    },
+    {
+      "vname": "action",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 220,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 220,
+        "column": 49
+      }
+    },
+    {
+      "vname": "book_id",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 220,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 220,
+        "column": 57
+      }
+    },
+    {
+      "vname": "action",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 224,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 224,
+        "column": 20
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 225,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 225,
+        "column": 20
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 226,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 226,
+        "column": 27
+      }
+    },
+    {
+      "vname": "code_store_not_open",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 226,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 226,
+        "column": 47
+      }
+    },
+    {
+      "vname": "action",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 226,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 226,
+        "column": 54
+      }
+    },
+    {
+      "vname": "book_id",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 226,
+        "column": 55
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 226,
+        "column": 62
+      }
+    },
+    {
+      "vname": "book_id",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 235,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 235,
+        "column": 30
+      }
+    },
+    {
+      "vname": "is_open",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 239,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 239,
+        "column": 20
+      }
+    },
+    {
+      "vname": "is_store_open",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 239,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 239,
+        "column": 29
+      }
+    },
+    {
+      "vname": "is_open",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 240,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 240,
+        "column": 18
+      }
+    },
+    {
+      "vname": "get_book",
+      "type": "Option (Book)",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 242,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 242,
+        "column": 15
+      }
+    },
+    {
+      "vname": "bookInventory",
+      "type": "Map (Uint32) (Book)",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 242,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 242,
+        "column": 32
+      }
+    },
+    {
+      "vname": "book_id",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 242,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 242,
+        "column": 40
+      }
+    },
+    {
+      "vname": "get_book",
+      "type": "Option (Book)",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 243,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 243,
+        "column": 21
+      }
+    },
+    {
+      "vname": "book_title",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 244,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 244,
+        "column": 30
+      }
+    },
+    {
+      "vname": "action",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 245,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 245,
+        "column": 22
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 246,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 246,
+        "column": 22
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 247,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 247,
+        "column": 29
+      }
+    },
+    {
+      "vname": "code_success",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 247,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 247,
+        "column": 42
+      }
+    },
+    {
+      "vname": "action",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 247,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 247,
+        "column": 49
+      }
+    },
+    {
+      "vname": "book_id",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 247,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 247,
+        "column": 57
+      }
+    },
+    {
+      "vname": "bookInventory",
+      "type": "Map (Uint32) (Book)",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 248,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 248,
+        "column": 29
+      }
+    },
+    {
+      "vname": "book_id",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 248,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 248,
+        "column": 37
+      }
+    },
+    {
+      "vname": "book_title",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 250,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 250,
+        "column": 30
+      }
+    },
+    {
+      "vname": "action",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 251,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 251,
+        "column": 22
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 252,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 252,
+        "column": 22
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 253,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 253,
+        "column": 29
+      }
+    },
+    {
+      "vname": "code_book_not_found",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 253,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 253,
+        "column": 49
+      }
+    },
+    {
+      "vname": "action",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 253,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 253,
+        "column": 56
+      }
+    },
+    {
+      "vname": "book_id",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 253,
+        "column": 57
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 253,
+        "column": 64
+      }
+    },
+    {
+      "vname": "action",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 257,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 257,
+        "column": 20
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 258,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 258,
+        "column": 20
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 259,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 259,
+        "column": 27
+      }
+    },
+    {
+      "vname": "code_store_not_open",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 259,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 259,
+        "column": 47
+      }
+    },
+    {
+      "vname": "action",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 259,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 259,
+        "column": 54
+      }
+    },
+    {
+      "vname": "book_id",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 259,
+        "column": 55
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 259,
+        "column": 62
+      }
+    },
+    {
+      "vname": "book_id",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 268,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 268,
+        "column": 30
+      }
+    },
+    {
+      "vname": "book_title",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 268,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 268,
+        "column": 50
+      }
+    },
+    {
+      "vname": "author",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 268,
+        "column": 60
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 268,
+        "column": 66
+      }
+    },
+    {
+      "vname": "does_book_exist",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 273,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 273,
+        "column": 20
+      }
+    },
+    {
+      "vname": "bookInventory",
+      "type": "Map (Uint32) (Book)",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 273,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 273,
+        "column": 44
+      }
+    },
+    {
+      "vname": "book_id",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 273,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 273,
+        "column": 52
+      }
+    },
+    {
+      "vname": "does_book_exist",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 274,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 274,
+        "column": 26
+      }
+    },
+    {
+      "vname": "action",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 277,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 277,
+        "column": 22
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 278,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 278,
+        "column": 22
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 279,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 279,
+        "column": 29
+      }
+    },
+    {
+      "vname": "code_book_not_found",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 279,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 279,
+        "column": 49
+      }
+    },
+    {
+      "vname": "action",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 279,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 279,
+        "column": 56
+      }
+    },
+    {
+      "vname": "book_id",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 279,
+        "column": 57
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 279,
+        "column": 64
+      }
+    },
+    {
+      "vname": "new_book",
+      "type": "Book",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 284,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 284,
+        "column": 26
+      }
+    },
+    {
+      "vname": "book_title",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 284,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 284,
+        "column": 35
+      }
+    },
+    {
+      "vname": "author",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 284,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 284,
+        "column": 42
+      }
+    },
+    {
+      "vname": "bookInventory",
+      "type": "Map (Uint32) (Book)",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 286,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 286,
+        "column": 22
+      }
+    },
+    {
+      "vname": "book_id",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 286,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 286,
+        "column": 30
+      }
+    },
+    {
+      "vname": "new_book",
+      "type": "Book",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 286,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 286,
+        "column": 43
+      }
+    },
+    {
+      "vname": "action",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 288,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 288,
+        "column": 22
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 289,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 289,
+        "column": 22
+      }
+    },
+    {
+      "vname": "status",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 290,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 290,
+        "column": 29
+      }
+    },
+    {
+      "vname": "code_success",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 290,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 290,
+        "column": 42
+      }
+    },
+    {
+      "vname": "action",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 290,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 290,
+        "column": 49
+      }
+    },
+    {
+      "vname": "book_id",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 290,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 290,
+        "column": 57
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "BookStore",

--- a/tests/checker/good/gold/cfinvoke.scilla.gold
+++ b/tests/checker/good/gold/cfinvoke.scilla.gold
@@ -6,6 +6,834 @@
     ],
     "ADT constructors": []
   },
+  "type_info": [
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 5,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 5,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 6,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 6,
+        "column": 6
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 7,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 7,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 8,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 8,
+        "column": 25
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 8,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 8,
+        "column": 33
+      }
+    },
+    {
+      "vname": "cfaddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 17,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 17,
+        "column": 8
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 18,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 18,
+        "column": 7
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 22,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 22,
+        "column": 10
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 22,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 22,
+        "column": 39
+      }
+    },
+    {
+      "vname": "_amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 22,
+        "column": 51
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 22,
+        "column": 58
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 23,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 23,
+        "column": 12
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 23,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 23,
+        "column": 17
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 23,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 23,
+        "column": 21
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 24,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 24,
+        "column": 7
+      }
+    },
+    {
+      "vname": "trans",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 27,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 27,
+        "column": 25
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 28,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 28,
+        "column": 10
+      }
+    },
+    {
+      "vname": "_balance",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 28,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 28,
+        "column": 18
+      }
+    },
+    {
+      "vname": "s",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 29,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 29,
+        "column": 6
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 29,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 29,
+        "column": 14
+      }
+    },
+    {
+      "vname": "donate_s",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 30,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 30,
+        "column": 20
+      }
+    },
+    {
+      "vname": "is_donate",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 31,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 31,
+        "column": 22
+      }
+    },
+    {
+      "vname": "trans",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 31,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 31,
+        "column": 31
+      }
+    },
+    {
+      "vname": "donate_s",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 31,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 31,
+        "column": 40
+      }
+    },
+    {
+      "vname": "is_donate",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 32,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 32,
+        "column": 18
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 35,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 35,
+        "column": 12
+      }
+    },
+    {
+      "vname": "cfaddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 35,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 35,
+        "column": 48
+      }
+    },
+    {
+      "vname": "_amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 35,
+        "column": 60
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 35,
+        "column": 67
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 36,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 36,
+        "column": 14
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 36,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 36,
+        "column": 19
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 36,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 36,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 37,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 37,
+        "column": 9
+      }
+    },
+    {
+      "vname": "claimback_s",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 39,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 39,
+        "column": 28
+      }
+    },
+    {
+      "vname": "is_claimback",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 40,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 40,
+        "column": 30
+      }
+    },
+    {
+      "vname": "trans",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 40,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 40,
+        "column": 36
+      }
+    },
+    {
+      "vname": "claimback_s",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 40,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 40,
+        "column": 48
+      }
+    },
+    {
+      "vname": "is_claimback",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 41,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 41,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 43,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 43,
+        "column": 14
+      }
+    },
+    {
+      "vname": "cfaddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 43,
+        "column": 47
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 43,
+        "column": 53
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 44,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 44,
+        "column": 16
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 44,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 44,
+        "column": 21
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 44,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 44,
+        "column": 25
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 45,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 45,
+        "column": 11
+      }
+    },
+    {
+      "vname": "getfunds_s",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 47,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 47,
+        "column": 28
+      }
+    },
+    {
+      "vname": "is_getfunds",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 48,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 48,
+        "column": 30
+      }
+    },
+    {
+      "vname": "trans",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 48,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 48,
+        "column": 37
+      }
+    },
+    {
+      "vname": "getfunds_s",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 48,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 48,
+        "column": 48
+      }
+    },
+    {
+      "vname": "is_getfunds",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 49,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 49,
+        "column": 24
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 51,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 51,
+        "column": 16
+      }
+    },
+    {
+      "vname": "cfaddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 51,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 51,
+        "column": 54
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 52,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 52,
+        "column": 18
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 52,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 52,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 52,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 52,
+        "column": 27
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 53,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 53,
+        "column": 13
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 55,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 55,
+        "column": 16
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 55,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 55,
+        "column": 47
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 56,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 56,
+        "column": 18
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 56,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 56,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 56,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 56,
+        "column": 27
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 57,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/cfinvoke.scilla",
+        "line": 57,
+        "column": 13
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "CrowdFundingInvoke",

--- a/tests/checker/good/gold/chain-call-balance-1.scilla.gold
+++ b/tests/checker/good/gold/chain-call-balance-1.scilla.gold
@@ -1,5 +1,217 @@
 {
   "cashflow_tags": { "State variables": [], "ADT constructors": [] },
+  "type_info": [
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 5,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 5,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 6,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 6,
+        "column": 6
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 7,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 7,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 8,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 8,
+        "column": 23
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 8,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 8,
+        "column": 31
+      }
+    },
+    {
+      "vname": "addrB",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 14,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 14,
+        "column": 38
+      }
+    },
+    {
+      "vname": "addrC",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 14,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 14,
+        "column": 55
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 16,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 16,
+        "column": 6
+      }
+    },
+    {
+      "vname": "_amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 16,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 16,
+        "column": 51
+      }
+    },
+    {
+      "vname": "addrB",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 16,
+        "column": 66
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 16,
+        "column": 71
+      }
+    },
+    {
+      "vname": "addrC",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 16,
+        "column": 81
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 16,
+        "column": 86
+      }
+    },
+    {
+      "vname": "ml",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 17,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 17,
+        "column": 8
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 17,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 17,
+        "column": 15
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 17,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 17,
+        "column": 17
+      }
+    },
+    {
+      "vname": "ml",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 18,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-1.scilla",
+        "line": 18,
+        "column": 5
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Test",

--- a/tests/checker/good/gold/chain-call-balance-2.scilla.gold
+++ b/tests/checker/good/gold/chain-call-balance-2.scilla.gold
@@ -1,5 +1,189 @@
 {
   "cashflow_tags": { "State variables": [], "ADT constructors": [] },
+  "type_info": [
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 5,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 5,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 6,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 6,
+        "column": 6
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 7,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 7,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 8,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 8,
+        "column": 23
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 8,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 8,
+        "column": 31
+      }
+    },
+    {
+      "vname": "addrC",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 14,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 14,
+        "column": 33
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 16,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 16,
+        "column": 6
+      }
+    },
+    {
+      "vname": "_amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 16,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 16,
+        "column": 47
+      }
+    },
+    {
+      "vname": "addrC",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 16,
+        "column": 62
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 16,
+        "column": 67
+      }
+    },
+    {
+      "vname": "ml",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 17,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 17,
+        "column": 8
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 17,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 17,
+        "column": 15
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 17,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 17,
+        "column": 17
+      }
+    },
+    {
+      "vname": "ml",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 18,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-2.scilla",
+        "line": 18,
+        "column": 5
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Test",

--- a/tests/checker/good/gold/chain-call-balance-3.scilla.gold
+++ b/tests/checker/good/gold/chain-call-balance-3.scilla.gold
@@ -1,5 +1,161 @@
 {
   "cashflow_tags": { "State variables": [], "ADT constructors": [] },
+  "type_info": [
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/chain-call-balance-3.scilla",
+        "line": 5,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-3.scilla",
+        "line": 5,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/chain-call-balance-3.scilla",
+        "line": 6,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-3.scilla",
+        "line": 6,
+        "column": 6
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/chain-call-balance-3.scilla",
+        "line": 7,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-3.scilla",
+        "line": 7,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/chain-call-balance-3.scilla",
+        "line": 8,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-3.scilla",
+        "line": 8,
+        "column": 23
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/chain-call-balance-3.scilla",
+        "line": 8,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-3.scilla",
+        "line": 8,
+        "column": 31
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/chain-call-balance-3.scilla",
+        "line": 15,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-3.scilla",
+        "line": 15,
+        "column": 6
+      }
+    },
+    {
+      "vname": "_this_address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/chain-call-balance-3.scilla",
+        "line": 15,
+        "column": 55
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-3.scilla",
+        "line": 15,
+        "column": 68
+      }
+    },
+    {
+      "vname": "ml",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/chain-call-balance-3.scilla",
+        "line": 16,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-3.scilla",
+        "line": 16,
+        "column": 8
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/chain-call-balance-3.scilla",
+        "line": 16,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-3.scilla",
+        "line": 16,
+        "column": 15
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/chain-call-balance-3.scilla",
+        "line": 16,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-3.scilla",
+        "line": 16,
+        "column": 17
+      }
+    },
+    {
+      "vname": "ml",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/chain-call-balance-3.scilla",
+        "line": 17,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/chain-call-balance-3.scilla",
+        "line": 17,
+        "column": 5
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Test",

--- a/tests/checker/good/gold/crowdfunding.scilla.gold
+++ b/tests/checker/good/gold/crowdfunding.scilla.gold
@@ -9,6 +9,2628 @@
     ],
     "ADT constructors": []
   },
+  "type_info": [
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 11,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 11,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 12,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 12,
+        "column": 6
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 13,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 13,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 14,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 14,
+        "column": 23
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 14,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 14,
+        "column": 31
+      }
+    },
+    {
+      "vname": "check_update",
+      "type":
+        "Map (ByStr20) (Uint128) -> ByStr20 -> Uint128 -> Option (Map (ByStr20) (Uint128))",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 16,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 16,
+        "column": 17
+      }
+    },
+    {
+      "vname": "bs",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 17,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 17,
+        "column": 5
+      }
+    },
+    {
+      "vname": "sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 18,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 18,
+        "column": 9
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 19,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 19,
+        "column": 9
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 20,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 20,
+        "column": 6
+      }
+    },
+    {
+      "vname": "bs",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 20,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 20,
+        "column": 32
+      }
+    },
+    {
+      "vname": "sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 20,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 20,
+        "column": 39
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 21,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 21,
+        "column": 12
+      }
+    },
+    {
+      "vname": "bs1",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 23,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 23,
+        "column": 10
+      }
+    },
+    {
+      "vname": "bs",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 23,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 23,
+        "column": 31
+      }
+    },
+    {
+      "vname": "sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 23,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 23,
+        "column": 38
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 23,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 23,
+        "column": 45
+      }
+    },
+    {
+      "vname": "bs1",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 24,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 24,
+        "column": 37
+      }
+    },
+    {
+      "vname": "blk_leq",
+      "type": "BNum -> BNum -> Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 28,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 28,
+        "column": 12
+      }
+    },
+    {
+      "vname": "blk1",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 29,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 29,
+        "column": 7
+      }
+    },
+    {
+      "vname": "blk2",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 30,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 30,
+        "column": 7
+      }
+    },
+    {
+      "vname": "bc1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 31,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 31,
+        "column": 8
+      }
+    },
+    {
+      "vname": "blk1",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 31,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 31,
+        "column": 31
+      }
+    },
+    {
+      "vname": "blk2",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 31,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 31,
+        "column": 36
+      }
+    },
+    {
+      "vname": "bc2",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 32,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 32,
+        "column": 8
+      }
+    },
+    {
+      "vname": "blk1",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 32,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 32,
+        "column": 30
+      }
+    },
+    {
+      "vname": "blk2",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 32,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 32,
+        "column": 35
+      }
+    },
+    {
+      "vname": "orb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 33,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 33,
+        "column": 8
+      }
+    },
+    {
+      "vname": "bc1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 33,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 33,
+        "column": 12
+      }
+    },
+    {
+      "vname": "bc2",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 33,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 33,
+        "column": 16
+      }
+    },
+    {
+      "vname": "accepted_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 35,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 35,
+        "column": 18
+      }
+    },
+    {
+      "vname": "missed_deadline_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 36,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 36,
+        "column": 25
+      }
+    },
+    {
+      "vname": "already_backed_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 37,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 37,
+        "column": 24
+      }
+    },
+    {
+      "vname": "not_owner_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 38,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 38,
+        "column": 19
+      }
+    },
+    {
+      "vname": "too_early_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 39,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 39,
+        "column": 19
+      }
+    },
+    {
+      "vname": "got_funds_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 40,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 40,
+        "column": 19
+      }
+    },
+    {
+      "vname": "cannot_get_funds",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 41,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 41,
+        "column": 21
+      }
+    },
+    {
+      "vname": "cannot_reclaim_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 42,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 42,
+        "column": 24
+      }
+    },
+    {
+      "vname": "reclaimed_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 43,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 43,
+        "column": 19
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 51,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 51,
+        "column": 7
+      }
+    },
+    {
+      "vname": "max_block",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 52,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 52,
+        "column": 11
+      }
+    },
+    {
+      "vname": "goal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 53,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 53,
+        "column": 6
+      }
+    },
+    {
+      "vname": "backers",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 56,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 56,
+        "column": 14
+      }
+    },
+    {
+      "vname": "funded",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 57,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 57,
+        "column": 13
+      }
+    },
+    {
+      "vname": "blk",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 60,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 60,
+        "column": 10
+      }
+    },
+    {
+      "vname": "in_time",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 61,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 61,
+        "column": 18
+      }
+    },
+    {
+      "vname": "blk_leq",
+      "type": "BNum -> BNum -> Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 61,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 61,
+        "column": 20
+      }
+    },
+    {
+      "vname": "blk",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 61,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 61,
+        "column": 24
+      }
+    },
+    {
+      "vname": "max_block",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 61,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 61,
+        "column": 34
+      }
+    },
+    {
+      "vname": "in_time",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 62,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 62,
+        "column": 16
+      }
+    },
+    {
+      "vname": "bs",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 64,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 64,
+        "column": 11
+      }
+    },
+    {
+      "vname": "backers",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 64,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 64,
+        "column": 19
+      }
+    },
+    {
+      "vname": "res",
+      "type": "Option (Map (ByStr20) (Uint128))",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 65,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 65,
+        "column": 12
+      }
+    },
+    {
+      "vname": "check_update",
+      "type":
+        "Map (ByStr20) (Uint128) -> ByStr20 -> Uint128 -> Option (Map (ByStr20) (Uint128))",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 65,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 65,
+        "column": 23
+      }
+    },
+    {
+      "vname": "bs",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 65,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 65,
+        "column": 26
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 65,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 65,
+        "column": 34
+      }
+    },
+    {
+      "vname": "_amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 65,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 65,
+        "column": 42
+      }
+    },
+    {
+      "vname": "res",
+      "type": "Option (Map (ByStr20) (Uint128))",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 66,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 66,
+        "column": 14
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 68,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 68,
+        "column": 10
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 68,
+        "column": 52
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 68,
+        "column": 59
+      }
+    },
+    {
+      "vname": "_amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 68,
+        "column": 70
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 68,
+        "column": 77
+      }
+    },
+    {
+      "vname": "already_backed_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 68,
+        "column": 86
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 68,
+        "column": 105
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 69,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 69,
+        "column": 8
+      }
+    },
+    {
+      "vname": "bs1",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 70,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 70,
+        "column": 15
+      }
+    },
+    {
+      "vname": "bs1",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 71,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 71,
+        "column": 21
+      }
+    },
+    {
+      "vname": "backers",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 71,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 71,
+        "column": 22
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 73,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 73,
+        "column": 10
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 73,
+        "column": 52
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 73,
+        "column": 59
+      }
+    },
+    {
+      "vname": "_amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 73,
+        "column": 70
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 73,
+        "column": 77
+      }
+    },
+    {
+      "vname": "accepted_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 73,
+        "column": 86
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 73,
+        "column": 99
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 74,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 74,
+        "column": 8
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 77,
+        "column": 4
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 77,
+        "column": 5
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 77,
+        "column": 47
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 77,
+        "column": 54
+      }
+    },
+    {
+      "vname": "_amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 77,
+        "column": 65
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 77,
+        "column": 72
+      }
+    },
+    {
+      "vname": "missed_deadline_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 77,
+        "column": 81
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 77,
+        "column": 101
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 78,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 78,
+        "column": 6
+      }
+    },
+    {
+      "vname": "is_owner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 83,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 83,
+        "column": 20
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 83,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 83,
+        "column": 30
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 83,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 83,
+        "column": 38
+      }
+    },
+    {
+      "vname": "is_owner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 84,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 84,
+        "column": 17
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 86,
+        "column": 4
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 86,
+        "column": 5
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 86,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 86,
+        "column": 55
+      }
+    },
+    {
+      "vname": "not_owner_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 86,
+        "column": 84
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 86,
+        "column": 98
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 87,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 87,
+        "column": 6
+      }
+    },
+    {
+      "vname": "blk",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 89,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 89,
+        "column": 12
+      }
+    },
+    {
+      "vname": "in_time",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 90,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 90,
+        "column": 20
+      }
+    },
+    {
+      "vname": "blk_leq",
+      "type": "BNum -> BNum -> Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 90,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 90,
+        "column": 22
+      }
+    },
+    {
+      "vname": "blk",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 90,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 90,
+        "column": 26
+      }
+    },
+    {
+      "vname": "max_block",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 90,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 90,
+        "column": 36
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 91,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 91,
+        "column": 10
+      }
+    },
+    {
+      "vname": "negb",
+      "type": "Bool -> Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 91,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 91,
+        "column": 14
+      }
+    },
+    {
+      "vname": "in_time",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 91,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 91,
+        "column": 22
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 92,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 92,
+        "column": 12
+      }
+    },
+    {
+      "vname": "_balance",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 92,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 92,
+        "column": 20
+      }
+    },
+    {
+      "vname": "c2",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 93,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 93,
+        "column": 10
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 93,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 93,
+        "column": 24
+      }
+    },
+    {
+      "vname": "goal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 93,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 93,
+        "column": 29
+      }
+    },
+    {
+      "vname": "c3",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 94,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 94,
+        "column": 10
+      }
+    },
+    {
+      "vname": "negb",
+      "type": "Bool -> Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 94,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 94,
+        "column": 14
+      }
+    },
+    {
+      "vname": "c2",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 94,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 94,
+        "column": 17
+      }
+    },
+    {
+      "vname": "c4",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 95,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 95,
+        "column": 10
+      }
+    },
+    {
+      "vname": "andb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 95,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 95,
+        "column": 14
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 95,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 95,
+        "column": 17
+      }
+    },
+    {
+      "vname": "c3",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 95,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 95,
+        "column": 20
+      }
+    },
+    {
+      "vname": "c4",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 96,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 96,
+        "column": 13
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 98,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 98,
+        "column": 9
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 98,
+        "column": 52
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 98,
+        "column": 59
+      }
+    },
+    {
+      "vname": "cannot_get_funds",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 98,
+        "column": 88
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 98,
+        "column": 104
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 99,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 99,
+        "column": 8
+      }
+    },
+    {
+      "vname": "tt",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 101,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 101,
+        "column": 12
+      }
+    },
+    {
+      "vname": "tt",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 102,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 102,
+        "column": 19
+      }
+    },
+    {
+      "vname": "funded",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 102,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 102,
+        "column": 20
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 103,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 103,
+        "column": 14
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 103,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 103,
+        "column": 43
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 103,
+        "column": 55
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 103,
+        "column": 58
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 104,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 104,
+        "column": 13
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 104,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 104,
+        "column": 18
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 104,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 104,
+        "column": 22
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 105,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 105,
+        "column": 7
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 105,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 105,
+        "column": 55
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 105,
+        "column": 66
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 105,
+        "column": 69
+      }
+    },
+    {
+      "vname": "got_funds_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 105,
+        "column": 78
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 105,
+        "column": 92
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 106,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 106,
+        "column": 8
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 107,
+        "column": 4
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 107,
+        "column": 8
+      }
+    },
+    {
+      "vname": "blk",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 114,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 114,
+        "column": 10
+      }
+    },
+    {
+      "vname": "after_deadline",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 115,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 115,
+        "column": 32
+      }
+    },
+    {
+      "vname": "max_block",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 115,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 115,
+        "column": 41
+      }
+    },
+    {
+      "vname": "blk",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 115,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 115,
+        "column": 45
+      }
+    },
+    {
+      "vname": "after_deadline",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 116,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 116,
+        "column": 23
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 118,
+        "column": 4
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 118,
+        "column": 5
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 118,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 118,
+        "column": 57
+      }
+    },
+    {
+      "vname": "too_early_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 118,
+        "column": 86
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 118,
+        "column": 100
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 119,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 119,
+        "column": 6
+      }
+    },
+    {
+      "vname": "bs",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 121,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 121,
+        "column": 10
+      }
+    },
+    {
+      "vname": "backers",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 121,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 121,
+        "column": 18
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 122,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 122,
+        "column": 12
+      }
+    },
+    {
+      "vname": "_balance",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 122,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 122,
+        "column": 20
+      }
+    },
+    {
+      "vname": "f",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 124,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 124,
+        "column": 8
+      }
+    },
+    {
+      "vname": "funded",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 124,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 124,
+        "column": 16
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 125,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 125,
+        "column": 10
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 125,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 125,
+        "column": 24
+      }
+    },
+    {
+      "vname": "goal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 125,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 125,
+        "column": 29
+      }
+    },
+    {
+      "vname": "c2",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 126,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 126,
+        "column": 10
+      }
+    },
+    {
+      "vname": "bs",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 126,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 126,
+        "column": 29
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 126,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 126,
+        "column": 37
+      }
+    },
+    {
+      "vname": "c3",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 127,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 127,
+        "column": 10
+      }
+    },
+    {
+      "vname": "negb",
+      "type": "Bool -> Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 127,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 127,
+        "column": 14
+      }
+    },
+    {
+      "vname": "f",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 127,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 127,
+        "column": 16
+      }
+    },
+    {
+      "vname": "c4",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 128,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 128,
+        "column": 10
+      }
+    },
+    {
+      "vname": "andb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 128,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 128,
+        "column": 14
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 128,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 128,
+        "column": 17
+      }
+    },
+    {
+      "vname": "c2",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 128,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 128,
+        "column": 20
+      }
+    },
+    {
+      "vname": "c5",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 129,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 129,
+        "column": 10
+      }
+    },
+    {
+      "vname": "andb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 129,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 129,
+        "column": 14
+      }
+    },
+    {
+      "vname": "c3",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 129,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 129,
+        "column": 17
+      }
+    },
+    {
+      "vname": "c4",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 129,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 129,
+        "column": 20
+      }
+    },
+    {
+      "vname": "c5",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 130,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 130,
+        "column": 13
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 132,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 132,
+        "column": 9
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 132,
+        "column": 54
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 132,
+        "column": 61
+      }
+    },
+    {
+      "vname": "cannot_reclaim_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 132,
+        "column": 90
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 132,
+        "column": 109
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 133,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 133,
+        "column": 8
+      }
+    },
+    {
+      "vname": "res",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 135,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 135,
+        "column": 14
+      }
+    },
+    {
+      "vname": "bs",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 135,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 135,
+        "column": 27
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 135,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 135,
+        "column": 35
+      }
+    },
+    {
+      "vname": "res",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 136,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 136,
+        "column": 16
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 138,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 138,
+        "column": 11
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 138,
+        "column": 56
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 138,
+        "column": 63
+      }
+    },
+    {
+      "vname": "cannot_reclaim_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 138,
+        "column": 92
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 138,
+        "column": 111
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 139,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 139,
+        "column": 10
+      }
+    },
+    {
+      "vname": "v",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 140,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 140,
+        "column": 15
+      }
+    },
+    {
+      "vname": "bs1",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 141,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 141,
+        "column": 16
+      }
+    },
+    {
+      "vname": "bs",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 141,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 141,
+        "column": 32
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 141,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 141,
+        "column": 40
+      }
+    },
+    {
+      "vname": "bs1",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 142,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 142,
+        "column": 23
+      }
+    },
+    {
+      "vname": "backers",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 142,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 142,
+        "column": 24
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 143,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 143,
+        "column": 16
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 143,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 143,
+        "column": 47
+      }
+    },
+    {
+      "vname": "v",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 143,
+        "column": 59
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 143,
+        "column": 60
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 144,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 144,
+        "column": 17
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 144,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 144,
+        "column": 22
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 144,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 144,
+        "column": 26
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 145,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 145,
+        "column": 11
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 145,
+        "column": 56
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 145,
+        "column": 63
+      }
+    },
+    {
+      "vname": "v",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 145,
+        "column": 74
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 145,
+        "column": 75
+      }
+    },
+    {
+      "vname": "reclaimed_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 145,
+        "column": 84
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 145,
+        "column": 98
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 146,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 146,
+        "column": 10
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 147,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding.scilla",
+        "line": 147,
+        "column": 12
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Crowdfunding",

--- a/tests/checker/good/gold/crowdfunding_proc.scilla.gold
+++ b/tests/checker/good/gold/crowdfunding_proc.scilla.gold
@@ -9,6 +9,2514 @@
     ],
     "ADT constructors": []
   },
+  "type_info": [
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 14,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 14,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 15,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 15,
+        "column": 6
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 16,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 16,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 17,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 17,
+        "column": 23
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 17,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 17,
+        "column": 31
+      }
+    },
+    {
+      "vname": "blk_leq",
+      "type": "BNum -> BNum -> Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 19,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 19,
+        "column": 12
+      }
+    },
+    {
+      "vname": "blk1",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 20,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 20,
+        "column": 7
+      }
+    },
+    {
+      "vname": "blk2",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 21,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 21,
+        "column": 7
+      }
+    },
+    {
+      "vname": "bc1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 22,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 22,
+        "column": 8
+      }
+    },
+    {
+      "vname": "blk1",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 22,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 22,
+        "column": 31
+      }
+    },
+    {
+      "vname": "blk2",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 22,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 22,
+        "column": 36
+      }
+    },
+    {
+      "vname": "bc2",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 23,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 23,
+        "column": 8
+      }
+    },
+    {
+      "vname": "blk1",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 23,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 23,
+        "column": 30
+      }
+    },
+    {
+      "vname": "blk2",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 23,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 23,
+        "column": 35
+      }
+    },
+    {
+      "vname": "orb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 24,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 24,
+        "column": 8
+      }
+    },
+    {
+      "vname": "bc1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 24,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 24,
+        "column": 12
+      }
+    },
+    {
+      "vname": "bc2",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 24,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 24,
+        "column": 16
+      }
+    },
+    {
+      "vname": "get_funds_allowed",
+      "type": "BNum -> BNum -> Uint128 -> Uint128 -> Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 26,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 26,
+        "column": 22
+      }
+    },
+    {
+      "vname": "cur_block",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 27,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 27,
+        "column": 12
+      }
+    },
+    {
+      "vname": "max_block",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 28,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 28,
+        "column": 12
+      }
+    },
+    {
+      "vname": "balance",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 29,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 29,
+        "column": 10
+      }
+    },
+    {
+      "vname": "goal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 30,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 30,
+        "column": 7
+      }
+    },
+    {
+      "vname": "in_time",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 31,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 31,
+        "column": 12
+      }
+    },
+    {
+      "vname": "blk_leq",
+      "type": "BNum -> BNum -> Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 31,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 31,
+        "column": 26
+      }
+    },
+    {
+      "vname": "cur_block",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 31,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 31,
+        "column": 36
+      }
+    },
+    {
+      "vname": "max_block",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 31,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 31,
+        "column": 46
+      }
+    },
+    {
+      "vname": "deadline_passed",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 32,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 32,
+        "column": 20
+      }
+    },
+    {
+      "vname": "negb",
+      "type": "Bool -> Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 32,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 32,
+        "column": 31
+      }
+    },
+    {
+      "vname": "in_time",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 32,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 32,
+        "column": 39
+      }
+    },
+    {
+      "vname": "target_not_reached",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 33,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 33,
+        "column": 23
+      }
+    },
+    {
+      "vname": "balance",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 33,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 33,
+        "column": 48
+      }
+    },
+    {
+      "vname": "goal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 33,
+        "column": 49
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 33,
+        "column": 53
+      }
+    },
+    {
+      "vname": "target_reached",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 34,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 34,
+        "column": 19
+      }
+    },
+    {
+      "vname": "negb",
+      "type": "Bool -> Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 34,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 34,
+        "column": 30
+      }
+    },
+    {
+      "vname": "target_not_reached",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 34,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 34,
+        "column": 49
+      }
+    },
+    {
+      "vname": "andb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 35,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 35,
+        "column": 9
+      }
+    },
+    {
+      "vname": "deadline_passed",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 35,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 35,
+        "column": 25
+      }
+    },
+    {
+      "vname": "target_reached",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 35,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 35,
+        "column": 40
+      }
+    },
+    {
+      "vname": "claimback_allowed",
+      "type": "Uint128 -> Uint128 -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 37,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 37,
+        "column": 22
+      }
+    },
+    {
+      "vname": "balance",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 38,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 38,
+        "column": 10
+      }
+    },
+    {
+      "vname": "goal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 39,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 39,
+        "column": 7
+      }
+    },
+    {
+      "vname": "already_funded",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 40,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 40,
+        "column": 17
+      }
+    },
+    {
+      "vname": "target_not_reached",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 41,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 41,
+        "column": 23
+      }
+    },
+    {
+      "vname": "balance",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 41,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 41,
+        "column": 48
+      }
+    },
+    {
+      "vname": "goal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 41,
+        "column": 49
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 41,
+        "column": 53
+      }
+    },
+    {
+      "vname": "not_already_funded",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 42,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 42,
+        "column": 23
+      }
+    },
+    {
+      "vname": "negb",
+      "type": "Bool -> Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 42,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 42,
+        "column": 34
+      }
+    },
+    {
+      "vname": "already_funded",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 42,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 42,
+        "column": 49
+      }
+    },
+    {
+      "vname": "andb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 43,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 43,
+        "column": 9
+      }
+    },
+    {
+      "vname": "target_not_reached",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 43,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 43,
+        "column": 28
+      }
+    },
+    {
+      "vname": "not_already_funded",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 43,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 43,
+        "column": 47
+      }
+    },
+    {
+      "vname": "accepted_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 45,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 45,
+        "column": 18
+      }
+    },
+    {
+      "vname": "missed_deadline_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 46,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 46,
+        "column": 25
+      }
+    },
+    {
+      "vname": "already_backed_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 47,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 47,
+        "column": 24
+      }
+    },
+    {
+      "vname": "not_owner_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 48,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 48,
+        "column": 19
+      }
+    },
+    {
+      "vname": "too_early_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 49,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 49,
+        "column": 19
+      }
+    },
+    {
+      "vname": "got_funds_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 50,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 50,
+        "column": 19
+      }
+    },
+    {
+      "vname": "cannot_get_funds",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 51,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 51,
+        "column": 21
+      }
+    },
+    {
+      "vname": "cannot_reclaim_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 52,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 52,
+        "column": 24
+      }
+    },
+    {
+      "vname": "reclaimed_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 53,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 53,
+        "column": 19
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 61,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 61,
+        "column": 7
+      }
+    },
+    {
+      "vname": "max_block",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 62,
+        "column": 1
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 62,
+        "column": 10
+      }
+    },
+    {
+      "vname": "goal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 63,
+        "column": 1
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 63,
+        "column": 5
+      }
+    },
+    {
+      "vname": "backers",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 66,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 66,
+        "column": 14
+      }
+    },
+    {
+      "vname": "funded",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 67,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 67,
+        "column": 13
+      }
+    },
+    {
+      "vname": "failure",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 69,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 69,
+        "column": 33
+      }
+    },
+    {
+      "vname": "error_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 69,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 69,
+        "column": 52
+      }
+    },
+    {
+      "vname": "failure",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 70,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 70,
+        "column": 16
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 72,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 72,
+        "column": 8
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 72,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 72,
+        "column": 57
+      }
+    },
+    {
+      "vname": "_amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 73,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 73,
+        "column": 26
+      }
+    },
+    {
+      "vname": "accepted_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 73,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 73,
+        "column": 48
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 74,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 74,
+        "column": 6
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 76,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 76,
+        "column": 8
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 76,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 76,
+        "column": 57
+      }
+    },
+    {
+      "vname": "_amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 77,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 77,
+        "column": 26
+      }
+    },
+    {
+      "vname": "error_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 77,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 77,
+        "column": 45
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 78,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 78,
+        "column": 6
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 83,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 83,
+        "column": 4
+      }
+    },
+    {
+      "vname": "backers",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 83,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 83,
+        "column": 22
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 83,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 83,
+        "column": 30
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 84,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 84,
+        "column": 10
+      }
+    },
+    {
+      "vname": "backers",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 87,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 87,
+        "column": 12
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 87,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 87,
+        "column": 20
+      }
+    },
+    {
+      "vname": "_amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 87,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 87,
+        "column": 32
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 88,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 88,
+        "column": 20
+      }
+    },
+    {
+      "vname": "accepted_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 88,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 88,
+        "column": 34
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 90,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 90,
+        "column": 20
+      }
+    },
+    {
+      "vname": "already_backed_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 90,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 90,
+        "column": 40
+      }
+    },
+    {
+      "vname": "blk",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 95,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 95,
+        "column": 10
+      }
+    },
+    {
+      "vname": "in_time",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 96,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 96,
+        "column": 18
+      }
+    },
+    {
+      "vname": "blk_leq",
+      "type": "BNum -> BNum -> Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 96,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 96,
+        "column": 20
+      }
+    },
+    {
+      "vname": "blk",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 96,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 96,
+        "column": 24
+      }
+    },
+    {
+      "vname": "max_block",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 96,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 96,
+        "column": 34
+      }
+    },
+    {
+      "vname": "in_time",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 97,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 97,
+        "column": 16
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 101,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 101,
+        "column": 8
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 102,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 102,
+        "column": 20
+      }
+    },
+    {
+      "vname": "missed_deadline_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 102,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 102,
+        "column": 41
+      }
+    },
+    {
+      "vname": "error_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 106,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 106,
+        "column": 38
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 107,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 107,
+        "column": 6
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 107,
+        "column": 49
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 107,
+        "column": 56
+      }
+    },
+    {
+      "vname": "_amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 108,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 108,
+        "column": 24
+      }
+    },
+    {
+      "vname": "error_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 108,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 108,
+        "column": 43
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 109,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 109,
+        "column": 4
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 113,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 113,
+        "column": 10
+      }
+    },
+    {
+      "vname": "_balance",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 113,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 113,
+        "column": 18
+      }
+    },
+    {
+      "vname": "tt",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 114,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 114,
+        "column": 8
+      }
+    },
+    {
+      "vname": "tt",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 115,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 115,
+        "column": 15
+      }
+    },
+    {
+      "vname": "funded",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 115,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 115,
+        "column": 16
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 116,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 116,
+        "column": 10
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 116,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 116,
+        "column": 39
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 116,
+        "column": 51
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 116,
+        "column": 54
+      }
+    },
+    {
+      "vname": "got_funds_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 116,
+        "column": 63
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 116,
+        "column": 77
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 117,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 117,
+        "column": 12
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 117,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 117,
+        "column": 17
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 117,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 117,
+        "column": 21
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 118,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 118,
+        "column": 7
+      }
+    },
+    {
+      "vname": "is_owner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 122,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 122,
+        "column": 20
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 122,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 122,
+        "column": 30
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 122,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 122,
+        "column": 38
+      }
+    },
+    {
+      "vname": "is_owner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 123,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 123,
+        "column": 17
+      }
+    },
+    {
+      "vname": "not_owner_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 125,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 125,
+        "column": 35
+      }
+    },
+    {
+      "vname": "blk",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 127,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 127,
+        "column": 12
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 128,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 128,
+        "column": 12
+      }
+    },
+    {
+      "vname": "_balance",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 128,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 128,
+        "column": 20
+      }
+    },
+    {
+      "vname": "allowed",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 129,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 129,
+        "column": 20
+      }
+    },
+    {
+      "vname": "get_funds_allowed",
+      "type": "BNum -> BNum -> Uint128 -> Uint128 -> Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 129,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 129,
+        "column": 32
+      }
+    },
+    {
+      "vname": "blk",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 129,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 129,
+        "column": 36
+      }
+    },
+    {
+      "vname": "max_block",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 129,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 129,
+        "column": 46
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 129,
+        "column": 47
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 129,
+        "column": 50
+      }
+    },
+    {
+      "vname": "goal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 129,
+        "column": 51
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 129,
+        "column": 55
+      }
+    },
+    {
+      "vname": "allowed",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 130,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 130,
+        "column": 18
+      }
+    },
+    {
+      "vname": "cannot_get_funds",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 132,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 132,
+        "column": 39
+      }
+    },
+    {
+      "vname": "error_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 139,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 139,
+        "column": 39
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 140,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 140,
+        "column": 6
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 140,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 140,
+        "column": 57
+      }
+    },
+    {
+      "vname": "_amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 141,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 141,
+        "column": 24
+      }
+    },
+    {
+      "vname": "error_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 141,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 141,
+        "column": 43
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 142,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 142,
+        "column": 4
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 145,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 145,
+        "column": 35
+      }
+    },
+    {
+      "vname": "backers",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 146,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 146,
+        "column": 17
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 146,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 146,
+        "column": 25
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 147,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 147,
+        "column": 10
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 147,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 147,
+        "column": 41
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 147,
+        "column": 53
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 147,
+        "column": 59
+      }
+    },
+    {
+      "vname": "reclaimed_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 147,
+        "column": 68
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 147,
+        "column": 82
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 148,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 148,
+        "column": 12
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 148,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 148,
+        "column": 17
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 148,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 148,
+        "column": 21
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 149,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 149,
+        "column": 6
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 149,
+        "column": 51
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 149,
+        "column": 58
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 149,
+        "column": 69
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 149,
+        "column": 75
+      }
+    },
+    {
+      "vname": "reclaimed_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 149,
+        "column": 84
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 149,
+        "column": 98
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 150,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 150,
+        "column": 4
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 151,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 151,
+        "column": 7
+      }
+    },
+    {
+      "vname": "blk",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 156,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 156,
+        "column": 10
+      }
+    },
+    {
+      "vname": "after_deadline",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 157,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 157,
+        "column": 32
+      }
+    },
+    {
+      "vname": "max_block",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 157,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 157,
+        "column": 41
+      }
+    },
+    {
+      "vname": "blk",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 157,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 157,
+        "column": 45
+      }
+    },
+    {
+      "vname": "after_deadline",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 158,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 158,
+        "column": 23
+      }
+    },
+    {
+      "vname": "too_early_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 160,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 160,
+        "column": 36
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 162,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 162,
+        "column": 12
+      }
+    },
+    {
+      "vname": "_balance",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 162,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 162,
+        "column": 20
+      }
+    },
+    {
+      "vname": "f",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 163,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 163,
+        "column": 8
+      }
+    },
+    {
+      "vname": "funded",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 163,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 163,
+        "column": 16
+      }
+    },
+    {
+      "vname": "allowed",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 164,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 164,
+        "column": 20
+      }
+    },
+    {
+      "vname": "claimback_allowed",
+      "type": "Uint128 -> Uint128 -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 164,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 164,
+        "column": 32
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 164,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 164,
+        "column": 36
+      }
+    },
+    {
+      "vname": "goal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 164,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 164,
+        "column": 41
+      }
+    },
+    {
+      "vname": "f",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 164,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 164,
+        "column": 43
+      }
+    },
+    {
+      "vname": "allowed",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 165,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 165,
+        "column": 18
+      }
+    },
+    {
+      "vname": "cannot_reclaim_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 167,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 167,
+        "column": 43
+      }
+    },
+    {
+      "vname": "res",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 169,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 169,
+        "column": 10
+      }
+    },
+    {
+      "vname": "backers",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 169,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 169,
+        "column": 21
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 169,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 169,
+        "column": 29
+      }
+    },
+    {
+      "vname": "res",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 170,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 170,
+        "column": 16
+      }
+    },
+    {
+      "vname": "cannot_reclaim_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 173,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 173,
+        "column": 45
+      }
+    },
+    {
+      "vname": "v",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 174,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 174,
+        "column": 15
+      }
+    },
+    {
+      "vname": "v",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 175,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/crowdfunding_proc.scilla",
+        "line": 175,
+        "column": 27
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Crowdfunding",

--- a/tests/checker/good/gold/earmarked-coin.scilla.gold
+++ b/tests/checker/good/gold/earmarked-coin.scilla.gold
@@ -11,6 +11,1226 @@
       }
     ]
   },
+  "type_info": [
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 21,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 21,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 22,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 22,
+        "column": 6
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 23,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 23,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 24,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 24,
+        "column": 23
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 24,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 24,
+        "column": 31
+      }
+    },
+    {
+      "vname": "success_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 26,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 26,
+        "column": 17
+      }
+    },
+    {
+      "vname": "already_earmarked_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 27,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 27,
+        "column": 27
+      }
+    },
+    {
+      "vname": "not_authorized_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 28,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 28,
+        "column": 24
+      }
+    },
+    {
+      "vname": "did_not_earmark_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 29,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 29,
+        "column": 25
+      }
+    },
+    {
+      "vname": "earmarked_coins",
+      "type": "Map (ByStr20) (EarmarkedCoin)",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 34,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 34,
+        "column": 22
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 38,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 38,
+        "column": 32
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 38,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 38,
+        "column": 53
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 39,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 39,
+        "column": 10
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 39,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 39,
+        "column": 43
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 39,
+        "column": 55
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 39,
+        "column": 61
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 40,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 40,
+        "column": 12
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 40,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 40,
+        "column": 17
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 40,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 40,
+        "column": 21
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 41,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 41,
+        "column": 7
+      }
+    },
+    {
+      "vname": "from",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 44,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 44,
+        "column": 42
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 44,
+        "column": 54
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 44,
+        "column": 56
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 45,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 45,
+        "column": 6
+      }
+    },
+    {
+      "vname": "from",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 46,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 46,
+        "column": 18
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 46,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 46,
+        "column": 27
+      }
+    },
+    {
+      "vname": "success_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 46,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 46,
+        "column": 48
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 47,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 47,
+        "column": 4
+      }
+    },
+    {
+      "vname": "from",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 50,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 50,
+        "column": 38
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 50,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 50,
+        "column": 52
+      }
+    },
+    {
+      "vname": "error_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 50,
+        "column": 64
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 50,
+        "column": 74
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 51,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 51,
+        "column": 6
+      }
+    },
+    {
+      "vname": "from",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 52,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 52,
+        "column": 18
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 52,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 52,
+        "column": 27
+      }
+    },
+    {
+      "vname": "error_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 52,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 52,
+        "column": 46
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 53,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 53,
+        "column": 4
+      }
+    },
+    {
+      "vname": "recip",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 64,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 64,
+        "column": 26
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 65,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 65,
+        "column": 4
+      }
+    },
+    {
+      "vname": "earmarked_coins",
+      "type": "Map (ByStr20) (EarmarkedCoin)",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 65,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 65,
+        "column": 30
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 65,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 65,
+        "column": 38
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 66,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 66,
+        "column": 10
+      }
+    },
+    {
+      "vname": "e_coin",
+      "type": "EarmarkedCoin",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 69,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 69,
+        "column": 18
+      }
+    },
+    {
+      "vname": "_amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 69,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 69,
+        "column": 35
+      }
+    },
+    {
+      "vname": "recip",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 69,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 69,
+        "column": 41
+      }
+    },
+    {
+      "vname": "earmarked_coins",
+      "type": "Map (ByStr20) (EarmarkedCoin)",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 70,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 70,
+        "column": 20
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 70,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 70,
+        "column": 28
+      }
+    },
+    {
+      "vname": "e_coin",
+      "type": "EarmarkedCoin",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 70,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 70,
+        "column": 39
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 71,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 71,
+        "column": 38
+      }
+    },
+    {
+      "vname": "_this_address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 71,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 71,
+        "column": 52
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 73,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 73,
+        "column": 34
+      }
+    },
+    {
+      "vname": "_this_address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 73,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 73,
+        "column": 48
+      }
+    },
+    {
+      "vname": "already_earmarked_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 73,
+        "column": 49
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 73,
+        "column": 71
+      }
+    },
+    {
+      "vname": "earmarked_coin_address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 78,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 78,
+        "column": 53
+      }
+    },
+    {
+      "vname": "e_coin_opt",
+      "type": "Option (EarmarkedCoin)",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 79,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 79,
+        "column": 13
+      }
+    },
+    {
+      "vname": "earmarked_coins",
+      "type": "Map (ByStr20) (EarmarkedCoin)",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 79,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 79,
+        "column": 32
+      }
+    },
+    {
+      "vname": "earmarked_coin_address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 79,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 79,
+        "column": 55
+      }
+    },
+    {
+      "vname": "e_coin_opt",
+      "type": "Option (EarmarkedCoin)",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 80,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 80,
+        "column": 19
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 81,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 81,
+        "column": 41
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 81,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 81,
+        "column": 31
+      }
+    },
+    {
+      "vname": "authorized_to_claim",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 83,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 83,
+        "column": 44
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 83,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 83,
+        "column": 47
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 83,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 83,
+        "column": 55
+      }
+    },
+    {
+      "vname": "authorized_to_claim",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 84,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 84,
+        "column": 30
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 86,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 86,
+        "column": 27
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 86,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 86,
+        "column": 37
+      }
+    },
+    {
+      "vname": "earmarked_coins",
+      "type": "Map (ByStr20) (EarmarkedCoin)",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 87,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 87,
+        "column": 29
+      }
+    },
+    {
+      "vname": "earmarked_coin_address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 87,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 87,
+        "column": 52
+      }
+    },
+    {
+      "vname": "_this_address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 88,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 88,
+        "column": 46
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 88,
+        "column": 47
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 88,
+        "column": 54
+      }
+    },
+    {
+      "vname": "_this_address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 90,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 90,
+        "column": 42
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 90,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 90,
+        "column": 50
+      }
+    },
+    {
+      "vname": "not_authorized_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 90,
+        "column": 51
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 90,
+        "column": 70
+      }
+    },
+    {
+      "vname": "_this_address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 94,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 94,
+        "column": 40
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 94,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 94,
+        "column": 48
+      }
+    },
+    {
+      "vname": "did_not_earmark_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 94,
+        "column": 49
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 94,
+        "column": 69
+      }
+    },
+    {
+      "vname": "e_coin_opt",
+      "type": "Option (EarmarkedCoin)",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 104,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 104,
+        "column": 13
+      }
+    },
+    {
+      "vname": "earmarked_coins",
+      "type": "Map (ByStr20) (EarmarkedCoin)",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 104,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 104,
+        "column": 32
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 104,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 104,
+        "column": 40
+      }
+    },
+    {
+      "vname": "e_coin_opt",
+      "type": "Option (EarmarkedCoin)",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 105,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 105,
+        "column": 19
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 106,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 106,
+        "column": 31
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 108,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 108,
+        "column": 25
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 108,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 108,
+        "column": 33
+      }
+    },
+    {
+      "vname": "earmarked_coins",
+      "type": "Map (ByStr20) (EarmarkedCoin)",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 109,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 109,
+        "column": 27
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 109,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 109,
+        "column": 35
+      }
+    },
+    {
+      "vname": "_this_address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 110,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 110,
+        "column": 44
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 110,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 110,
+        "column": 52
+      }
+    },
+    {
+      "vname": "_this_address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 113,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 113,
+        "column": 40
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 113,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 113,
+        "column": 48
+      }
+    },
+    {
+      "vname": "did_not_earmark_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 113,
+        "column": 49
+      },
+      "end_location": {
+        "file": "contracts/earmarked-coin.scilla",
+        "line": 113,
+        "column": 69
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "EarmarkedCoin",

--- a/tests/checker/good/gold/ecdsa.scilla.gold
+++ b/tests/checker/good/gold/ecdsa.scilla.gold
@@ -5,6 +5,554 @@
     ],
     "ADT constructors": []
   },
+  "type_info": [
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 7,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 7,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 8,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 8,
+        "column": 6
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 9,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 9,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 10,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 10,
+        "column": 23
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 10,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 10,
+        "column": 31
+      }
+    },
+    {
+      "vname": "fst_f",
+      "type": "Pair (ByStr32) (ByStr33) -> ByStr32",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 12,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 12,
+        "column": 10
+      }
+    },
+    {
+      "vname": "fst",
+      "type": "forall 'A. forall 'B. Pair ('A) ('B) -> 'A",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 12,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 12,
+        "column": 16
+      }
+    },
+    {
+      "vname": "snd_f",
+      "type": "Pair (ByStr32) (ByStr33) -> ByStr33",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 13,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 13,
+        "column": 10
+      }
+    },
+    {
+      "vname": "snd",
+      "type": "forall 'A. forall 'B. Pair ('A) ('B) -> 'B",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 13,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 13,
+        "column": 16
+      }
+    },
+    {
+      "vname": "pub_key",
+      "type": "Option (ByStr33)",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 18,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 18,
+        "column": 14
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "ByStr",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 20,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 20,
+        "column": 22
+      }
+    },
+    {
+      "vname": "sig",
+      "type": "ByStr64",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 20,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 20,
+        "column": 35
+      }
+    },
+    {
+      "vname": "pubk_o",
+      "type": "Option (ByStr33)",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 21,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 21,
+        "column": 16
+      }
+    },
+    {
+      "vname": "pub_key",
+      "type": "Option (ByStr33)",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 21,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 21,
+        "column": 20
+      }
+    },
+    {
+      "vname": "pubk_o",
+      "type": "Option (ByStr33)",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 22,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 22,
+        "column": 15
+      }
+    },
+    {
+      "vname": "pubk",
+      "type": "ByStr33",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 23,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 23,
+        "column": 14
+      }
+    },
+    {
+      "vname": "sig",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 24,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 24,
+        "column": 12
+      }
+    },
+    {
+      "vname": "pubk",
+      "type": "ByStr33",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 24,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 24,
+        "column": 36
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "ByStr",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 24,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 24,
+        "column": 40
+      }
+    },
+    {
+      "vname": "sig",
+      "type": "ByStr64",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 24,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 24,
+        "column": 44
+      }
+    },
+    {
+      "vname": "sig",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 25,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 25,
+        "column": 14
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 27,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 27,
+        "column": 10
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 27,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 27,
+        "column": 44
+      }
+    },
+    {
+      "vname": "mone",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 28,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 28,
+        "column": 16
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 28,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 28,
+        "column": 21
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 28,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 28,
+        "column": 23
+      }
+    },
+    {
+      "vname": "mone",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 29,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 29,
+        "column": 11
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 31,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 31,
+        "column": 10
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 31,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 31,
+        "column": 44
+      }
+    },
+    {
+      "vname": "mone",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 32,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 32,
+        "column": 16
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 32,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 32,
+        "column": 21
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 32,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 32,
+        "column": 23
+      }
+    },
+    {
+      "vname": "mone",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 33,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 33,
+        "column": 11
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 37,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 37,
+        "column": 8
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 37,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 37,
+        "column": 42
+      }
+    },
+    {
+      "vname": "mone",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 38,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 38,
+        "column": 14
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 38,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 38,
+        "column": 19
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 38,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 38,
+        "column": 21
+      }
+    },
+    {
+      "vname": "mone",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 39,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 39,
+        "column": 9
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Ecdsa",

--- a/tests/checker/good/gold/empty.scilla.gold
+++ b/tests/checker/good/gold/empty.scilla.gold
@@ -1,5 +1,6 @@
 {
   "cashflow_tags": { "State variables": [], "ADT constructors": [] },
+  "type_info": [],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Empty",

--- a/tests/checker/good/gold/fungible-token.scilla.gold
+++ b/tests/checker/good/gold/fungible-token.scilla.gold
@@ -11,6 +11,3718 @@
     ],
     "ADT constructors": []
   },
+  "type_info": [
+    {
+      "vname": "one",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 10,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 10,
+        "column": 8
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 11,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 11,
+        "column": 9
+      }
+    },
+    {
+      "vname": "min_int",
+      "type": "Uint128 -> Uint128 -> Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 13,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 13,
+        "column": 12
+      }
+    },
+    {
+      "vname": "a",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 14,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 14,
+        "column": 4
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 14,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 14,
+        "column": 25
+      }
+    },
+    {
+      "vname": "alt",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 15,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 15,
+        "column": 6
+      }
+    },
+    {
+      "vname": "a",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 15,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 15,
+        "column": 25
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 15,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 15,
+        "column": 27
+      }
+    },
+    {
+      "vname": "alt",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 16,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 16,
+        "column": 12
+      }
+    },
+    {
+      "vname": "a",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 18,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 18,
+        "column": 6
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 20,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 20,
+        "column": 6
+      }
+    },
+    {
+      "vname": "le_int",
+      "type": "Uint128 -> Uint128 -> Bool",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 23,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 23,
+        "column": 11
+      }
+    },
+    {
+      "vname": "a",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 24,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 24,
+        "column": 4
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 24,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 24,
+        "column": 25
+      }
+    },
+    {
+      "vname": "x",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 25,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 25,
+        "column": 6
+      }
+    },
+    {
+      "vname": "a",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 25,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 25,
+        "column": 25
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 25,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 25,
+        "column": 27
+      }
+    },
+    {
+      "vname": "x",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 26,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 26,
+        "column": 12
+      }
+    },
+    {
+      "vname": "y",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 29,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 29,
+        "column": 8
+      }
+    },
+    {
+      "vname": "a",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 29,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 29,
+        "column": 27
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 29,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 29,
+        "column": 29
+      }
+    },
+    {
+      "vname": "y",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 30,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 30,
+        "column": 14
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 37,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 37,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 38,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 38,
+        "column": 8
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 39,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 39,
+        "column": 16
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 40,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 40,
+        "column": 27
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 40,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 40,
+        "column": 35
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 48,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 48,
+        "column": 7
+      }
+    },
+    {
+      "vname": "total_tokens",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 49,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 49,
+        "column": 14
+      }
+    },
+    {
+      "vname": "decimals",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 50,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 50,
+        "column": 10
+      }
+    },
+    {
+      "vname": "name",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 51,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 51,
+        "column": 6
+      }
+    },
+    {
+      "vname": "symbol",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 52,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 52,
+        "column": 8
+      }
+    },
+    {
+      "vname": "balances",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 56,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 56,
+        "column": 15
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 57,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 57,
+        "column": 4
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 58,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 58,
+        "column": 18
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 58,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 58,
+        "column": 24
+      }
+    },
+    {
+      "vname": "total_tokens",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 58,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 58,
+        "column": 37
+      }
+    },
+    {
+      "vname": "allowed",
+      "type": "Map (ByStr20) (Map (ByStr20) (Uint128))",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 59,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 59,
+        "column": 14
+      }
+    },
+    {
+      "vname": "tokenOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 61,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 61,
+        "column": 33
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 62,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 62,
+        "column": 6
+      }
+    },
+    {
+      "vname": "balances",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 62,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 62,
+        "column": 18
+      }
+    },
+    {
+      "vname": "tokenOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 62,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 62,
+        "column": 29
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 63,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 63,
+        "column": 12
+      }
+    },
+    {
+      "vname": "v",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 64,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 64,
+        "column": 11
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 65,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 65,
+        "column": 12
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 65,
+        "column": 54
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 65,
+        "column": 61
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 65,
+        "column": 73
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 65,
+        "column": 77
+      }
+    },
+    {
+      "vname": "tokenOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 66,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 66,
+        "column": 33
+      }
+    },
+    {
+      "vname": "v",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 66,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 66,
+        "column": 46
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 67,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 67,
+        "column": 14
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 67,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 67,
+        "column": 19
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 67,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 67,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 68,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 68,
+        "column": 9
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 70,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 70,
+        "column": 12
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 70,
+        "column": 54
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 70,
+        "column": 61
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 70,
+        "column": 73
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 70,
+        "column": 77
+      }
+    },
+    {
+      "vname": "tokenOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 71,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 71,
+        "column": 33
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 71,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 71,
+        "column": 49
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 72,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 72,
+        "column": 14
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 72,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 72,
+        "column": 19
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 72,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 72,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 73,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 73,
+        "column": 9
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 78,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 78,
+        "column": 10
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 78,
+        "column": 54
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 78,
+        "column": 61
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 78,
+        "column": 73
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 78,
+        "column": 77
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 79,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 79,
+        "column": 27
+      }
+    },
+    {
+      "vname": "total_tokens",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 79,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 79,
+        "column": 55
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 80,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 80,
+        "column": 12
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 80,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 80,
+        "column": 17
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 80,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 80,
+        "column": 21
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 81,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 81,
+        "column": 7
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 84,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 84,
+        "column": 24
+      }
+    },
+    {
+      "vname": "tokens",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 84,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 84,
+        "column": 42
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 85,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 85,
+        "column": 6
+      }
+    },
+    {
+      "vname": "balances",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 85,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 85,
+        "column": 18
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 85,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 85,
+        "column": 26
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 86,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 86,
+        "column": 12
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 87,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 87,
+        "column": 11
+      }
+    },
+    {
+      "vname": "can_do",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 88,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 88,
+        "column": 18
+      }
+    },
+    {
+      "vname": "le_int",
+      "type": "Uint128 -> Uint128 -> Bool",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 88,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 88,
+        "column": 20
+      }
+    },
+    {
+      "vname": "tokens",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 88,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 88,
+        "column": 27
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 88,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 88,
+        "column": 29
+      }
+    },
+    {
+      "vname": "can_do",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 89,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 89,
+        "column": 17
+      }
+    },
+    {
+      "vname": "new_sender_bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 92,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 92,
+        "column": 36
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 92,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 92,
+        "column": 37
+      }
+    },
+    {
+      "vname": "tokens",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 92,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 92,
+        "column": 44
+      }
+    },
+    {
+      "vname": "balances",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 93,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 93,
+        "column": 15
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 93,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 93,
+        "column": 23
+      }
+    },
+    {
+      "vname": "new_sender_bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 93,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 93,
+        "column": 42
+      }
+    },
+    {
+      "vname": "to_bal",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 96,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 96,
+        "column": 13
+      }
+    },
+    {
+      "vname": "balances",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 96,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 96,
+        "column": 25
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 96,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 96,
+        "column": 28
+      }
+    },
+    {
+      "vname": "new_to_bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 97,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 97,
+        "column": 28
+      }
+    },
+    {
+      "vname": "to_bal",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 97,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 97,
+        "column": 32
+      }
+    },
+    {
+      "vname": "x",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 98,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 98,
+        "column": 15
+      }
+    },
+    {
+      "vname": "x",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 98,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 98,
+        "column": 32
+      }
+    },
+    {
+      "vname": "tokens",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 98,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 98,
+        "column": 39
+      }
+    },
+    {
+      "vname": "tokens",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 99,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 99,
+        "column": 23
+      }
+    },
+    {
+      "vname": "balances",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 102,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 102,
+        "column": 14
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 102,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 102,
+        "column": 17
+      }
+    },
+    {
+      "vname": "new_to_bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 102,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 102,
+        "column": 32
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 103,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 103,
+        "column": 14
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 103,
+        "column": 54
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 103,
+        "column": 61
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 103,
+        "column": 73
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 103,
+        "column": 77
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 104,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 104,
+        "column": 31
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 104,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 104,
+        "column": 47
+      }
+    },
+    {
+      "vname": "tokens",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 104,
+        "column": 58
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 104,
+        "column": 64
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 105,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 105,
+        "column": 16
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 105,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 105,
+        "column": 21
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 105,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 105,
+        "column": 25
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 106,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 106,
+        "column": 11
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 109,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 109,
+        "column": 14
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 109,
+        "column": 54
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 109,
+        "column": 61
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 109,
+        "column": 73
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 109,
+        "column": 77
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 110,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 110,
+        "column": 31
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 110,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 110,
+        "column": 47
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 110,
+        "column": 58
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 110,
+        "column": 62
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 111,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 111,
+        "column": 16
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 111,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 111,
+        "column": 21
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 111,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 111,
+        "column": 25
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 112,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 112,
+        "column": 11
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 116,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 116,
+        "column": 12
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 116,
+        "column": 52
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 116,
+        "column": 59
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 116,
+        "column": 71
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 116,
+        "column": 75
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 117,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 117,
+        "column": 29
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 117,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 117,
+        "column": 45
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 117,
+        "column": 56
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 117,
+        "column": 60
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 118,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 118,
+        "column": 14
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 118,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 118,
+        "column": 19
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 118,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 118,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 119,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 119,
+        "column": 9
+      }
+    },
+    {
+      "vname": "from",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 123,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 123,
+        "column": 30
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 123,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 123,
+        "column": 44
+      }
+    },
+    {
+      "vname": "tokens",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 123,
+        "column": 56
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 123,
+        "column": 62
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 124,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 124,
+        "column": 6
+      }
+    },
+    {
+      "vname": "balances",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 124,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 124,
+        "column": 18
+      }
+    },
+    {
+      "vname": "from",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 124,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 124,
+        "column": 23
+      }
+    },
+    {
+      "vname": "sender_allowed_from",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 126,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 126,
+        "column": 22
+      }
+    },
+    {
+      "vname": "allowed",
+      "type": "Map (ByStr20) (Map (ByStr20) (Uint128))",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 126,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 126,
+        "column": 33
+      }
+    },
+    {
+      "vname": "from",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 126,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 126,
+        "column": 38
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 126,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 126,
+        "column": 47
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 127,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 127,
+        "column": 12
+      }
+    },
+    {
+      "vname": "a",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 128,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 128,
+        "column": 11
+      }
+    },
+    {
+      "vname": "sender_allowed_from",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 129,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 129,
+        "column": 30
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 130,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 130,
+        "column": 13
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 132,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 132,
+        "column": 12
+      }
+    },
+    {
+      "vname": "min_int",
+      "type": "Uint128 -> Uint128 -> Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 132,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 132,
+        "column": 20
+      }
+    },
+    {
+      "vname": "a",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 132,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 132,
+        "column": 22
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 132,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 132,
+        "column": 24
+      }
+    },
+    {
+      "vname": "can_do",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 133,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 133,
+        "column": 22
+      }
+    },
+    {
+      "vname": "le_int",
+      "type": "Uint128 -> Uint128 -> Bool",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 133,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 133,
+        "column": 24
+      }
+    },
+    {
+      "vname": "tokens",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 133,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 133,
+        "column": 31
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 133,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 133,
+        "column": 33
+      }
+    },
+    {
+      "vname": "can_do",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 134,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 134,
+        "column": 21
+      }
+    },
+    {
+      "vname": "new_from_bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 137,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 137,
+        "column": 38
+      }
+    },
+    {
+      "vname": "a",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 137,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 137,
+        "column": 41
+      }
+    },
+    {
+      "vname": "tokens",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 137,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 137,
+        "column": 48
+      }
+    },
+    {
+      "vname": "balances",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 138,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 138,
+        "column": 21
+      }
+    },
+    {
+      "vname": "from",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 138,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 138,
+        "column": 26
+      }
+    },
+    {
+      "vname": "new_from_bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 138,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 138,
+        "column": 43
+      }
+    },
+    {
+      "vname": "to_bal",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 139,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 139,
+        "column": 19
+      }
+    },
+    {
+      "vname": "balances",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 139,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 139,
+        "column": 31
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 139,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 139,
+        "column": 34
+      }
+    },
+    {
+      "vname": "to_bal",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 140,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 140,
+        "column": 25
+      }
+    },
+    {
+      "vname": "tb",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 141,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 141,
+        "column": 22
+      }
+    },
+    {
+      "vname": "new_to_bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 142,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 142,
+        "column": 38
+      }
+    },
+    {
+      "vname": "tb",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 142,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 142,
+        "column": 44
+      }
+    },
+    {
+      "vname": "tokens",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 142,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 142,
+        "column": 51
+      }
+    },
+    {
+      "vname": "balances",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 143,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 143,
+        "column": 25
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 143,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 143,
+        "column": 28
+      }
+    },
+    {
+      "vname": "new_to_bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 143,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 143,
+        "column": 43
+      }
+    },
+    {
+      "vname": "balances",
+      "type": "Map (ByStr20) (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 146,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 146,
+        "column": 25
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 146,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 146,
+        "column": 28
+      }
+    },
+    {
+      "vname": "tokens",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 146,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 146,
+        "column": 39
+      }
+    },
+    {
+      "vname": "new_allowed",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 149,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 149,
+        "column": 36
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 149,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 149,
+        "column": 40
+      }
+    },
+    {
+      "vname": "tokens",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 149,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 149,
+        "column": 47
+      }
+    },
+    {
+      "vname": "allowed",
+      "type": "Map (ByStr20) (Map (ByStr20) (Uint128))",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 150,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 150,
+        "column": 20
+      }
+    },
+    {
+      "vname": "from",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 150,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 150,
+        "column": 25
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 150,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 150,
+        "column": 34
+      }
+    },
+    {
+      "vname": "new_allowed",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 150,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 150,
+        "column": 50
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 151,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 151,
+        "column": 20
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 151,
+        "column": 64
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 151,
+        "column": 71
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 151,
+        "column": 83
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 151,
+        "column": 87
+      }
+    },
+    {
+      "vname": "from",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 152,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 152,
+        "column": 34
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 152,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 152,
+        "column": 50
+      }
+    },
+    {
+      "vname": "tokens",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 152,
+        "column": 61
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 152,
+        "column": 67
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 153,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 153,
+        "column": 22
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 153,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 153,
+        "column": 27
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 153,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 153,
+        "column": 31
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 154,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 154,
+        "column": 17
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 156,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 156,
+        "column": 20
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 156,
+        "column": 64
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 156,
+        "column": 71
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 156,
+        "column": 83
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 156,
+        "column": 87
+      }
+    },
+    {
+      "vname": "from",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 157,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 157,
+        "column": 34
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 157,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 157,
+        "column": 50
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 157,
+        "column": 61
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 157,
+        "column": 65
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 158,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 158,
+        "column": 22
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 158,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 158,
+        "column": 27
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 158,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 158,
+        "column": 31
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 159,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 159,
+        "column": 17
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 162,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 162,
+        "column": 16
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 162,
+        "column": 60
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 162,
+        "column": 67
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 162,
+        "column": 79
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 162,
+        "column": 83
+      }
+    },
+    {
+      "vname": "from",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 163,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 163,
+        "column": 30
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 163,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 163,
+        "column": 46
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 163,
+        "column": 57
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 163,
+        "column": 61
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 164,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 164,
+        "column": 18
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 164,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 164,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 164,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 164,
+        "column": 27
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 165,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 165,
+        "column": 13
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 168,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 168,
+        "column": 9
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 168,
+        "column": 53
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 168,
+        "column": 60
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 168,
+        "column": 72
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 168,
+        "column": 76
+      }
+    },
+    {
+      "vname": "from",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 169,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 169,
+        "column": 26
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 169,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 169,
+        "column": 42
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 169,
+        "column": 53
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 169,
+        "column": 57
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 170,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 170,
+        "column": 14
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 170,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 170,
+        "column": 19
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 170,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 170,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 171,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 171,
+        "column": 9
+      }
+    },
+    {
+      "vname": "spender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 175,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 175,
+        "column": 28
+      }
+    },
+    {
+      "vname": "tokens",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 175,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 175,
+        "column": 46
+      }
+    },
+    {
+      "vname": "allowed",
+      "type": "Map (ByStr20) (Map (ByStr20) (Uint128))",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 176,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 176,
+        "column": 10
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 176,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 176,
+        "column": 18
+      }
+    },
+    {
+      "vname": "spender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 176,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 176,
+        "column": 27
+      }
+    },
+    {
+      "vname": "tokens",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 176,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 176,
+        "column": 38
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 177,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 177,
+        "column": 10
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 177,
+        "column": 49
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 177,
+        "column": 56
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 177,
+        "column": 68
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 177,
+        "column": 72
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 178,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 178,
+        "column": 29
+      }
+    },
+    {
+      "vname": "spender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 178,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 178,
+        "column": 48
+      }
+    },
+    {
+      "vname": "tokens",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 178,
+        "column": 59
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 178,
+        "column": 65
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 179,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 179,
+        "column": 12
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 179,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 179,
+        "column": 17
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 179,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 179,
+        "column": 21
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 180,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 180,
+        "column": 7
+      }
+    },
+    {
+      "vname": "tokenOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 183,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 183,
+        "column": 33
+      }
+    },
+    {
+      "vname": "spender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 183,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 183,
+        "column": 52
+      }
+    },
+    {
+      "vname": "spender_allowance",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 184,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 184,
+        "column": 20
+      }
+    },
+    {
+      "vname": "allowed",
+      "type": "Map (ByStr20) (Map (ByStr20) (Uint128))",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 184,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 184,
+        "column": 31
+      }
+    },
+    {
+      "vname": "tokenOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 184,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 184,
+        "column": 42
+      }
+    },
+    {
+      "vname": "spender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 184,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 184,
+        "column": 51
+      }
+    },
+    {
+      "vname": "spender_allowance",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 185,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 185,
+        "column": 26
+      }
+    },
+    {
+      "vname": "n",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 186,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 186,
+        "column": 11
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 187,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 187,
+        "column": 14
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 187,
+        "column": 56
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 187,
+        "column": 63
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 187,
+        "column": 75
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 187,
+        "column": 79
+      }
+    },
+    {
+      "vname": "tokenOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 188,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 188,
+        "column": 33
+      }
+    },
+    {
+      "vname": "spender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 188,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 188,
+        "column": 52
+      }
+    },
+    {
+      "vname": "n",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 188,
+        "column": 63
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 188,
+        "column": 64
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 189,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 189,
+        "column": 16
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 189,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 189,
+        "column": 21
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 189,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 189,
+        "column": 25
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 190,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 190,
+        "column": 11
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 192,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 192,
+        "column": 14
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 192,
+        "column": 56
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 192,
+        "column": 63
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 192,
+        "column": 75
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 192,
+        "column": 79
+      }
+    },
+    {
+      "vname": "tokenOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 193,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 193,
+        "column": 33
+      }
+    },
+    {
+      "vname": "spender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 193,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 193,
+        "column": 52
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 193,
+        "column": 63
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 193,
+        "column": 67
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 194,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 194,
+        "column": 16
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 194,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 194,
+        "column": 21
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 194,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 194,
+        "column": 25
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 195,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 195,
+        "column": 11
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "FungibleToken",

--- a/tests/checker/good/gold/helloWorld.scilla.gold
+++ b/tests/checker/good/gold/helloWorld.scilla.gold
@@ -6,6 +6,582 @@
     ],
     "ADT constructors": []
   },
+  "type_info": [
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 12,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 12,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 13,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 13,
+        "column": 6
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 14,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 14,
+        "column": 10
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 15,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 15,
+        "column": 21
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 15,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 15,
+        "column": 29
+      }
+    },
+    {
+      "vname": "not_owner_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 17,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 17,
+        "column": 19
+      }
+    },
+    {
+      "vname": "set_hello_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 18,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 18,
+        "column": 19
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 25,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 25,
+        "column": 7
+      }
+    },
+    {
+      "vname": "welcome_msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 27,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 27,
+        "column": 18
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 29,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 29,
+        "column": 25
+      }
+    },
+    {
+      "vname": "is_owner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 30,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 30,
+        "column": 20
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 30,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 30,
+        "column": 30
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 30,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 30,
+        "column": 38
+      }
+    },
+    {
+      "vname": "is_owner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 31,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 31,
+        "column": 17
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 33,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 33,
+        "column": 8
+      }
+    },
+    {
+      "vname": "not_owner_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 33,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 33,
+        "column": 58
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 34,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 34,
+        "column": 6
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 36,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 36,
+        "column": 23
+      }
+    },
+    {
+      "vname": "welcome_msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 36,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 36,
+        "column": 28
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 37,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 37,
+        "column": 8
+      }
+    },
+    {
+      "vname": "set_hello_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 37,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 37,
+        "column": 58
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 38,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 38,
+        "column": 6
+      }
+    },
+    {
+      "vname": "r",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 44,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 44,
+        "column": 8
+      }
+    },
+    {
+      "vname": "welcome_msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 44,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 44,
+        "column": 21
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 45,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 45,
+        "column": 8
+      }
+    },
+    {
+      "vname": "r",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 45,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 45,
+        "column": 42
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 46,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 46,
+        "column": 6
+      }
+    },
+    {
+      "vname": "msg1",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 50,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 50,
+        "column": 12
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 50,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 50,
+        "column": 42
+      }
+    },
+    {
+      "vname": "msg2",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 51,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 51,
+        "column": 12
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 51,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 51,
+        "column": 42
+      }
+    },
+    {
+      "vname": "msgs1",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 52,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 52,
+        "column": 14
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 52,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 52,
+        "column": 18
+      }
+    },
+    {
+      "vname": "msg1",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 52,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 52,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msgs2",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 53,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 53,
+        "column": 14
+      }
+    },
+    {
+      "vname": "msg2",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 53,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 53,
+        "column": 30
+      }
+    },
+    {
+      "vname": "msgs1",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 53,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 53,
+        "column": 36
+      }
+    },
+    {
+      "vname": "msgs2",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 54,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 54,
+        "column": 8
+      }
+    },
+    {
+      "vname": "msg1",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 58,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 58,
+        "column": 12
+      }
+    },
+    {
+      "vname": "_this_address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 58,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 58,
+        "column": 63
+      }
+    },
+    {
+      "vname": "msg1",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 59,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 59,
+        "column": 7
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "HelloWorld",

--- a/tests/checker/good/gold/inplace-map.scilla.gold
+++ b/tests/checker/good/gold/inplace-map.scilla.gold
@@ -7,6 +7,1674 @@
     ],
     "ADT constructors": []
   },
+  "type_info": [
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 8,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 8,
+        "column": 7
+      }
+    },
+    {
+      "vname": "gmap",
+      "type": "Map (String) (Int32)",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 10,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 10,
+        "column": 11
+      }
+    },
+    {
+      "vname": "gmap3",
+      "type": "Map (String) (Map (Int32) (Map (Int64) (String)))",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 11,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 11,
+        "column": 12
+      }
+    },
+    {
+      "vname": "is_owner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 14,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 14,
+        "column": 20
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 14,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 14,
+        "column": 30
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 14,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 14,
+        "column": 38
+      }
+    },
+    {
+      "vname": "is_owner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 15,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 15,
+        "column": 17
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 17,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 17,
+        "column": 12
+      }
+    },
+    {
+      "vname": "k",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 18,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 18,
+        "column": 8
+      }
+    },
+    {
+      "vname": "gmap",
+      "type": "Map (String) (Int32)",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 19,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 19,
+        "column": 9
+      }
+    },
+    {
+      "vname": "k",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 19,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 19,
+        "column": 11
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 19,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 19,
+        "column": 19
+      }
+    },
+    {
+      "vname": "k",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 21,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 21,
+        "column": 8
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Option (Int32)",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 22,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 22,
+        "column": 6
+      }
+    },
+    {
+      "vname": "gmap",
+      "type": "Map (String) (Int32)",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 22,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 22,
+        "column": 14
+      }
+    },
+    {
+      "vname": "k",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 22,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 22,
+        "column": 16
+      }
+    },
+    {
+      "vname": "j",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 23,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 23,
+        "column": 8
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Option (Int32)",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 24,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 24,
+        "column": 12
+      }
+    },
+    {
+      "vname": "tt",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 25,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 25,
+        "column": 14
+      }
+    },
+    {
+      "vname": "gmap",
+      "type": "Map (String) (Int32)",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 26,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 26,
+        "column": 11
+      }
+    },
+    {
+      "vname": "j",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 26,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 26,
+        "column": 13
+      }
+    },
+    {
+      "vname": "tt",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 26,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 26,
+        "column": 20
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 28,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 28,
+        "column": 16
+      }
+    },
+    {
+      "vname": "gmap",
+      "type": "Map (String) (Int32)",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 29,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 29,
+        "column": 11
+      }
+    },
+    {
+      "vname": "j",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 29,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 29,
+        "column": 13
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 29,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 29,
+        "column": 22
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 35,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 35,
+        "column": 6
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 36,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 36,
+        "column": 6
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Int64",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 37,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 37,
+        "column": 6
+      }
+    },
+    {
+      "vname": "gmap3",
+      "type": "Map (String) (Map (Int32) (Map (Int64) (String)))",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 38,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 38,
+        "column": 8
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 38,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 38,
+        "column": 10
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 38,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 38,
+        "column": 13
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Int64",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 38,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 38,
+        "column": 16
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 38,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 38,
+        "column": 22
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 42,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 42,
+        "column": 6
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 43,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 43,
+        "column": 6
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Int64",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 44,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 44,
+        "column": 6
+      }
+    },
+    {
+      "vname": "d",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 45,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 45,
+        "column": 4
+      }
+    },
+    {
+      "vname": "gmap3",
+      "type": "Map (String) (Map (Int32) (Map (Int64) (String)))",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 45,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 45,
+        "column": 13
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 45,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 45,
+        "column": 15
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 45,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 45,
+        "column": 18
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Int64",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 45,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 45,
+        "column": 21
+      }
+    },
+    {
+      "vname": "d",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 46,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 46,
+        "column": 10
+      }
+    },
+    {
+      "vname": "dd",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 47,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 47,
+        "column": 12
+      }
+    },
+    {
+      "vname": "gmap",
+      "type": "Map (String) (Int32)",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 48,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 48,
+        "column": 9
+      }
+    },
+    {
+      "vname": "dd",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 48,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 48,
+        "column": 12
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 48,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 48,
+        "column": 18
+      }
+    },
+    {
+      "vname": "not_found",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 50,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 50,
+        "column": 24
+      }
+    },
+    {
+      "vname": "gmap",
+      "type": "Map (String) (Int32)",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 51,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 51,
+        "column": 9
+      }
+    },
+    {
+      "vname": "not_found",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 51,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 51,
+        "column": 19
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 51,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 51,
+        "column": 25
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 56,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 56,
+        "column": 6
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 57,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 57,
+        "column": 6
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Int64",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 58,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 58,
+        "column": 6
+      }
+    },
+    {
+      "vname": "d",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 59,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 59,
+        "column": 4
+      }
+    },
+    {
+      "vname": "gmap3",
+      "type": "Map (String) (Map (Int32) (Map (Int64) (String)))",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 59,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 59,
+        "column": 13
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 59,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 59,
+        "column": 15
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 59,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 59,
+        "column": 18
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Int64",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 59,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 59,
+        "column": 21
+      }
+    },
+    {
+      "vname": "d",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 60,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 60,
+        "column": 10
+      }
+    },
+    {
+      "vname": "dd",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 61,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 61,
+        "column": 12
+      }
+    },
+    {
+      "vname": "gmap",
+      "type": "Map (String) (Int32)",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 62,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 62,
+        "column": 9
+      }
+    },
+    {
+      "vname": "dd",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 62,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 62,
+        "column": 12
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 62,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 62,
+        "column": 18
+      }
+    },
+    {
+      "vname": "not_found",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 64,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 64,
+        "column": 24
+      }
+    },
+    {
+      "vname": "gmap",
+      "type": "Map (String) (Int32)",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 65,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 65,
+        "column": 9
+      }
+    },
+    {
+      "vname": "not_found",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 65,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 65,
+        "column": 19
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 65,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 65,
+        "column": 25
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 70,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 70,
+        "column": 6
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 71,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 71,
+        "column": 6
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Int64",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 72,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 72,
+        "column": 6
+      }
+    },
+    {
+      "vname": "gmap3",
+      "type": "Map (String) (Map (Int32) (Map (Int64) (String)))",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 73,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 73,
+        "column": 15
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 73,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 73,
+        "column": 17
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 73,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 73,
+        "column": 20
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Int64",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 73,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 73,
+        "column": 23
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 77,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 77,
+        "column": 6
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 78,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 78,
+        "column": 6
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Int64",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 79,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 79,
+        "column": 6
+      }
+    },
+    {
+      "vname": "gmap3",
+      "type": "Map (String) (Map (Int32) (Map (Int64) (String)))",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 80,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 80,
+        "column": 15
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 80,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 80,
+        "column": 17
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 80,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 80,
+        "column": 20
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Int64",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 80,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 80,
+        "column": 23
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 84,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 84,
+        "column": 6
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 85,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 85,
+        "column": 6
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Int64",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 86,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 86,
+        "column": 6
+      }
+    },
+    {
+      "vname": "gmap3",
+      "type": "Map (String) (Map (Int32) (Map (Int64) (String)))",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 87,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 87,
+        "column": 15
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 87,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 87,
+        "column": 17
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 91,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 91,
+        "column": 6
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 92,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 92,
+        "column": 6
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Int64",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 93,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 93,
+        "column": 6
+      }
+    },
+    {
+      "vname": "d",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 94,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 94,
+        "column": 4
+      }
+    },
+    {
+      "vname": "gmap3",
+      "type": "Map (String) (Map (Int32) (Map (Int64) (String)))",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 94,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 94,
+        "column": 21
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 94,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 94,
+        "column": 23
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 94,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 94,
+        "column": 26
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Int64",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 94,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 94,
+        "column": 29
+      }
+    },
+    {
+      "vname": "d",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 95,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 95,
+        "column": 10
+      }
+    },
+    {
+      "vname": "ex",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 97,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 97,
+        "column": 10
+      }
+    },
+    {
+      "vname": "gmap",
+      "type": "Map (String) (Int32)",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 98,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 98,
+        "column": 9
+      }
+    },
+    {
+      "vname": "ex",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 98,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 98,
+        "column": 12
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 98,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 98,
+        "column": 18
+      }
+    },
+    {
+      "vname": "ex",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 100,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 100,
+        "column": 10
+      }
+    },
+    {
+      "vname": "gmap",
+      "type": "Map (String) (Int32)",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 101,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 101,
+        "column": 9
+      }
+    },
+    {
+      "vname": "ex",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 101,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 101,
+        "column": 12
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 101,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 101,
+        "column": 18
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 106,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 106,
+        "column": 6
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 107,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 107,
+        "column": 6
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Int64",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 108,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 108,
+        "column": 6
+      }
+    },
+    {
+      "vname": "d",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 109,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 109,
+        "column": 4
+      }
+    },
+    {
+      "vname": "gmap3",
+      "type": "Map (String) (Map (Int32) (Map (Int64) (String)))",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 109,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 109,
+        "column": 20
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 109,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 109,
+        "column": 22
+      }
+    },
+    {
+      "vname": "d",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 110,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 110,
+        "column": 10
+      }
+    },
+    {
+      "vname": "ex",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 112,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 112,
+        "column": 10
+      }
+    },
+    {
+      "vname": "gmap",
+      "type": "Map (String) (Int32)",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 113,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 113,
+        "column": 9
+      }
+    },
+    {
+      "vname": "ex",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 113,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 113,
+        "column": 12
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 113,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 113,
+        "column": 18
+      }
+    },
+    {
+      "vname": "ex",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 115,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 115,
+        "column": 10
+      }
+    },
+    {
+      "vname": "gmap",
+      "type": "Map (String) (Int32)",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 116,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 116,
+        "column": 9
+      }
+    },
+    {
+      "vname": "ex",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 116,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 116,
+        "column": 12
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 116,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 116,
+        "column": 18
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Test",

--- a/tests/checker/good/gold/map_corners_test.scilla.gold
+++ b/tests/checker/good/gold/map_corners_test.scilla.gold
@@ -9,6 +9,8072 @@
     ],
     "ADT constructors": []
   },
+  "type_info": [
+    {
+      "vname": "f_s1",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 11,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 11,
+        "column": 11
+      }
+    },
+    {
+      "vname": "f_m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 12,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 12,
+        "column": 11
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 13,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 13,
+        "column": 11
+      }
+    },
+    {
+      "vname": "f_m3",
+      "type": "Map (String) (Map (String) (Map (String) (String)))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 14,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 14,
+        "column": 11
+      }
+    },
+    {
+      "vname": "f_m",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 15,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 15,
+        "column": 10
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 17,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 17,
+        "column": 22
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Exception",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 18,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 18,
+        "column": 6
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 18,
+        "column": 49
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 18,
+        "column": 54
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Exception",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 19,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 19,
+        "column": 4
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 22,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 22,
+        "column": 26
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 22,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 22,
+        "column": 40
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Exception",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 23,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 23,
+        "column": 6
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 23,
+        "column": 49
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 23,
+        "column": 54
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 23,
+        "column": 65
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 23,
+        "column": 68
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Exception",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 24,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 24,
+        "column": 4
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 30,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 30,
+        "column": 14
+      }
+    },
+    {
+      "vname": "f",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 31,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 31,
+        "column": 6
+      }
+    },
+    {
+      "vname": "f_s1",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 31,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 31,
+        "column": 12
+      }
+    },
+    {
+      "vname": "s",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 32,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 32,
+        "column": 6
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 33,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 33,
+        "column": 6
+      }
+    },
+    {
+      "vname": "f",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 33,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 33,
+        "column": 19
+      }
+    },
+    {
+      "vname": "s",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 33,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 33,
+        "column": 21
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 34,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 34,
+        "column": 10
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 36,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 36,
+        "column": 15
+      }
+    },
+    {
+      "vname": "s2",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 41,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 41,
+        "column": 8
+      }
+    },
+    {
+      "vname": "s2",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 42,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 42,
+        "column": 13
+      }
+    },
+    {
+      "vname": "f_s1",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 42,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 42,
+        "column": 12
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 48,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 48,
+        "column": 14
+      }
+    },
+    {
+      "vname": "f",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 49,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 49,
+        "column": 6
+      }
+    },
+    {
+      "vname": "f_s1",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 49,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 49,
+        "column": 12
+      }
+    },
+    {
+      "vname": "s",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 50,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 50,
+        "column": 6
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 51,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 51,
+        "column": 6
+      }
+    },
+    {
+      "vname": "f",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 51,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 51,
+        "column": 19
+      }
+    },
+    {
+      "vname": "s",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 51,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 51,
+        "column": 21
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 52,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 52,
+        "column": 10
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 54,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 54,
+        "column": 15
+      }
+    },
+    {
+      "vname": "key1",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 59,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 59,
+        "column": 12
+      }
+    },
+    {
+      "vname": "val1",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 60,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 60,
+        "column": 12
+      }
+    },
+    {
+      "vname": "f_m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 61,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 61,
+        "column": 7
+      }
+    },
+    {
+      "vname": "key1",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 61,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 61,
+        "column": 12
+      }
+    },
+    {
+      "vname": "val1",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 61,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 61,
+        "column": 21
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 66,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 66,
+        "column": 14
+      }
+    },
+    {
+      "vname": "s",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 67,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 67,
+        "column": 6
+      }
+    },
+    {
+      "vname": "key1",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 69,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 69,
+        "column": 12
+      }
+    },
+    {
+      "vname": "val1",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 70,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 70,
+        "column": 7
+      }
+    },
+    {
+      "vname": "f_m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 70,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 70,
+        "column": 15
+      }
+    },
+    {
+      "vname": "key1",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 70,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 70,
+        "column": 20
+      }
+    },
+    {
+      "vname": "val1",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 71,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 71,
+        "column": 13
+      }
+    },
+    {
+      "vname": "val",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 72,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 72,
+        "column": 13
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 73,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 73,
+        "column": 8
+      }
+    },
+    {
+      "vname": "val",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 73,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 73,
+        "column": 23
+      }
+    },
+    {
+      "vname": "s",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 73,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 73,
+        "column": 25
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 74,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 74,
+        "column": 12
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 76,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 76,
+        "column": 10
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 77,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 77,
+        "column": 21
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 77,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 77,
+        "column": 23
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 81,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 81,
+        "column": 15
+      }
+    },
+    {
+      "vname": "key2",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 85,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 85,
+        "column": 12
+      }
+    },
+    {
+      "vname": "val2",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 86,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 86,
+        "column": 7
+      }
+    },
+    {
+      "vname": "f_m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 86,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 86,
+        "column": 15
+      }
+    },
+    {
+      "vname": "key2",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 86,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 86,
+        "column": 20
+      }
+    },
+    {
+      "vname": "val2",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 87,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 87,
+        "column": 13
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 89,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 89,
+        "column": 8
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 90,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 90,
+        "column": 19
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 90,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 90,
+        "column": 21
+      }
+    },
+    {
+      "vname": "f_m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 95,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 95,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key1",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 95,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 95,
+        "column": 19
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 100,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 100,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key1",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 103,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 103,
+        "column": 12
+      }
+    },
+    {
+      "vname": "key1_found",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 104,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 104,
+        "column": 13
+      }
+    },
+    {
+      "vname": "f_m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 104,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 104,
+        "column": 28
+      }
+    },
+    {
+      "vname": "key1",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 104,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 104,
+        "column": 33
+      }
+    },
+    {
+      "vname": "key1_found",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 105,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 105,
+        "column": 19
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 107,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 107,
+        "column": 15
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 112,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 112,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key2a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 113,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 113,
+        "column": 14
+      }
+    },
+    {
+      "vname": "s",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 114,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 114,
+        "column": 6
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 115,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 115,
+        "column": 7
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 115,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 115,
+        "column": 13
+      }
+    },
+    {
+      "vname": "key2a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 115,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 115,
+        "column": 20
+      }
+    },
+    {
+      "vname": "s",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 115,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 115,
+        "column": 26
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 120,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 120,
+        "column": 14
+      }
+    },
+    {
+      "vname": "s",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 121,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 121,
+        "column": 6
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 124,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 124,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key2a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 125,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 125,
+        "column": 14
+      }
+    },
+    {
+      "vname": "val",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 126,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 126,
+        "column": 6
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 126,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 126,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 126,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 126,
+        "column": 20
+      }
+    },
+    {
+      "vname": "key2a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 126,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 126,
+        "column": 27
+      }
+    },
+    {
+      "vname": "val",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 127,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 127,
+        "column": 12
+      }
+    },
+    {
+      "vname": "v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 128,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 128,
+        "column": 11
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 129,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 129,
+        "column": 8
+      }
+    },
+    {
+      "vname": "v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 129,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 129,
+        "column": 21
+      }
+    },
+    {
+      "vname": "s",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 129,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 129,
+        "column": 23
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 130,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 130,
+        "column": 12
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 133,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 133,
+        "column": 10
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 134,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 134,
+        "column": 21
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 134,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 134,
+        "column": 23
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 137,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 137,
+        "column": 15
+      }
+    },
+    {
+      "vname": "l_m2",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 141,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 141,
+        "column": 12
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 142,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 142,
+        "column": 6
+      }
+    },
+    {
+      "vname": "key2b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 143,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 143,
+        "column": 10
+      }
+    },
+    {
+      "vname": "s1",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 144,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 144,
+        "column": 7
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 145,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 145,
+        "column": 7
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 145,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 145,
+        "column": 27
+      }
+    },
+    {
+      "vname": "key2b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 145,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 145,
+        "column": 33
+      }
+    },
+    {
+      "vname": "s1",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 145,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 145,
+        "column": 36
+      }
+    },
+    {
+      "vname": "key2c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 146,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 146,
+        "column": 10
+      }
+    },
+    {
+      "vname": "s2",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 147,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 147,
+        "column": 7
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 148,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 148,
+        "column": 19
+      }
+    },
+    {
+      "vname": "key2c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 148,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 148,
+        "column": 25
+      }
+    },
+    {
+      "vname": "s2",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 148,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 148,
+        "column": 28
+      }
+    },
+    {
+      "vname": "key1b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 149,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 149,
+        "column": 14
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 150,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 150,
+        "column": 7
+      }
+    },
+    {
+      "vname": "key1b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 150,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 150,
+        "column": 13
+      }
+    },
+    {
+      "vname": "l_m2",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 150,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 150,
+        "column": 22
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 156,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 156,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 162,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 162,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key2a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 162,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 162,
+        "column": 31
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 163,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 163,
+        "column": 5
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 163,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 163,
+        "column": 13
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 163,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 163,
+        "column": 19
+      }
+    },
+    {
+      "vname": "key2a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 163,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 163,
+        "column": 26
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 164,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 164,
+        "column": 11
+      }
+    },
+    {
+      "vname": "c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 165,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 165,
+        "column": 11
+      }
+    },
+    {
+      "vname": "v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 166,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 166,
+        "column": 8
+      }
+    },
+    {
+      "vname": "eq",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 167,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 167,
+        "column": 10
+      }
+    },
+    {
+      "vname": "c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 167,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 167,
+        "column": 22
+      }
+    },
+    {
+      "vname": "v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 167,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 167,
+        "column": 24
+      }
+    },
+    {
+      "vname": "eq",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 168,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 168,
+        "column": 13
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 171,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 171,
+        "column": 10
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 172,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 172,
+        "column": 21
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 172,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 172,
+        "column": 23
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 175,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 175,
+        "column": 8
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 176,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 176,
+        "column": 19
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 176,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 176,
+        "column": 21
+      }
+    },
+    {
+      "vname": "key1b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 179,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 179,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key2b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 179,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 179,
+        "column": 31
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 180,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 180,
+        "column": 5
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 180,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 180,
+        "column": 13
+      }
+    },
+    {
+      "vname": "key1b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 180,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 180,
+        "column": 19
+      }
+    },
+    {
+      "vname": "key2b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 180,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 180,
+        "column": 26
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 181,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 181,
+        "column": 11
+      }
+    },
+    {
+      "vname": "c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 182,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 182,
+        "column": 11
+      }
+    },
+    {
+      "vname": "v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 183,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 183,
+        "column": 8
+      }
+    },
+    {
+      "vname": "eq",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 184,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 184,
+        "column": 10
+      }
+    },
+    {
+      "vname": "c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 184,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 184,
+        "column": 22
+      }
+    },
+    {
+      "vname": "v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 184,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 184,
+        "column": 24
+      }
+    },
+    {
+      "vname": "eq",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 185,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 185,
+        "column": 13
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 188,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 188,
+        "column": 10
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 189,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 189,
+        "column": 21
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 189,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 189,
+        "column": 23
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 192,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 192,
+        "column": 8
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 193,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 193,
+        "column": 19
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 193,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 193,
+        "column": 21
+      }
+    },
+    {
+      "vname": "key1b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 196,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 196,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key2c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 196,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 196,
+        "column": 31
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 197,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 197,
+        "column": 5
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 197,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 197,
+        "column": 13
+      }
+    },
+    {
+      "vname": "key1b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 197,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 197,
+        "column": 19
+      }
+    },
+    {
+      "vname": "key2c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 197,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 197,
+        "column": 26
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 198,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 198,
+        "column": 11
+      }
+    },
+    {
+      "vname": "c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 199,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 199,
+        "column": 11
+      }
+    },
+    {
+      "vname": "v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 200,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 200,
+        "column": 8
+      }
+    },
+    {
+      "vname": "eq",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 201,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 201,
+        "column": 10
+      }
+    },
+    {
+      "vname": "c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 201,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 201,
+        "column": 22
+      }
+    },
+    {
+      "vname": "v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 201,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 201,
+        "column": 24
+      }
+    },
+    {
+      "vname": "eq",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 202,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 202,
+        "column": 13
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 205,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 205,
+        "column": 10
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 206,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 206,
+        "column": 21
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 206,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 206,
+        "column": 23
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 209,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 209,
+        "column": 8
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 210,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 210,
+        "column": 19
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 210,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 210,
+        "column": 21
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 214,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 214,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key1b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 214,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 214,
+        "column": 20
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 220,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 220,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 224,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 224,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key2a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 224,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 224,
+        "column": 31
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 225,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 225,
+        "column": 5
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 225,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 225,
+        "column": 13
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 225,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 225,
+        "column": 19
+      }
+    },
+    {
+      "vname": "key2a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 225,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 225,
+        "column": 26
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 226,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 226,
+        "column": 11
+      }
+    },
+    {
+      "vname": "c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 227,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 227,
+        "column": 11
+      }
+    },
+    {
+      "vname": "v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 228,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 228,
+        "column": 8
+      }
+    },
+    {
+      "vname": "eq",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 229,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 229,
+        "column": 10
+      }
+    },
+    {
+      "vname": "c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 229,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 229,
+        "column": 22
+      }
+    },
+    {
+      "vname": "v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 229,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 229,
+        "column": 24
+      }
+    },
+    {
+      "vname": "eq",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 230,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 230,
+        "column": 13
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 233,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 233,
+        "column": 10
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 234,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 234,
+        "column": 21
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 234,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 234,
+        "column": 23
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 237,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 237,
+        "column": 8
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 238,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 238,
+        "column": 19
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 238,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 238,
+        "column": 21
+      }
+    },
+    {
+      "vname": "key1b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 242,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 242,
+        "column": 14
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Option (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 243,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 243,
+        "column": 5
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 243,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 243,
+        "column": 13
+      }
+    },
+    {
+      "vname": "key1b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 243,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 243,
+        "column": 19
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Option (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 244,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 244,
+        "column": 11
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 246,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 246,
+        "column": 10
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 247,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 247,
+        "column": 21
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 247,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 247,
+        "column": 23
+      }
+    },
+    {
+      "vname": "key1b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 252,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 252,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key2b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 252,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 252,
+        "column": 31
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 253,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 253,
+        "column": 5
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 253,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 253,
+        "column": 13
+      }
+    },
+    {
+      "vname": "key1b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 253,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 253,
+        "column": 19
+      }
+    },
+    {
+      "vname": "key2b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 253,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 253,
+        "column": 26
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 254,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 254,
+        "column": 11
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 256,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 256,
+        "column": 10
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 257,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 257,
+        "column": 21
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 257,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 257,
+        "column": 23
+      }
+    },
+    {
+      "vname": "key1b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 262,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 262,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key2d",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 262,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 262,
+        "column": 31
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 263,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 263,
+        "column": 5
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 263,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 263,
+        "column": 13
+      }
+    },
+    {
+      "vname": "key1b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 263,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 263,
+        "column": 19
+      }
+    },
+    {
+      "vname": "key2d",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 263,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 263,
+        "column": 26
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 264,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 264,
+        "column": 11
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 266,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 266,
+        "column": 10
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 267,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 267,
+        "column": 21
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 267,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 267,
+        "column": 23
+      }
+    },
+    {
+      "vname": "key1b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 272,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 272,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key2c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 272,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 272,
+        "column": 31
+      }
+    },
+    {
+      "vname": "s",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 273,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 273,
+        "column": 6
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 274,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 274,
+        "column": 7
+      }
+    },
+    {
+      "vname": "key1b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 274,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 274,
+        "column": 13
+      }
+    },
+    {
+      "vname": "key2c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 274,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 274,
+        "column": 20
+      }
+    },
+    {
+      "vname": "s",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 274,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 274,
+        "column": 26
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 280,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 280,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 285,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 285,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key2a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 285,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 285,
+        "column": 31
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 286,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 286,
+        "column": 5
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 286,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 286,
+        "column": 13
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 286,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 286,
+        "column": 19
+      }
+    },
+    {
+      "vname": "key2a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 286,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 286,
+        "column": 26
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 287,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 287,
+        "column": 11
+      }
+    },
+    {
+      "vname": "c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 288,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 288,
+        "column": 11
+      }
+    },
+    {
+      "vname": "v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 289,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 289,
+        "column": 8
+      }
+    },
+    {
+      "vname": "eq",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 290,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 290,
+        "column": 10
+      }
+    },
+    {
+      "vname": "c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 290,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 290,
+        "column": 22
+      }
+    },
+    {
+      "vname": "v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 290,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 290,
+        "column": 24
+      }
+    },
+    {
+      "vname": "eq",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 291,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 291,
+        "column": 13
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 294,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 294,
+        "column": 10
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 295,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 295,
+        "column": 21
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 295,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 295,
+        "column": 23
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 298,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 298,
+        "column": 8
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 299,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 299,
+        "column": 19
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 299,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 299,
+        "column": 21
+      }
+    },
+    {
+      "vname": "key1b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 302,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 302,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key2c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 302,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 302,
+        "column": 31
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 303,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 303,
+        "column": 5
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 303,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 303,
+        "column": 13
+      }
+    },
+    {
+      "vname": "key1b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 303,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 303,
+        "column": 19
+      }
+    },
+    {
+      "vname": "key2c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 303,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 303,
+        "column": 26
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 304,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 304,
+        "column": 11
+      }
+    },
+    {
+      "vname": "c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 305,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 305,
+        "column": 11
+      }
+    },
+    {
+      "vname": "v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 306,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 306,
+        "column": 8
+      }
+    },
+    {
+      "vname": "eq",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 307,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 307,
+        "column": 10
+      }
+    },
+    {
+      "vname": "c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 307,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 307,
+        "column": 22
+      }
+    },
+    {
+      "vname": "v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 307,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 307,
+        "column": 24
+      }
+    },
+    {
+      "vname": "eq",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 308,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 308,
+        "column": 13
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 311,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 311,
+        "column": 10
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 312,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 312,
+        "column": 21
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 312,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 312,
+        "column": 23
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 315,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 315,
+        "column": 8
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 316,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 316,
+        "column": 19
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 316,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 316,
+        "column": 21
+      }
+    },
+    {
+      "vname": "em",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 320,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 320,
+        "column": 8
+      }
+    },
+    {
+      "vname": "em",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 321,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 321,
+        "column": 13
+      }
+    },
+    {
+      "vname": "f_m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 321,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 321,
+        "column": 12
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 327,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 327,
+        "column": 14
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 330,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 330,
+        "column": 8
+      }
+    },
+    {
+      "vname": "f_m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 330,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 330,
+        "column": 13
+      }
+    },
+    {
+      "vname": "m1_size",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 331,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 331,
+        "column": 18
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 331,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 331,
+        "column": 28
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 332,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 332,
+        "column": 12
+      }
+    },
+    {
+      "vname": "is_empty",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 333,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 333,
+        "column": 20
+      }
+    },
+    {
+      "vname": "m1_size",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 333,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 333,
+        "column": 32
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 333,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 333,
+        "column": 37
+      }
+    },
+    {
+      "vname": "is_empty",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 334,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 334,
+        "column": 17
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 337,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 337,
+        "column": 15
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 341,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 341,
+        "column": 14
+      }
+    },
+    {
+      "vname": "val",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 342,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 342,
+        "column": 10
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 343,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 343,
+        "column": 8
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 343,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 343,
+        "column": 22
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 343,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 343,
+        "column": 28
+      }
+    },
+    {
+      "vname": "val",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 343,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 343,
+        "column": 32
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 344,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 344,
+        "column": 13
+      }
+    },
+    {
+      "vname": "f_m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 344,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 344,
+        "column": 12
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 349,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 349,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 353,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 353,
+        "column": 14
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 354,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 354,
+        "column": 8
+      }
+    },
+    {
+      "vname": "f_m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 354,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 354,
+        "column": 13
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 355,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 355,
+        "column": 8
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 355,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 355,
+        "column": 22
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 355,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 355,
+        "column": 28
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 356,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 356,
+        "column": 11
+      }
+    },
+    {
+      "vname": "c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 357,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 357,
+        "column": 11
+      }
+    },
+    {
+      "vname": "v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 358,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 358,
+        "column": 8
+      }
+    },
+    {
+      "vname": "eq",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 359,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 359,
+        "column": 10
+      }
+    },
+    {
+      "vname": "c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 359,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 359,
+        "column": 22
+      }
+    },
+    {
+      "vname": "v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 359,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 359,
+        "column": 24
+      }
+    },
+    {
+      "vname": "eq",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 360,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 360,
+        "column": 13
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 363,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 363,
+        "column": 10
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 364,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 364,
+        "column": 21
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 364,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 364,
+        "column": 23
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 367,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 367,
+        "column": 8
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 368,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 368,
+        "column": 19
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 368,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 368,
+        "column": 21
+      }
+    },
+    {
+      "vname": "f_m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 372,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 372,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 372,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 372,
+        "column": 20
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 378,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 378,
+        "column": 14
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 381,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 381,
+        "column": 8
+      }
+    },
+    {
+      "vname": "f_m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 381,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 381,
+        "column": 13
+      }
+    },
+    {
+      "vname": "m1_size",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 382,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 382,
+        "column": 18
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 382,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 382,
+        "column": 28
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 383,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 383,
+        "column": 12
+      }
+    },
+    {
+      "vname": "is_empty",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 384,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 384,
+        "column": 20
+      }
+    },
+    {
+      "vname": "m1_size",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 384,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 384,
+        "column": 32
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 384,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 384,
+        "column": 37
+      }
+    },
+    {
+      "vname": "is_empty",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 385,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 385,
+        "column": 17
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 388,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 388,
+        "column": 15
+      }
+    },
+    {
+      "vname": "e2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 392,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 392,
+        "column": 8
+      }
+    },
+    {
+      "vname": "e2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 393,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 393,
+        "column": 13
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 393,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 393,
+        "column": 12
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 398,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 398,
+        "column": 14
+      }
+    },
+    {
+      "vname": "m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 401,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 401,
+        "column": 8
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 401,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 401,
+        "column": 13
+      }
+    },
+    {
+      "vname": "m2_size",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 402,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 402,
+        "column": 18
+      }
+    },
+    {
+      "vname": "m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 402,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 402,
+        "column": 28
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 403,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 403,
+        "column": 12
+      }
+    },
+    {
+      "vname": "is_empty",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 404,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 404,
+        "column": 20
+      }
+    },
+    {
+      "vname": "m2_size",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 404,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 404,
+        "column": 32
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 404,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 404,
+        "column": 37
+      }
+    },
+    {
+      "vname": "is_empty",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 405,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 405,
+        "column": 17
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 408,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 408,
+        "column": 15
+      }
+    },
+    {
+      "vname": "e1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 412,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 412,
+        "column": 8
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 413,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 413,
+        "column": 14
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 414,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 414,
+        "column": 7
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 414,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 414,
+        "column": 13
+      }
+    },
+    {
+      "vname": "e1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 414,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 414,
+        "column": 20
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 419,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 419,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 422,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 422,
+        "column": 14
+      }
+    },
+    {
+      "vname": "mo",
+      "type": "Option (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 423,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 423,
+        "column": 5
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 423,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 423,
+        "column": 13
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 423,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 423,
+        "column": 19
+      }
+    },
+    {
+      "vname": "mo",
+      "type": "Option (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 424,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 424,
+        "column": 11
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 425,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 425,
+        "column": 11
+      }
+    },
+    {
+      "vname": "m_size",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 426,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 426,
+        "column": 18
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 426,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 426,
+        "column": 28
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 427,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 427,
+        "column": 14
+      }
+    },
+    {
+      "vname": "is_empty",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 428,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 428,
+        "column": 22
+      }
+    },
+    {
+      "vname": "m_size",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 428,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 428,
+        "column": 33
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 428,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 428,
+        "column": 38
+      }
+    },
+    {
+      "vname": "is_empty",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 429,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 429,
+        "column": 19
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 432,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 432,
+        "column": 14
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 433,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 433,
+        "column": 21
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 433,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 433,
+        "column": 25
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 436,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 436,
+        "column": 15
+      }
+    },
+    {
+      "vname": "m3",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 440,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 440,
+        "column": 8
+      }
+    },
+    {
+      "vname": "m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 441,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 441,
+        "column": 8
+      }
+    },
+    {
+      "vname": "key2a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 442,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 442,
+        "column": 10
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 443,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 443,
+        "column": 6
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 444,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 444,
+        "column": 18
+      }
+    },
+    {
+      "vname": "key2a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 444,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 444,
+        "column": 24
+      }
+    },
+    {
+      "vname": "m3",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 444,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 444,
+        "column": 27
+      }
+    },
+    {
+      "vname": "m3",
+      "type": "Map (String) (Map (String) (Map (String) (String)))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 445,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 445,
+        "column": 8
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Map (String) (Map (String) (Map (String) (String)))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 446,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 446,
+        "column": 6
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Map (String) (Map (String) (Map (String) (String)))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 447,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 447,
+        "column": 18
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 447,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 447,
+        "column": 24
+      }
+    },
+    {
+      "vname": "m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 447,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 447,
+        "column": 27
+      }
+    },
+    {
+      "vname": "m3",
+      "type": "Map (String) (Map (String) (Map (String) (String)))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 449,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 449,
+        "column": 13
+      }
+    },
+    {
+      "vname": "f_m3",
+      "type": "Map (String) (Map (String) (Map (String) (String)))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 449,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 449,
+        "column": 12
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 455,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 455,
+        "column": 14
+      }
+    },
+    {
+      "vname": "m3",
+      "type": "Map (String) (Map (String) (Map (String) (String)))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 458,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 458,
+        "column": 8
+      }
+    },
+    {
+      "vname": "f_m3",
+      "type": "Map (String) (Map (String) (Map (String) (String)))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 458,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 458,
+        "column": 13
+      }
+    },
+    {
+      "vname": "m3_size",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 459,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 459,
+        "column": 18
+      }
+    },
+    {
+      "vname": "m3",
+      "type": "Map (String) (Map (String) (Map (String) (String)))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 459,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 459,
+        "column": 28
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 460,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 460,
+        "column": 10
+      }
+    },
+    {
+      "vname": "is_empty",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 461,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 461,
+        "column": 20
+      }
+    },
+    {
+      "vname": "m3_size",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 461,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 461,
+        "column": 32
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 461,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 461,
+        "column": 36
+      }
+    },
+    {
+      "vname": "is_empty",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 462,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 462,
+        "column": 17
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 465,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 465,
+        "column": 15
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 469,
+        "column": 4
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 469,
+        "column": 5
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 470,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 470,
+        "column": 10
+      }
+    },
+    {
+      "vname": "f_m",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 470,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 470,
+        "column": 9
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 476,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 476,
+        "column": 14
+      }
+    },
+    {
+      "vname": "m3",
+      "type": "Map (String) (Map (String) (Map (String) (String)))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 479,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 479,
+        "column": 8
+      }
+    },
+    {
+      "vname": "f_m3",
+      "type": "Map (String) (Map (String) (Map (String) (String)))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 479,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 479,
+        "column": 13
+      }
+    },
+    {
+      "vname": "m3_size",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 480,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 480,
+        "column": 18
+      }
+    },
+    {
+      "vname": "m3",
+      "type": "Map (String) (Map (String) (Map (String) (String)))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 480,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 480,
+        "column": 28
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 481,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 481,
+        "column": 10
+      }
+    },
+    {
+      "vname": "is_one",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 482,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 482,
+        "column": 16
+      }
+    },
+    {
+      "vname": "m3_size",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 482,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 482,
+        "column": 30
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 482,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 482,
+        "column": 34
+      }
+    },
+    {
+      "vname": "is_one",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 483,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 483,
+        "column": 15
+      }
+    },
+    {
+      "vname": "err",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 486,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 486,
+        "column": 12
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 487,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 487,
+        "column": 19
+      }
+    },
+    {
+      "vname": "err",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 487,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 487,
+        "column": 23
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 490,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 490,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key2a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 491,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 491,
+        "column": 14
+      }
+    },
+    {
+      "vname": "m2o",
+      "type": "Option (Map (String) (Map (String) (String)))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 492,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 492,
+        "column": 10
+      }
+    },
+    {
+      "vname": "m3",
+      "type": "Map (String) (Map (String) (Map (String) (String)))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 492,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 492,
+        "column": 23
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 492,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 492,
+        "column": 29
+      }
+    },
+    {
+      "vname": "m2o",
+      "type": "Option (Map (String) (Map (String) (String)))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 493,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 493,
+        "column": 12
+      }
+    },
+    {
+      "vname": "m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 494,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 494,
+        "column": 12
+      }
+    },
+    {
+      "vname": "m2_size",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 495,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 495,
+        "column": 20
+      }
+    },
+    {
+      "vname": "m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 495,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 495,
+        "column": 30
+      }
+    },
+    {
+      "vname": "is_one",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 496,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 496,
+        "column": 18
+      }
+    },
+    {
+      "vname": "m2_size",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 496,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 496,
+        "column": 32
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 496,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 496,
+        "column": 36
+      }
+    },
+    {
+      "vname": "is_one",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 497,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 497,
+        "column": 17
+      }
+    },
+    {
+      "vname": "m1o",
+      "type": "Option (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 499,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 499,
+        "column": 14
+      }
+    },
+    {
+      "vname": "m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 499,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 499,
+        "column": 27
+      }
+    },
+    {
+      "vname": "key2a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 499,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 499,
+        "column": 33
+      }
+    },
+    {
+      "vname": "m1o",
+      "type": "Option (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 500,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 500,
+        "column": 16
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 501,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 501,
+        "column": 16
+      }
+    },
+    {
+      "vname": "m1_size",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 502,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 502,
+        "column": 24
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 502,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 502,
+        "column": 34
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 503,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 503,
+        "column": 18
+      }
+    },
+    {
+      "vname": "is_empty",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 504,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 504,
+        "column": 26
+      }
+    },
+    {
+      "vname": "m1_size",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 504,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 504,
+        "column": 38
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 504,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 504,
+        "column": 43
+      }
+    },
+    {
+      "vname": "is_empty",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 505,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 505,
+        "column": 23
+      }
+    },
+    {
+      "vname": "err",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 508,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 508,
+        "column": 18
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 509,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 509,
+        "column": 25
+      }
+    },
+    {
+      "vname": "err",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 509,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 509,
+        "column": 29
+      }
+    },
+    {
+      "vname": "err",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 512,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 512,
+        "column": 16
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 513,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 513,
+        "column": 23
+      }
+    },
+    {
+      "vname": "err",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 513,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 513,
+        "column": 27
+      }
+    },
+    {
+      "vname": "err",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 516,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 516,
+        "column": 14
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 517,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 517,
+        "column": 21
+      }
+    },
+    {
+      "vname": "err",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 517,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 517,
+        "column": 25
+      }
+    },
+    {
+      "vname": "err",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 520,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 520,
+        "column": 12
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 521,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 521,
+        "column": 19
+      }
+    },
+    {
+      "vname": "err",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 521,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 521,
+        "column": 23
+      }
+    },
+    {
+      "vname": "key1b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 525,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 525,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key2b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 525,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 525,
+        "column": 31
+      }
+    },
+    {
+      "vname": "key1c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 526,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 526,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key2c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 526,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 526,
+        "column": 31
+      }
+    },
+    {
+      "vname": "key1d",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 527,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 527,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key2d",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 527,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 527,
+        "column": 31
+      }
+    },
+    {
+      "vname": "v1",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 528,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 528,
+        "column": 8
+      }
+    },
+    {
+      "vname": "v2",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 528,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 528,
+        "column": 20
+      }
+    },
+    {
+      "vname": "v3",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 528,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 528,
+        "column": 32
+      }
+    },
+    {
+      "vname": "v4",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 528,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 528,
+        "column": 44
+      }
+    },
+    {
+      "vname": "m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 529,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 529,
+        "column": 8
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 530,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 530,
+        "column": 8
+      }
+    },
+    {
+      "vname": "m2_full",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 531,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 531,
+        "column": 18
+      }
+    },
+    {
+      "vname": "m21",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 532,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 532,
+        "column": 8
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 532,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 532,
+        "column": 29
+      }
+    },
+    {
+      "vname": "key2a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 532,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 532,
+        "column": 35
+      }
+    },
+    {
+      "vname": "v1",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 532,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 532,
+        "column": 38
+      }
+    },
+    {
+      "vname": "m22",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 533,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 533,
+        "column": 8
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 533,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 533,
+        "column": 29
+      }
+    },
+    {
+      "vname": "key2b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 533,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 533,
+        "column": 35
+      }
+    },
+    {
+      "vname": "v2",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 533,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 533,
+        "column": 38
+      }
+    },
+    {
+      "vname": "m23",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 534,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 534,
+        "column": 8
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 534,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 534,
+        "column": 29
+      }
+    },
+    {
+      "vname": "key2c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 534,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 534,
+        "column": 35
+      }
+    },
+    {
+      "vname": "v3",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 534,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 534,
+        "column": 38
+      }
+    },
+    {
+      "vname": "m24",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 535,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 535,
+        "column": 8
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 535,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 535,
+        "column": 29
+      }
+    },
+    {
+      "vname": "key2d",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 535,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 535,
+        "column": 35
+      }
+    },
+    {
+      "vname": "v4",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 535,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 535,
+        "column": 38
+      }
+    },
+    {
+      "vname": "m11",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 536,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 536,
+        "column": 8
+      }
+    },
+    {
+      "vname": "m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 536,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 536,
+        "column": 29
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 536,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 536,
+        "column": 35
+      }
+    },
+    {
+      "vname": "m21",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 536,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 536,
+        "column": 39
+      }
+    },
+    {
+      "vname": "m12",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 537,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 537,
+        "column": 8
+      }
+    },
+    {
+      "vname": "m11",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 537,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 537,
+        "column": 30
+      }
+    },
+    {
+      "vname": "key1b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 537,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 537,
+        "column": 36
+      }
+    },
+    {
+      "vname": "m22",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 537,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 537,
+        "column": 40
+      }
+    },
+    {
+      "vname": "m13",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 538,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 538,
+        "column": 8
+      }
+    },
+    {
+      "vname": "m12",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 538,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 538,
+        "column": 30
+      }
+    },
+    {
+      "vname": "key1c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 538,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 538,
+        "column": 36
+      }
+    },
+    {
+      "vname": "m23",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 538,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 538,
+        "column": 40
+      }
+    },
+    {
+      "vname": "m14",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 539,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 539,
+        "column": 8
+      }
+    },
+    {
+      "vname": "m13",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 539,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 539,
+        "column": 30
+      }
+    },
+    {
+      "vname": "key1d",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 539,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 539,
+        "column": 36
+      }
+    },
+    {
+      "vname": "m24",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 539,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 539,
+        "column": 40
+      }
+    },
+    {
+      "vname": "m14",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 540,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 540,
+        "column": 8
+      }
+    },
+    {
+      "vname": "m2_full",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 541,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 541,
+        "column": 18
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 541,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 541,
+        "column": 12
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 546,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 546,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 553,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 553,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key2a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 553,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 553,
+        "column": 31
+      }
+    },
+    {
+      "vname": "key1b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 554,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 554,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key2b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 554,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 554,
+        "column": 31
+      }
+    },
+    {
+      "vname": "key1c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 555,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 555,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key2c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 555,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 555,
+        "column": 31
+      }
+    },
+    {
+      "vname": "key1d",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 556,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 556,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key2d",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 556,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 556,
+        "column": 31
+      }
+    },
+    {
+      "vname": "t1",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 558,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 558,
+        "column": 5
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 558,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 558,
+        "column": 13
+      }
+    },
+    {
+      "vname": "key1a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 558,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 558,
+        "column": 19
+      }
+    },
+    {
+      "vname": "key2a",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 558,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 558,
+        "column": 26
+      }
+    },
+    {
+      "vname": "t2",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 559,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 559,
+        "column": 5
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 559,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 559,
+        "column": 13
+      }
+    },
+    {
+      "vname": "key1b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 559,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 559,
+        "column": 19
+      }
+    },
+    {
+      "vname": "key2b",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 559,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 559,
+        "column": 26
+      }
+    },
+    {
+      "vname": "t3",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 560,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 560,
+        "column": 5
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 560,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 560,
+        "column": 13
+      }
+    },
+    {
+      "vname": "key1c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 560,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 560,
+        "column": 19
+      }
+    },
+    {
+      "vname": "key2c",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 560,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 560,
+        "column": 26
+      }
+    },
+    {
+      "vname": "t4",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 561,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 561,
+        "column": 5
+      }
+    },
+    {
+      "vname": "f_m2",
+      "type": "Map (String) (Map (String) (String))",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 561,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 561,
+        "column": 13
+      }
+    },
+    {
+      "vname": "key1d",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 561,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 561,
+        "column": 19
+      }
+    },
+    {
+      "vname": "key2d",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 561,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 561,
+        "column": 26
+      }
+    },
+    {
+      "vname": "v1",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 562,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 562,
+        "column": 8
+      }
+    },
+    {
+      "vname": "v2",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 562,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 562,
+        "column": 20
+      }
+    },
+    {
+      "vname": "v3",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 562,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 562,
+        "column": 32
+      }
+    },
+    {
+      "vname": "v4",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 562,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 562,
+        "column": 44
+      }
+    },
+    {
+      "vname": "b1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 564,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 564,
+        "column": 8
+      }
+    },
+    {
+      "vname": "t1",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 564,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 564,
+        "column": 16
+      }
+    },
+    {
+      "vname": "t1v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 565,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 565,
+        "column": 17
+      }
+    },
+    {
+      "vname": "t1v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 566,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 566,
+        "column": 23
+      }
+    },
+    {
+      "vname": "v1",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 566,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 566,
+        "column": 26
+      }
+    },
+    {
+      "vname": "b2",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 570,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 570,
+        "column": 8
+      }
+    },
+    {
+      "vname": "t2",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 570,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 570,
+        "column": 16
+      }
+    },
+    {
+      "vname": "t2v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 571,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 571,
+        "column": 17
+      }
+    },
+    {
+      "vname": "t2v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 572,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 572,
+        "column": 23
+      }
+    },
+    {
+      "vname": "v2",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 572,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 572,
+        "column": 26
+      }
+    },
+    {
+      "vname": "b3",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 576,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 576,
+        "column": 8
+      }
+    },
+    {
+      "vname": "t3",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 576,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 576,
+        "column": 16
+      }
+    },
+    {
+      "vname": "t3v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 577,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 577,
+        "column": 17
+      }
+    },
+    {
+      "vname": "t3v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 578,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 578,
+        "column": 23
+      }
+    },
+    {
+      "vname": "v3",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 578,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 578,
+        "column": 26
+      }
+    },
+    {
+      "vname": "b4",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 582,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 582,
+        "column": 8
+      }
+    },
+    {
+      "vname": "t4",
+      "type": "Option (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 582,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 582,
+        "column": 16
+      }
+    },
+    {
+      "vname": "t4v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 583,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 583,
+        "column": 17
+      }
+    },
+    {
+      "vname": "t4v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 584,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 584,
+        "column": 23
+      }
+    },
+    {
+      "vname": "v4",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 584,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 584,
+        "column": 26
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 588,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 588,
+        "column": 6
+      }
+    },
+    {
+      "vname": "a1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 589,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 589,
+        "column": 7
+      }
+    },
+    {
+      "vname": "andb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 589,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 589,
+        "column": 18
+      }
+    },
+    {
+      "vname": "b1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 589,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 589,
+        "column": 21
+      }
+    },
+    {
+      "vname": "b2",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 589,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 589,
+        "column": 24
+      }
+    },
+    {
+      "vname": "a2",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 590,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 590,
+        "column": 7
+      }
+    },
+    {
+      "vname": "andb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 590,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 590,
+        "column": 18
+      }
+    },
+    {
+      "vname": "b3",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 590,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 590,
+        "column": 21
+      }
+    },
+    {
+      "vname": "b4",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 590,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 590,
+        "column": 24
+      }
+    },
+    {
+      "vname": "andb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 591,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 591,
+        "column": 9
+      }
+    },
+    {
+      "vname": "a1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 591,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 591,
+        "column": 12
+      }
+    },
+    {
+      "vname": "a2",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 591,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 591,
+        "column": 15
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 593,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 593,
+        "column": 10
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 596,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 596,
+        "column": 15
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 600,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 600,
+        "column": 8
+      }
+    },
+    {
+      "vname": "k",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 601,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 601,
+        "column": 6
+      }
+    },
+    {
+      "vname": "v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 602,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 602,
+        "column": 6
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 603,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 603,
+        "column": 6
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 604,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 604,
+        "column": 18
+      }
+    },
+    {
+      "vname": "k",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 604,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 604,
+        "column": 20
+      }
+    },
+    {
+      "vname": "v",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 604,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 604,
+        "column": 22
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 606,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 606,
+        "column": 13
+      }
+    },
+    {
+      "vname": "f_m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 606,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 606,
+        "column": 12
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 613,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 613,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 617,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 617,
+        "column": 10
+      }
+    },
+    {
+      "vname": "found",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 618,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 618,
+        "column": 8
+      }
+    },
+    {
+      "vname": "f_m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 618,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 618,
+        "column": 23
+      }
+    },
+    {
+      "vname": "key",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 618,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 618,
+        "column": 27
+      }
+    },
+    {
+      "vname": "found",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 619,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 619,
+        "column": 14
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 622,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 622,
+        "column": 15
+      }
+    },
+    {
+      "vname": "f_m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 626,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 626,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 626,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 626,
+        "column": 18
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 632,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 632,
+        "column": 14
+      }
+    },
+    {
+      "vname": "key",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 636,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 636,
+        "column": 10
+      }
+    },
+    {
+      "vname": "found",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 637,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 637,
+        "column": 8
+      }
+    },
+    {
+      "vname": "f_m1",
+      "type": "Map (String) (String)",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 637,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 637,
+        "column": 23
+      }
+    },
+    {
+      "vname": "key",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 637,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 637,
+        "column": 27
+      }
+    },
+    {
+      "vname": "found",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 638,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 638,
+        "column": 14
+      }
+    },
+    {
+      "vname": "tname",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 640,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 640,
+        "column": 15
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "MapCornersTest",

--- a/tests/checker/good/gold/map_key_test.scilla.gold
+++ b/tests/checker/good/gold/map_key_test.scilla.gold
@@ -5,6 +5,134 @@
       { "TestType": [ { "constructor": "T", "tags": [ "NoInfo" ] } ] }
     ]
   },
+  "type_info": [
+    {
+      "vname": "map",
+      "type": "Map (String) (TestType)",
+      "start_location": {
+        "file": "contracts/map_key_test.scilla",
+        "line": 12,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/map_key_test.scilla",
+        "line": 12,
+        "column": 10
+      }
+    },
+    {
+      "vname": "k",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_key_test.scilla",
+        "line": 13,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_key_test.scilla",
+        "line": 13,
+        "column": 6
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/map_key_test.scilla",
+        "line": 14,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_key_test.scilla",
+        "line": 14,
+        "column": 12
+      }
+    },
+    {
+      "vname": "v",
+      "type": "TestType",
+      "start_location": {
+        "file": "contracts/map_key_test.scilla",
+        "line": 15,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/map_key_test.scilla",
+        "line": 15,
+        "column": 6
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/map_key_test.scilla",
+        "line": 15,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/map_key_test.scilla",
+        "line": 15,
+        "column": 13
+      }
+    },
+    {
+      "vname": "map2",
+      "type": "Map (String) (TestType)",
+      "start_location": {
+        "file": "contracts/map_key_test.scilla",
+        "line": 16,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/map_key_test.scilla",
+        "line": 16,
+        "column": 12
+      }
+    },
+    {
+      "vname": "map",
+      "type": "Map (String) (TestType)",
+      "start_location": {
+        "file": "contracts/map_key_test.scilla",
+        "line": 16,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/map_key_test.scilla",
+        "line": 16,
+        "column": 25
+      }
+    },
+    {
+      "vname": "k",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/map_key_test.scilla",
+        "line": 16,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/map_key_test.scilla",
+        "line": 16,
+        "column": 27
+      }
+    },
+    {
+      "vname": "v",
+      "type": "TestType",
+      "start_location": {
+        "file": "contracts/map_key_test.scilla",
+        "line": 16,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/map_key_test.scilla",
+        "line": 16,
+        "column": 29
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Test",

--- a/tests/checker/good/gold/mappair.scilla.gold
+++ b/tests/checker/good/gold/mappair.scilla.gold
@@ -10,6 +10,1870 @@
     ],
     "ADT constructors": []
   },
+  "type_info": [
+    {
+      "vname": "no_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 7,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 7,
+        "column": 11
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 9,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 9,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 10,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 10,
+        "column": 6
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 11,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 11,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 12,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 12,
+        "column": 23
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 12,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 12,
+        "column": 31
+      }
+    },
+    {
+      "vname": "flip_obool",
+      "type": "Option (Bool) -> Option (Bool)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 14,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 14,
+        "column": 15
+      }
+    },
+    {
+      "vname": "ob",
+      "type": "Option (Bool)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 15,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 15,
+        "column": 5
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 16,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 16,
+        "column": 6
+      }
+    },
+    {
+      "vname": "f",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 17,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 17,
+        "column": 6
+      }
+    },
+    {
+      "vname": "ob",
+      "type": "Option (Bool)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 18,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 18,
+        "column": 13
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 19,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 19,
+        "column": 28
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 20,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 20,
+        "column": 13
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 21,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 21,
+        "column": 14
+      }
+    },
+    {
+      "vname": "f",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 22,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 22,
+        "column": 30
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 23,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 23,
+        "column": 31
+      }
+    },
+    {
+      "vname": "fst_f",
+      "type": "Pair (List (Int64)) (Option (Bool)) -> List (Int64)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 27,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 27,
+        "column": 10
+      }
+    },
+    {
+      "vname": "fst",
+      "type": "forall 'A. forall 'B. Pair ('A) ('B) -> 'A",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 27,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 27,
+        "column": 16
+      }
+    },
+    {
+      "vname": "snd_f",
+      "type": "Pair (List (Int64)) (Option (Bool)) -> Option (Bool)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 28,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 28,
+        "column": 10
+      }
+    },
+    {
+      "vname": "snd",
+      "type": "forall 'A. forall 'B. Pair ('A) ('B) -> 'B",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 28,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 28,
+        "column": 16
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 31,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 31,
+        "column": 7
+      }
+    },
+    {
+      "vname": "gmap",
+      "type": "Map (ByStr20) (Pair (Int32) (Int32))",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 33,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 33,
+        "column": 11
+      }
+    },
+    {
+      "vname": "gpair",
+      "type": "Pair (List (Int64)) (Option (Bool))",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 34,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 34,
+        "column": 12
+      }
+    },
+    {
+      "vname": "el",
+      "type": "List (Int64)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 35,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 35,
+        "column": 7
+      }
+    },
+    {
+      "vname": "n",
+      "type": "Option (Bool)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 36,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 36,
+        "column": 6
+      }
+    },
+    {
+      "vname": "el",
+      "type": "List (Int64)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 37,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 37,
+        "column": 43
+      }
+    },
+    {
+      "vname": "n",
+      "type": "Option (Bool)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 37,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 37,
+        "column": 45
+      }
+    },
+    {
+      "vname": "llist",
+      "type": "List (List (Int64))",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 39,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 39,
+        "column": 12
+      }
+    },
+    {
+      "vname": "plist",
+      "type": "List (Option (Int32))",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 40,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 40,
+        "column": 12
+      }
+    },
+    {
+      "vname": "gnat",
+      "type": "Nat",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 42,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 42,
+        "column": 11
+      }
+    },
+    {
+      "vname": "is_owner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 45,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 45,
+        "column": 20
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 45,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 45,
+        "column": 30
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 45,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 45,
+        "column": 38
+      }
+    },
+    {
+      "vname": "is_owner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 46,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 46,
+        "column": 17
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 48,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 48,
+        "column": 12
+      }
+    },
+    {
+      "vname": "two",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 49,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 49,
+        "column": 12
+      }
+    },
+    {
+      "vname": "p",
+      "type": "Pair (Int32) (Int32)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 50,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 50,
+        "column": 8
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 50,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 50,
+        "column": 35
+      }
+    },
+    {
+      "vname": "two",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 50,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 50,
+        "column": 39
+      }
+    },
+    {
+      "vname": "gmap",
+      "type": "Map (ByStr20) (Pair (Int32) (Int32))",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 51,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 51,
+        "column": 9
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 51,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 51,
+        "column": 17
+      }
+    },
+    {
+      "vname": "p",
+      "type": "Pair (Int32) (Int32)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 51,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 51,
+        "column": 23
+      }
+    },
+    {
+      "vname": "no_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 52,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 52,
+        "column": 11
+      }
+    },
+    {
+      "vname": "three",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 54,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 54,
+        "column": 16
+      }
+    },
+    {
+      "vname": "four",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 55,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 55,
+        "column": 14
+      }
+    },
+    {
+      "vname": "p",
+      "type": "Pair (Int32) (Int32)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 56,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 56,
+        "column": 8
+      }
+    },
+    {
+      "vname": "three",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 56,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 56,
+        "column": 37
+      }
+    },
+    {
+      "vname": "four",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 56,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 56,
+        "column": 42
+      }
+    },
+    {
+      "vname": "gmap",
+      "type": "Map (ByStr20) (Pair (Int32) (Int32))",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 57,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 57,
+        "column": 9
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 57,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 57,
+        "column": 17
+      }
+    },
+    {
+      "vname": "p",
+      "type": "Pair (Int32) (Int32)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 57,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 57,
+        "column": 23
+      }
+    },
+    {
+      "vname": "no_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 58,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 58,
+        "column": 11
+      }
+    },
+    {
+      "vname": "num",
+      "type": "Int64",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 62,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 62,
+        "column": 28
+      }
+    },
+    {
+      "vname": "p",
+      "type": "Pair (List (Int64)) (Option (Bool))",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 63,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 63,
+        "column": 6
+      }
+    },
+    {
+      "vname": "gpair",
+      "type": "Pair (List (Int64)) (Option (Bool))",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 63,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 63,
+        "column": 13
+      }
+    },
+    {
+      "vname": "l1",
+      "type": "List (Int64)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 65,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 65,
+        "column": 8
+      }
+    },
+    {
+      "vname": "fst_f",
+      "type": "Pair (List (Int64)) (Option (Bool)) -> List (Int64)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 65,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 65,
+        "column": 13
+      }
+    },
+    {
+      "vname": "p",
+      "type": "Pair (List (Int64)) (Option (Bool))",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 65,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 65,
+        "column": 15
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Option (Bool)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 67,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 67,
+        "column": 6
+      }
+    },
+    {
+      "vname": "snd_f",
+      "type": "Pair (List (Int64)) (Option (Bool)) -> Option (Bool)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 67,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 67,
+        "column": 12
+      }
+    },
+    {
+      "vname": "p",
+      "type": "Pair (List (Int64)) (Option (Bool))",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 67,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 67,
+        "column": 14
+      }
+    },
+    {
+      "vname": "bflip",
+      "type": "Option (Bool)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 69,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 69,
+        "column": 14
+      }
+    },
+    {
+      "vname": "flip_obool",
+      "type": "Option (Bool) -> Option (Bool)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 69,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 69,
+        "column": 21
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Option (Bool)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 69,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 69,
+        "column": 23
+      }
+    },
+    {
+      "vname": "l2",
+      "type": "List (Int64)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 71,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 71,
+        "column": 8
+      }
+    },
+    {
+      "vname": "num",
+      "type": "Int64",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 71,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 71,
+        "column": 23
+      }
+    },
+    {
+      "vname": "l1",
+      "type": "List (Int64)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 71,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 71,
+        "column": 26
+      }
+    },
+    {
+      "vname": "new_p",
+      "type": "Pair (List (Int64)) (Option (Bool))",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 73,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 73,
+        "column": 14
+      }
+    },
+    {
+      "vname": "l2",
+      "type": "List (Int64)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 73,
+        "column": 47
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 73,
+        "column": 49
+      }
+    },
+    {
+      "vname": "bflip",
+      "type": "Option (Bool)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 73,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 73,
+        "column": 55
+      }
+    },
+    {
+      "vname": "new_p",
+      "type": "Pair (List (Int64)) (Option (Bool))",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 74,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 74,
+        "column": 17
+      }
+    },
+    {
+      "vname": "gpair",
+      "type": "Pair (List (Int64)) (Option (Bool))",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 74,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 74,
+        "column": 14
+      }
+    },
+    {
+      "vname": "len",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 75,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 75,
+        "column": 10
+      }
+    },
+    {
+      "vname": "my_list_length",
+      "type": "List (Int64) -> Uint32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 75,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 75,
+        "column": 23
+      }
+    },
+    {
+      "vname": "list_length",
+      "type": "forall 'A. List ('A) -> Uint32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 75,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 75,
+        "column": 41
+      }
+    },
+    {
+      "vname": "my_list_length",
+      "type": "List (Int64) -> Uint32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 75,
+        "column": 52
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 75,
+        "column": 66
+      }
+    },
+    {
+      "vname": "l2",
+      "type": "List (Int64)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 75,
+        "column": 67
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 75,
+        "column": 69
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 76,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 76,
+        "column": 10
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 76,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 76,
+        "column": 41
+      }
+    },
+    {
+      "vname": "len",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 76,
+        "column": 77
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 76,
+        "column": 80
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 77,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 77,
+        "column": 12
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 77,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 77,
+        "column": 17
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 77,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 77,
+        "column": 21
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 78,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 78,
+        "column": 7
+      }
+    },
+    {
+      "vname": "n",
+      "type": "Nat",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 82,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 82,
+        "column": 6
+      }
+    },
+    {
+      "vname": "gnat",
+      "type": "Nat",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 82,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 82,
+        "column": 12
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Nat",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 83,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 83,
+        "column": 6
+      }
+    },
+    {
+      "vname": "n",
+      "type": "Nat",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 83,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 83,
+        "column": 13
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Nat",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 84,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 84,
+        "column": 12
+      }
+    },
+    {
+      "vname": "gnat",
+      "type": "Nat",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 84,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 84,
+        "column": 12
+      }
+    },
+    {
+      "vname": "i",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 85,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 85,
+        "column": 6
+      }
+    },
+    {
+      "vname": "nat_to_int",
+      "type": "Nat -> Uint32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 85,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 85,
+        "column": 17
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Nat",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 85,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 85,
+        "column": 19
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 86,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 86,
+        "column": 10
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 86,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 86,
+        "column": 41
+      }
+    },
+    {
+      "vname": "i",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 86,
+        "column": 70
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 86,
+        "column": 71
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 87,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 87,
+        "column": 12
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 87,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 87,
+        "column": 17
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 87,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 87,
+        "column": 21
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 88,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 88,
+        "column": 7
+      }
+    },
+    {
+      "vname": "n",
+      "type": "List (List (Int64))",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 92,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 92,
+        "column": 6
+      }
+    },
+    {
+      "vname": "llist",
+      "type": "List (List (Int64))",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 92,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 92,
+        "column": 13
+      }
+    },
+    {
+      "vname": "lfl",
+      "type": "List (List (Int64)) -> List (Int64)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 93,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 93,
+        "column": 10
+      }
+    },
+    {
+      "vname": "list_flatten",
+      "type": "forall 'A. List (List ('A)) -> List ('A)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 93,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 93,
+        "column": 21
+      }
+    },
+    {
+      "vname": "m",
+      "type": "List (Int64)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 94,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 94,
+        "column": 6
+      }
+    },
+    {
+      "vname": "lfl",
+      "type": "List (List (Int64)) -> List (Int64)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 94,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 94,
+        "column": 10
+      }
+    },
+    {
+      "vname": "n",
+      "type": "List (List (Int64))",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 94,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 94,
+        "column": 12
+      }
+    },
+    {
+      "vname": "len",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 95,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 95,
+        "column": 10
+      }
+    },
+    {
+      "vname": "my_list_length",
+      "type": "List (Int64) -> Uint32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 95,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 95,
+        "column": 23
+      }
+    },
+    {
+      "vname": "list_length",
+      "type": "forall 'A. List ('A) -> Uint32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 95,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 95,
+        "column": 41
+      }
+    },
+    {
+      "vname": "my_list_length",
+      "type": "List (Int64) -> Uint32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 95,
+        "column": 52
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 95,
+        "column": 66
+      }
+    },
+    {
+      "vname": "m",
+      "type": "List (Int64)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 95,
+        "column": 67
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 95,
+        "column": 68
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 96,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 96,
+        "column": 10
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 96,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 96,
+        "column": 41
+      }
+    },
+    {
+      "vname": "len",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 96,
+        "column": 77
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 96,
+        "column": 80
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 97,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 97,
+        "column": 12
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 97,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 97,
+        "column": 17
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 97,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 97,
+        "column": 21
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 98,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 98,
+        "column": 7
+      }
+    },
+    {
+      "vname": "n",
+      "type": "List (Option (Int32))",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 102,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 102,
+        "column": 6
+      }
+    },
+    {
+      "vname": "plist",
+      "type": "List (Option (Int32))",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 102,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 102,
+        "column": 13
+      }
+    },
+    {
+      "vname": "len",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 103,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 103,
+        "column": 10
+      }
+    },
+    {
+      "vname": "my_list_length",
+      "type": "List (Option (Int32)) -> Uint32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 103,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 103,
+        "column": 23
+      }
+    },
+    {
+      "vname": "list_length",
+      "type": "forall 'A. List ('A) -> Uint32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 103,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 103,
+        "column": 41
+      }
+    },
+    {
+      "vname": "my_list_length",
+      "type": "List (Option (Int32)) -> Uint32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 103,
+        "column": 62
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 103,
+        "column": 76
+      }
+    },
+    {
+      "vname": "n",
+      "type": "List (Option (Int32))",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 103,
+        "column": 77
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 103,
+        "column": 78
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 104,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 104,
+        "column": 10
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 104,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 104,
+        "column": 41
+      }
+    },
+    {
+      "vname": "len",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 104,
+        "column": 77
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 104,
+        "column": 80
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 105,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 105,
+        "column": 12
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 105,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 105,
+        "column": 17
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 105,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 105,
+        "column": 21
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 106,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 106,
+        "column": 7
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Test",

--- a/tests/checker/good/gold/multiple-msgs.scilla.gold
+++ b/tests/checker/good/gold/multiple-msgs.scilla.gold
@@ -1,5 +1,231 @@
 {
   "cashflow_tags": { "State variables": [], "ADT constructors": [] },
+  "type_info": [
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 12,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 12,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 13,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 13,
+        "column": 6
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 14,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 14,
+        "column": 10
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 15,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 15,
+        "column": 21
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 15,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 15,
+        "column": 29
+      }
+    },
+    {
+      "vname": "msg1",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 26,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 26,
+        "column": 12
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 26,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 26,
+        "column": 42
+      }
+    },
+    {
+      "vname": "msg2",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 27,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 27,
+        "column": 12
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 27,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 27,
+        "column": 42
+      }
+    },
+    {
+      "vname": "msgs1",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 28,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 28,
+        "column": 14
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 28,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 28,
+        "column": 18
+      }
+    },
+    {
+      "vname": "msg1",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 28,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 28,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msgs2",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 29,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 29,
+        "column": 14
+      }
+    },
+    {
+      "vname": "msg2",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 29,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 29,
+        "column": 30
+      }
+    },
+    {
+      "vname": "msgs1",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 29,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 29,
+        "column": 36
+      }
+    },
+    {
+      "vname": "msgs2",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 30,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 30,
+        "column": 8
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "HelloWorld",

--- a/tests/checker/good/gold/nonfungible-token.scilla.gold
+++ b/tests/checker/good/gold/nonfungible-token.scilla.gold
@@ -11,6 +11,4617 @@
     ],
     "ADT constructors": []
   },
+  "type_info": [
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 9,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 9,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 10,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 10,
+        "column": 6
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 11,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 11,
+        "column": 10
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 12,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 12,
+        "column": 19
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 12,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 12,
+        "column": 27
+      }
+    },
+    {
+      "vname": "checkContractOwner",
+      "type": "ByStr20 -> ByStr20 -> Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 15,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 15,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msgSender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 16,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 16,
+        "column": 14
+      }
+    },
+    {
+      "vname": "contractOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 17,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 17,
+        "column": 18
+      }
+    },
+    {
+      "vname": "msgSender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 18,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 18,
+        "column": 29
+      }
+    },
+    {
+      "vname": "contractOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 18,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 18,
+        "column": 43
+      }
+    },
+    {
+      "vname": "isTokenOwner",
+      "type": "ByStr20 -> Uint256 -> Map (Uint256) (ByStr20) -> Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 21,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 21,
+        "column": 17
+      }
+    },
+    {
+      "vname": "msgSender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 22,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 22,
+        "column": 14
+      }
+    },
+    {
+      "vname": "tokenId",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 23,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 23,
+        "column": 12
+      }
+    },
+    {
+      "vname": "tokenOwnerMap_tmp",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 24,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 24,
+        "column": 22
+      }
+    },
+    {
+      "vname": "tokenOwner",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 25,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 25,
+        "column": 19
+      }
+    },
+    {
+      "vname": "tokenOwnerMap_tmp",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 25,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 25,
+        "column": 55
+      }
+    },
+    {
+      "vname": "tokenId",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 25,
+        "column": 56
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 25,
+        "column": 63
+      }
+    },
+    {
+      "vname": "tokenOwner",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 26,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 26,
+        "column": 25
+      }
+    },
+    {
+      "vname": "val",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 28,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 28,
+        "column": 19
+      }
+    },
+    {
+      "vname": "val",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 29,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 29,
+        "column": 27
+      }
+    },
+    {
+      "vname": "msgSender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 29,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 29,
+        "column": 37
+      }
+    },
+    {
+      "vname": "isApproved",
+      "type": "ByStr20 -> Uint256 -> Map (Uint256) (ByStr20) -> Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 34,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 34,
+        "column": 15
+      }
+    },
+    {
+      "vname": "msgSender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 35,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 35,
+        "column": 14
+      }
+    },
+    {
+      "vname": "tokenID",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 36,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 36,
+        "column": 12
+      }
+    },
+    {
+      "vname": "approvalMap_tmp",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 37,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 37,
+        "column": 20
+      }
+    },
+    {
+      "vname": "val",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 38,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 38,
+        "column": 12
+      }
+    },
+    {
+      "vname": "approvalMap_tmp",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 38,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 38,
+        "column": 46
+      }
+    },
+    {
+      "vname": "tokenID",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 38,
+        "column": 47
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 38,
+        "column": 54
+      }
+    },
+    {
+      "vname": "val",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 39,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 39,
+        "column": 18
+      }
+    },
+    {
+      "vname": "val",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 41,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 41,
+        "column": 19
+      }
+    },
+    {
+      "vname": "val",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 42,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 42,
+        "column": 27
+      }
+    },
+    {
+      "vname": "msgSender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 42,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 42,
+        "column": 37
+      }
+    },
+    {
+      "vname": "isApprovedForAll",
+      "type":
+        "ByStr20 -> ByStr20 -> Map (ByStr20) (Map (ByStr20) (Bool)) -> Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 46,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 46,
+        "column": 21
+      }
+    },
+    {
+      "vname": "msgSender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 47,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 47,
+        "column": 14
+      }
+    },
+    {
+      "vname": "tokenOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 48,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 48,
+        "column": 15
+      }
+    },
+    {
+      "vname": "operatorMap",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 49,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 49,
+        "column": 16
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Option (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 50,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 50,
+        "column": 10
+      }
+    },
+    {
+      "vname": "operatorMap",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 50,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 50,
+        "column": 40
+      }
+    },
+    {
+      "vname": "tokenOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 50,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 50,
+        "column": 51
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Option (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 51,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 51,
+        "column": 16
+      }
+    },
+    {
+      "vname": "val",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 54,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 54,
+        "column": 19
+      }
+    },
+    {
+      "vname": "check_list",
+      "type": "Option (Bool)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 56,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 56,
+        "column": 23
+      }
+    },
+    {
+      "vname": "val",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 56,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 56,
+        "column": 45
+      }
+    },
+    {
+      "vname": "msgSender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 56,
+        "column": 46
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 56,
+        "column": 55
+      }
+    },
+    {
+      "vname": "check_list",
+      "type": "Option (Bool)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 57,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 57,
+        "column": 29
+      }
+    },
+    {
+      "vname": "is_sender_approved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 59,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 59,
+        "column": 38
+      }
+    },
+    {
+      "vname": "is_sender_approved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 61,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 61,
+        "column": 41
+      }
+    },
+    {
+      "vname": "isApprovedOrOwner",
+      "type": "Bool -> Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 70,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 70,
+        "column": 22
+      }
+    },
+    {
+      "vname": "isOwner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 71,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 71,
+        "column": 12
+      }
+    },
+    {
+      "vname": "isApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 72,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 72,
+        "column": 15
+      }
+    },
+    {
+      "vname": "isApprovedForAll",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 73,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 73,
+        "column": 21
+      }
+    },
+    {
+      "vname": "isOwnerOrApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 74,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 74,
+        "column": 26
+      }
+    },
+    {
+      "vname": "orb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 74,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 74,
+        "column": 37
+      }
+    },
+    {
+      "vname": "isOwner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 74,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 74,
+        "column": 45
+      }
+    },
+    {
+      "vname": "isApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 74,
+        "column": 46
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 74,
+        "column": 56
+      }
+    },
+    {
+      "vname": "orb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 75,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 75,
+        "column": 12
+      }
+    },
+    {
+      "vname": "isOwnerOrApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 75,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 75,
+        "column": 30
+      }
+    },
+    {
+      "vname": "isApprovedForAll",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 75,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 75,
+        "column": 47
+      }
+    },
+    {
+      "vname": "makeErrorEvent",
+      "type": "String -> Uint32 -> Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 78,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 78,
+        "column": 19
+      }
+    },
+    {
+      "vname": "location",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 79,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 79,
+        "column": 13
+      }
+    },
+    {
+      "vname": "errorCode",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 80,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 80,
+        "column": 14
+      }
+    },
+    {
+      "vname": "location",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 81,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 81,
+        "column": 49
+      }
+    },
+    {
+      "vname": "errorCode",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 81,
+        "column": 57
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 81,
+        "column": 66
+      }
+    },
+    {
+      "vname": "code_success",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 84,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 84,
+        "column": 17
+      }
+    },
+    {
+      "vname": "code_failure",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 85,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 85,
+        "column": 17
+      }
+    },
+    {
+      "vname": "code_not_authorized",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 86,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 86,
+        "column": 24
+      }
+    },
+    {
+      "vname": "code_not_found",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 87,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 87,
+        "column": 19
+      }
+    },
+    {
+      "vname": "code_bad_request",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 88,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 88,
+        "column": 21
+      }
+    },
+    {
+      "vname": "code_token_exists",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 89,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 89,
+        "column": 22
+      }
+    },
+    {
+      "vname": "code_unexpected_error",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 90,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 90,
+        "column": 26
+      }
+    },
+    {
+      "vname": "contractOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 98,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 98,
+        "column": 15
+      }
+    },
+    {
+      "vname": "name",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 99,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 99,
+        "column": 6
+      }
+    },
+    {
+      "vname": "symbol",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 100,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 100,
+        "column": 8
+      }
+    },
+    {
+      "vname": "tokenOwnerMap",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 106,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 106,
+        "column": 20
+      }
+    },
+    {
+      "vname": "ownedTokenCount",
+      "type": "Map (ByStr20) (Uint256)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 108,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 108,
+        "column": 22
+      }
+    },
+    {
+      "vname": "tokenApprovals",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 112,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 112,
+        "column": 21
+      }
+    },
+    {
+      "vname": "operatorApprovals",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 115,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 115,
+        "column": 24
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 121,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 121,
+        "column": 29
+      }
+    },
+    {
+      "vname": "optionBal",
+      "type": "Option (Uint256)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 122,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 122,
+        "column": 14
+      }
+    },
+    {
+      "vname": "ownedTokenCount",
+      "type": "Map (ByStr20) (Uint256)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 122,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 122,
+        "column": 33
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 122,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 122,
+        "column": 41
+      }
+    },
+    {
+      "vname": "balance",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 123,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 123,
+        "column": 20
+      }
+    },
+    {
+      "vname": "optionBal",
+      "type": "Option (Uint256)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 123,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 123,
+        "column": 30
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 124,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 124,
+        "column": 15
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 124,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 124,
+        "column": 22
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 127,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 127,
+        "column": 8
+      }
+    },
+    {
+      "vname": "balance",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 127,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 127,
+        "column": 47
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 128,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 128,
+        "column": 6
+      }
+    },
+    {
+      "vname": "tokenId",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 133,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 133,
+        "column": 27
+      }
+    },
+    {
+      "vname": "someVal",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 134,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 134,
+        "column": 12
+      }
+    },
+    {
+      "vname": "tokenOwnerMap",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 134,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 134,
+        "column": 29
+      }
+    },
+    {
+      "vname": "tokenId",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 134,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 134,
+        "column": 37
+      }
+    },
+    {
+      "vname": "someVal",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 135,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 135,
+        "column": 18
+      }
+    },
+    {
+      "vname": "val",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 136,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 136,
+        "column": 15
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 137,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 137,
+        "column": 12
+      }
+    },
+    {
+      "vname": "tokenId",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 137,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 137,
+        "column": 48
+      }
+    },
+    {
+      "vname": "val",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 137,
+        "column": 57
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 137,
+        "column": 60
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 138,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 138,
+        "column": 10
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 140,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 140,
+        "column": 12
+      }
+    },
+    {
+      "vname": "raisedAt",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 140,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 140,
+        "column": 21
+      }
+    },
+    {
+      "vname": "makeErrorEvent",
+      "type": "String -> Uint32 -> Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 140,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 140,
+        "column": 55
+      }
+    },
+    {
+      "vname": "raisedAt",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 140,
+        "column": 56
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 140,
+        "column": 64
+      }
+    },
+    {
+      "vname": "code_not_found",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 140,
+        "column": 65
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 140,
+        "column": 79
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 141,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 141,
+        "column": 10
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 149,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 149,
+        "column": 19
+      }
+    },
+    {
+      "vname": "tokenId",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 149,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 149,
+        "column": 37
+      }
+    },
+    {
+      "vname": "isAuthorized",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 152,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 152,
+        "column": 30
+      }
+    },
+    {
+      "vname": "checkContractOwner",
+      "type": "ByStr20 -> ByStr20 -> Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 152,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 152,
+        "column": 38
+      }
+    },
+    {
+      "vname": "contractOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 152,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 152,
+        "column": 52
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 152,
+        "column": 53
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 152,
+        "column": 60
+      }
+    },
+    {
+      "vname": "isAuthorized",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 153,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 153,
+        "column": 23
+      }
+    },
+    {
+      "vname": "currentTokenOwnerMap",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 155,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 155,
+        "column": 50
+      }
+    },
+    {
+      "vname": "tokenOwnerMap",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 155,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 155,
+        "column": 46
+      }
+    },
+    {
+      "vname": "tokenExist",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 157,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 157,
+        "column": 19
+      }
+    },
+    {
+      "vname": "tokenOwnerMap",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 157,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 157,
+        "column": 43
+      }
+    },
+    {
+      "vname": "tokenId",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 157,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 157,
+        "column": 51
+      }
+    },
+    {
+      "vname": "tokenExist",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 158,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 158,
+        "column": 25
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 161,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 161,
+        "column": 16
+      }
+    },
+    {
+      "vname": "raisedAt",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 161,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 161,
+        "column": 25
+      }
+    },
+    {
+      "vname": "makeErrorEvent",
+      "type": "String -> Uint32 -> Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 161,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 161,
+        "column": 56
+      }
+    },
+    {
+      "vname": "raisedAt",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 161,
+        "column": 57
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 161,
+        "column": 65
+      }
+    },
+    {
+      "vname": "code_token_exists",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 161,
+        "column": 66
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 161,
+        "column": 83
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 162,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 162,
+        "column": 14
+      }
+    },
+    {
+      "vname": "tokenOwnerMap",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 165,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 165,
+        "column": 26
+      }
+    },
+    {
+      "vname": "tokenId",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 165,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 165,
+        "column": 34
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 165,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 165,
+        "column": 41
+      }
+    },
+    {
+      "vname": "userCnt",
+      "type": "Option (Uint256)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 167,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 167,
+        "column": 20
+      }
+    },
+    {
+      "vname": "ownedTokenCount",
+      "type": "Map (ByStr20) (Uint256)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 167,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 167,
+        "column": 39
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 167,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 167,
+        "column": 42
+      }
+    },
+    {
+      "vname": "userCnt",
+      "type": "Option (Uint256)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 168,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 168,
+        "column": 26
+      }
+    },
+    {
+      "vname": "val",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 169,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 169,
+        "column": 23
+      }
+    },
+    {
+      "vname": "newVal",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 171,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 171,
+        "column": 29
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 171,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 171,
+        "column": 28
+      }
+    },
+    {
+      "vname": "val",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 171,
+        "column": 60
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 171,
+        "column": 63
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 171,
+        "column": 64
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 171,
+        "column": 67
+      }
+    },
+    {
+      "vname": "ownedTokenCount",
+      "type": "Map (ByStr20) (Uint256)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 172,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 172,
+        "column": 32
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 172,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 172,
+        "column": 35
+      }
+    },
+    {
+      "vname": "newVal",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 172,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 172,
+        "column": 46
+      }
+    },
+    {
+      "vname": "newVal",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 175,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 175,
+        "column": 30
+      }
+    },
+    {
+      "vname": "ownedTokenCount",
+      "type": "Map (ByStr20) (Uint256)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 176,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 176,
+        "column": 32
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 176,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 176,
+        "column": 35
+      }
+    },
+    {
+      "vname": "newVal",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 176,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 176,
+        "column": 46
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 180,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 180,
+        "column": 16
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 180,
+        "column": 53
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 180,
+        "column": 60
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 180,
+        "column": 73
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 180,
+        "column": 75
+      }
+    },
+    {
+      "vname": "tokenId",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 180,
+        "column": 84
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 180,
+        "column": 91
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 181,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 181,
+        "column": 14
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 185,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 185,
+        "column": 12
+      }
+    },
+    {
+      "vname": "raisedAt",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 185,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 185,
+        "column": 21
+      }
+    },
+    {
+      "vname": "makeErrorEvent",
+      "type": "String -> Uint32 -> Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 185,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 185,
+        "column": 52
+      }
+    },
+    {
+      "vname": "raisedAt",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 185,
+        "column": 53
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 185,
+        "column": 61
+      }
+    },
+    {
+      "vname": "code_not_authorized",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 185,
+        "column": 62
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 185,
+        "column": 81
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 186,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 186,
+        "column": 10
+      }
+    },
+    {
+      "vname": "from",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 196,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 196,
+        "column": 29
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 196,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 196,
+        "column": 42
+      }
+    },
+    {
+      "vname": "tokenId",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 196,
+        "column": 53
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 196,
+        "column": 60
+      }
+    },
+    {
+      "vname": "copy_tokenOwnerMap",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 197,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 197,
+        "column": 42
+      }
+    },
+    {
+      "vname": "tokenOwnerMap",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 197,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 197,
+        "column": 40
+      }
+    },
+    {
+      "vname": "copy_tokenApprovals",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 198,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 198,
+        "column": 44
+      }
+    },
+    {
+      "vname": "tokenApprovals",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 198,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 198,
+        "column": 42
+      }
+    },
+    {
+      "vname": "copy_operatorApproval",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 199,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 199,
+        "column": 48
+      }
+    },
+    {
+      "vname": "operatorApprovals",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 199,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 199,
+        "column": 47
+      }
+    },
+    {
+      "vname": "getTokenOwner",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 202,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 202,
+        "column": 18
+      }
+    },
+    {
+      "vname": "tokenOwnerMap",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 202,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 202,
+        "column": 35
+      }
+    },
+    {
+      "vname": "tokenId",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 202,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 202,
+        "column": 43
+      }
+    },
+    {
+      "vname": "getTokenOwner",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 203,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 203,
+        "column": 24
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 206,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 206,
+        "column": 12
+      }
+    },
+    {
+      "vname": "raisedAt",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 206,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 206,
+        "column": 21
+      }
+    },
+    {
+      "vname": "makeErrorEvent",
+      "type": "String -> Uint32 -> Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 206,
+        "column": 46
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 206,
+        "column": 60
+      }
+    },
+    {
+      "vname": "raisedAt",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 206,
+        "column": 61
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 206,
+        "column": 69
+      }
+    },
+    {
+      "vname": "code_not_found",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 206,
+        "column": 70
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 206,
+        "column": 84
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 207,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 207,
+        "column": 10
+      }
+    },
+    {
+      "vname": "tokenOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 209,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 209,
+        "column": 22
+      }
+    },
+    {
+      "vname": "checkOwner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 212,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 212,
+        "column": 30
+      }
+    },
+    {
+      "vname": "isTokenOwner",
+      "type": "ByStr20 -> Uint256 -> Map (Uint256) (ByStr20) -> Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 212,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 212,
+        "column": 34
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 212,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 212,
+        "column": 42
+      }
+    },
+    {
+      "vname": "tokenId",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 212,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 212,
+        "column": 50
+      }
+    },
+    {
+      "vname": "copy_tokenOwnerMap",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 212,
+        "column": 51
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 212,
+        "column": 69
+      }
+    },
+    {
+      "vname": "checkApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 213,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 213,
+        "column": 36
+      }
+    },
+    {
+      "vname": "isApproved",
+      "type": "ByStr20 -> Uint256 -> Map (Uint256) (ByStr20) -> Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 213,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 213,
+        "column": 35
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 213,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 213,
+        "column": 43
+      }
+    },
+    {
+      "vname": "tokenId",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 213,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 213,
+        "column": 51
+      }
+    },
+    {
+      "vname": "copy_tokenApprovals",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 213,
+        "column": 52
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 213,
+        "column": 71
+      }
+    },
+    {
+      "vname": "checkApprovedForAll",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 214,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 214,
+        "column": 48
+      }
+    },
+    {
+      "vname": "isApprovedForAll",
+      "type":
+        "ByStr20 -> ByStr20 -> Map (ByStr20) (Map (ByStr20) (Bool)) -> Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 214,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 214,
+        "column": 47
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 214,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 214,
+        "column": 55
+      }
+    },
+    {
+      "vname": "tokenOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 214,
+        "column": 56
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 214,
+        "column": 66
+      }
+    },
+    {
+      "vname": "copy_operatorApproval",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 214,
+        "column": 67
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 214,
+        "column": 88
+      }
+    },
+    {
+      "vname": "isFromTokenOwner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 217,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 217,
+        "column": 42
+      }
+    },
+    {
+      "vname": "tokenOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 217,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 217,
+        "column": 49
+      }
+    },
+    {
+      "vname": "from",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 217,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 217,
+        "column": 54
+      }
+    },
+    {
+      "vname": "isFromTokenOwner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 218,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 218,
+        "column": 31
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 221,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 221,
+        "column": 16
+      }
+    },
+    {
+      "vname": "raisedAt",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 221,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 221,
+        "column": 25
+      }
+    },
+    {
+      "vname": "makeErrorEvent",
+      "type": "String -> Uint32 -> Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 221,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 221,
+        "column": 64
+      }
+    },
+    {
+      "vname": "raisedAt",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 221,
+        "column": 65
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 221,
+        "column": 73
+      }
+    },
+    {
+      "vname": "code_bad_request",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 221,
+        "column": 74
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 221,
+        "column": 90
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 222,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 222,
+        "column": 14
+      }
+    },
+    {
+      "vname": "isAuthorized",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 225,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 225,
+        "column": 38
+      }
+    },
+    {
+      "vname": "isApprovedOrOwner",
+      "type": "Bool -> Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 225,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 225,
+        "column": 45
+      }
+    },
+    {
+      "vname": "checkOwner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 225,
+        "column": 46
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 225,
+        "column": 56
+      }
+    },
+    {
+      "vname": "checkApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 225,
+        "column": 57
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 225,
+        "column": 70
+      }
+    },
+    {
+      "vname": "checkApprovedForAll",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 225,
+        "column": 71
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 225,
+        "column": 90
+      }
+    },
+    {
+      "vname": "isAuthorized",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 227,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 227,
+        "column": 31
+      }
+    },
+    {
+      "vname": "checkApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 230,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 230,
+        "column": 36
+      }
+    },
+    {
+      "vname": "tokenApprovals",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 233,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 233,
+        "column": 42
+      }
+    },
+    {
+      "vname": "tokenId",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 233,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 233,
+        "column": 50
+      }
+    },
+    {
+      "vname": "tokenOwnerMap",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 238,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 238,
+        "column": 30
+      }
+    },
+    {
+      "vname": "tokenId",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 238,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 238,
+        "column": 38
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 238,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 238,
+        "column": 45
+      }
+    },
+    {
+      "vname": "curr_otc",
+      "type": "Map (ByStr20) (Uint256)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 241,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 241,
+        "column": 34
+      }
+    },
+    {
+      "vname": "ownedTokenCount",
+      "type": "Map (ByStr20) (Uint256)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 241,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 241,
+        "column": 44
+      }
+    },
+    {
+      "vname": "somePrevBal",
+      "type": "Option (Uint256)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 244,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 244,
+        "column": 28
+      }
+    },
+    {
+      "vname": "ownedTokenCount",
+      "type": "Map (ByStr20) (Uint256)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 244,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 244,
+        "column": 47
+      }
+    },
+    {
+      "vname": "from",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 244,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 244,
+        "column": 52
+      }
+    },
+    {
+      "vname": "somePrevBal",
+      "type": "Option (Uint256)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 245,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 245,
+        "column": 34
+      }
+    },
+    {
+      "vname": "prevBal",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 246,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 246,
+        "column": 31
+      }
+    },
+    {
+      "vname": "newBal",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 247,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 247,
+        "column": 35
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 247,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 247,
+        "column": 34
+      }
+    },
+    {
+      "vname": "prevBal",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 247,
+        "column": 66
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 247,
+        "column": 73
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 247,
+        "column": 74
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 247,
+        "column": 77
+      }
+    },
+    {
+      "vname": "ownedTokenCount",
+      "type": "Map (ByStr20) (Uint256)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 248,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 248,
+        "column": 36
+      }
+    },
+    {
+      "vname": "from",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 248,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 248,
+        "column": 41
+      }
+    },
+    {
+      "vname": "newBal",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 248,
+        "column": 46
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 248,
+        "column": 52
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 250,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 250,
+        "column": 24
+      }
+    },
+    {
+      "vname": "raisedAt",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 250,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 250,
+        "column": 33
+      }
+    },
+    {
+      "vname": "makeErrorEvent",
+      "type": "String -> Uint32 -> Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 250,
+        "column": 58
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 250,
+        "column": 72
+      }
+    },
+    {
+      "vname": "raisedAt",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 250,
+        "column": 73
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 250,
+        "column": 81
+      }
+    },
+    {
+      "vname": "code_unexpected_error",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 250,
+        "column": 82
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 250,
+        "column": 103
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 251,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 251,
+        "column": 22
+      }
+    },
+    {
+      "vname": "userCnt",
+      "type": "Option (Uint256)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 255,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 255,
+        "column": 24
+      }
+    },
+    {
+      "vname": "ownedTokenCount",
+      "type": "Map (ByStr20) (Uint256)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 255,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 255,
+        "column": 43
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 255,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 255,
+        "column": 46
+      }
+    },
+    {
+      "vname": "newVal",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 257,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 257,
+        "column": 30
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 257,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 257,
+        "column": 29
+      }
+    },
+    {
+      "vname": "userCnt",
+      "type": "Option (Uint256)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 257,
+        "column": 55
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 257,
+        "column": 62
+      }
+    },
+    {
+      "vname": "val",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 258,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 258,
+        "column": 27
+      }
+    },
+    {
+      "vname": "val",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 260,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 260,
+        "column": 36
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 260,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 260,
+        "column": 40
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 261,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 261,
+        "column": 30
+      }
+    },
+    {
+      "vname": "ownedTokenCount",
+      "type": "Map (ByStr20) (Uint256)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 263,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 263,
+        "column": 32
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 263,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 263,
+        "column": 35
+      }
+    },
+    {
+      "vname": "newVal",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 263,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 263,
+        "column": 46
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 264,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 264,
+        "column": 20
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 264,
+        "column": 67
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 264,
+        "column": 74
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 264,
+        "column": 87
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 264,
+        "column": 89
+      }
+    },
+    {
+      "vname": "tokenId",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 264,
+        "column": 98
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 264,
+        "column": 105
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 265,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 265,
+        "column": 18
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 268,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 268,
+        "column": 20
+      }
+    },
+    {
+      "vname": "raisedAt",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 268,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 268,
+        "column": 29
+      }
+    },
+    {
+      "vname": "makeErrorEvent",
+      "type": "String -> Uint32 -> Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 268,
+        "column": 54
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 268,
+        "column": 68
+      }
+    },
+    {
+      "vname": "raisedAt",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 268,
+        "column": 69
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 268,
+        "column": 77
+      }
+    },
+    {
+      "vname": "code_not_authorized",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 268,
+        "column": 78
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 268,
+        "column": 97
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 269,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 269,
+        "column": 18
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 282,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 282,
+        "column": 22
+      }
+    },
+    {
+      "vname": "tokenId",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 282,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 282,
+        "column": 40
+      }
+    },
+    {
+      "vname": "copy_tokenOwnerMap",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 284,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 284,
+        "column": 42
+      }
+    },
+    {
+      "vname": "tokenOwnerMap",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 284,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 284,
+        "column": 40
+      }
+    },
+    {
+      "vname": "copy_operatorApproval",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 285,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 285,
+        "column": 48
+      }
+    },
+    {
+      "vname": "operatorApprovals",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 285,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 285,
+        "column": 47
+      }
+    },
+    {
+      "vname": "getTokenOwner",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 288,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 288,
+        "column": 18
+      }
+    },
+    {
+      "vname": "tokenOwnerMap",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 288,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 288,
+        "column": 35
+      }
+    },
+    {
+      "vname": "tokenId",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 288,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 288,
+        "column": 43
+      }
+    },
+    {
+      "vname": "getTokenOwner",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 289,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 289,
+        "column": 24
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 292,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 292,
+        "column": 12
+      }
+    },
+    {
+      "vname": "raisedAt",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 292,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 292,
+        "column": 21
+      }
+    },
+    {
+      "vname": "makeErrorEvent",
+      "type": "String -> Uint32 -> Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 292,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 292,
+        "column": 55
+      }
+    },
+    {
+      "vname": "raisedAt",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 292,
+        "column": 56
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 292,
+        "column": 64
+      }
+    },
+    {
+      "vname": "code_not_found",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 292,
+        "column": 65
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 292,
+        "column": 79
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 293,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 293,
+        "column": 10
+      }
+    },
+    {
+      "vname": "tokenOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 294,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 294,
+        "column": 22
+      }
+    },
+    {
+      "vname": "checkApprovedForAll",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 295,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 295,
+        "column": 48
+      }
+    },
+    {
+      "vname": "isApprovedForAll",
+      "type":
+        "ByStr20 -> ByStr20 -> Map (ByStr20) (Map (ByStr20) (Bool)) -> Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 295,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 295,
+        "column": 47
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 295,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 295,
+        "column": 55
+      }
+    },
+    {
+      "vname": "tokenOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 295,
+        "column": 56
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 295,
+        "column": 66
+      }
+    },
+    {
+      "vname": "copy_operatorApproval",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 295,
+        "column": 67
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 295,
+        "column": 88
+      }
+    },
+    {
+      "vname": "checkOwner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 296,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 296,
+        "column": 30
+      }
+    },
+    {
+      "vname": "isTokenOwner",
+      "type": "ByStr20 -> Uint256 -> Map (Uint256) (ByStr20) -> Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 296,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 296,
+        "column": 34
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 296,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 296,
+        "column": 42
+      }
+    },
+    {
+      "vname": "tokenId",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 296,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 296,
+        "column": 50
+      }
+    },
+    {
+      "vname": "copy_tokenOwnerMap",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 296,
+        "column": 51
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 296,
+        "column": 69
+      }
+    },
+    {
+      "vname": "isAuthorized",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 297,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 297,
+        "column": 34
+      }
+    },
+    {
+      "vname": "orb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 297,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 297,
+        "column": 27
+      }
+    },
+    {
+      "vname": "checkApprovedForAll",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 297,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 297,
+        "column": 47
+      }
+    },
+    {
+      "vname": "checkOwner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 297,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 297,
+        "column": 58
+      }
+    },
+    {
+      "vname": "isAuthorized",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 298,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 298,
+        "column": 27
+      }
+    },
+    {
+      "vname": "tokenApprovals",
+      "type": "Map (Uint256) (ByStr20)",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 301,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 301,
+        "column": 27
+      }
+    },
+    {
+      "vname": "tokenId",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 301,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 301,
+        "column": 35
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 301,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 301,
+        "column": 42
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 303,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 303,
+        "column": 16
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 303,
+        "column": 58
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 303,
+        "column": 65
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 303,
+        "column": 79
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 303,
+        "column": 81
+      }
+    },
+    {
+      "vname": "tokenId",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 303,
+        "column": 90
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 303,
+        "column": 97
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 304,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 304,
+        "column": 14
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 307,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 307,
+        "column": 16
+      }
+    },
+    {
+      "vname": "raisedAt",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 307,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 307,
+        "column": 25
+      }
+    },
+    {
+      "vname": "makeErrorEvent",
+      "type": "String -> Uint32 -> Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 307,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 307,
+        "column": 59
+      }
+    },
+    {
+      "vname": "raisedAt",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 307,
+        "column": 60
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 307,
+        "column": 68
+      }
+    },
+    {
+      "vname": "code_not_authorized",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 307,
+        "column": 69
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 307,
+        "column": 88
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 308,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 308,
+        "column": 14
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 317,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 317,
+        "column": 32
+      }
+    },
+    {
+      "vname": "approved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 317,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 317,
+        "column": 51
+      }
+    },
+    {
+      "vname": "copy_operatorApproval",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 319,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 319,
+        "column": 48
+      }
+    },
+    {
+      "vname": "operatorApprovals",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 319,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 319,
+        "column": 47
+      }
+    },
+    {
+      "vname": "isValidOperation",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 321,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 321,
+        "column": 38
+      }
+    },
+    {
+      "vname": "check",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 321,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 321,
+        "column": 29
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 321,
+        "column": 47
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 321,
+        "column": 54
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 321,
+        "column": 55
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 321,
+        "column": 57
+      }
+    },
+    {
+      "vname": "negb",
+      "type": "Bool -> Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 321,
+        "column": 61
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 321,
+        "column": 65
+      }
+    },
+    {
+      "vname": "check",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 321,
+        "column": 66
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 321,
+        "column": 71
+      }
+    },
+    {
+      "vname": "isValidOperation",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 323,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 323,
+        "column": 27
+      }
+    },
+    {
+      "vname": "operatorApprovals",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 326,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 326,
+        "column": 26
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 326,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 326,
+        "column": 34
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 326,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 326,
+        "column": 38
+      }
+    },
+    {
+      "vname": "approved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 326,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 326,
+        "column": 51
+      }
+    },
+    {
+      "vname": "approvedStr",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 328,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 328,
+        "column": 32
+      }
+    },
+    {
+      "vname": "bool_to_string",
+      "type": "Bool -> String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 328,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 328,
+        "column": 37
+      }
+    },
+    {
+      "vname": "approved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 328,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 328,
+        "column": 46
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 329,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 329,
+        "column": 12
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 329,
+        "column": 64
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 329,
+        "column": 71
+      }
+    },
+    {
+      "vname": "to",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 329,
+        "column": 84
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 329,
+        "column": 86
+      }
+    },
+    {
+      "vname": "approvedStr",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 329,
+        "column": 96
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 329,
+        "column": 107
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 330,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 330,
+        "column": 10
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 332,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 332,
+        "column": 12
+      }
+    },
+    {
+      "vname": "raisedAt",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 332,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 332,
+        "column": 21
+      }
+    },
+    {
+      "vname": "makeErrorEvent",
+      "type": "String -> Uint32 -> Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 332,
+        "column": 51
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 332,
+        "column": 65
+      }
+    },
+    {
+      "vname": "raisedAt",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 332,
+        "column": 66
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 332,
+        "column": 74
+      }
+    },
+    {
+      "vname": "code_not_authorized",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 332,
+        "column": 75
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 332,
+        "column": 94
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 333,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 333,
+        "column": 10
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "NonfungibleToken",

--- a/tests/checker/good/gold/one-msg.scilla.gold
+++ b/tests/checker/good/gold/one-msg.scilla.gold
@@ -1,5 +1,273 @@
 {
   "cashflow_tags": { "State variables": [], "ADT constructors": [] },
+  "type_info": [
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 12,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 12,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 13,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 13,
+        "column": 6
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 14,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 14,
+        "column": 10
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 15,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 15,
+        "column": 21
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 15,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 15,
+        "column": 29
+      }
+    },
+    {
+      "vname": "msg1",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 26,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 26,
+        "column": 12
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 26,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 26,
+        "column": 42
+      }
+    },
+    {
+      "vname": "msg2",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 27,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 27,
+        "column": 12
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 27,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 27,
+        "column": 42
+      }
+    },
+    {
+      "vname": "msgs1",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 28,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 28,
+        "column": 14
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 28,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 28,
+        "column": 18
+      }
+    },
+    {
+      "vname": "msg1",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 28,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 28,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msgs2",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 29,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 29,
+        "column": 14
+      }
+    },
+    {
+      "vname": "msg2",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 29,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 29,
+        "column": 30
+      }
+    },
+    {
+      "vname": "msgs1",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 29,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 29,
+        "column": 36
+      }
+    },
+    {
+      "vname": "msgs2",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 30,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 30,
+        "column": 14
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 31,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 31,
+        "column": 14
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 32,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 32,
+        "column": 7
+      }
+    },
+    {
+      "vname": "msgs1",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 34,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 34,
+        "column": 10
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "HelloWorld",

--- a/tests/checker/good/gold/one-msg1.scilla.gold
+++ b/tests/checker/good/gold/one-msg1.scilla.gold
@@ -1,5 +1,315 @@
 {
   "cashflow_tags": { "State variables": [], "ADT constructors": [] },
+  "type_info": [
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 12,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 12,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 13,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 13,
+        "column": 6
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 14,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 14,
+        "column": 10
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 15,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 15,
+        "column": 21
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 15,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 15,
+        "column": 29
+      }
+    },
+    {
+      "vname": "msg1",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 27,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 27,
+        "column": 12
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 27,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 27,
+        "column": 42
+      }
+    },
+    {
+      "vname": "msg2",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 28,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 28,
+        "column": 12
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 28,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 28,
+        "column": 42
+      }
+    },
+    {
+      "vname": "msgs1",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 29,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 29,
+        "column": 14
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 29,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 29,
+        "column": 18
+      }
+    },
+    {
+      "vname": "msg1",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 29,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 29,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msgs2",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 30,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 30,
+        "column": 14
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 30,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 30,
+        "column": 18
+      }
+    },
+    {
+      "vname": "msg2",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 30,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 30,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msgs2",
+      "type": "Pair (List (Message)) (List (Message))",
+      "start_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 31,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 31,
+        "column": 14
+      }
+    },
+    {
+      "vname": "msgs1",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 31,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 31,
+        "column": 53
+      }
+    },
+    {
+      "vname": "msgs2",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 31,
+        "column": 54
+      },
+      "end_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 31,
+        "column": 59
+      }
+    },
+    {
+      "vname": "msgs2",
+      "type": "Pair (List (Message)) (List (Message))",
+      "start_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 32,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 32,
+        "column": 14
+      }
+    },
+    {
+      "vname": "m2",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 33,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 33,
+        "column": 15
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 33,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 33,
+        "column": 12
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 34,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 34,
+        "column": 7
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "HelloWorld",

--- a/tests/checker/good/gold/ping.scilla.gold
+++ b/tests/checker/good/gold/ping.scilla.gold
@@ -6,6 +6,568 @@
     ],
     "ADT constructors": []
   },
+  "type_info": [
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 5,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 5,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 6,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 6,
+        "column": 6
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 7,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 7,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 8,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 8,
+        "column": 25
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 8,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 8,
+        "column": 33
+      }
+    },
+    {
+      "vname": "count",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 19,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 19,
+        "column": 12
+      }
+    },
+    {
+      "vname": "pong_addr",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 20,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 20,
+        "column": 16
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 23,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 23,
+        "column": 10
+      }
+    },
+    {
+      "vname": "paOpt",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 24,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 24,
+        "column": 14
+      }
+    },
+    {
+      "vname": "pong_addr",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 24,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 24,
+        "column": 21
+      }
+    },
+    {
+      "vname": "paOpt",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 25,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 25,
+        "column": 14
+      }
+    },
+    {
+      "vname": "pongAddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 26,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 26,
+        "column": 18
+      }
+    },
+    {
+      "vname": "cnt",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 27,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 27,
+        "column": 12
+      }
+    },
+    {
+      "vname": "count",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 27,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 27,
+        "column": 17
+      }
+    },
+    {
+      "vname": "is_game_over",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 28,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 28,
+        "column": 30
+      }
+    },
+    {
+      "vname": "cnt",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 28,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 28,
+        "column": 34
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 28,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 28,
+        "column": 38
+      }
+    },
+    {
+      "vname": "is_game_over",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 29,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 29,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 31,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 31,
+        "column": 14
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 32,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 32,
+        "column": 10
+      }
+    },
+    {
+      "vname": "deccount",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 34,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 34,
+        "column": 24
+      }
+    },
+    {
+      "vname": "cnt",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 34,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 34,
+        "column": 33
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 34,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 34,
+        "column": 37
+      }
+    },
+    {
+      "vname": "deccount",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 35,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 35,
+        "column": 24
+      }
+    },
+    {
+      "vname": "count",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 35,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 35,
+        "column": 18
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 36,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 36,
+        "column": 14
+      }
+    },
+    {
+      "vname": "pongAddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 36,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 36,
+        "column": 50
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 37,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 37,
+        "column": 16
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 37,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 37,
+        "column": 21
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 37,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 37,
+        "column": 25
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 38,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 38,
+        "column": 11
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 39,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 39,
+        "column": 10
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 40,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 40,
+        "column": 8
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 43,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 43,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 44,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 44,
+        "column": 8
+      }
+    },
+    {
+      "vname": "pongAddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 48,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 48,
+        "column": 33
+      }
+    },
+    {
+      "vname": "paOpt",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 49,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 49,
+        "column": 14
+      }
+    },
+    {
+      "vname": "pongAddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 49,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 49,
+        "column": 34
+      }
+    },
+    {
+      "vname": "paOpt",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 50,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 50,
+        "column": 21
+      }
+    },
+    {
+      "vname": "pong_addr",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 50,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/ping.scilla",
+        "line": 50,
+        "column": 22
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Ping",

--- a/tests/checker/good/gold/pong.scilla.gold
+++ b/tests/checker/good/gold/pong.scilla.gold
@@ -6,6 +6,568 @@
     ],
     "ADT constructors": []
   },
+  "type_info": [
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 5,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 5,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 6,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 6,
+        "column": 6
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 7,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 7,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 8,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 8,
+        "column": 25
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 8,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 8,
+        "column": 33
+      }
+    },
+    {
+      "vname": "count",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 19,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 19,
+        "column": 12
+      }
+    },
+    {
+      "vname": "ping_addr",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 20,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 20,
+        "column": 16
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 23,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 23,
+        "column": 10
+      }
+    },
+    {
+      "vname": "paOpt",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 24,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 24,
+        "column": 14
+      }
+    },
+    {
+      "vname": "ping_addr",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 24,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 24,
+        "column": 21
+      }
+    },
+    {
+      "vname": "paOpt",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 25,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 25,
+        "column": 14
+      }
+    },
+    {
+      "vname": "pingAddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 26,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 26,
+        "column": 18
+      }
+    },
+    {
+      "vname": "cnt",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 27,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 27,
+        "column": 12
+      }
+    },
+    {
+      "vname": "count",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 27,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 27,
+        "column": 17
+      }
+    },
+    {
+      "vname": "is_game_over",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 28,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 28,
+        "column": 30
+      }
+    },
+    {
+      "vname": "cnt",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 28,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 28,
+        "column": 34
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 28,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 28,
+        "column": 38
+      }
+    },
+    {
+      "vname": "is_game_over",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 29,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 29,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 31,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 31,
+        "column": 14
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 32,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 32,
+        "column": 10
+      }
+    },
+    {
+      "vname": "deccount",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 34,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 34,
+        "column": 24
+      }
+    },
+    {
+      "vname": "cnt",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 34,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 34,
+        "column": 33
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 34,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 34,
+        "column": 37
+      }
+    },
+    {
+      "vname": "deccount",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 35,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 35,
+        "column": 24
+      }
+    },
+    {
+      "vname": "count",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 35,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 35,
+        "column": 18
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 36,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 36,
+        "column": 14
+      }
+    },
+    {
+      "vname": "pingAddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 36,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 36,
+        "column": 50
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 37,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 37,
+        "column": 16
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 37,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 37,
+        "column": 21
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 37,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 37,
+        "column": 25
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 38,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 38,
+        "column": 11
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 39,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 39,
+        "column": 10
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 40,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 40,
+        "column": 8
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 43,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 43,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 44,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 44,
+        "column": 8
+      }
+    },
+    {
+      "vname": "pingAddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 48,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 48,
+        "column": 33
+      }
+    },
+    {
+      "vname": "paOpt",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 49,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 49,
+        "column": 14
+      }
+    },
+    {
+      "vname": "pingAddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 49,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 49,
+        "column": 34
+      }
+    },
+    {
+      "vname": "paOpt",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 50,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 50,
+        "column": 21
+      }
+    },
+    {
+      "vname": "ping_addr",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 50,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/pong.scilla",
+        "line": 50,
+        "column": 22
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Pong",

--- a/tests/checker/good/gold/schnorr.scilla.gold
+++ b/tests/checker/good/gold/schnorr.scilla.gold
@@ -3,6 +3,554 @@
     "State variables": [ { "field": "pub_key", "tag": "(Option NotMoney)" } ],
     "ADT constructors": []
   },
+  "type_info": [
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 7,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 7,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 8,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 8,
+        "column": 6
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 9,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 9,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 10,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 10,
+        "column": 23
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 10,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 10,
+        "column": 31
+      }
+    },
+    {
+      "vname": "fst_f",
+      "type": "Pair (ByStr32) (ByStr33) -> ByStr32",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 12,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 12,
+        "column": 10
+      }
+    },
+    {
+      "vname": "fst",
+      "type": "forall 'A. forall 'B. Pair ('A) ('B) -> 'A",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 12,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 12,
+        "column": 16
+      }
+    },
+    {
+      "vname": "snd_f",
+      "type": "Pair (ByStr32) (ByStr33) -> ByStr33",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 13,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 13,
+        "column": 10
+      }
+    },
+    {
+      "vname": "snd",
+      "type": "forall 'A. forall 'B. Pair ('A) ('B) -> 'B",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 13,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 13,
+        "column": 16
+      }
+    },
+    {
+      "vname": "pub_key",
+      "type": "Option (ByStr33)",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 18,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 18,
+        "column": 14
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "ByStr",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 20,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 20,
+        "column": 22
+      }
+    },
+    {
+      "vname": "sig",
+      "type": "ByStr64",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 20,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 20,
+        "column": 35
+      }
+    },
+    {
+      "vname": "pubk_o",
+      "type": "Option (ByStr33)",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 21,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 21,
+        "column": 16
+      }
+    },
+    {
+      "vname": "pub_key",
+      "type": "Option (ByStr33)",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 21,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 21,
+        "column": 20
+      }
+    },
+    {
+      "vname": "pubk_o",
+      "type": "Option (ByStr33)",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 22,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 22,
+        "column": 15
+      }
+    },
+    {
+      "vname": "pubk",
+      "type": "ByStr33",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 23,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 23,
+        "column": 14
+      }
+    },
+    {
+      "vname": "sig",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 24,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 24,
+        "column": 12
+      }
+    },
+    {
+      "vname": "pubk",
+      "type": "ByStr33",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 24,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 24,
+        "column": 38
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "ByStr",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 24,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 24,
+        "column": 42
+      }
+    },
+    {
+      "vname": "sig",
+      "type": "ByStr64",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 24,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 24,
+        "column": 46
+      }
+    },
+    {
+      "vname": "sig",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 25,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 25,
+        "column": 14
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 27,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 27,
+        "column": 10
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 27,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 27,
+        "column": 44
+      }
+    },
+    {
+      "vname": "mone",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 28,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 28,
+        "column": 16
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 28,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 28,
+        "column": 21
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 28,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 28,
+        "column": 23
+      }
+    },
+    {
+      "vname": "mone",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 29,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 29,
+        "column": 11
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 31,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 31,
+        "column": 10
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 31,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 31,
+        "column": 44
+      }
+    },
+    {
+      "vname": "mone",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 32,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 32,
+        "column": 16
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 32,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 32,
+        "column": 21
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 32,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 32,
+        "column": 23
+      }
+    },
+    {
+      "vname": "mone",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 33,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 33,
+        "column": 11
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 37,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 37,
+        "column": 8
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 37,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 37,
+        "column": 42
+      }
+    },
+    {
+      "vname": "mone",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 38,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 38,
+        "column": 14
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 38,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 38,
+        "column": 19
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 38,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 38,
+        "column": 21
+      }
+    },
+    {
+      "vname": "mone",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 39,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 39,
+        "column": 9
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Schnorr",

--- a/tests/checker/good/gold/simple-dex.scilla.gold
+++ b/tests/checker/good/gold/simple-dex.scilla.gold
@@ -17,6 +17,4044 @@
       }
     ]
   },
+  "type_info": [
+    {
+      "vname": "getAddressFromPair",
+      "type": "Pair (ByStr20) (Uint128) -> ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 12,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 12,
+        "column": 23
+      }
+    },
+    {
+      "vname": "fst",
+      "type": "forall 'A. forall 'B. Pair ('A) ('B) -> 'A",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 12,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 12,
+        "column": 29
+      }
+    },
+    {
+      "vname": "getValueFromPair",
+      "type": "Pair (ByStr20) (Uint128) -> Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 13,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 13,
+        "column": 21
+      }
+    },
+    {
+      "vname": "snd",
+      "type": "forall 'A. forall 'B. Pair ('A) ('B) -> 'B",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 13,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 13,
+        "column": 27
+      }
+    },
+    {
+      "vname": "make_error_event",
+      "type": "String -> String -> Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 16,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 16,
+        "column": 21
+      }
+    },
+    {
+      "vname": "location",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 17,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 17,
+        "column": 11
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 18,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 18,
+        "column": 6
+      }
+    },
+    {
+      "vname": "location",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 19,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 19,
+        "column": 48
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 19,
+        "column": 59
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 19,
+        "column": 62
+      }
+    },
+    {
+      "vname": "createOrderId",
+      "type": "Order -> ByStr32",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 26,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 26,
+        "column": 18
+      }
+    },
+    {
+      "vname": "order",
+      "type": "Order",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 27,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 27,
+        "column": 8
+      }
+    },
+    {
+      "vname": "order",
+      "type": "Order",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 28,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 28,
+        "column": 29
+      }
+    },
+    {
+      "vname": "transaction_msg",
+      "type": "ByStr20 -> String -> ByStr20 -> ByStr20 -> Uint128 -> Message",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 31,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 31,
+        "column": 20
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 32,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 32,
+        "column": 12
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 33,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 33,
+        "column": 6
+      }
+    },
+    {
+      "vname": "transferFromAddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 34,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 34,
+        "column": 19
+      }
+    },
+    {
+      "vname": "transferToAddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 35,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 35,
+        "column": 17
+      }
+    },
+    {
+      "vname": "transferAmt",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 36,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 36,
+        "column": 14
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 37,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 37,
+        "column": 16
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 37,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 37,
+        "column": 40
+      }
+    },
+    {
+      "vname": "transferFromAddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 38,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 38,
+        "column": 28
+      }
+    },
+    {
+      "vname": "transferToAddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 38,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 38,
+        "column": 48
+      }
+    },
+    {
+      "vname": "transferAmt",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 38,
+        "column": 58
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 38,
+        "column": 69
+      }
+    },
+    {
+      "vname": "transaction_msg_as_list",
+      "type":
+        "ByStr20 -> String -> ByStr20 -> ByStr20 -> Uint128 -> List (Message)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 41,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 41,
+        "column": 28
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 42,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 42,
+        "column": 12
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 43,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 43,
+        "column": 6
+      }
+    },
+    {
+      "vname": "transferFromAddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 44,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 44,
+        "column": 19
+      }
+    },
+    {
+      "vname": "transferToAddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 45,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 45,
+        "column": 17
+      }
+    },
+    {
+      "vname": "transferAmt",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 46,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 46,
+        "column": 14
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 47,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 47,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 48,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 48,
+        "column": 10
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 49,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 49,
+        "column": 16
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 50,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 50,
+        "column": 27
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 50,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 50,
+        "column": 35
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 51,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 51,
+        "column": 8
+      }
+    },
+    {
+      "vname": "transaction_msg",
+      "type": "ByStr20 -> String -> ByStr20 -> ByStr20 -> Uint128 -> Message",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 51,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 51,
+        "column": 30
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 51,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 51,
+        "column": 40
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 51,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 51,
+        "column": 44
+      }
+    },
+    {
+      "vname": "transferFromAddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 51,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 51,
+        "column": 61
+      }
+    },
+    {
+      "vname": "transferToAddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 51,
+        "column": 62
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 51,
+        "column": 76
+      }
+    },
+    {
+      "vname": "transferAmt",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 51,
+        "column": 77
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 51,
+        "column": 88
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 52,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 52,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 52,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 52,
+        "column": 16
+      }
+    },
+    {
+      "vname": "computePendingReturnsVal",
+      "type": "Option (Uint128) -> Uint128 -> Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 57,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 57,
+        "column": 29
+      }
+    },
+    {
+      "vname": "prevVal",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 58,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 58,
+        "column": 10
+      }
+    },
+    {
+      "vname": "incomingTokensAmt",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 59,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 59,
+        "column": 20
+      }
+    },
+    {
+      "vname": "prevVal",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 60,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 60,
+        "column": 18
+      }
+    },
+    {
+      "vname": "v",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 61,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 61,
+        "column": 13
+      }
+    },
+    {
+      "vname": "v",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 62,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 62,
+        "column": 20
+      }
+    },
+    {
+      "vname": "incomingTokensAmt",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 62,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 62,
+        "column": 38
+      }
+    },
+    {
+      "vname": "incomingTokensAmt",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 64,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 64,
+        "column": 24
+      }
+    },
+    {
+      "vname": "contractOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 72,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 72,
+        "column": 15
+      }
+    },
+    {
+      "vname": "orderbook",
+      "type": "Map (ByStr32) (Order)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 79,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 79,
+        "column": 16
+      }
+    },
+    {
+      "vname": "orderInfo",
+      "type": "Map (ByStr32) (Pair (ByStr20) (BNum))",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 82,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 82,
+        "column": 16
+      }
+    },
+    {
+      "vname": "pendingReturns",
+      "type": "Map (ByStr20) (Map (ByStr20) (Uint128))",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 86,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 86,
+        "column": 21
+      }
+    },
+    {
+      "vname": "tokenA",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 89,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 89,
+        "column": 28
+      }
+    },
+    {
+      "vname": "valueA",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 89,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 89,
+        "column": 45
+      }
+    },
+    {
+      "vname": "tokenB",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 89,
+        "column": 56
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 89,
+        "column": 62
+      }
+    },
+    {
+      "vname": "valueB",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 89,
+        "column": 73
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 89,
+        "column": 79
+      }
+    },
+    {
+      "vname": "expirationBlock",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 89,
+        "column": 90
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 89,
+        "column": 105
+      }
+    },
+    {
+      "vname": "currentBlock",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 90,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 90,
+        "column": 28
+      }
+    },
+    {
+      "vname": "validExpirationBlock",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 91,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 91,
+        "column": 44
+      }
+    },
+    {
+      "vname": "minBlocksFromCreation",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 91,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 91,
+        "column": 48
+      }
+    },
+    {
+      "vname": "minExpiration",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 92,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 92,
+        "column": 40
+      }
+    },
+    {
+      "vname": "currentBlock",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 92,
+        "column": 60
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 92,
+        "column": 72
+      }
+    },
+    {
+      "vname": "minBlocksFromCreation",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 92,
+        "column": 73
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 92,
+        "column": 94
+      }
+    },
+    {
+      "vname": "minExpiration",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 93,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 93,
+        "column": 52
+      }
+    },
+    {
+      "vname": "expirationBlock",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 93,
+        "column": 53
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 93,
+        "column": 68
+      }
+    },
+    {
+      "vname": "validExpirationBlock",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 94,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 94,
+        "column": 29
+      }
+    },
+    {
+      "vname": "newOrder",
+      "type": "Order",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 97,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 97,
+        "column": 22
+      }
+    },
+    {
+      "vname": "tokenA",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 97,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 97,
+        "column": 28
+      }
+    },
+    {
+      "vname": "valueA",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 97,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 97,
+        "column": 35
+      }
+    },
+    {
+      "vname": "tokenB",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 97,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 97,
+        "column": 42
+      }
+    },
+    {
+      "vname": "valueB",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 97,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 97,
+        "column": 49
+      }
+    },
+    {
+      "vname": "orderId",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 98,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 98,
+        "column": 20
+      }
+    },
+    {
+      "vname": "createOrderId",
+      "type": "Order -> ByStr32",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 98,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 98,
+        "column": 28
+      }
+    },
+    {
+      "vname": "newOrder",
+      "type": "Order",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 98,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 98,
+        "column": 37
+      }
+    },
+    {
+      "vname": "orderbook",
+      "type": "Map (ByStr32) (Order)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 99,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 99,
+        "column": 14
+      }
+    },
+    {
+      "vname": "orderId",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 99,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 99,
+        "column": 22
+      }
+    },
+    {
+      "vname": "newOrder",
+      "type": "Order",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 99,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 99,
+        "column": 35
+      }
+    },
+    {
+      "vname": "p",
+      "type": "Pair (ByStr20) (BNum)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 102,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 102,
+        "column": 8
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 102,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 102,
+        "column": 40
+      }
+    },
+    {
+      "vname": "expirationBlock",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 102,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 102,
+        "column": 56
+      }
+    },
+    {
+      "vname": "orderInfo",
+      "type": "Map (ByStr32) (Pair (ByStr20) (BNum))",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 103,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 103,
+        "column": 14
+      }
+    },
+    {
+      "vname": "orderId",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 103,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 103,
+        "column": 22
+      }
+    },
+    {
+      "vname": "p",
+      "type": "Pair (ByStr20) (BNum)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 103,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 103,
+        "column": 28
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 105,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 105,
+        "column": 8
+      }
+    },
+    {
+      "vname": "orderId",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 105,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 105,
+        "column": 52
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 106,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 106,
+        "column": 6
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 109,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 109,
+        "column": 14
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 109,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 109,
+        "column": 15
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 110,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 110,
+        "column": 16
+      }
+    },
+    {
+      "vname": "transaction_msg_as_list",
+      "type":
+        "ByStr20 -> String -> ByStr20 -> ByStr20 -> Uint128 -> List (Message)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 111,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 111,
+        "column": 35
+      }
+    },
+    {
+      "vname": "tokenA",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 111,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 111,
+        "column": 42
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 111,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 111,
+        "column": 46
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 111,
+        "column": 47
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 111,
+        "column": 54
+      }
+    },
+    {
+      "vname": "_this_address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 111,
+        "column": 55
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 111,
+        "column": 68
+      }
+    },
+    {
+      "vname": "valueA",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 111,
+        "column": 69
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 111,
+        "column": 75
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 112,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 112,
+        "column": 9
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 114,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 114,
+        "column": 8
+      }
+    },
+    {
+      "vname": "func",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 114,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 114,
+        "column": 13
+      }
+    },
+    {
+      "vname": "error_msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 115,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 115,
+        "column": 18
+      }
+    },
+    {
+      "vname": "make_error_event",
+      "type": "String -> String -> Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 116,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 116,
+        "column": 25
+      }
+    },
+    {
+      "vname": "func",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 116,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 116,
+        "column": 30
+      }
+    },
+    {
+      "vname": "error_msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 116,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 116,
+        "column": 40
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 117,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 117,
+        "column": 6
+      }
+    },
+    {
+      "vname": "orderId",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 123,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 123,
+        "column": 29
+      }
+    },
+    {
+      "vname": "getOrder",
+      "type": "Option (Order)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 124,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 124,
+        "column": 11
+      }
+    },
+    {
+      "vname": "orderbook",
+      "type": "Map (ByStr32) (Order)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 124,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 124,
+        "column": 24
+      }
+    },
+    {
+      "vname": "orderId",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 124,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 124,
+        "column": 32
+      }
+    },
+    {
+      "vname": "getOrder",
+      "type": "Option (Order)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 125,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 125,
+        "column": 17
+      }
+    },
+    {
+      "vname": "valueB",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 126,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 126,
+        "column": 44
+      }
+    },
+    {
+      "vname": "tokenB",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 126,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 126,
+        "column": 37
+      }
+    },
+    {
+      "vname": "valueA",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 126,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 126,
+        "column": 30
+      }
+    },
+    {
+      "vname": "tokenA",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 126,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 126,
+        "column": 23
+      }
+    },
+    {
+      "vname": "optionOrderInfo",
+      "type": "Option (Pair (ByStr20) (BNum))",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 128,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 128,
+        "column": 20
+      }
+    },
+    {
+      "vname": "orderInfo",
+      "type": "Map (ByStr32) (Pair (ByStr20) (BNum))",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 128,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 128,
+        "column": 33
+      }
+    },
+    {
+      "vname": "orderId",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 128,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 128,
+        "column": 41
+      }
+    },
+    {
+      "vname": "optionOrderInfo",
+      "type": "Option (Pair (ByStr20) (BNum))",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 129,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 129,
+        "column": 26
+      }
+    },
+    {
+      "vname": "info",
+      "type": "Pair (ByStr20) (BNum)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 130,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 130,
+        "column": 16
+      }
+    },
+    {
+      "vname": "currentBlock",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 131,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 131,
+        "column": 32
+      }
+    },
+    {
+      "vname": "blockBeforeExpiration",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 132,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 132,
+        "column": 50
+      }
+    },
+    {
+      "vname": "getBNum",
+      "type": "Pair (ByStr20) (BNum) -> BNum",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 132,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 132,
+        "column": 38
+      }
+    },
+    {
+      "vname": "snd",
+      "type": "forall 'A. forall 'B. Pair ('A) ('B) -> 'B",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 132,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 132,
+        "column": 48
+      }
+    },
+    {
+      "vname": "expirationBlock",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 133,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 133,
+        "column": 46
+      }
+    },
+    {
+      "vname": "getBNum",
+      "type": "Pair (ByStr20) (BNum) -> BNum",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 133,
+        "column": 53
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 133,
+        "column": 60
+      }
+    },
+    {
+      "vname": "info",
+      "type": "Pair (ByStr20) (BNum)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 133,
+        "column": 61
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 133,
+        "column": 65
+      }
+    },
+    {
+      "vname": "currentBlock",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 134,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 134,
+        "column": 55
+      }
+    },
+    {
+      "vname": "expirationBlock",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 134,
+        "column": 56
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 134,
+        "column": 71
+      }
+    },
+    {
+      "vname": "blockBeforeExpiration",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 135,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 135,
+        "column": 34
+      }
+    },
+    {
+      "vname": "makerAddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 137,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 137,
+        "column": 28
+      }
+    },
+    {
+      "vname": "getMakerAddr",
+      "type": "Pair (ByStr20) (BNum) -> ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 137,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 137,
+        "column": 33
+      }
+    },
+    {
+      "vname": "fst",
+      "type": "forall 'A. forall 'B. Pair ('A) ('B) -> 'A",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 137,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 137,
+        "column": 43
+      }
+    },
+    {
+      "vname": "getMakerAddr",
+      "type": "Pair (ByStr20) (BNum) -> ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 138,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 138,
+        "column": 33
+      }
+    },
+    {
+      "vname": "info",
+      "type": "Pair (ByStr20) (BNum)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 138,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 138,
+        "column": 38
+      }
+    },
+    {
+      "vname": "prevVal",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 140,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 140,
+        "column": 16
+      }
+    },
+    {
+      "vname": "pendingReturns",
+      "type": "Map (ByStr20) (Map (ByStr20) (Uint128))",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 140,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 140,
+        "column": 34
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 140,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 140,
+        "column": 42
+      }
+    },
+    {
+      "vname": "tokenA",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 140,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 140,
+        "column": 50
+      }
+    },
+    {
+      "vname": "takerAmt",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 141,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 141,
+        "column": 26
+      }
+    },
+    {
+      "vname": "computePendingReturnsVal",
+      "type": "Option (Uint128) -> Uint128 -> Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 141,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 141,
+        "column": 44
+      }
+    },
+    {
+      "vname": "prevVal",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 141,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 141,
+        "column": 52
+      }
+    },
+    {
+      "vname": "valueA",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 141,
+        "column": 53
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 141,
+        "column": 59
+      }
+    },
+    {
+      "vname": "pendingReturns",
+      "type": "Map (ByStr20) (Map (ByStr20) (Uint128))",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 142,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 142,
+        "column": 23
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 142,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 142,
+        "column": 31
+      }
+    },
+    {
+      "vname": "tokenA",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 142,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 142,
+        "column": 39
+      }
+    },
+    {
+      "vname": "takerAmt",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 142,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 142,
+        "column": 52
+      }
+    },
+    {
+      "vname": "prevVal",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 144,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 144,
+        "column": 16
+      }
+    },
+    {
+      "vname": "pendingReturns",
+      "type": "Map (ByStr20) (Map (ByStr20) (Uint128))",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 144,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 144,
+        "column": 34
+      }
+    },
+    {
+      "vname": "makerAddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 144,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 144,
+        "column": 44
+      }
+    },
+    {
+      "vname": "tokenB",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 144,
+        "column": 46
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 144,
+        "column": 52
+      }
+    },
+    {
+      "vname": "makerAmt",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 145,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 145,
+        "column": 26
+      }
+    },
+    {
+      "vname": "computePendingReturnsVal",
+      "type": "Option (Uint128) -> Uint128 -> Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 145,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 145,
+        "column": 44
+      }
+    },
+    {
+      "vname": "prevVal",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 145,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 145,
+        "column": 52
+      }
+    },
+    {
+      "vname": "valueB",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 145,
+        "column": 53
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 145,
+        "column": 59
+      }
+    },
+    {
+      "vname": "pendingReturns",
+      "type": "Map (ByStr20) (Map (ByStr20) (Uint128))",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 146,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 146,
+        "column": 23
+      }
+    },
+    {
+      "vname": "makerAddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 146,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 146,
+        "column": 33
+      }
+    },
+    {
+      "vname": "tokenB",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 146,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 146,
+        "column": 41
+      }
+    },
+    {
+      "vname": "makerAmt",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 146,
+        "column": 46
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 146,
+        "column": 54
+      }
+    },
+    {
+      "vname": "orderInfo",
+      "type": "Map (ByStr32) (Pair (ByStr20) (BNum))",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 149,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 149,
+        "column": 25
+      }
+    },
+    {
+      "vname": "orderId",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 149,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 149,
+        "column": 33
+      }
+    },
+    {
+      "vname": "orderbook",
+      "type": "Map (ByStr32) (Order)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 150,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 150,
+        "column": 25
+      }
+    },
+    {
+      "vname": "orderId",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 150,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 150,
+        "column": 33
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 152,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 152,
+        "column": 12
+      }
+    },
+    {
+      "vname": "orderId",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 152,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 152,
+        "column": 55
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 153,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 153,
+        "column": 10
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 155,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 155,
+        "column": 18
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 155,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 155,
+        "column": 19
+      }
+    },
+    {
+      "vname": "transaction_msg_as_list",
+      "type":
+        "ByStr20 -> String -> ByStr20 -> ByStr20 -> Uint128 -> List (Message)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 156,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 156,
+        "column": 39
+      }
+    },
+    {
+      "vname": "tokenB",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 156,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 156,
+        "column": 46
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 156,
+        "column": 47
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 156,
+        "column": 50
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 156,
+        "column": 51
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 156,
+        "column": 58
+      }
+    },
+    {
+      "vname": "_this_address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 156,
+        "column": 59
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 156,
+        "column": 72
+      }
+    },
+    {
+      "vname": "valueB",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 156,
+        "column": 73
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 156,
+        "column": 79
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 157,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 157,
+        "column": 13
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 159,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 159,
+        "column": 12
+      }
+    },
+    {
+      "vname": "func",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 159,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 159,
+        "column": 17
+      }
+    },
+    {
+      "vname": "error_msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 160,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 160,
+        "column": 22
+      }
+    },
+    {
+      "vname": "make_error_event",
+      "type": "String -> String -> Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 161,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 161,
+        "column": 29
+      }
+    },
+    {
+      "vname": "func",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 161,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 161,
+        "column": 34
+      }
+    },
+    {
+      "vname": "error_msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 161,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 161,
+        "column": 44
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 162,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 162,
+        "column": 10
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 165,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 165,
+        "column": 10
+      }
+    },
+    {
+      "vname": "func",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 165,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 165,
+        "column": 15
+      }
+    },
+    {
+      "vname": "error_msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 166,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 166,
+        "column": 20
+      }
+    },
+    {
+      "vname": "make_error_event",
+      "type": "String -> String -> Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 167,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 167,
+        "column": 27
+      }
+    },
+    {
+      "vname": "func",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 167,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 167,
+        "column": 32
+      }
+    },
+    {
+      "vname": "error_msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 167,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 167,
+        "column": 42
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 168,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 168,
+        "column": 8
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 171,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 171,
+        "column": 8
+      }
+    },
+    {
+      "vname": "func",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 171,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 171,
+        "column": 13
+      }
+    },
+    {
+      "vname": "error_msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 172,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 172,
+        "column": 18
+      }
+    },
+    {
+      "vname": "make_error_event",
+      "type": "String -> String -> Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 173,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 173,
+        "column": 25
+      }
+    },
+    {
+      "vname": "func",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 173,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 173,
+        "column": 30
+      }
+    },
+    {
+      "vname": "error_msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 173,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 173,
+        "column": 40
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 174,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 174,
+        "column": 6
+      }
+    },
+    {
+      "vname": "token",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 180,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 180,
+        "column": 27
+      }
+    },
+    {
+      "vname": "getAmtOutstanding",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 181,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 181,
+        "column": 20
+      }
+    },
+    {
+      "vname": "pendingReturns",
+      "type": "Map (ByStr20) (Map (ByStr20) (Uint128))",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 181,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 181,
+        "column": 38
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 181,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 181,
+        "column": 46
+      }
+    },
+    {
+      "vname": "token",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 181,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 181,
+        "column": 53
+      }
+    },
+    {
+      "vname": "getAmtOutstanding",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 182,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 182,
+        "column": 26
+      }
+    },
+    {
+      "vname": "amtOutstanding",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 183,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 183,
+        "column": 24
+      }
+    },
+    {
+      "vname": "pendingReturns",
+      "type": "Map (ByStr20) (Map (ByStr20) (Uint128))",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 184,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 184,
+        "column": 28
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 184,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 184,
+        "column": 36
+      }
+    },
+    {
+      "vname": "token",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 184,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 184,
+        "column": 43
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 185,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 185,
+        "column": 10
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 185,
+        "column": 56
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 185,
+        "column": 63
+      }
+    },
+    {
+      "vname": "token",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 185,
+        "column": 76
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 185,
+        "column": 81
+      }
+    },
+    {
+      "vname": "amtOutstanding",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 185,
+        "column": 88
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 185,
+        "column": 102
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 186,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 186,
+        "column": 8
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 188,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 188,
+        "column": 16
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 188,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 188,
+        "column": 17
+      }
+    },
+    {
+      "vname": "transaction_msg_as_list",
+      "type":
+        "ByStr20 -> String -> ByStr20 -> ByStr20 -> Uint128 -> List (Message)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 189,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 189,
+        "column": 37
+      }
+    },
+    {
+      "vname": "token",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 189,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 189,
+        "column": 43
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 189,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 189,
+        "column": 47
+      }
+    },
+    {
+      "vname": "_this_address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 189,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 189,
+        "column": 61
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 189,
+        "column": 62
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 189,
+        "column": 69
+      }
+    },
+    {
+      "vname": "amtOutstanding",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 189,
+        "column": 70
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 189,
+        "column": 84
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 190,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 190,
+        "column": 11
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 192,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 192,
+        "column": 10
+      }
+    },
+    {
+      "vname": "func",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 192,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 192,
+        "column": 15
+      }
+    },
+    {
+      "vname": "error_msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 193,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 193,
+        "column": 20
+      }
+    },
+    {
+      "vname": "make_error_event",
+      "type": "String -> String -> Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 194,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 194,
+        "column": 27
+      }
+    },
+    {
+      "vname": "func",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 194,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 194,
+        "column": 32
+      }
+    },
+    {
+      "vname": "error_msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 194,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 194,
+        "column": 42
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 195,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 195,
+        "column": 8
+      }
+    },
+    {
+      "vname": "orderId",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 201,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 201,
+        "column": 31
+      }
+    },
+    {
+      "vname": "getOrderInfo",
+      "type": "Option (Pair (ByStr20) (BNum))",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 202,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 202,
+        "column": 15
+      }
+    },
+    {
+      "vname": "orderInfo",
+      "type": "Map (ByStr32) (Pair (ByStr20) (BNum))",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 202,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 202,
+        "column": 28
+      }
+    },
+    {
+      "vname": "orderId",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 202,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 202,
+        "column": 36
+      }
+    },
+    {
+      "vname": "getOrderInfo",
+      "type": "Option (Pair (ByStr20) (BNum))",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 203,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 203,
+        "column": 21
+      }
+    },
+    {
+      "vname": "orderInfoForId",
+      "type": "Pair (ByStr20) (BNum)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 204,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 204,
+        "column": 24
+      }
+    },
+    {
+      "vname": "makerAddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 205,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 205,
+        "column": 26
+      }
+    },
+    {
+      "vname": "getMakerAddr",
+      "type": "Pair (ByStr20) (BNum) -> ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 205,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 205,
+        "column": 31
+      }
+    },
+    {
+      "vname": "fst",
+      "type": "forall 'A. forall 'B. Pair ('A) ('B) -> 'A",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 205,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 205,
+        "column": 41
+      }
+    },
+    {
+      "vname": "getMakerAddr",
+      "type": "Pair (ByStr20) (BNum) -> ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 206,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 206,
+        "column": 31
+      }
+    },
+    {
+      "vname": "orderInfoForId",
+      "type": "Pair (ByStr20) (BNum)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 206,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 206,
+        "column": 46
+      }
+    },
+    {
+      "vname": "checkSender",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 207,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 207,
+        "column": 30
+      }
+    },
+    {
+      "vname": "makerAddr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 207,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 207,
+        "column": 41
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 207,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 207,
+        "column": 49
+      }
+    },
+    {
+      "vname": "checkSender",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 208,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 208,
+        "column": 24
+      }
+    },
+    {
+      "vname": "fetchOrder",
+      "type": "Option (Order)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 211,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 211,
+        "column": 19
+      }
+    },
+    {
+      "vname": "orderbook",
+      "type": "Map (ByStr32) (Order)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 211,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 211,
+        "column": 32
+      }
+    },
+    {
+      "vname": "orderId",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 211,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 211,
+        "column": 40
+      }
+    },
+    {
+      "vname": "fetchOrder",
+      "type": "Option (Order)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 212,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 212,
+        "column": 25
+      }
+    },
+    {
+      "vname": "valueA",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 213,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 213,
+        "column": 36
+      }
+    },
+    {
+      "vname": "tokenA",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 213,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 213,
+        "column": 29
+      }
+    },
+    {
+      "vname": "prevVal",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 216,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 216,
+        "column": 18
+      }
+    },
+    {
+      "vname": "pendingReturns",
+      "type": "Map (ByStr20) (Map (ByStr20) (Uint128))",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 216,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 216,
+        "column": 36
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 216,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 216,
+        "column": 44
+      }
+    },
+    {
+      "vname": "tokenA",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 216,
+        "column": 46
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 216,
+        "column": 52
+      }
+    },
+    {
+      "vname": "takerAmt",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 217,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 217,
+        "column": 28
+      }
+    },
+    {
+      "vname": "computePendingReturnsVal",
+      "type": "Option (Uint128) -> Uint128 -> Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 217,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 217,
+        "column": 46
+      }
+    },
+    {
+      "vname": "prevVal",
+      "type": "Option (Uint128)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 217,
+        "column": 47
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 217,
+        "column": 54
+      }
+    },
+    {
+      "vname": "valueA",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 217,
+        "column": 55
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 217,
+        "column": 61
+      }
+    },
+    {
+      "vname": "pendingReturns",
+      "type": "Map (ByStr20) (Map (ByStr20) (Uint128))",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 218,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 218,
+        "column": 25
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 218,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 218,
+        "column": 33
+      }
+    },
+    {
+      "vname": "tokenA",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 218,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 218,
+        "column": 41
+      }
+    },
+    {
+      "vname": "takerAmt",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 218,
+        "column": 46
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 218,
+        "column": 54
+      }
+    },
+    {
+      "vname": "orderInfo",
+      "type": "Map (ByStr32) (Pair (ByStr20) (BNum))",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 221,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 221,
+        "column": 27
+      }
+    },
+    {
+      "vname": "orderId",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 221,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 221,
+        "column": 35
+      }
+    },
+    {
+      "vname": "orderbook",
+      "type": "Map (ByStr32) (Order)",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 222,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 222,
+        "column": 27
+      }
+    },
+    {
+      "vname": "orderId",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 222,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 222,
+        "column": 35
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 224,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 224,
+        "column": 14
+      }
+    },
+    {
+      "vname": "orderId",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 224,
+        "column": 61
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 224,
+        "column": 68
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 225,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 225,
+        "column": 12
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 229,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 229,
+        "column": 14
+      }
+    },
+    {
+      "vname": "func",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 229,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 229,
+        "column": 19
+      }
+    },
+    {
+      "vname": "error_msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 230,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 230,
+        "column": 24
+      }
+    },
+    {
+      "vname": "make_error_event",
+      "type": "String -> String -> Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 231,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 231,
+        "column": 31
+      }
+    },
+    {
+      "vname": "func",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 231,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 231,
+        "column": 36
+      }
+    },
+    {
+      "vname": "error_msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 231,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 231,
+        "column": 46
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 232,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 232,
+        "column": 12
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 237,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 237,
+        "column": 12
+      }
+    },
+    {
+      "vname": "func",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 237,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 237,
+        "column": 17
+      }
+    },
+    {
+      "vname": "error_msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 238,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 238,
+        "column": 22
+      }
+    },
+    {
+      "vname": "make_error_event",
+      "type": "String -> String -> Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 239,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 239,
+        "column": 29
+      }
+    },
+    {
+      "vname": "func",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 239,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 239,
+        "column": 34
+      }
+    },
+    {
+      "vname": "error_msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 239,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 239,
+        "column": 44
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 240,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 240,
+        "column": 10
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 244,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 244,
+        "column": 10
+      }
+    },
+    {
+      "vname": "func",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 244,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 244,
+        "column": 15
+      }
+    },
+    {
+      "vname": "error_msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 245,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 245,
+        "column": 20
+      }
+    },
+    {
+      "vname": "make_error_event",
+      "type": "String -> String -> Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 246,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 246,
+        "column": 27
+      }
+    },
+    {
+      "vname": "func",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 246,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 246,
+        "column": 32
+      }
+    },
+    {
+      "vname": "error_msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 246,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 246,
+        "column": 42
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 247,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 247,
+        "column": 8
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "SimpleDex",

--- a/tests/checker/good/gold/ud-proxy.scilla.gold
+++ b/tests/checker/good/gold/ud-proxy.scilla.gold
@@ -7,6 +7,834 @@
     ],
     "ADT constructors": []
   },
+  "type_info": [
+    {
+      "vname": "true",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 7,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 7,
+        "column": 9
+      }
+    },
+    {
+      "vname": "nilMessage",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 8,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 8,
+        "column": 15
+      }
+    },
+    {
+      "vname": "oneMsg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 10,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 10,
+        "column": 11
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 11,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 11,
+        "column": 6
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 12,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 12,
+        "column": 23
+      }
+    },
+    {
+      "vname": "nilMessage",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 12,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 12,
+        "column": 34
+      }
+    },
+    {
+      "vname": "eAdminSet",
+      "type": "ByStr20 -> Bool -> Event",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 14,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 14,
+        "column": 14
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 15,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 15,
+        "column": 10
+      }
+    },
+    {
+      "vname": "isApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 16,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 16,
+        "column": 13
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 17,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 17,
+        "column": 46
+      }
+    },
+    {
+      "vname": "isApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 17,
+        "column": 60
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 17,
+        "column": 70
+      }
+    },
+    {
+      "vname": "eError",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 19,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 19,
+        "column": 11
+      }
+    },
+    {
+      "vname": "initialAdmin",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 23,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 23,
+        "column": 14
+      }
+    },
+    {
+      "vname": "registry",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 23,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 23,
+        "column": 33
+      }
+    },
+    {
+      "vname": "admins",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 25,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 25,
+        "column": 13
+      }
+    },
+    {
+      "vname": "empty",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 26,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 26,
+        "column": 8
+      }
+    },
+    {
+      "vname": "empty",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 27,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 27,
+        "column": 22
+      }
+    },
+    {
+      "vname": "initialAdmin",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 27,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 27,
+        "column": 35
+      }
+    },
+    {
+      "vname": "true",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 27,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 27,
+        "column": 40
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 29,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 29,
+        "column": 28
+      }
+    },
+    {
+      "vname": "isApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 29,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 29,
+        "column": 49
+      }
+    },
+    {
+      "vname": "maybeAdmin",
+      "type": "Option (Bool)",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 30,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 30,
+        "column": 13
+      }
+    },
+    {
+      "vname": "admins",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 30,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 30,
+        "column": 23
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 30,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 30,
+        "column": 31
+      }
+    },
+    {
+      "vname": "isSenderAdmin",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 32,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 32,
+        "column": 30
+      }
+    },
+    {
+      "vname": "maybeAdmin",
+      "type": "Option (Bool)",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 33,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 33,
+        "column": 21
+      }
+    },
+    {
+      "vname": "approval",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 34,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 34,
+        "column": 20
+      }
+    },
+    {
+      "vname": "approval",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 34,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 34,
+        "column": 32
+      }
+    },
+    {
+      "vname": "isSenderAdmin",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 38,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 38,
+        "column": 22
+      }
+    },
+    {
+      "vname": "admins",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 40,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 40,
+        "column": 11
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 40,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 40,
+        "column": 19
+      }
+    },
+    {
+      "vname": "isApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 40,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 40,
+        "column": 34
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 42,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 42,
+        "column": 8
+      }
+    },
+    {
+      "vname": "eAdminSet",
+      "type": "ByStr20 -> Bool -> Event",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 42,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 42,
+        "column": 18
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 42,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 42,
+        "column": 26
+      }
+    },
+    {
+      "vname": "isApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 42,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 42,
+        "column": 37
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 43,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 43,
+        "column": 6
+      }
+    },
+    {
+      "vname": "eError",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 45,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 45,
+        "column": 11
+      }
+    },
+    {
+      "vname": "label",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 49,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 49,
+        "column": 24
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 49,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 49,
+        "column": 39
+      }
+    },
+    {
+      "vname": "resolver",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 49,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 49,
+        "column": 58
+      }
+    },
+    {
+      "vname": "maybeAdmin",
+      "type": "Option (Bool)",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 50,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 50,
+        "column": 13
+      }
+    },
+    {
+      "vname": "admins",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 50,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 50,
+        "column": 23
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 50,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 50,
+        "column": 31
+      }
+    },
+    {
+      "vname": "isSenderAdmin",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 52,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 52,
+        "column": 30
+      }
+    },
+    {
+      "vname": "maybeAdmin",
+      "type": "Option (Bool)",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 53,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 53,
+        "column": 21
+      }
+    },
+    {
+      "vname": "isAdmin",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 54,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 54,
+        "column": 19
+      }
+    },
+    {
+      "vname": "isAdmin",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 54,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 54,
+        "column": 30
+      }
+    },
+    {
+      "vname": "isSenderAdmin",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 58,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 58,
+        "column": 22
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 60,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 60,
+        "column": 14
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 61,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 61,
+        "column": 8
+      }
+    },
+    {
+      "vname": "registry",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 61,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 61,
+        "column": 52
+      }
+    },
+    {
+      "vname": "label",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 62,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 62,
+        "column": 28
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 62,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 62,
+        "column": 42
+      }
+    },
+    {
+      "vname": "resolver",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 62,
+        "column": 54
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 62,
+        "column": 62
+      }
+    },
+    {
+      "vname": "oneMsg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 63,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 63,
+        "column": 13
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 63,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 63,
+        "column": 15
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 64,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 64,
+        "column": 9
+      }
+    },
+    {
+      "vname": "eError",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 66,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 66,
+        "column": 11
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Admin",

--- a/tests/checker/good/gold/ud-registry.scilla.gold
+++ b/tests/checker/good/gold/ud-registry.scilla.gold
@@ -17,6 +17,8821 @@
       }
     ]
   },
+  "type_info": [
+    {
+      "vname": "zeroUint64",
+      "type": "Uint64",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 6,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 6,
+        "column": 15
+      }
+    },
+    {
+      "vname": "zeroByStr20",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 7,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 7,
+        "column": 16
+      }
+    },
+    {
+      "vname": "zeroByStr32",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 8,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 8,
+        "column": 16
+      }
+    },
+    {
+      "vname": "nilByStr20",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 10,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 10,
+        "column": 15
+      }
+    },
+    {
+      "vname": "nilMessage",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 11,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 11,
+        "column": 15
+      }
+    },
+    {
+      "vname": "oneMsg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 12,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 12,
+        "column": 11
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 13,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 13,
+        "column": 6
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 14,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 14,
+        "column": 23
+      }
+    },
+    {
+      "vname": "nilMessage",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 14,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 14,
+        "column": 34
+      }
+    },
+    {
+      "vname": "eqByStr20",
+      "type": "ByStr20 -> ByStr20 -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 15,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 15,
+        "column": 14
+      }
+    },
+    {
+      "vname": "bs1",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 16,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 16,
+        "column": 6
+      }
+    },
+    {
+      "vname": "bs2",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 17,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 17,
+        "column": 6
+      }
+    },
+    {
+      "vname": "bs1",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 18,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 18,
+        "column": 19
+      }
+    },
+    {
+      "vname": "bs2",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 18,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 18,
+        "column": 23
+      }
+    },
+    {
+      "vname": "listByStr20Contains",
+      "type": "List (ByStr20) -> ByStr20 -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 19,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 19,
+        "column": 24
+      }
+    },
+    {
+      "vname": "list",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 20,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 20,
+        "column": 7
+      }
+    },
+    {
+      "vname": "bs",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 21,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 21,
+        "column": 5
+      }
+    },
+    {
+      "vname": "listMemByStr20",
+      "type":
+        "(ByStr20 -> ByStr20 -> Bool) -> ByStr20 -> List (ByStr20) -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 22,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 22,
+        "column": 19
+      }
+    },
+    {
+      "vname": "list_mem",
+      "type": "forall 'A. ('A -> 'A -> Bool) -> 'A -> List ('A) -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 22,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 22,
+        "column": 34
+      }
+    },
+    {
+      "vname": "listMemByStr20",
+      "type":
+        "(ByStr20 -> ByStr20 -> Bool) -> ByStr20 -> List (ByStr20) -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 23,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 23,
+        "column": 21
+      }
+    },
+    {
+      "vname": "eqByStr20",
+      "type": "ByStr20 -> ByStr20 -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 23,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 23,
+        "column": 31
+      }
+    },
+    {
+      "vname": "bs",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 23,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 23,
+        "column": 34
+      }
+    },
+    {
+      "vname": "list",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 23,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 23,
+        "column": 39
+      }
+    },
+    {
+      "vname": "listByStr20Excludes",
+      "type": "List (ByStr20) -> ByStr20 -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 24,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 24,
+        "column": 24
+      }
+    },
+    {
+      "vname": "list",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 25,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 25,
+        "column": 7
+      }
+    },
+    {
+      "vname": "bs",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 26,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 26,
+        "column": 5
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 27,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 27,
+        "column": 6
+      }
+    },
+    {
+      "vname": "listByStr20Contains",
+      "type": "List (ByStr20) -> ByStr20 -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 27,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 27,
+        "column": 32
+      }
+    },
+    {
+      "vname": "list",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 27,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 27,
+        "column": 37
+      }
+    },
+    {
+      "vname": "bs",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 27,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 27,
+        "column": 40
+      }
+    },
+    {
+      "vname": "negb",
+      "type": "Bool -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 27,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 27,
+        "column": 48
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 27,
+        "column": 49
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 27,
+        "column": 50
+      }
+    },
+    {
+      "vname": "listByStr20FilterOut",
+      "type": "List (ByStr20) -> ByStr20 -> List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 28,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 28,
+        "column": 25
+      }
+    },
+    {
+      "vname": "list",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 29,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 29,
+        "column": 7
+      }
+    },
+    {
+      "vname": "bs",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 30,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 30,
+        "column": 5
+      }
+    },
+    {
+      "vname": "listByStr20Filter",
+      "type": "(ByStr20 -> Bool) -> List (ByStr20) -> List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 31,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 31,
+        "column": 22
+      }
+    },
+    {
+      "vname": "list_filter",
+      "type": "forall 'A. ('A -> Bool) -> List ('A) -> List ('A)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 31,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 31,
+        "column": 40
+      }
+    },
+    {
+      "vname": "fn",
+      "type": "ByStr20 -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 32,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 32,
+        "column": 7
+      }
+    },
+    {
+      "vname": "v",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 32,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 32,
+        "column": 15
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 33,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 33,
+        "column": 8
+      }
+    },
+    {
+      "vname": "v",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 33,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 33,
+        "column": 27
+      }
+    },
+    {
+      "vname": "bs",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 33,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 33,
+        "column": 30
+      }
+    },
+    {
+      "vname": "negb",
+      "type": "Bool -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 34,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 34,
+        "column": 12
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 34,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 34,
+        "column": 14
+      }
+    },
+    {
+      "vname": "listByStr20Filter",
+      "type": "(ByStr20 -> Bool) -> List (ByStr20) -> List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 35,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 35,
+        "column": 24
+      }
+    },
+    {
+      "vname": "fn",
+      "type": "ByStr20 -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 35,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 35,
+        "column": 27
+      }
+    },
+    {
+      "vname": "list",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 35,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 35,
+        "column": 32
+      }
+    },
+    {
+      "vname": "xandb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 36,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 36,
+        "column": 10
+      }
+    },
+    {
+      "vname": "b1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 37,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 37,
+        "column": 5
+      }
+    },
+    {
+      "vname": "b2",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 38,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 38,
+        "column": 5
+      }
+    },
+    {
+      "vname": "b1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 39,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 39,
+        "column": 13
+      }
+    },
+    {
+      "vname": "b2",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 41,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 41,
+        "column": 15
+      }
+    },
+    {
+      "vname": "b2",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 46,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 46,
+        "column": 15
+      }
+    },
+    {
+      "vname": "eAdminSet",
+      "type": "ByStr20 -> Bool -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 51,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 51,
+        "column": 14
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 52,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 52,
+        "column": 10
+      }
+    },
+    {
+      "vname": "isApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 53,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 53,
+        "column": 13
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 54,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 54,
+        "column": 46
+      }
+    },
+    {
+      "vname": "isApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 54,
+        "column": 60
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 54,
+        "column": 70
+      }
+    },
+    {
+      "vname": "eApprovedFor",
+      "type": "ByStr20 -> ByStr20 -> Bool -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 55,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 55,
+        "column": 17
+      }
+    },
+    {
+      "vname": "user",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 56,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 56,
+        "column": 7
+      }
+    },
+    {
+      "vname": "operator",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 57,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 57,
+        "column": 11
+      }
+    },
+    {
+      "vname": "isApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 58,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 58,
+        "column": 13
+      }
+    },
+    {
+      "vname": "user",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 59,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 59,
+        "column": 43
+      }
+    },
+    {
+      "vname": "operator",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 59,
+        "column": 55
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 59,
+        "column": 63
+      }
+    },
+    {
+      "vname": "isApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 59,
+        "column": 77
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 59,
+        "column": 87
+      }
+    },
+    {
+      "vname": "eApproved",
+      "type": "ByStr20 -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 60,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 60,
+        "column": 14
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 61,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 61,
+        "column": 10
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 62,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 62,
+        "column": 46
+      }
+    },
+    {
+      "vname": "eNewRegistrar",
+      "type": "ByStr20 -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 63,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 63,
+        "column": 18
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 64,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 64,
+        "column": 10
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 65,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 65,
+        "column": 50
+      }
+    },
+    {
+      "vname": "eNewDomain",
+      "type": "ByStr32 -> String -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 66,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 66,
+        "column": 15
+      }
+    },
+    {
+      "vname": "parent",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 67,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 67,
+        "column": 9
+      }
+    },
+    {
+      "vname": "label",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 68,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 68,
+        "column": 8
+      }
+    },
+    {
+      "vname": "parent",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 69,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 69,
+        "column": 45
+      }
+    },
+    {
+      "vname": "label",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 69,
+        "column": 54
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 69,
+        "column": 59
+      }
+    },
+    {
+      "vname": "eConfigured",
+      "type": "ByStr32 -> ByStr20 -> ByStr20 -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 70,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 70,
+        "column": 16
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 71,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 71,
+        "column": 7
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 72,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 72,
+        "column": 8
+      }
+    },
+    {
+      "vname": "resolver",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 73,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 73,
+        "column": 11
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 74,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 74,
+        "column": 42
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 74,
+        "column": 51
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 74,
+        "column": 56
+      }
+    },
+    {
+      "vname": "resolver",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 74,
+        "column": 68
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 74,
+        "column": 76
+      }
+    },
+    {
+      "vname": "eError",
+      "type": "String -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 75,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 75,
+        "column": 11
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 76,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 76,
+        "column": 6
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 77,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 77,
+        "column": 35
+      }
+    },
+    {
+      "vname": "recordMemberOwner",
+      "type": "Option (Record) -> ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 80,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 80,
+        "column": 22
+      }
+    },
+    {
+      "vname": "maybeRecord",
+      "type": "Option (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 81,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 81,
+        "column": 14
+      }
+    },
+    {
+      "vname": "maybeRecord",
+      "type": "Option (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 82,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 82,
+        "column": 22
+      }
+    },
+    {
+      "vname": "zeroByStr20",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 83,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 83,
+        "column": 26
+      }
+    },
+    {
+      "vname": "record",
+      "type": "Record",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 84,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 84,
+        "column": 18
+      }
+    },
+    {
+      "vname": "record",
+      "type": "Record",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 85,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 85,
+        "column": 19
+      }
+    },
+    {
+      "vname": "resolver",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 86,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 86,
+        "column": 30
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 86,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 86,
+        "column": 21
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 86,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 86,
+        "column": 39
+      }
+    },
+    {
+      "vname": "parentLabelToNode",
+      "type": "ByStr32 -> String -> ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 89,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 89,
+        "column": 22
+      }
+    },
+    {
+      "vname": "parent",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 90,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 90,
+        "column": 9
+      }
+    },
+    {
+      "vname": "label",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 91,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 91,
+        "column": 8
+      }
+    },
+    {
+      "vname": "labelHash",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 92,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 92,
+        "column": 14
+      }
+    },
+    {
+      "vname": "label",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 92,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 92,
+        "column": 45
+      }
+    },
+    {
+      "vname": "nodeInput",
+      "type": "ByStr64",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 93,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 93,
+        "column": 14
+      }
+    },
+    {
+      "vname": "parent",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 93,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 93,
+        "column": 42
+      }
+    },
+    {
+      "vname": "labelHash",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 93,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 93,
+        "column": 52
+      }
+    },
+    {
+      "vname": "nodeInput",
+      "type": "ByStr64",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 94,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 94,
+        "column": 35
+      }
+    },
+    {
+      "vname": "getIsOAO",
+      "type":
+        "ByStr20 -> ByStr20 -> Option (ByStr20) -> Option (List (ByStr20)) -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 95,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 95,
+        "column": 13
+      }
+    },
+    {
+      "vname": "sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 96,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 96,
+        "column": 9
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 97,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 97,
+        "column": 14
+      }
+    },
+    {
+      "vname": "maybeApproved",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 98,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 98,
+        "column": 16
+      }
+    },
+    {
+      "vname": "maybeOperators",
+      "type": "Option (List (ByStr20))",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 99,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 99,
+        "column": 17
+      }
+    },
+    {
+      "vname": "isOwner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 100,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 100,
+        "column": 12
+      }
+    },
+    {
+      "vname": "sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 100,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 100,
+        "column": 36
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 100,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 100,
+        "column": 48
+      }
+    },
+    {
+      "vname": "isApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 101,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 101,
+        "column": 15
+      }
+    },
+    {
+      "vname": "maybeApproved",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 102,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 102,
+        "column": 26
+      }
+    },
+    {
+      "vname": "approved",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 104,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 104,
+        "column": 22
+      }
+    },
+    {
+      "vname": "sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 104,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 104,
+        "column": 43
+      }
+    },
+    {
+      "vname": "approved",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 104,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 104,
+        "column": 52
+      }
+    },
+    {
+      "vname": "isOperator",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 106,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 106,
+        "column": 15
+      }
+    },
+    {
+      "vname": "maybeOperators",
+      "type": "Option (List (ByStr20))",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 106,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 106,
+        "column": 42
+      }
+    },
+    {
+      "vname": "operators",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 108,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 108,
+        "column": 21
+      }
+    },
+    {
+      "vname": "listByStr20Contains",
+      "type": "List (ByStr20) -> ByStr20 -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 108,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 108,
+        "column": 44
+      }
+    },
+    {
+      "vname": "operators",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 108,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 108,
+        "column": 54
+      }
+    },
+    {
+      "vname": "sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 108,
+        "column": 55
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 108,
+        "column": 61
+      }
+    },
+    {
+      "vname": "b1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 110,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 110,
+        "column": 7
+      }
+    },
+    {
+      "vname": "orb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 110,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 110,
+        "column": 17
+      }
+    },
+    {
+      "vname": "isOwner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 110,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 110,
+        "column": 25
+      }
+    },
+    {
+      "vname": "isApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 110,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 110,
+        "column": 36
+      }
+    },
+    {
+      "vname": "orb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 110,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 110,
+        "column": 43
+      }
+    },
+    {
+      "vname": "b1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 110,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 110,
+        "column": 46
+      }
+    },
+    {
+      "vname": "isOperator",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 110,
+        "column": 47
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 110,
+        "column": 57
+      }
+    },
+    {
+      "vname": "initialOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 112,
+        "column": 2
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 112,
+        "column": 14
+      }
+    },
+    {
+      "vname": "rootNode",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 112,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 112,
+        "column": 33
+      }
+    },
+    {
+      "vname": "records",
+      "type": "Map (ByStr32) (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 113,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 113,
+        "column": 14
+      }
+    },
+    {
+      "vname": "empty",
+      "type": "Map (ByStr32) (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 114,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 114,
+        "column": 8
+      }
+    },
+    {
+      "vname": "rootRecord",
+      "type": "Record",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 115,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 115,
+        "column": 13
+      }
+    },
+    {
+      "vname": "initialOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 115,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 115,
+        "column": 39
+      }
+    },
+    {
+      "vname": "zeroByStr20",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 115,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 115,
+        "column": 51
+      }
+    },
+    {
+      "vname": "empty",
+      "type": "Map (ByStr32) (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 116,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 116,
+        "column": 22
+      }
+    },
+    {
+      "vname": "rootNode",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 116,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 116,
+        "column": 31
+      }
+    },
+    {
+      "vname": "rootRecord",
+      "type": "Record",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 116,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 116,
+        "column": 42
+      }
+    },
+    {
+      "vname": "registrar",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 117,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 117,
+        "column": 16
+      }
+    },
+    {
+      "vname": "zeroByStr20",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 117,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 117,
+        "column": 39
+      }
+    },
+    {
+      "vname": "approvals",
+      "type": "Map (ByStr32) (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 118,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 118,
+        "column": 16
+      }
+    },
+    {
+      "vname": "operators",
+      "type": "Map (ByStr20) (List (ByStr20))",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 119,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 119,
+        "column": 16
+      }
+    },
+    {
+      "vname": "admins",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 120,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 120,
+        "column": 13
+      }
+    },
+    {
+      "vname": "initialOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 120,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 120,
+        "column": 57
+      }
+    },
+    {
+      "vname": "nilByStr20",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 120,
+        "column": 58
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 120,
+        "column": 68
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 121,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 121,
+        "column": 28
+      }
+    },
+    {
+      "vname": "isApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 121,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 121,
+        "column": 49
+      }
+    },
+    {
+      "vname": "currentAdmins",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 122,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 122,
+        "column": 30
+      }
+    },
+    {
+      "vname": "admins",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 122,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 122,
+        "column": 26
+      }
+    },
+    {
+      "vname": "isSenderAdmin",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 123,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 123,
+        "column": 30
+      }
+    },
+    {
+      "vname": "listByStr20Contains",
+      "type": "List (ByStr20) -> ByStr20 -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 123,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 123,
+        "column": 38
+      }
+    },
+    {
+      "vname": "currentAdmins",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 123,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 123,
+        "column": 52
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 123,
+        "column": 53
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 123,
+        "column": 60
+      }
+    },
+    {
+      "vname": "isSenderAdmin",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 124,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 124,
+        "column": 22
+      }
+    },
+    {
+      "vname": "needsToChange",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 126,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 126,
+        "column": 32
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 127,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 127,
+        "column": 8
+      }
+    },
+    {
+      "vname": "listByStr20Excludes",
+      "type": "List (ByStr20) -> ByStr20 -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 127,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 127,
+        "column": 34
+      }
+    },
+    {
+      "vname": "currentAdmins",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 127,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 127,
+        "column": 48
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 127,
+        "column": 49
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 127,
+        "column": 56
+      }
+    },
+    {
+      "vname": "xandb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 127,
+        "column": 60
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 127,
+        "column": 65
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 127,
+        "column": 66
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 127,
+        "column": 67
+      }
+    },
+    {
+      "vname": "isApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 127,
+        "column": 68
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 127,
+        "column": 78
+      }
+    },
+    {
+      "vname": "needsToChange",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 128,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 128,
+        "column": 24
+      }
+    },
+    {
+      "vname": "newAdmins",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 130,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 130,
+        "column": 26
+      }
+    },
+    {
+      "vname": "isApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 130,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 130,
+        "column": 35
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 131,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 131,
+        "column": 41
+      }
+    },
+    {
+      "vname": "currentAdmins",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 131,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 131,
+        "column": 55
+      }
+    },
+    {
+      "vname": "listByStr20FilterOut",
+      "type": "List (ByStr20) -> ByStr20 -> List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 132,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 132,
+        "column": 40
+      }
+    },
+    {
+      "vname": "currentAdmins",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 132,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 132,
+        "column": 54
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 132,
+        "column": 55
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 132,
+        "column": 62
+      }
+    },
+    {
+      "vname": "newAdmins",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 134,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 134,
+        "column": 26
+      }
+    },
+    {
+      "vname": "admins",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 134,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 134,
+        "column": 20
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 135,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 135,
+        "column": 10
+      }
+    },
+    {
+      "vname": "eAdminSet",
+      "type": "ByStr20 -> Bool -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 135,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 135,
+        "column": 20
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 135,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 135,
+        "column": 28
+      }
+    },
+    {
+      "vname": "isApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 135,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 135,
+        "column": 39
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 136,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 136,
+        "column": 8
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 140,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 140,
+        "column": 8
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 140,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 140,
+        "column": 10
+      }
+    },
+    {
+      "vname": "eError",
+      "type": "String -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 140,
+        "column": 49
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 140,
+        "column": 55
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 140,
+        "column": 56
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 140,
+        "column": 57
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 141,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 141,
+        "column": 6
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 144,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 144,
+        "column": 24
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 144,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 144,
+        "column": 42
+      }
+    },
+    {
+      "vname": "maybeRecord",
+      "type": "Option (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 145,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 145,
+        "column": 14
+      }
+    },
+    {
+      "vname": "records",
+      "type": "Map (ByStr32) (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 145,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 145,
+        "column": 25
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 145,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 145,
+        "column": 30
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 146,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 146,
+        "column": 26
+      }
+    },
+    {
+      "vname": "recordMemberOwner",
+      "type": "Option (Record) -> ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 146,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 146,
+        "column": 34
+      }
+    },
+    {
+      "vname": "maybeRecord",
+      "type": "Option (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 146,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 146,
+        "column": 46
+      }
+    },
+    {
+      "vname": "isSenderNodeOwner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 147,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 147,
+        "column": 38
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 147,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 147,
+        "column": 41
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 147,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 147,
+        "column": 53
+      }
+    },
+    {
+      "vname": "isSenderNodeOwner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 148,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 148,
+        "column": 26
+      }
+    },
+    {
+      "vname": "maybeApproved",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 150,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 150,
+        "column": 18
+      }
+    },
+    {
+      "vname": "approvals",
+      "type": "Map (ByStr32) (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 150,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 150,
+        "column": 31
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 150,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 150,
+        "column": 36
+      }
+    },
+    {
+      "vname": "currentlyApproved",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 151,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 151,
+        "column": 40
+      }
+    },
+    {
+      "vname": "maybeApproved",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 151,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 151,
+        "column": 44
+      }
+    },
+    {
+      "vname": "zeroByStr20",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 152,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 152,
+        "column": 28
+      }
+    },
+    {
+      "vname": "approved",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 153,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 153,
+        "column": 22
+      }
+    },
+    {
+      "vname": "approved",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 153,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 153,
+        "column": 34
+      }
+    },
+    {
+      "vname": "needsToChange",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 155,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 155,
+        "column": 32
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 155,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 155,
+        "column": 22
+      }
+    },
+    {
+      "vname": "currentlyApproved",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 155,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 155,
+        "column": 57
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 155,
+        "column": 58
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 155,
+        "column": 65
+      }
+    },
+    {
+      "vname": "negb",
+      "type": "Bool -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 155,
+        "column": 69
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 155,
+        "column": 73
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 155,
+        "column": 74
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 155,
+        "column": 75
+      }
+    },
+    {
+      "vname": "needsToChange",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 156,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 156,
+        "column": 24
+      }
+    },
+    {
+      "vname": "approvals",
+      "type": "Map (ByStr32) (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 158,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 158,
+        "column": 16
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 158,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 158,
+        "column": 21
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 158,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 158,
+        "column": 33
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 159,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 159,
+        "column": 10
+      }
+    },
+    {
+      "vname": "eApproved",
+      "type": "ByStr20 -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 159,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 159,
+        "column": 20
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 159,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 159,
+        "column": 28
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 160,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 160,
+        "column": 8
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 164,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 164,
+        "column": 8
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 164,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 164,
+        "column": 10
+      }
+    },
+    {
+      "vname": "eError",
+      "type": "String -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 164,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 164,
+        "column": 50
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 164,
+        "column": 51
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 164,
+        "column": 52
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 165,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 165,
+        "column": 6
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 168,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 168,
+        "column": 30
+      }
+    },
+    {
+      "vname": "isApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 168,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 168,
+        "column": 51
+      }
+    },
+    {
+      "vname": "maybeOperators",
+      "type": "Option (List (ByStr20))",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 169,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 169,
+        "column": 17
+      }
+    },
+    {
+      "vname": "operators",
+      "type": "Map (ByStr20) (List (ByStr20))",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 169,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 169,
+        "column": 30
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 169,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 169,
+        "column": 38
+      }
+    },
+    {
+      "vname": "currentOperators",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 170,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 170,
+        "column": 36
+      }
+    },
+    {
+      "vname": "maybeOperators",
+      "type": "Option (List (ByStr20))",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 170,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 170,
+        "column": 42
+      }
+    },
+    {
+      "vname": "nilByStr20",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 171,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 171,
+        "column": 25
+      }
+    },
+    {
+      "vname": "ops",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 172,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 172,
+        "column": 15
+      }
+    },
+    {
+      "vname": "ops",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 172,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 172,
+        "column": 22
+      }
+    },
+    {
+      "vname": "needsToChange",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 174,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 174,
+        "column": 30
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 174,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 174,
+        "column": 20
+      }
+    },
+    {
+      "vname": "listByStr20Excludes",
+      "type": "List (ByStr20) -> ByStr20 -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 174,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 174,
+        "column": 46
+      }
+    },
+    {
+      "vname": "currentOperators",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 174,
+        "column": 47
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 174,
+        "column": 63
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 174,
+        "column": 64
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 174,
+        "column": 71
+      }
+    },
+    {
+      "vname": "xandb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 175,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 175,
+        "column": 10
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 175,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 175,
+        "column": 12
+      }
+    },
+    {
+      "vname": "isApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 175,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 175,
+        "column": 23
+      }
+    },
+    {
+      "vname": "needsToChange",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 176,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 176,
+        "column": 22
+      }
+    },
+    {
+      "vname": "newOperators",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 178,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 178,
+        "column": 30
+      }
+    },
+    {
+      "vname": "isApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 178,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 178,
+        "column": 36
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 179,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 179,
+        "column": 39
+      }
+    },
+    {
+      "vname": "currentOperators",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 179,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 179,
+        "column": 56
+      }
+    },
+    {
+      "vname": "listByStr20FilterOut",
+      "type": "List (ByStr20) -> ByStr20 -> List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 180,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 180,
+        "column": 38
+      }
+    },
+    {
+      "vname": "currentOperators",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 180,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 180,
+        "column": 55
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 180,
+        "column": 56
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 180,
+        "column": 63
+      }
+    },
+    {
+      "vname": "operators",
+      "type": "Map (ByStr20) (List (ByStr20))",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 182,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 182,
+        "column": 14
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 182,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 182,
+        "column": 22
+      }
+    },
+    {
+      "vname": "newOperators",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 182,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 182,
+        "column": 39
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 183,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 183,
+        "column": 8
+      }
+    },
+    {
+      "vname": "eApprovedFor",
+      "type": "ByStr20 -> ByStr20 -> Bool -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 183,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 183,
+        "column": 21
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 183,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 183,
+        "column": 29
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 183,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 183,
+        "column": 37
+      }
+    },
+    {
+      "vname": "isApproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 183,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 183,
+        "column": 48
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 184,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 184,
+        "column": 6
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 188,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 188,
+        "column": 30
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 188,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 188,
+        "column": 46
+      }
+    },
+    {
+      "vname": "resolver",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 188,
+        "column": 57
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 188,
+        "column": 65
+      }
+    },
+    {
+      "vname": "maybeRecord",
+      "type": "Option (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 189,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 189,
+        "column": 14
+      }
+    },
+    {
+      "vname": "records",
+      "type": "Map (ByStr32) (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 189,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 189,
+        "column": 25
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 189,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 189,
+        "column": 30
+      }
+    },
+    {
+      "vname": "maybeApproved",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 190,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 190,
+        "column": 16
+      }
+    },
+    {
+      "vname": "approvals",
+      "type": "Map (ByStr32) (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 190,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 190,
+        "column": 29
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 190,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 190,
+        "column": 34
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 191,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 191,
+        "column": 26
+      }
+    },
+    {
+      "vname": "recordMemberOwner",
+      "type": "Option (Record) -> ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 191,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 191,
+        "column": 34
+      }
+    },
+    {
+      "vname": "maybeRecord",
+      "type": "Option (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 191,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 191,
+        "column": 46
+      }
+    },
+    {
+      "vname": "maybeOperators",
+      "type": "Option (List (ByStr20))",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 192,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 192,
+        "column": 17
+      }
+    },
+    {
+      "vname": "operators",
+      "type": "Map (ByStr20) (List (ByStr20))",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 192,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 192,
+        "column": 30
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 192,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 192,
+        "column": 42
+      }
+    },
+    {
+      "vname": "isSenderOAO",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 193,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 193,
+        "column": 26
+      }
+    },
+    {
+      "vname": "getIsOAO",
+      "type":
+        "ByStr20 -> ByStr20 -> Option (ByStr20) -> Option (List (ByStr20)) -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 193,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 193,
+        "column": 25
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 193,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 193,
+        "column": 33
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 193,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 193,
+        "column": 45
+      }
+    },
+    {
+      "vname": "maybeApproved",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 193,
+        "column": 46
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 193,
+        "column": 59
+      }
+    },
+    {
+      "vname": "maybeOperators",
+      "type": "Option (List (ByStr20))",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 193,
+        "column": 60
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 193,
+        "column": 74
+      }
+    },
+    {
+      "vname": "isSenderOAO",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 194,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 194,
+        "column": 20
+      }
+    },
+    {
+      "vname": "newRecord",
+      "type": "Record",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 196,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 196,
+        "column": 24
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 196,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 196,
+        "column": 29
+      }
+    },
+    {
+      "vname": "resolver",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 196,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 196,
+        "column": 38
+      }
+    },
+    {
+      "vname": "records",
+      "type": "Map (ByStr32) (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 197,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 197,
+        "column": 12
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 197,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 197,
+        "column": 17
+      }
+    },
+    {
+      "vname": "newRecord",
+      "type": "Record",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 197,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 197,
+        "column": 31
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 198,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 198,
+        "column": 8
+      }
+    },
+    {
+      "vname": "eConfigured",
+      "type": "ByStr32 -> ByStr20 -> ByStr20 -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 198,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 198,
+        "column": 20
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 198,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 198,
+        "column": 25
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 198,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 198,
+        "column": 31
+      }
+    },
+    {
+      "vname": "resolver",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 198,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 198,
+        "column": 40
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 199,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 199,
+        "column": 6
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 200,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 200,
+        "column": 14
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 200,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 200,
+        "column": 13
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 200,
+        "column": 55
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 200,
+        "column": 59
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 200,
+        "column": 68
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 200,
+        "column": 73
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 201,
+        "column": 53
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 201,
+        "column": 60
+      }
+    },
+    {
+      "vname": "oneMsg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 202,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 202,
+        "column": 16
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 202,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 202,
+        "column": 18
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 203,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 203,
+        "column": 9
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 205,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 205,
+        "column": 8
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 205,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 205,
+        "column": 10
+      }
+    },
+    {
+      "vname": "eError",
+      "type": "String -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 205,
+        "column": 66
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 205,
+        "column": 72
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 205,
+        "column": 73
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 205,
+        "column": 74
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 206,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 206,
+        "column": 6
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 207,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 207,
+        "column": 14
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 207,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 207,
+        "column": 13
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 207,
+        "column": 55
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 207,
+        "column": 59
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 207,
+        "column": 68
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 207,
+        "column": 79
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 208,
+        "column": 53
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 208,
+        "column": 60
+      }
+    },
+    {
+      "vname": "oneMsg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 209,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 209,
+        "column": 16
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 209,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 209,
+        "column": 18
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 210,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 210,
+        "column": 9
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 213,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 213,
+        "column": 34
+      }
+    },
+    {
+      "vname": "resolver",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 213,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 213,
+        "column": 53
+      }
+    },
+    {
+      "vname": "maybeRecord",
+      "type": "Option (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 214,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 214,
+        "column": 14
+      }
+    },
+    {
+      "vname": "records",
+      "type": "Map (ByStr32) (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 214,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 214,
+        "column": 25
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 214,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 214,
+        "column": 30
+      }
+    },
+    {
+      "vname": "maybeApproved",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 215,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 215,
+        "column": 16
+      }
+    },
+    {
+      "vname": "approvals",
+      "type": "Map (ByStr32) (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 215,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 215,
+        "column": 29
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 215,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 215,
+        "column": 34
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 216,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 216,
+        "column": 26
+      }
+    },
+    {
+      "vname": "recordMemberOwner",
+      "type": "Option (Record) -> ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 216,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 216,
+        "column": 34
+      }
+    },
+    {
+      "vname": "maybeRecord",
+      "type": "Option (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 216,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 216,
+        "column": 46
+      }
+    },
+    {
+      "vname": "maybeOperators",
+      "type": "Option (List (ByStr20))",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 217,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 217,
+        "column": 17
+      }
+    },
+    {
+      "vname": "operators",
+      "type": "Map (ByStr20) (List (ByStr20))",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 217,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 217,
+        "column": 30
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 217,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 217,
+        "column": 42
+      }
+    },
+    {
+      "vname": "isSenderOAO",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 218,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 218,
+        "column": 26
+      }
+    },
+    {
+      "vname": "getIsOAO",
+      "type":
+        "ByStr20 -> ByStr20 -> Option (ByStr20) -> Option (List (ByStr20)) -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 218,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 218,
+        "column": 25
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 218,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 218,
+        "column": 33
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 218,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 218,
+        "column": 45
+      }
+    },
+    {
+      "vname": "maybeApproved",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 218,
+        "column": 46
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 218,
+        "column": 59
+      }
+    },
+    {
+      "vname": "maybeOperators",
+      "type": "Option (List (ByStr20))",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 218,
+        "column": 60
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 218,
+        "column": 74
+      }
+    },
+    {
+      "vname": "isSenderOAO",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 219,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 219,
+        "column": 20
+      }
+    },
+    {
+      "vname": "newRecord",
+      "type": "Record",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 221,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 221,
+        "column": 24
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 221,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 221,
+        "column": 35
+      }
+    },
+    {
+      "vname": "resolver",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 221,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 221,
+        "column": 44
+      }
+    },
+    {
+      "vname": "records",
+      "type": "Map (ByStr32) (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 222,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 222,
+        "column": 12
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 222,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 222,
+        "column": 17
+      }
+    },
+    {
+      "vname": "newRecord",
+      "type": "Record",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 222,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 222,
+        "column": 31
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 223,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 223,
+        "column": 8
+      }
+    },
+    {
+      "vname": "eConfigured",
+      "type": "ByStr32 -> ByStr20 -> ByStr20 -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 223,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 223,
+        "column": 20
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 223,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 223,
+        "column": 25
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 223,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 223,
+        "column": 37
+      }
+    },
+    {
+      "vname": "resolver",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 223,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 223,
+        "column": 46
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 224,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 224,
+        "column": 6
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 226,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 226,
+        "column": 8
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 226,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 226,
+        "column": 10
+      }
+    },
+    {
+      "vname": "eError",
+      "type": "String -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 226,
+        "column": 66
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 226,
+        "column": 72
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 226,
+        "column": 73
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 226,
+        "column": 74
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 227,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 227,
+        "column": 6
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 230,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 230,
+        "column": 25
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 230,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 230,
+        "column": 41
+      }
+    },
+    {
+      "vname": "maybeRecord",
+      "type": "Option (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 231,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 231,
+        "column": 14
+      }
+    },
+    {
+      "vname": "records",
+      "type": "Map (ByStr32) (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 231,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 231,
+        "column": 25
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 231,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 231,
+        "column": 30
+      }
+    },
+    {
+      "vname": "maybeApproved",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 232,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 232,
+        "column": 16
+      }
+    },
+    {
+      "vname": "approvals",
+      "type": "Map (ByStr32) (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 232,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 232,
+        "column": 29
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 232,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 232,
+        "column": 34
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 233,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 233,
+        "column": 26
+      }
+    },
+    {
+      "vname": "recordMemberOwner",
+      "type": "Option (Record) -> ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 233,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 233,
+        "column": 34
+      }
+    },
+    {
+      "vname": "maybeRecord",
+      "type": "Option (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 233,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 233,
+        "column": 46
+      }
+    },
+    {
+      "vname": "maybeOperators",
+      "type": "Option (List (ByStr20))",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 234,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 234,
+        "column": 17
+      }
+    },
+    {
+      "vname": "operators",
+      "type": "Map (ByStr20) (List (ByStr20))",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 234,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 234,
+        "column": 30
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 234,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 234,
+        "column": 42
+      }
+    },
+    {
+      "vname": "isSenderOAO",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 235,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 235,
+        "column": 26
+      }
+    },
+    {
+      "vname": "getIsOAO",
+      "type":
+        "ByStr20 -> ByStr20 -> Option (ByStr20) -> Option (List (ByStr20)) -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 235,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 235,
+        "column": 25
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 235,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 235,
+        "column": 33
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 235,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 235,
+        "column": 45
+      }
+    },
+    {
+      "vname": "maybeApproved",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 235,
+        "column": 46
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 235,
+        "column": 59
+      }
+    },
+    {
+      "vname": "maybeOperators",
+      "type": "Option (List (ByStr20))",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 235,
+        "column": 60
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 235,
+        "column": 74
+      }
+    },
+    {
+      "vname": "isSenderOAO",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 236,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 236,
+        "column": 20
+      }
+    },
+    {
+      "vname": "approvals",
+      "type": "Map (ByStr32) (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 238,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 238,
+        "column": 21
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 238,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 238,
+        "column": 26
+      }
+    },
+    {
+      "vname": "newRecord",
+      "type": "Record",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 239,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 239,
+        "column": 24
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 239,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 239,
+        "column": 29
+      }
+    },
+    {
+      "vname": "zeroByStr20",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 239,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 239,
+        "column": 41
+      }
+    },
+    {
+      "vname": "records",
+      "type": "Map (ByStr32) (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 240,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 240,
+        "column": 12
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 240,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 240,
+        "column": 17
+      }
+    },
+    {
+      "vname": "newRecord",
+      "type": "Record",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 240,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 240,
+        "column": 31
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 241,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 241,
+        "column": 8
+      }
+    },
+    {
+      "vname": "eConfigured",
+      "type": "ByStr32 -> ByStr20 -> ByStr20 -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 241,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 241,
+        "column": 20
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 241,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 241,
+        "column": 25
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 241,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 241,
+        "column": 31
+      }
+    },
+    {
+      "vname": "zeroByStr20",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 241,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 241,
+        "column": 43
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 242,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 242,
+        "column": 6
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 243,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 243,
+        "column": 14
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 243,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 243,
+        "column": 13
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 243,
+        "column": 54
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 243,
+        "column": 58
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 243,
+        "column": 67
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 243,
+        "column": 72
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 244,
+        "column": 53
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 244,
+        "column": 60
+      }
+    },
+    {
+      "vname": "oneMsg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 245,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 245,
+        "column": 16
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 245,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 245,
+        "column": 18
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 246,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 246,
+        "column": 9
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 248,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 248,
+        "column": 8
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 248,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 248,
+        "column": 10
+      }
+    },
+    {
+      "vname": "eError",
+      "type": "String -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 248,
+        "column": 66
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 248,
+        "column": 72
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 248,
+        "column": 73
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 248,
+        "column": 74
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 249,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 249,
+        "column": 6
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 250,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 250,
+        "column": 14
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 250,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 250,
+        "column": 13
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 250,
+        "column": 54
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 250,
+        "column": 58
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 250,
+        "column": 67
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 250,
+        "column": 72
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 251,
+        "column": 53
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 251,
+        "column": 60
+      }
+    },
+    {
+      "vname": "oneMsg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 252,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 252,
+        "column": 16
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 252,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 252,
+        "column": 18
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 253,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 253,
+        "column": 9
+      }
+    },
+    {
+      "vname": "parent",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 256,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 256,
+        "column": 25
+      }
+    },
+    {
+      "vname": "label",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 256,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 256,
+        "column": 41
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 256,
+        "column": 51
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 256,
+        "column": 56
+      }
+    },
+    {
+      "vname": "maybeRecord",
+      "type": "Option (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 257,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 257,
+        "column": 14
+      }
+    },
+    {
+      "vname": "records",
+      "type": "Map (ByStr32) (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 257,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 257,
+        "column": 25
+      }
+    },
+    {
+      "vname": "parent",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 257,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 257,
+        "column": 32
+      }
+    },
+    {
+      "vname": "maybeApproved",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 258,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 258,
+        "column": 16
+      }
+    },
+    {
+      "vname": "approvals",
+      "type": "Map (ByStr32) (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 258,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 258,
+        "column": 29
+      }
+    },
+    {
+      "vname": "parent",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 258,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 258,
+        "column": 36
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 259,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 259,
+        "column": 26
+      }
+    },
+    {
+      "vname": "recordMemberOwner",
+      "type": "Option (Record) -> ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 259,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 259,
+        "column": 34
+      }
+    },
+    {
+      "vname": "maybeRecord",
+      "type": "Option (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 259,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 259,
+        "column": 46
+      }
+    },
+    {
+      "vname": "maybeOperators",
+      "type": "Option (List (ByStr20))",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 260,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 260,
+        "column": 17
+      }
+    },
+    {
+      "vname": "operators",
+      "type": "Map (ByStr20) (List (ByStr20))",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 260,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 260,
+        "column": 30
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 260,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 260,
+        "column": 42
+      }
+    },
+    {
+      "vname": "isSenderOAO",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 261,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 261,
+        "column": 26
+      }
+    },
+    {
+      "vname": "getIsOAO",
+      "type":
+        "ByStr20 -> ByStr20 -> Option (ByStr20) -> Option (List (ByStr20)) -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 261,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 261,
+        "column": 25
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 261,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 261,
+        "column": 33
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 261,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 261,
+        "column": 45
+      }
+    },
+    {
+      "vname": "maybeApproved",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 261,
+        "column": 46
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 261,
+        "column": 59
+      }
+    },
+    {
+      "vname": "maybeOperators",
+      "type": "Option (List (ByStr20))",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 261,
+        "column": 60
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 261,
+        "column": 74
+      }
+    },
+    {
+      "vname": "isSenderOAO",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 262,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 262,
+        "column": 20
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 264,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 264,
+        "column": 14
+      }
+    },
+    {
+      "vname": "parentLabelToNode",
+      "type": "ByStr32 -> String -> ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 264,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 264,
+        "column": 29
+      }
+    },
+    {
+      "vname": "parent",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 264,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 264,
+        "column": 36
+      }
+    },
+    {
+      "vname": "label",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 264,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 264,
+        "column": 42
+      }
+    },
+    {
+      "vname": "recordExists",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 265,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 265,
+        "column": 17
+      }
+    },
+    {
+      "vname": "records",
+      "type": "Map (ByStr32) (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 265,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 265,
+        "column": 35
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 265,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 265,
+        "column": 40
+      }
+    },
+    {
+      "vname": "recordExists",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 266,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 266,
+        "column": 23
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 268,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 268,
+        "column": 10
+      }
+    },
+    {
+      "vname": "eNewDomain",
+      "type": "ByStr32 -> String -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 268,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 268,
+        "column": 21
+      }
+    },
+    {
+      "vname": "parent",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 268,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 268,
+        "column": 28
+      }
+    },
+    {
+      "vname": "label",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 268,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 268,
+        "column": 34
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 269,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 269,
+        "column": 8
+      }
+    },
+    {
+      "vname": "approvals",
+      "type": "Map (ByStr32) (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 272,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 272,
+        "column": 21
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 272,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 272,
+        "column": 26
+      }
+    },
+    {
+      "vname": "newRecord",
+      "type": "Record",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 273,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 273,
+        "column": 24
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 273,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 273,
+        "column": 29
+      }
+    },
+    {
+      "vname": "zeroByStr20",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 273,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 273,
+        "column": 41
+      }
+    },
+    {
+      "vname": "records",
+      "type": "Map (ByStr32) (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 274,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 274,
+        "column": 12
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 274,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 274,
+        "column": 17
+      }
+    },
+    {
+      "vname": "newRecord",
+      "type": "Record",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 274,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 274,
+        "column": 31
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 275,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 275,
+        "column": 8
+      }
+    },
+    {
+      "vname": "eConfigured",
+      "type": "ByStr32 -> ByStr20 -> ByStr20 -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 275,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 275,
+        "column": 20
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 275,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 275,
+        "column": 25
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 275,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 275,
+        "column": 31
+      }
+    },
+    {
+      "vname": "zeroByStr20",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 275,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 275,
+        "column": 43
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 276,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 276,
+        "column": 6
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 277,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 277,
+        "column": 14
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 277,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 277,
+        "column": 13
+      }
+    },
+    {
+      "vname": "parent",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 277,
+        "column": 54
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 277,
+        "column": 60
+      }
+    },
+    {
+      "vname": "label",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 277,
+        "column": 69
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 277,
+        "column": 74
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 278,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 278,
+        "column": 33
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 278,
+        "column": 67
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 278,
+        "column": 74
+      }
+    },
+    {
+      "vname": "oneMsg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 279,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 279,
+        "column": 16
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 279,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 279,
+        "column": 18
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 280,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 280,
+        "column": 9
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 282,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 282,
+        "column": 8
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 282,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 282,
+        "column": 10
+      }
+    },
+    {
+      "vname": "eError",
+      "type": "String -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 282,
+        "column": 68
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 282,
+        "column": 74
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 282,
+        "column": 75
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 282,
+        "column": 76
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 283,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 283,
+        "column": 6
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 284,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 284,
+        "column": 14
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 284,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 284,
+        "column": 13
+      }
+    },
+    {
+      "vname": "parent",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 284,
+        "column": 54
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 284,
+        "column": 60
+      }
+    },
+    {
+      "vname": "label",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 284,
+        "column": 69
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 284,
+        "column": 74
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 285,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 285,
+        "column": 39
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 285,
+        "column": 73
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 285,
+        "column": 80
+      }
+    },
+    {
+      "vname": "oneMsg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 286,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 286,
+        "column": 16
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 286,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 286,
+        "column": 18
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 287,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 287,
+        "column": 9
+      }
+    },
+    {
+      "vname": "label",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 290,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 290,
+        "column": 24
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 290,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 290,
+        "column": 39
+      }
+    },
+    {
+      "vname": "resolver",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 290,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 290,
+        "column": 58
+      }
+    },
+    {
+      "vname": "currentAdmins",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 291,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 291,
+        "column": 30
+      }
+    },
+    {
+      "vname": "admins",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 291,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 291,
+        "column": 26
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 292,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 292,
+        "column": 12
+      }
+    },
+    {
+      "vname": "parentLabelToNode",
+      "type": "ByStr32 -> String -> ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 292,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 292,
+        "column": 27
+      }
+    },
+    {
+      "vname": "rootNode",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 292,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 292,
+        "column": 36
+      }
+    },
+    {
+      "vname": "label",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 292,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 292,
+        "column": 42
+      }
+    },
+    {
+      "vname": "recordExists",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 293,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 293,
+        "column": 15
+      }
+    },
+    {
+      "vname": "records",
+      "type": "Map (ByStr32) (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 293,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 293,
+        "column": 33
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 293,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 293,
+        "column": 38
+      }
+    },
+    {
+      "vname": "maybeRecord",
+      "type": "Option (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 294,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 294,
+        "column": 14
+      }
+    },
+    {
+      "vname": "records",
+      "type": "Map (ByStr32) (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 294,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 294,
+        "column": 25
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 294,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 294,
+        "column": 30
+      }
+    },
+    {
+      "vname": "currentRegistrar",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 295,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 295,
+        "column": 36
+      }
+    },
+    {
+      "vname": "registrar",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 295,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 295,
+        "column": 32
+      }
+    },
+    {
+      "vname": "isOk",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 296,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 296,
+        "column": 12
+      }
+    },
+    {
+      "vname": "isSenderAdmin",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 297,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 297,
+        "column": 18
+      }
+    },
+    {
+      "vname": "listByStr20Contains",
+      "type": "List (ByStr20) -> ByStr20 -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 297,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 297,
+        "column": 44
+      }
+    },
+    {
+      "vname": "currentAdmins",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 297,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 297,
+        "column": 58
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 297,
+        "column": 59
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 297,
+        "column": 66
+      }
+    },
+    {
+      "vname": "isSenderRegistrar",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 298,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 298,
+        "column": 22
+      }
+    },
+    {
+      "vname": "currentRegistrar",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 298,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 298,
+        "column": 56
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 298,
+        "column": 57
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 298,
+        "column": 64
+      }
+    },
+    {
+      "vname": "isOkSender",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 299,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 299,
+        "column": 15
+      }
+    },
+    {
+      "vname": "orb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 299,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 299,
+        "column": 25
+      }
+    },
+    {
+      "vname": "isSenderRegistrar",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 299,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 299,
+        "column": 43
+      }
+    },
+    {
+      "vname": "isSenderAdmin",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 299,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 299,
+        "column": 57
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 300,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 300,
+        "column": 16
+      }
+    },
+    {
+      "vname": "recordMemberOwner",
+      "type": "Option (Record) -> ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 300,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 300,
+        "column": 40
+      }
+    },
+    {
+      "vname": "maybeRecord",
+      "type": "Option (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 300,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 300,
+        "column": 52
+      }
+    },
+    {
+      "vname": "recordIsUnowned",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 301,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 301,
+        "column": 20
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 301,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 301,
+        "column": 49
+      }
+    },
+    {
+      "vname": "zeroByStr20",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 301,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 301,
+        "column": 61
+      }
+    },
+    {
+      "vname": "recordIsOwnedByRegistrar",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 302,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 302,
+        "column": 29
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 302,
+        "column": 47
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 302,
+        "column": 58
+      }
+    },
+    {
+      "vname": "currentRegistrar",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 302,
+        "column": 59
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 302,
+        "column": 75
+      }
+    },
+    {
+      "vname": "isRegistrarSenderAndOwned",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 303,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 303,
+        "column": 30
+      }
+    },
+    {
+      "vname": "andb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 303,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 303,
+        "column": 41
+      }
+    },
+    {
+      "vname": "recordIsOwnedByRegistrar",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 303,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 303,
+        "column": 66
+      }
+    },
+    {
+      "vname": "isSenderRegistrar",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 303,
+        "column": 67
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 303,
+        "column": 84
+      }
+    },
+    {
+      "vname": "isOkRecordOwner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 304,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 304,
+        "column": 20
+      }
+    },
+    {
+      "vname": "orb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 304,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 304,
+        "column": 30
+      }
+    },
+    {
+      "vname": "recordIsUnowned",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 304,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 304,
+        "column": 46
+      }
+    },
+    {
+      "vname": "isRegistrarSenderAndOwned",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 304,
+        "column": 47
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 304,
+        "column": 72
+      }
+    },
+    {
+      "vname": "andb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 305,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 305,
+        "column": 11
+      }
+    },
+    {
+      "vname": "isOkSender",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 305,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 305,
+        "column": 22
+      }
+    },
+    {
+      "vname": "isOkRecordOwner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 305,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 305,
+        "column": 38
+      }
+    },
+    {
+      "vname": "isOk",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 306,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 306,
+        "column": 13
+      }
+    },
+    {
+      "vname": "recordExists",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 308,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 308,
+        "column": 23
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 310,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 310,
+        "column": 10
+      }
+    },
+    {
+      "vname": "eNewDomain",
+      "type": "ByStr32 -> String -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 310,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 310,
+        "column": 21
+      }
+    },
+    {
+      "vname": "rootNode",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 310,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 310,
+        "column": 30
+      }
+    },
+    {
+      "vname": "label",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 310,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 310,
+        "column": 36
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 311,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 311,
+        "column": 8
+      }
+    },
+    {
+      "vname": "newRecord",
+      "type": "Record",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 314,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 314,
+        "column": 24
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 314,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 314,
+        "column": 29
+      }
+    },
+    {
+      "vname": "resolver",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 314,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 314,
+        "column": 38
+      }
+    },
+    {
+      "vname": "records",
+      "type": "Map (ByStr32) (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 315,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 315,
+        "column": 12
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 315,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 315,
+        "column": 17
+      }
+    },
+    {
+      "vname": "newRecord",
+      "type": "Record",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 315,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 315,
+        "column": 31
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 316,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 316,
+        "column": 8
+      }
+    },
+    {
+      "vname": "eConfigured",
+      "type": "ByStr32 -> ByStr20 -> ByStr20 -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 316,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 316,
+        "column": 20
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 316,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 316,
+        "column": 25
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 316,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 316,
+        "column": 31
+      }
+    },
+    {
+      "vname": "resolver",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 316,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 316,
+        "column": 40
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 317,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 317,
+        "column": 6
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 319,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 319,
+        "column": 8
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 319,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 319,
+        "column": 10
+      }
+    },
+    {
+      "vname": "eError",
+      "type": "String -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 319,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 319,
+        "column": 41
+      }
+    },
+    {
+      "vname": "m",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 319,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 319,
+        "column": 43
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 320,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 320,
+        "column": 6
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 323,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 323,
+        "column": 32
+      }
+    },
+    {
+      "vname": "currentAdmins",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 324,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 324,
+        "column": 30
+      }
+    },
+    {
+      "vname": "admins",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 324,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 324,
+        "column": 26
+      }
+    },
+    {
+      "vname": "isOk",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 325,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 325,
+        "column": 12
+      }
+    },
+    {
+      "vname": "listByStr20Contains",
+      "type": "List (ByStr20) -> ByStr20 -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 325,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 325,
+        "column": 29
+      }
+    },
+    {
+      "vname": "currentAdmins",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 325,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 325,
+        "column": 43
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 325,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 325,
+        "column": 51
+      }
+    },
+    {
+      "vname": "isOk",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 326,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 326,
+        "column": 13
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 328,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 328,
+        "column": 8
+      }
+    },
+    {
+      "vname": "eNewRegistrar",
+      "type": "ByStr20 -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 328,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 328,
+        "column": 22
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 328,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 328,
+        "column": 30
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 329,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 329,
+        "column": 6
+      }
+    },
+    {
+      "vname": "address",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 330,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 330,
+        "column": 25
+      }
+    },
+    {
+      "vname": "registrar",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 330,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 330,
+        "column": 24
+      }
+    },
+    {
+      "vname": "parent",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 334,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 334,
+        "column": 27
+      }
+    },
+    {
+      "vname": "label",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 334,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 334,
+        "column": 43
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 335,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 335,
+        "column": 12
+      }
+    },
+    {
+      "vname": "parentLabelToNode",
+      "type": "ByStr32 -> String -> ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 335,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 335,
+        "column": 27
+      }
+    },
+    {
+      "vname": "parent",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 335,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 335,
+        "column": 34
+      }
+    },
+    {
+      "vname": "label",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 335,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 335,
+        "column": 40
+      }
+    },
+    {
+      "vname": "maybeRecord",
+      "type": "Option (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 336,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 336,
+        "column": 14
+      }
+    },
+    {
+      "vname": "records",
+      "type": "Map (ByStr32) (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 336,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 336,
+        "column": 25
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 336,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 336,
+        "column": 30
+      }
+    },
+    {
+      "vname": "maybeApproved",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 337,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 337,
+        "column": 16
+      }
+    },
+    {
+      "vname": "approvals",
+      "type": "Map (ByStr32) (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 337,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 337,
+        "column": 29
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 337,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 337,
+        "column": 34
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 338,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 338,
+        "column": 26
+      }
+    },
+    {
+      "vname": "recordMemberOwner",
+      "type": "Option (Record) -> ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 338,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 338,
+        "column": 34
+      }
+    },
+    {
+      "vname": "maybeRecord",
+      "type": "Option (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 338,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 338,
+        "column": 46
+      }
+    },
+    {
+      "vname": "approved",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 339,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 339,
+        "column": 20
+      }
+    },
+    {
+      "vname": "maybeApproved",
+      "type": "Option (ByStr20)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 340,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 340,
+        "column": 24
+      }
+    },
+    {
+      "vname": "zeroByStr20",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 341,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 341,
+        "column": 26
+      }
+    },
+    {
+      "vname": "approved",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 342,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 342,
+        "column": 20
+      }
+    },
+    {
+      "vname": "approved",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 342,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 342,
+        "column": 32
+      }
+    },
+    {
+      "vname": "currentRegistrar",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 344,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 344,
+        "column": 36
+      }
+    },
+    {
+      "vname": "registrar",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 344,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 344,
+        "column": 32
+      }
+    },
+    {
+      "vname": "isOk",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 345,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 345,
+        "column": 12
+      }
+    },
+    {
+      "vname": "isRecordUnowned",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 346,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 346,
+        "column": 20
+      }
+    },
+    {
+      "vname": "recordOwner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 346,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 346,
+        "column": 49
+      }
+    },
+    {
+      "vname": "zeroByStr20",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 346,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 346,
+        "column": 61
+      }
+    },
+    {
+      "vname": "isUnapproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 347,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 347,
+        "column": 17
+      }
+    },
+    {
+      "vname": "approved",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 347,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 347,
+        "column": 43
+      }
+    },
+    {
+      "vname": "zeroByStr20",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 347,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 347,
+        "column": 55
+      }
+    },
+    {
+      "vname": "andb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 348,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 348,
+        "column": 11
+      }
+    },
+    {
+      "vname": "isRecordUnowned",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 348,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 348,
+        "column": 27
+      }
+    },
+    {
+      "vname": "isUnapproved",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 348,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 348,
+        "column": 40
+      }
+    },
+    {
+      "vname": "isOk",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 349,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 349,
+        "column": 13
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 352,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 352,
+        "column": 14
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 353,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 353,
+        "column": 8
+      }
+    },
+    {
+      "vname": "_amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 353,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 353,
+        "column": 50
+      }
+    },
+    {
+      "vname": "currentRegistrar",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 353,
+        "column": 64
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 353,
+        "column": 80
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 354,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 354,
+        "column": 31
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 354,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 354,
+        "column": 43
+      }
+    },
+    {
+      "vname": "parent",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 354,
+        "column": 53
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 354,
+        "column": 59
+      }
+    },
+    {
+      "vname": "label",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 354,
+        "column": 68
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 354,
+        "column": 73
+      }
+    },
+    {
+      "vname": "oneMsg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 355,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 355,
+        "column": 15
+      }
+    },
+    {
+      "vname": "m",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 355,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 355,
+        "column": 17
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 356,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 356,
+        "column": 9
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 360,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 360,
+        "column": 37
+      }
+    },
+    {
+      "vname": "maybeRecord",
+      "type": "Option (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 361,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 361,
+        "column": 14
+      }
+    },
+    {
+      "vname": "records",
+      "type": "Map (ByStr32) (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 361,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 361,
+        "column": 25
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 361,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 361,
+        "column": 30
+      }
+    },
+    {
+      "vname": "maybeRecord",
+      "type": "Option (Record)",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 362,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 362,
+        "column": 20
+      }
+    },
+    {
+      "vname": "record",
+      "type": "Record",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 364,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 364,
+        "column": 16
+      }
+    },
+    {
+      "vname": "record",
+      "type": "Record",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 365,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 365,
+        "column": 17
+      }
+    },
+    {
+      "vname": "resolver",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 366,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 366,
+        "column": 28
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 366,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 366,
+        "column": 19
+      }
+    },
+    {
+      "vname": "isOk",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 367,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 367,
+        "column": 16
+      }
+    },
+    {
+      "vname": "resolver",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 367,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 367,
+        "column": 33
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 367,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 367,
+        "column": 41
+      }
+    },
+    {
+      "vname": "isOk",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 368,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 368,
+        "column": 17
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 370,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 370,
+        "column": 12
+      }
+    },
+    {
+      "vname": "eConfigured",
+      "type": "ByStr32 -> ByStr20 -> ByStr20 -> Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 370,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 370,
+        "column": 24
+      }
+    },
+    {
+      "vname": "node",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 370,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 370,
+        "column": 29
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 370,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 370,
+        "column": 35
+      }
+    },
+    {
+      "vname": "resolver",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 370,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 370,
+        "column": 44
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 371,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/ud-registry.scilla",
+        "line": 371,
+        "column": 10
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Registry",

--- a/tests/checker/good/gold/wallet.scilla.gold
+++ b/tests/checker/good/gold/wallet.scilla.gold
@@ -19,6 +19,7025 @@
       }
     ]
   },
+  "type_info": [
+    {
+      "vname": "mk_transaction_added_event",
+      "type": "Uint32 -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 11,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 11,
+        "column": 31
+      }
+    },
+    {
+      "vname": "tc",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 12,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 12,
+        "column": 5
+      }
+    },
+    {
+      "vname": "tc",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 13,
+        "column": 60
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 13,
+        "column": 62
+      }
+    },
+    {
+      "vname": "mk_transaction_signed_event",
+      "type": "Uint32 -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 16,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 16,
+        "column": 32
+      }
+    },
+    {
+      "vname": "no_of_sigs",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 17,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 17,
+        "column": 13
+      }
+    },
+    {
+      "vname": "no_of_sigs",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 18,
+        "column": 61
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 18,
+        "column": 71
+      }
+    },
+    {
+      "vname": "mk_candidate_owner_added_event",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 21,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 21,
+        "column": 35
+      }
+    },
+    {
+      "vname": "mk_owner_signed_event",
+      "type": "Uint32 -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 25,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 25,
+        "column": 26
+      }
+    },
+    {
+      "vname": "no_of_sigs",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 26,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 26,
+        "column": 13
+      }
+    },
+    {
+      "vname": "no_of_sigs",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 27,
+        "column": 55
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 27,
+        "column": 65
+      }
+    },
+    {
+      "vname": "mk_new_owner_approved_event",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 30,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 30,
+        "column": 32
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 49,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 49,
+        "column": 19
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 50,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 50,
+        "column": 6
+      }
+    },
+    {
+      "vname": "err_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 51,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 51,
+        "column": 11
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 52,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 52,
+        "column": 14
+      }
+    },
+    {
+      "vname": "err_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 67,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 67,
+        "column": 53
+      }
+    },
+    {
+      "vname": "transaction_inc",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 69,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 69,
+        "column": 20
+      }
+    },
+    {
+      "vname": "empty_sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 70,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 70,
+        "column": 15
+      }
+    },
+    {
+      "vname": "mk_owners_map",
+      "type": "List (ByStr20) -> Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 77,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 77,
+        "column": 18
+      }
+    },
+    {
+      "vname": "initial_owners",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 78,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 78,
+        "column": 17
+      }
+    },
+    {
+      "vname": "init",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 79,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 79,
+        "column": 9
+      }
+    },
+    {
+      "vname": "iter",
+      "type": "Map (ByStr20) (Bool) -> ByStr20 -> Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 80,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 80,
+        "column": 9
+      }
+    },
+    {
+      "vname": "acc",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 81,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 81,
+        "column": 10
+      }
+    },
+    {
+      "vname": "cur_owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 82,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 82,
+        "column": 16
+      }
+    },
+    {
+      "vname": "mem",
+      "type": "Option (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 83,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 83,
+        "column": 12
+      }
+    },
+    {
+      "vname": "acc",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 83,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 83,
+        "column": 34
+      }
+    },
+    {
+      "vname": "cur_owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 83,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 83,
+        "column": 44
+      }
+    },
+    {
+      "vname": "mem",
+      "type": "Option (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 84,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 84,
+        "column": 18
+      }
+    },
+    {
+      "vname": "acc",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 87,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 87,
+        "column": 14
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 90,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 90,
+        "column": 12
+      }
+    },
+    {
+      "vname": "acc",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 91,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 91,
+        "column": 26
+      }
+    },
+    {
+      "vname": "cur_owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 91,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 91,
+        "column": 36
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 91,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 91,
+        "column": 38
+      }
+    },
+    {
+      "vname": "folder",
+      "type":
+        "(Map (ByStr20) (Bool) -> ByStr20 -> Map (ByStr20) (Bool)) -> Map (ByStr20) (Bool) -> List (ByStr20) -> Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 93,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 93,
+        "column": 11
+      }
+    },
+    {
+      "vname": "list_foldl",
+      "type":
+        "forall 'A. forall 'B. ('B -> 'A -> 'B) -> 'B -> List ('A) -> 'B",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 93,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 93,
+        "column": 28
+      }
+    },
+    {
+      "vname": "folder",
+      "type":
+        "(Map (ByStr20) (Bool) -> ByStr20 -> Map (ByStr20) (Bool)) -> Map (ByStr20) (Bool) -> List (ByStr20) -> Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 94,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 94,
+        "column": 11
+      }
+    },
+    {
+      "vname": "iter",
+      "type": "Map (ByStr20) (Bool) -> ByStr20 -> Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 94,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 94,
+        "column": 16
+      }
+    },
+    {
+      "vname": "init",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 94,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 94,
+        "column": 21
+      }
+    },
+    {
+      "vname": "initial_owners",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 94,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 94,
+        "column": 36
+      }
+    },
+    {
+      "vname": "check_contract_validity",
+      "type": "Map (ByStr20) (Bool) -> Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 97,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 97,
+        "column": 28
+      }
+    },
+    {
+      "vname": "owners",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 98,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 98,
+        "column": 9
+      }
+    },
+    {
+      "vname": "no_of_owners",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 99,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 99,
+        "column": 17
+      }
+    },
+    {
+      "vname": "owners",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 99,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 99,
+        "column": 43
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 100,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 100,
+        "column": 9
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 101,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 101,
+        "column": 20
+      }
+    },
+    {
+      "vname": "no_of_owners",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 101,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 101,
+        "column": 33
+      }
+    },
+    {
+      "vname": "transaction_executed",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 103,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 103,
+        "column": 25
+      }
+    },
+    {
+      "vname": "transaction_msg",
+      "type": "ByStr20 -> Uint128 -> String -> Message",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 106,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 106,
+        "column": 20
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 107,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 107,
+        "column": 12
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 108,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 108,
+        "column": 9
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 109,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 109,
+        "column": 6
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 110,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 110,
+        "column": 16
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 110,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 110,
+        "column": 40
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 110,
+        "column": 52
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 110,
+        "column": 58
+      }
+    },
+    {
+      "vname": "transaction_executed",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 111,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 111,
+        "column": 33
+      }
+    },
+    {
+      "vname": "transaction_msg_as_list",
+      "type": "ByStr20 -> Uint128 -> String -> List (Message)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 114,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 114,
+        "column": 28
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 115,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 115,
+        "column": 12
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 116,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 116,
+        "column": 9
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 117,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 117,
+        "column": 6
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 118,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 118,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 119,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 119,
+        "column": 10
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 120,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 120,
+        "column": 16
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 121,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 121,
+        "column": 27
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 121,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 121,
+        "column": 35
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 122,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 122,
+        "column": 8
+      }
+    },
+    {
+      "vname": "transaction_msg",
+      "type": "ByStr20 -> Uint128 -> String -> Message",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 122,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 122,
+        "column": 30
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 122,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 122,
+        "column": 40
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 122,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 122,
+        "column": 47
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 122,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 122,
+        "column": 51
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 123,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 123,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 123,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 123,
+        "column": 16
+      }
+    },
+    {
+      "vname": "address_mem",
+      "type": "ByStr20 -> Map (ByStr20) (Bool) -> Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 126,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 126,
+        "column": 16
+      }
+    },
+    {
+      "vname": "sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 127,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 127,
+        "column": 9
+      }
+    },
+    {
+      "vname": "mem_map",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 128,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 128,
+        "column": 10
+      }
+    },
+    {
+      "vname": "mem",
+      "type": "Option (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 129,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 129,
+        "column": 8
+      }
+    },
+    {
+      "vname": "mem_map",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 129,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 129,
+        "column": 34
+      }
+    },
+    {
+      "vname": "sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 129,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 129,
+        "column": 41
+      }
+    },
+    {
+      "vname": "mem",
+      "type": "Option (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 130,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 130,
+        "column": 14
+      }
+    },
+    {
+      "vname": "initial_owners",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 164,
+        "column": 1
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 164,
+        "column": 15
+      }
+    },
+    {
+      "vname": "required_signatures",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 165,
+        "column": 1
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 165,
+        "column": 20
+      }
+    },
+    {
+      "vname": "validity_checked",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 169,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 169,
+        "column": 23
+      }
+    },
+    {
+      "vname": "contract_valid",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 170,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 170,
+        "column": 21
+      }
+    },
+    {
+      "vname": "owners",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 177,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 177,
+        "column": 13
+      }
+    },
+    {
+      "vname": "transactionCount",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 179,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 179,
+        "column": 23
+      }
+    },
+    {
+      "vname": "signatures",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 182,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 182,
+        "column": 17
+      }
+    },
+    {
+      "vname": "transactions",
+      "type": "Map (Uint32) (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 185,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 185,
+        "column": 19
+      }
+    },
+    {
+      "vname": "owner_signatures",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 189,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 189,
+        "column": 23
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 194,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 194,
+        "column": 40
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 194,
+        "column": 52
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 194,
+        "column": 58
+      }
+    },
+    {
+      "vname": "tc",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 195,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 195,
+        "column": 8
+      }
+    },
+    {
+      "vname": "transactionCount",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 195,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 195,
+        "column": 25
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 197,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 197,
+        "column": 12
+      }
+    },
+    {
+      "vname": "amount_is_zero",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 198,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 198,
+        "column": 32
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 198,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 198,
+        "column": 37
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 198,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 198,
+        "column": 42
+      }
+    },
+    {
+      "vname": "amount_is_zero",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 200,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 200,
+        "column": 23
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 203,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 203,
+        "column": 12
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 204,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 204,
+        "column": 8
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 204,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 204,
+        "column": 23
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 204,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 204,
+        "column": 27
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 205,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 205,
+        "column": 6
+      }
+    },
+    {
+      "vname": "transaction",
+      "type": "Transaction",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 208,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 208,
+        "column": 28
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 208,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 208,
+        "column": 34
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 208,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 208,
+        "column": 41
+      }
+    },
+    {
+      "vname": "ts_tmp",
+      "type": "Map (Uint32) (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 211,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 211,
+        "column": 18
+      }
+    },
+    {
+      "vname": "transactions",
+      "type": "Map (Uint32) (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 211,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 211,
+        "column": 27
+      }
+    },
+    {
+      "vname": "ts_new",
+      "type": "Map (Uint32) (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 212,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 212,
+        "column": 18
+      }
+    },
+    {
+      "vname": "ts_tmp",
+      "type": "Map (Uint32) (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 212,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 212,
+        "column": 32
+      }
+    },
+    {
+      "vname": "tc",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 212,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 212,
+        "column": 35
+      }
+    },
+    {
+      "vname": "transaction",
+      "type": "Transaction",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 212,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 212,
+        "column": 47
+      }
+    },
+    {
+      "vname": "sigs_tmp",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 215,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 215,
+        "column": 22
+      }
+    },
+    {
+      "vname": "signatures",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 215,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 215,
+        "column": 27
+      }
+    },
+    {
+      "vname": "sigs_new",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 216,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 216,
+        "column": 22
+      }
+    },
+    {
+      "vname": "sigs_tmp",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 216,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 216,
+        "column": 36
+      }
+    },
+    {
+      "vname": "tc",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 216,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 216,
+        "column": 39
+      }
+    },
+    {
+      "vname": "empty_sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 216,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 216,
+        "column": 50
+      }
+    },
+    {
+      "vname": "tc_new",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 219,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 219,
+        "column": 18
+      }
+    },
+    {
+      "vname": "tc",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 219,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 219,
+        "column": 28
+      }
+    },
+    {
+      "vname": "transaction_inc",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 219,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 219,
+        "column": 44
+      }
+    },
+    {
+      "vname": "tc_new",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 222,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 222,
+        "column": 31
+      }
+    },
+    {
+      "vname": "transactionCount",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 222,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 222,
+        "column": 38
+      }
+    },
+    {
+      "vname": "ts_new",
+      "type": "Map (Uint32) (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 223,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 223,
+        "column": 27
+      }
+    },
+    {
+      "vname": "transactions",
+      "type": "Map (Uint32) (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 223,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 223,
+        "column": 30
+      }
+    },
+    {
+      "vname": "sigs_new",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 224,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 224,
+        "column": 27
+      }
+    },
+    {
+      "vname": "signatures",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 224,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 224,
+        "column": 26
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 227,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 227,
+        "column": 8
+      }
+    },
+    {
+      "vname": "mk_transaction_added_event",
+      "type": "Uint32 -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 227,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 227,
+        "column": 35
+      }
+    },
+    {
+      "vname": "tc",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 227,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 227,
+        "column": 38
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 228,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 228,
+        "column": 6
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 233,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 233,
+        "column": 42
+      }
+    },
+    {
+      "vname": "sender_mem",
+      "type": "Map (ByStr20) (Bool) -> Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 235,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 235,
+        "column": 24
+      }
+    },
+    {
+      "vname": "address_mem",
+      "type": "ByStr20 -> Map (ByStr20) (Bool) -> Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 235,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 235,
+        "column": 27
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 235,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 235,
+        "column": 35
+      }
+    },
+    {
+      "vname": "owners_tmp",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 238,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 238,
+        "column": 24
+      }
+    },
+    {
+      "vname": "owners",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 238,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 238,
+        "column": 23
+      }
+    },
+    {
+      "vname": "sender_is_owner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 239,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 239,
+        "column": 34
+      }
+    },
+    {
+      "vname": "sender_mem",
+      "type": "Map (ByStr20) (Bool) -> Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 239,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 239,
+        "column": 31
+      }
+    },
+    {
+      "vname": "owners_tmp",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 239,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 239,
+        "column": 42
+      }
+    },
+    {
+      "vname": "sender_is_owner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 240,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 240,
+        "column": 24
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 242,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 242,
+        "column": 12
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 243,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 243,
+        "column": 8
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 243,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 243,
+        "column": 23
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 243,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 243,
+        "column": 27
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 244,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 244,
+        "column": 6
+      }
+    },
+    {
+      "vname": "ts_tmp",
+      "type": "Map (Uint32) (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 247,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 247,
+        "column": 18
+      }
+    },
+    {
+      "vname": "transactions",
+      "type": "Map (Uint32) (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 247,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 247,
+        "column": 27
+      }
+    },
+    {
+      "vname": "transaction",
+      "type": "Option (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 248,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 248,
+        "column": 28
+      }
+    },
+    {
+      "vname": "ts_tmp",
+      "type": "Map (Uint32) (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 248,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 248,
+        "column": 37
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 248,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 248,
+        "column": 51
+      }
+    },
+    {
+      "vname": "transaction",
+      "type": "Option (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 249,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 249,
+        "column": 22
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 251,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 251,
+        "column": 14
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 252,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 252,
+        "column": 10
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 252,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 252,
+        "column": 25
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 252,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 252,
+        "column": 29
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 253,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 253,
+        "column": 8
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 254,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 254,
+        "column": 35
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 254,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 254,
+        "column": 28
+      }
+    },
+    {
+      "vname": "sigs_tmp",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 256,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 256,
+        "column": 24
+      }
+    },
+    {
+      "vname": "signatures",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 256,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 256,
+        "column": 29
+      }
+    },
+    {
+      "vname": "sigs_opt",
+      "type": "Option (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 257,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 257,
+        "column": 24
+      }
+    },
+    {
+      "vname": "sigs_tmp",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 257,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 257,
+        "column": 38
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 257,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 257,
+        "column": 52
+      }
+    },
+    {
+      "vname": "sigs_opt",
+      "type": "Option (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 258,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 258,
+        "column": 21
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 260,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 260,
+        "column": 16
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 261,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 261,
+        "column": 12
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 261,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 261,
+        "column": 27
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 261,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 261,
+        "column": 31
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 262,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 262,
+        "column": 10
+      }
+    },
+    {
+      "vname": "sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 263,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 263,
+        "column": 18
+      }
+    },
+    {
+      "vname": "sender_has_signed",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 265,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 265,
+        "column": 44
+      }
+    },
+    {
+      "vname": "sender_mem",
+      "type": "Map (ByStr20) (Bool) -> Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 265,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 265,
+        "column": 39
+      }
+    },
+    {
+      "vname": "sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 265,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 265,
+        "column": 44
+      }
+    },
+    {
+      "vname": "sender_has_signed",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 266,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 266,
+        "column": 32
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 268,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 268,
+        "column": 18
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 269,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 269,
+        "column": 14
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 269,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 269,
+        "column": 29
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 269,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 269,
+        "column": 33
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 270,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 270,
+        "column": 12
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 273,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 273,
+        "column": 14
+      }
+    },
+    {
+      "vname": "new_sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 274,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 274,
+        "column": 28
+      }
+    },
+    {
+      "vname": "sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 274,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 274,
+        "column": 38
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 274,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 274,
+        "column": 46
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 274,
+        "column": 47
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 274,
+        "column": 48
+      }
+    },
+    {
+      "vname": "new_signatures",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 275,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 275,
+        "column": 40
+      }
+    },
+    {
+      "vname": "sigs_tmp",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 275,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 275,
+        "column": 48
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 275,
+        "column": 49
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 275,
+        "column": 62
+      }
+    },
+    {
+      "vname": "new_sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 275,
+        "column": 63
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 275,
+        "column": 71
+      }
+    },
+    {
+      "vname": "new_signatures",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 276,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 276,
+        "column": 39
+      }
+    },
+    {
+      "vname": "signatures",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 276,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 276,
+        "column": 32
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 284,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 284,
+        "column": 45
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 284,
+        "column": 56
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 284,
+        "column": 59
+      }
+    },
+    {
+      "vname": "transactions_tmp",
+      "type": "Map (Uint32) (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 285,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 285,
+        "column": 36
+      }
+    },
+    {
+      "vname": "transactions",
+      "type": "Map (Uint32) (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 285,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 285,
+        "column": 35
+      }
+    },
+    {
+      "vname": "transaction_opt",
+      "type": "Option (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 286,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 286,
+        "column": 34
+      }
+    },
+    {
+      "vname": "transactions_tmp",
+      "type": "Map (Uint32) (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 286,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 286,
+        "column": 49
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 286,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 286,
+        "column": 63
+      }
+    },
+    {
+      "vname": "transaction_opt",
+      "type": "Option (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 287,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 287,
+        "column": 24
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 290,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 290,
+        "column": 12
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 291,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 291,
+        "column": 8
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 291,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 291,
+        "column": 23
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 291,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 291,
+        "column": 27
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 292,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 292,
+        "column": 6
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 293,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 293,
+        "column": 33
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 293,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 293,
+        "column": 26
+      }
+    },
+    {
+      "vname": "recipient_is_sender",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 295,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 295,
+        "column": 44
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 295,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 295,
+        "column": 47
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 295,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 295,
+        "column": 55
+      }
+    },
+    {
+      "vname": "recipient_is_sender",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 296,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 296,
+        "column": 30
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 298,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 298,
+        "column": 14
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 299,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 299,
+        "column": 10
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 299,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 299,
+        "column": 25
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 299,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 299,
+        "column": 29
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 300,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 300,
+        "column": 8
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 303,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 303,
+        "column": 14
+      }
+    },
+    {
+      "vname": "_balance",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 303,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 303,
+        "column": 22
+      }
+    },
+    {
+      "vname": "not_enough_money",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 304,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 304,
+        "column": 40
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 304,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 304,
+        "column": 40
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 304,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 304,
+        "column": 47
+      }
+    },
+    {
+      "vname": "not_enough_money",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 305,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 305,
+        "column": 29
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 307,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 307,
+        "column": 16
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 308,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 308,
+        "column": 12
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 308,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 308,
+        "column": 27
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 308,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 308,
+        "column": 31
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 309,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 309,
+        "column": 10
+      }
+    },
+    {
+      "vname": "signatures_tmp",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 311,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 311,
+        "column": 38
+      }
+    },
+    {
+      "vname": "signatures",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 311,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 311,
+        "column": 37
+      }
+    },
+    {
+      "vname": "sigs_opt",
+      "type": "Option (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 312,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 312,
+        "column": 26
+      }
+    },
+    {
+      "vname": "signatures_tmp",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 312,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 312,
+        "column": 46
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 312,
+        "column": 47
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 312,
+        "column": 60
+      }
+    },
+    {
+      "vname": "sigs_opt",
+      "type": "Option (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 313,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 313,
+        "column": 23
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 316,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 316,
+        "column": 18
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 317,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 317,
+        "column": 14
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 317,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 317,
+        "column": 29
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 317,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 317,
+        "column": 33
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 318,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 318,
+        "column": 12
+      }
+    },
+    {
+      "vname": "sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 319,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 319,
+        "column": 20
+      }
+    },
+    {
+      "vname": "no_of_sigs",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 321,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 321,
+        "column": 32
+      }
+    },
+    {
+      "vname": "sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 321,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 321,
+        "column": 41
+      }
+    },
+    {
+      "vname": "not_enough_signatures",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 322,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 322,
+        "column": 54
+      }
+    },
+    {
+      "vname": "no_of_sigs",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 322,
+        "column": 46
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 322,
+        "column": 56
+      }
+    },
+    {
+      "vname": "required_signatures",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 322,
+        "column": 57
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 322,
+        "column": 76
+      }
+    },
+    {
+      "vname": "not_enough_signatures",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 323,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 323,
+        "column": 38
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 325,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 325,
+        "column": 20
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 326,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 326,
+        "column": 16
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 326,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 326,
+        "column": 31
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 326,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 326,
+        "column": 35
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 327,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 327,
+        "column": 14
+      }
+    },
+    {
+      "vname": "new_transactions",
+      "type": "Map (Uint32) (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 331,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 331,
+        "column": 46
+      }
+    },
+    {
+      "vname": "transactions_tmp",
+      "type": "Map (Uint32) (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 331,
+        "column": 47
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 331,
+        "column": 63
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 331,
+        "column": 64
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 331,
+        "column": 77
+      }
+    },
+    {
+      "vname": "new_transactions",
+      "type": "Map (Uint32) (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 332,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 332,
+        "column": 45
+      }
+    },
+    {
+      "vname": "transactions",
+      "type": "Map (Uint32) (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 332,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 332,
+        "column": 38
+      }
+    },
+    {
+      "vname": "new_signatures",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 333,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 333,
+        "column": 42
+      }
+    },
+    {
+      "vname": "signatures_tmp",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 333,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 333,
+        "column": 59
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 333,
+        "column": 60
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 333,
+        "column": 73
+      }
+    },
+    {
+      "vname": "new_signatures",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 334,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 334,
+        "column": 41
+      }
+    },
+    {
+      "vname": "signatures",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 334,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 334,
+        "column": 34
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 335,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 335,
+        "column": 22
+      }
+    },
+    {
+      "vname": "transaction_msg_as_list",
+      "type": "ByStr20 -> Uint128 -> String -> List (Message)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 335,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 335,
+        "column": 43
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 335,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 335,
+        "column": 53
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 335,
+        "column": 54
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 335,
+        "column": 60
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 335,
+        "column": 61
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 335,
+        "column": 64
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 336,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 336,
+        "column": 17
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 345,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 345,
+        "column": 42
+      }
+    },
+    {
+      "vname": "sigs_tmp",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 347,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 347,
+        "column": 20
+      }
+    },
+    {
+      "vname": "signatures",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 347,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 347,
+        "column": 25
+      }
+    },
+    {
+      "vname": "sigs_opt",
+      "type": "Option (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 348,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 348,
+        "column": 20
+      }
+    },
+    {
+      "vname": "sigs_tmp",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 348,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 348,
+        "column": 34
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 348,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 348,
+        "column": 48
+      }
+    },
+    {
+      "vname": "sigs_opt",
+      "type": "Option (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 349,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 349,
+        "column": 17
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 351,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 351,
+        "column": 12
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 352,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 352,
+        "column": 8
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 352,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 352,
+        "column": 23
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 352,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 352,
+        "column": 27
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 353,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 353,
+        "column": 6
+      }
+    },
+    {
+      "vname": "sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 354,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 354,
+        "column": 14
+      }
+    },
+    {
+      "vname": "sender_has_signed",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 356,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 356,
+        "column": 40
+      }
+    },
+    {
+      "vname": "address_mem",
+      "type": "ByStr20 -> Map (ByStr20) (Bool) -> Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 356,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 356,
+        "column": 36
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 356,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 356,
+        "column": 44
+      }
+    },
+    {
+      "vname": "sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 356,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 356,
+        "column": 49
+      }
+    },
+    {
+      "vname": "sender_has_signed",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 357,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 357,
+        "column": 28
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 359,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 359,
+        "column": 14
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 360,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 360,
+        "column": 10
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 360,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 360,
+        "column": 25
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 360,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 360,
+        "column": 29
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 361,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 361,
+        "column": 8
+      }
+    },
+    {
+      "vname": "new_sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 363,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 363,
+        "column": 24
+      }
+    },
+    {
+      "vname": "sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 363,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 363,
+        "column": 37
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 363,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 363,
+        "column": 45
+      }
+    },
+    {
+      "vname": "new_signatures",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 364,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 364,
+        "column": 36
+      }
+    },
+    {
+      "vname": "sigs_tmp",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 364,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 364,
+        "column": 44
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 364,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 364,
+        "column": 58
+      }
+    },
+    {
+      "vname": "new_sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 364,
+        "column": 59
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 364,
+        "column": 67
+      }
+    },
+    {
+      "vname": "new_signatures",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 365,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 365,
+        "column": 35
+      }
+    },
+    {
+      "vname": "signatures",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 365,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 365,
+        "column": 28
+      }
+    },
+    {
+      "vname": "new_owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 371,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 371,
+        "column": 43
+      }
+    },
+    {
+      "vname": "sigs_tmp",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 373,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 373,
+        "column": 20
+      }
+    },
+    {
+      "vname": "owner_signatures",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 373,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 373,
+        "column": 31
+      }
+    },
+    {
+      "vname": "sigs_opt",
+      "type": "Option (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 374,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 374,
+        "column": 20
+      }
+    },
+    {
+      "vname": "sigs_tmp",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 374,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 374,
+        "column": 34
+      }
+    },
+    {
+      "vname": "new_owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 374,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 374,
+        "column": 44
+      }
+    },
+    {
+      "vname": "sigs_opt",
+      "type": "Option (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 375,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 375,
+        "column": 17
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 377,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 377,
+        "column": 12
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 378,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 378,
+        "column": 8
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 378,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 378,
+        "column": 23
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 378,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 378,
+        "column": 27
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 379,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 379,
+        "column": 6
+      }
+    },
+    {
+      "vname": "sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 380,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 380,
+        "column": 14
+      }
+    },
+    {
+      "vname": "sender_has_signed",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 382,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 382,
+        "column": 40
+      }
+    },
+    {
+      "vname": "address_mem",
+      "type": "ByStr20 -> Map (ByStr20) (Bool) -> Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 382,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 382,
+        "column": 36
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 382,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 382,
+        "column": 44
+      }
+    },
+    {
+      "vname": "sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 382,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 382,
+        "column": 49
+      }
+    },
+    {
+      "vname": "sender_has_signed",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 383,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 383,
+        "column": 28
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 385,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 385,
+        "column": 14
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 386,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 386,
+        "column": 10
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 386,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 386,
+        "column": 25
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 386,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 386,
+        "column": 29
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 387,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 387,
+        "column": 8
+      }
+    },
+    {
+      "vname": "new_sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 389,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 389,
+        "column": 24
+      }
+    },
+    {
+      "vname": "sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 389,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 389,
+        "column": 37
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 389,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 389,
+        "column": 45
+      }
+    },
+    {
+      "vname": "new_signatures",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 390,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 390,
+        "column": 36
+      }
+    },
+    {
+      "vname": "sigs_tmp",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 390,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 390,
+        "column": 44
+      }
+    },
+    {
+      "vname": "new_owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 390,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 390,
+        "column": 54
+      }
+    },
+    {
+      "vname": "new_sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 390,
+        "column": 55
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 390,
+        "column": 63
+      }
+    },
+    {
+      "vname": "new_signatures",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 391,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 391,
+        "column": 41
+      }
+    },
+    {
+      "vname": "owner_signatures",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 391,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 391,
+        "column": 40
+      }
+    },
+    {
+      "vname": "candidate",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 397,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 397,
+        "column": 40
+      }
+    },
+    {
+      "vname": "checked",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 400,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 400,
+        "column": 18
+      }
+    },
+    {
+      "vname": "validity_checked",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 400,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 400,
+        "column": 30
+      }
+    },
+    {
+      "vname": "checked",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 401,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 401,
+        "column": 16
+      }
+    },
+    {
+      "vname": "owners_map",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 403,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 403,
+        "column": 26
+      }
+    },
+    {
+      "vname": "mk_owners_map",
+      "type": "List (ByStr20) -> Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 403,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 403,
+        "column": 31
+      }
+    },
+    {
+      "vname": "initial_owners",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 403,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 403,
+        "column": 46
+      }
+    },
+    {
+      "vname": "owners_map",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 404,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 404,
+        "column": 25
+      }
+    },
+    {
+      "vname": "owners",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 404,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 404,
+        "column": 18
+      }
+    },
+    {
+      "vname": "valid_contract",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 405,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 405,
+        "column": 34
+      }
+    },
+    {
+      "vname": "check_contract_validity",
+      "type": "Map (ByStr20) (Bool) -> Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 405,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 405,
+        "column": 45
+      }
+    },
+    {
+      "vname": "owners_map",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 405,
+        "column": 46
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 405,
+        "column": 56
+      }
+    },
+    {
+      "vname": "valid_contract",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 406,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 406,
+        "column": 37
+      }
+    },
+    {
+      "vname": "contract_valid",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 406,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 406,
+        "column": 34
+      }
+    },
+    {
+      "vname": "checked",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 407,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 407,
+        "column": 20
+      }
+    },
+    {
+      "vname": "checked",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 408,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 408,
+        "column": 32
+      }
+    },
+    {
+      "vname": "validity_checked",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 408,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 408,
+        "column": 38
+      }
+    },
+    {
+      "vname": "valid",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 412,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 412,
+        "column": 14
+      }
+    },
+    {
+      "vname": "contract_valid",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 412,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 412,
+        "column": 26
+      }
+    },
+    {
+      "vname": "valid",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 413,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 413,
+        "column": 14
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 415,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 415,
+        "column": 12
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 416,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 416,
+        "column": 8
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 416,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 416,
+        "column": 23
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 416,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 416,
+        "column": 27
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 417,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 417,
+        "column": 6
+      }
+    },
+    {
+      "vname": "owner_signatures_tmp",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 419,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 419,
+        "column": 46
+      }
+    },
+    {
+      "vname": "owner_signatures",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 419,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 419,
+        "column": 45
+      }
+    },
+    {
+      "vname": "sigs_option",
+      "type": "Option (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 420,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 420,
+        "column": 28
+      }
+    },
+    {
+      "vname": "owner_signatures_tmp",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 420,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 420,
+        "column": 51
+      }
+    },
+    {
+      "vname": "candidate",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 420,
+        "column": 52
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 420,
+        "column": 61
+      }
+    },
+    {
+      "vname": "sigs_option",
+      "type": "Option (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 421,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 421,
+        "column": 22
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 424,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 424,
+        "column": 14
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 425,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 425,
+        "column": 10
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 425,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 425,
+        "column": 25
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 425,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 425,
+        "column": 29
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 426,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 426,
+        "column": 8
+      }
+    },
+    {
+      "vname": "owners_tmp",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 428,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 428,
+        "column": 28
+      }
+    },
+    {
+      "vname": "owners",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 428,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 428,
+        "column": 27
+      }
+    },
+    {
+      "vname": "owner_option",
+      "type": "Option (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 429,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 429,
+        "column": 32
+      }
+    },
+    {
+      "vname": "owners_tmp",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 429,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 429,
+        "column": 44
+      }
+    },
+    {
+      "vname": "candidate",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 429,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 429,
+        "column": 54
+      }
+    },
+    {
+      "vname": "owner_option",
+      "type": "Option (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 430,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 430,
+        "column": 25
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 433,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 433,
+        "column": 16
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 434,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 434,
+        "column": 12
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 434,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 434,
+        "column": 27
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 434,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 434,
+        "column": 31
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 435,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 435,
+        "column": 10
+      }
+    },
+    {
+      "vname": "empty_sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 438,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 438,
+        "column": 30
+      }
+    },
+    {
+      "vname": "new_owner_signatures",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 439,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 439,
+        "column": 50
+      }
+    },
+    {
+      "vname": "owner_signatures_tmp",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 439,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 439,
+        "column": 64
+      }
+    },
+    {
+      "vname": "candidate",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 439,
+        "column": 65
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 439,
+        "column": 74
+      }
+    },
+    {
+      "vname": "empty_sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 439,
+        "column": 75
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 439,
+        "column": 85
+      }
+    },
+    {
+      "vname": "new_owner_signatures",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 440,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 440,
+        "column": 49
+      }
+    },
+    {
+      "vname": "owner_signatures",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 440,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 440,
+        "column": 42
+      }
+    },
+    {
+      "vname": "candidate",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 447,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 447,
+        "column": 38
+      }
+    },
+    {
+      "vname": "sender_mem",
+      "type": "Map (ByStr20) (Bool) -> Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 449,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 449,
+        "column": 24
+      }
+    },
+    {
+      "vname": "address_mem",
+      "type": "ByStr20 -> Map (ByStr20) (Bool) -> Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 449,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 449,
+        "column": 27
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 449,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 449,
+        "column": 35
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 450,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 450,
+        "column": 6
+      }
+    },
+    {
+      "vname": "owners_tmp",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 453,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 453,
+        "column": 24
+      }
+    },
+    {
+      "vname": "owners",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 453,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 453,
+        "column": 23
+      }
+    },
+    {
+      "vname": "sender_is_owner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 454,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 454,
+        "column": 34
+      }
+    },
+    {
+      "vname": "sender_mem",
+      "type": "Map (ByStr20) (Bool) -> Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 454,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 454,
+        "column": 31
+      }
+    },
+    {
+      "vname": "owners_tmp",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 454,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 454,
+        "column": 42
+      }
+    },
+    {
+      "vname": "sender_is_owner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 455,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 455,
+        "column": 24
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 457,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 457,
+        "column": 12
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 458,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 458,
+        "column": 8
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 458,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 458,
+        "column": 23
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 458,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 458,
+        "column": 27
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 459,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 459,
+        "column": 6
+      }
+    },
+    {
+      "vname": "owner_signatures_tmp",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 461,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 461,
+        "column": 46
+      }
+    },
+    {
+      "vname": "owner_signatures",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 461,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 461,
+        "column": 45
+      }
+    },
+    {
+      "vname": "sigs_option",
+      "type": "Option (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 462,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 462,
+        "column": 28
+      }
+    },
+    {
+      "vname": "owner_signatures_tmp",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 462,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 462,
+        "column": 51
+      }
+    },
+    {
+      "vname": "candidate",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 462,
+        "column": 52
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 462,
+        "column": 61
+      }
+    },
+    {
+      "vname": "sigs_option",
+      "type": "Option (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 463,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 463,
+        "column": 22
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 466,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 466,
+        "column": 14
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 467,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 467,
+        "column": 10
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 467,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 467,
+        "column": 25
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 467,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 467,
+        "column": 29
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 468,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 468,
+        "column": 8
+      }
+    },
+    {
+      "vname": "sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 469,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 469,
+        "column": 16
+      }
+    },
+    {
+      "vname": "sender_has_signed",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 471,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 471,
+        "column": 42
+      }
+    },
+    {
+      "vname": "sender_mem",
+      "type": "Map (ByStr20) (Bool) -> Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 471,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 471,
+        "column": 37
+      }
+    },
+    {
+      "vname": "sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 471,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 471,
+        "column": 42
+      }
+    },
+    {
+      "vname": "sender_has_signed",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 472,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 472,
+        "column": 30
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 474,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 474,
+        "column": 16
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 475,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 475,
+        "column": 12
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 475,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 475,
+        "column": 27
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 475,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 475,
+        "column": 31
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 476,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 476,
+        "column": 10
+      }
+    },
+    {
+      "vname": "new_sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 478,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 478,
+        "column": 26
+      }
+    },
+    {
+      "vname": "sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 478,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 478,
+        "column": 36
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 478,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 478,
+        "column": 44
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 478,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 478,
+        "column": 46
+      }
+    },
+    {
+      "vname": "new_owner_signatures",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 479,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 479,
+        "column": 50
+      }
+    },
+    {
+      "vname": "owner_signatures_tmp",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 479,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 479,
+        "column": 64
+      }
+    },
+    {
+      "vname": "candidate",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 479,
+        "column": 65
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 479,
+        "column": 74
+      }
+    },
+    {
+      "vname": "new_sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 479,
+        "column": 75
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 479,
+        "column": 83
+      }
+    },
+    {
+      "vname": "new_owner_signatures",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 480,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 480,
+        "column": 49
+      }
+    },
+    {
+      "vname": "owner_signatures",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 480,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 480,
+        "column": 42
+      }
+    },
+    {
+      "vname": "no_of_sigs",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 482,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 482,
+        "column": 30
+      }
+    },
+    {
+      "vname": "new_sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 482,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 482,
+        "column": 43
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 483,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 483,
+        "column": 12
+      }
+    },
+    {
+      "vname": "mk_owner_signed_event",
+      "type": "Uint32 -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 483,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 483,
+        "column": 34
+      }
+    },
+    {
+      "vname": "no_of_sigs",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 483,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 483,
+        "column": 45
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 484,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 484,
+        "column": 10
+      }
+    },
+    {
+      "vname": "owner_signatures_tmp",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 492,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 492,
+        "column": 44
+      }
+    },
+    {
+      "vname": "owner_signatures",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 492,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 492,
+        "column": 43
+      }
+    },
+    {
+      "vname": "sigs_option",
+      "type": "Option (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 493,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 493,
+        "column": 26
+      }
+    },
+    {
+      "vname": "owner_signatures_tmp",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 493,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 493,
+        "column": 49
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 493,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 493,
+        "column": 57
+      }
+    },
+    {
+      "vname": "sigs_option",
+      "type": "Option (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 495,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 495,
+        "column": 20
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 498,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 498,
+        "column": 12
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 499,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 499,
+        "column": 8
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 499,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 499,
+        "column": 23
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 499,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 499,
+        "column": 27
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 500,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 500,
+        "column": 6
+      }
+    },
+    {
+      "vname": "sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 501,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 501,
+        "column": 14
+      }
+    },
+    {
+      "vname": "current_owners",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 502,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 502,
+        "column": 34
+      }
+    },
+    {
+      "vname": "owners",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 502,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 502,
+        "column": 29
+      }
+    },
+    {
+      "vname": "no_of_owners",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 503,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 503,
+        "column": 30
+      }
+    },
+    {
+      "vname": "current_owners",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 503,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 503,
+        "column": 47
+      }
+    },
+    {
+      "vname": "no_of_sigs",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 504,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 504,
+        "column": 26
+      }
+    },
+    {
+      "vname": "sigs",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 504,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 504,
+        "column": 35
+      }
+    },
+    {
+      "vname": "all_have_signed",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 505,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 505,
+        "column": 36
+      }
+    },
+    {
+      "vname": "uint32_eq",
+      "type": "Uint32 -> Uint32 -> Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 505,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 505,
+        "column": 32
+      }
+    },
+    {
+      "vname": "no_of_sigs",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 505,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 505,
+        "column": 43
+      }
+    },
+    {
+      "vname": "no_of_owners",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 505,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 505,
+        "column": 56
+      }
+    },
+    {
+      "vname": "all_have_signed",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 506,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 506,
+        "column": 26
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 509,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 509,
+        "column": 14
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 510,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 510,
+        "column": 10
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 510,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 510,
+        "column": 25
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 510,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 510,
+        "column": 29
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 511,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 511,
+        "column": 8
+      }
+    },
+    {
+      "vname": "new_owner_signatures",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 515,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 515,
+        "column": 48
+      }
+    },
+    {
+      "vname": "owner_signatures_tmp",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 515,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 515,
+        "column": 65
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 515,
+        "column": 66
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 515,
+        "column": 73
+      }
+    },
+    {
+      "vname": "new_owner_signatures",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 516,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 516,
+        "column": 47
+      }
+    },
+    {
+      "vname": "owner_signatures",
+      "type": "Map (ByStr20) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 516,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 516,
+        "column": 40
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 517,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 517,
+        "column": 10
+      }
+    },
+    {
+      "vname": "new_owners",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 518,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 518,
+        "column": 28
+      }
+    },
+    {
+      "vname": "current_owners",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 518,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 518,
+        "column": 46
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 518,
+        "column": 47
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 518,
+        "column": 54
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 518,
+        "column": 55
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 518,
+        "column": 56
+      }
+    },
+    {
+      "vname": "new_owners",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 519,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 519,
+        "column": 27
+      }
+    },
+    {
+      "vname": "owners",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 519,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 519,
+        "column": 20
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 521,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 521,
+        "column": 10
+      }
+    },
+    {
+      "vname": "mk_new_owner_approved_event",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 521,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 521,
+        "column": 38
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 522,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 522,
+        "column": 8
+      }
+    },
+    {
+      "vname": "checked",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 530,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 530,
+        "column": 18
+      }
+    },
+    {
+      "vname": "validity_checked",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 530,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 530,
+        "column": 30
+      }
+    },
+    {
+      "vname": "checked",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 531,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 531,
+        "column": 16
+      }
+    },
+    {
+      "vname": "owners_map",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 533,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 533,
+        "column": 26
+      }
+    },
+    {
+      "vname": "mk_owners_map",
+      "type": "List (ByStr20) -> Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 533,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 533,
+        "column": 31
+      }
+    },
+    {
+      "vname": "initial_owners",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 533,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 533,
+        "column": 46
+      }
+    },
+    {
+      "vname": "owners_map",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 534,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 534,
+        "column": 25
+      }
+    },
+    {
+      "vname": "owners",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 534,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 534,
+        "column": 18
+      }
+    },
+    {
+      "vname": "valid_contract",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 535,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 535,
+        "column": 34
+      }
+    },
+    {
+      "vname": "check_contract_validity",
+      "type": "Map (ByStr20) (Bool) -> Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 535,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 535,
+        "column": 45
+      }
+    },
+    {
+      "vname": "owners_map",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 535,
+        "column": 46
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 535,
+        "column": 56
+      }
+    },
+    {
+      "vname": "valid_contract",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 536,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 536,
+        "column": 37
+      }
+    },
+    {
+      "vname": "contract_valid",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 536,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 536,
+        "column": 34
+      }
+    },
+    {
+      "vname": "checked",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 537,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 537,
+        "column": 20
+      }
+    },
+    {
+      "vname": "checked",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 538,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 538,
+        "column": 32
+      }
+    },
+    {
+      "vname": "validity_checked",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 538,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 538,
+        "column": 38
+      }
+    },
+    {
+      "vname": "valid",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 543,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 543,
+        "column": 14
+      }
+    },
+    {
+      "vname": "contract_valid",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 543,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 543,
+        "column": 26
+      }
+    },
+    {
+      "vname": "valid",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 544,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 544,
+        "column": 14
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 546,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 546,
+        "column": 12
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 547,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 547,
+        "column": 8
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 547,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 547,
+        "column": 23
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 547,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 547,
+        "column": 27
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 548,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet.scilla",
+        "line": 548,
+        "column": 6
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Wallet",

--- a/tests/checker/good/gold/wallet_2.scilla.gold
+++ b/tests/checker/good/gold/wallet_2.scilla.gold
@@ -21,6 +21,4239 @@
       }
     ]
   },
+  "type_info": [
+    {
+      "vname": "mk_contract_initialized_event",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 11,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 11,
+        "column": 34
+      }
+    },
+    {
+      "vname": "mk_transaction_added_event",
+      "type": "Uint32 -> Event",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 15,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 15,
+        "column": 31
+      }
+    },
+    {
+      "vname": "tc",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 16,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 16,
+        "column": 5
+      }
+    },
+    {
+      "vname": "tc",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 17,
+        "column": 60
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 17,
+        "column": 62
+      }
+    },
+    {
+      "vname": "mk_transaction_executed_event",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 20,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 20,
+        "column": 34
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 38,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 38,
+        "column": 19
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 39,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 39,
+        "column": 6
+      }
+    },
+    {
+      "vname": "err_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 40,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 40,
+        "column": 11
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 41,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 41,
+        "column": 14
+      }
+    },
+    {
+      "vname": "err_code",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 55,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 55,
+        "column": 53
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 57,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 57,
+        "column": 6
+      }
+    },
+    {
+      "vname": "f",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 58,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 58,
+        "column": 6
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 59,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 59,
+        "column": 9
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 60,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 60,
+        "column": 8
+      }
+    },
+    {
+      "vname": "transaction_inc",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 61,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 61,
+        "column": 20
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 61,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 61,
+        "column": 26
+      }
+    },
+    {
+      "vname": "mk_owners_map",
+      "type": "List (ByStr20) -> Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 69,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 69,
+        "column": 18
+      }
+    },
+    {
+      "vname": "owners",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 70,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 70,
+        "column": 9
+      }
+    },
+    {
+      "vname": "init",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 71,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 71,
+        "column": 9
+      }
+    },
+    {
+      "vname": "iter",
+      "type": "Map (ByStr20) (Bool) -> ByStr20 -> Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 72,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 72,
+        "column": 9
+      }
+    },
+    {
+      "vname": "acc",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 73,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 73,
+        "column": 10
+      }
+    },
+    {
+      "vname": "cur_owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 74,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 74,
+        "column": 16
+      }
+    },
+    {
+      "vname": "acc",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 76,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 76,
+        "column": 24
+      }
+    },
+    {
+      "vname": "cur_owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 76,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 76,
+        "column": 34
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 76,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 76,
+        "column": 36
+      }
+    },
+    {
+      "vname": "folder",
+      "type":
+        "(Map (ByStr20) (Bool) -> ByStr20 -> Map (ByStr20) (Bool)) -> Map (ByStr20) (Bool) -> List (ByStr20) -> Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 78,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 78,
+        "column": 11
+      }
+    },
+    {
+      "vname": "list_foldl",
+      "type":
+        "forall 'A. forall 'B. ('B -> 'A -> 'B) -> 'B -> List ('A) -> 'B",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 78,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 78,
+        "column": 28
+      }
+    },
+    {
+      "vname": "folder",
+      "type":
+        "(Map (ByStr20) (Bool) -> ByStr20 -> Map (ByStr20) (Bool)) -> Map (ByStr20) (Bool) -> List (ByStr20) -> Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 79,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 79,
+        "column": 11
+      }
+    },
+    {
+      "vname": "iter",
+      "type": "Map (ByStr20) (Bool) -> ByStr20 -> Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 79,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 79,
+        "column": 16
+      }
+    },
+    {
+      "vname": "init",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 79,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 79,
+        "column": 21
+      }
+    },
+    {
+      "vname": "owners",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 79,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 79,
+        "column": 28
+      }
+    },
+    {
+      "vname": "check_validity_and_build_owners_map",
+      "type": "List (ByStr20) -> Uint32 -> Option (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 82,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 82,
+        "column": 40
+      }
+    },
+    {
+      "vname": "owners",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 83,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 83,
+        "column": 9
+      }
+    },
+    {
+      "vname": "required_signatures",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 84,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 84,
+        "column": 22
+      }
+    },
+    {
+      "vname": "len",
+      "type": "List (ByStr20) -> Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 85,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 85,
+        "column": 8
+      }
+    },
+    {
+      "vname": "list_length",
+      "type": "forall 'A. List ('A) -> Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 85,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 85,
+        "column": 26
+      }
+    },
+    {
+      "vname": "no_of_owners",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 86,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 86,
+        "column": 17
+      }
+    },
+    {
+      "vname": "len",
+      "type": "List (ByStr20) -> Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 86,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 86,
+        "column": 27
+      }
+    },
+    {
+      "vname": "owners",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 86,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 86,
+        "column": 34
+      }
+    },
+    {
+      "vname": "owners_ok",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 87,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 87,
+        "column": 14
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 87,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 87,
+        "column": 36
+      }
+    },
+    {
+      "vname": "no_of_owners",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 87,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 87,
+        "column": 49
+      }
+    },
+    {
+      "vname": "required_sigs_not_too_low",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 88,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 88,
+        "column": 30
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 88,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 88,
+        "column": 52
+      }
+    },
+    {
+      "vname": "required_signatures",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 88,
+        "column": 53
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 88,
+        "column": 72
+      }
+    },
+    {
+      "vname": "required_sigs_too_high",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 89,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 89,
+        "column": 27
+      }
+    },
+    {
+      "vname": "no_of_owners",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 89,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 89,
+        "column": 57
+      }
+    },
+    {
+      "vname": "required_signatures",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 89,
+        "column": 58
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 89,
+        "column": 77
+      }
+    },
+    {
+      "vname": "required_sigs_not_too_high",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 90,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 90,
+        "column": 31
+      }
+    },
+    {
+      "vname": "negb",
+      "type": "Bool -> Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 90,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 90,
+        "column": 42
+      }
+    },
+    {
+      "vname": "required_sigs_too_high",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 90,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 90,
+        "column": 65
+      }
+    },
+    {
+      "vname": "required_sigs_ok",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 91,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 91,
+        "column": 21
+      }
+    },
+    {
+      "vname": "andb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 91,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 91,
+        "column": 32
+      }
+    },
+    {
+      "vname": "required_sigs_not_too_high",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 91,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 91,
+        "column": 59
+      }
+    },
+    {
+      "vname": "required_sigs_not_too_low",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 91,
+        "column": 60
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 91,
+        "column": 85
+      }
+    },
+    {
+      "vname": "all_ok",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 92,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 92,
+        "column": 11
+      }
+    },
+    {
+      "vname": "andb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 92,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 92,
+        "column": 22
+      }
+    },
+    {
+      "vname": "required_sigs_ok",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 92,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 92,
+        "column": 39
+      }
+    },
+    {
+      "vname": "owners_ok",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 92,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 92,
+        "column": 49
+      }
+    },
+    {
+      "vname": "all_ok",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 93,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 93,
+        "column": 17
+      }
+    },
+    {
+      "vname": "owners_map",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 95,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 95,
+        "column": 17
+      }
+    },
+    {
+      "vname": "mk_owners_map",
+      "type": "List (ByStr20) -> Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 95,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 95,
+        "column": 37
+      }
+    },
+    {
+      "vname": "owners",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 95,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 95,
+        "column": 44
+      }
+    },
+    {
+      "vname": "size_of_owners_map",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 96,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 96,
+        "column": 25
+      }
+    },
+    {
+      "vname": "owners_map",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 96,
+        "column": 45
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 96,
+        "column": 55
+      }
+    },
+    {
+      "vname": "equal_size",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 97,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 97,
+        "column": 17
+      }
+    },
+    {
+      "vname": "size_of_owners_map",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 97,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 97,
+        "column": 53
+      }
+    },
+    {
+      "vname": "no_of_owners",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 97,
+        "column": 54
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 97,
+        "column": 66
+      }
+    },
+    {
+      "vname": "equal_size",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 98,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 98,
+        "column": 23
+      }
+    },
+    {
+      "vname": "owners_map",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 101,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 101,
+        "column": 43
+      }
+    },
+    {
+      "vname": "transaction_msg",
+      "type": "ByStr20 -> Uint128 -> String -> Message",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 111,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 111,
+        "column": 20
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 112,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 112,
+        "column": 12
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 113,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 113,
+        "column": 9
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 114,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 114,
+        "column": 6
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 115,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 115,
+        "column": 16
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 115,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 115,
+        "column": 40
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 115,
+        "column": 52
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 115,
+        "column": 58
+      }
+    },
+    {
+      "vname": "transaction_msg_as_list",
+      "type": "ByStr20 -> Uint128 -> String -> List (Message)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 118,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 118,
+        "column": 28
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 119,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 119,
+        "column": 12
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 120,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 120,
+        "column": 9
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 121,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 121,
+        "column": 6
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 122,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 122,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 123,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 123,
+        "column": 10
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 124,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 124,
+        "column": 16
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 125,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 125,
+        "column": 27
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 125,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 125,
+        "column": 35
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 126,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 126,
+        "column": 8
+      }
+    },
+    {
+      "vname": "transaction_msg",
+      "type": "ByStr20 -> Uint128 -> String -> Message",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 126,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 126,
+        "column": 30
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 126,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 126,
+        "column": 40
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 126,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 126,
+        "column": 47
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 126,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 126,
+        "column": 51
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 127,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 127,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 127,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 127,
+        "column": 16
+      }
+    },
+    {
+      "vname": "valid",
+      "type": "ContractValidity",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 134,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 134,
+        "column": 10
+      }
+    },
+    {
+      "vname": "invalid",
+      "type": "ContractValidity",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 135,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 135,
+        "column": 12
+      }
+    },
+    {
+      "vname": "owners_list",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 216,
+        "column": 1
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 216,
+        "column": 12
+      }
+    },
+    {
+      "vname": "required_signatures",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 217,
+        "column": 1
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 217,
+        "column": 20
+      }
+    },
+    {
+      "vname": "contract_valid",
+      "type": "ContractValidity",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 221,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 221,
+        "column": 21
+      }
+    },
+    {
+      "vname": "owners",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 228,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 228,
+        "column": 13
+      }
+    },
+    {
+      "vname": "transactionCount",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 230,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 230,
+        "column": 23
+      }
+    },
+    {
+      "vname": "signatures",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 233,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 233,
+        "column": 17
+      }
+    },
+    {
+      "vname": "signature_counts",
+      "type": "Map (Uint32) (Uint32)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 237,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 237,
+        "column": 23
+      }
+    },
+    {
+      "vname": "transactions",
+      "type": "Map (Uint32) (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 241,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 241,
+        "column": 19
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 243,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 243,
+        "column": 25
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 244,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 244,
+        "column": 6
+      }
+    },
+    {
+      "vname": "mk_error_event",
+      "type": "Error -> Event",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 244,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 244,
+        "column": 21
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 244,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 244,
+        "column": 25
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 245,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 245,
+        "column": 4
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 249,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 249,
+        "column": 38
+      }
+    },
+    {
+      "vname": "signee",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 249,
+        "column": 49
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 249,
+        "column": 55
+      }
+    },
+    {
+      "vname": "sig",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 250,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 250,
+        "column": 6
+      }
+    },
+    {
+      "vname": "signatures",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 250,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 250,
+        "column": 27
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 250,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 250,
+        "column": 41
+      }
+    },
+    {
+      "vname": "signee",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 250,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 250,
+        "column": 49
+      }
+    },
+    {
+      "vname": "sig",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 251,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 251,
+        "column": 12
+      }
+    },
+    {
+      "vname": "count",
+      "type": "Option (Uint32)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 253,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 253,
+        "column": 10
+      }
+    },
+    {
+      "vname": "signature_counts",
+      "type": "Map (Uint32) (Uint32)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 253,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 253,
+        "column": 30
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 253,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 253,
+        "column": 44
+      }
+    },
+    {
+      "vname": "count",
+      "type": "Option (Uint32)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 254,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 254,
+        "column": 16
+      }
+    },
+    {
+      "vname": "signature_counts",
+      "type": "Map (Uint32) (Uint32)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 257,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 257,
+        "column": 23
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 257,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 257,
+        "column": 37
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 257,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 257,
+        "column": 45
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 258,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 258,
+        "column": 13
+      }
+    },
+    {
+      "vname": "new_c",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 259,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 259,
+        "column": 18
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 259,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 259,
+        "column": 28
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 259,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 259,
+        "column": 32
+      }
+    },
+    {
+      "vname": "signature_counts",
+      "type": "Map (Uint32) (Uint32)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 260,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 260,
+        "column": 23
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 260,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 260,
+        "column": 37
+      }
+    },
+    {
+      "vname": "new_c",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 260,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 260,
+        "column": 47
+      }
+    },
+    {
+      "vname": "signatures",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 262,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 262,
+        "column": 15
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 262,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 262,
+        "column": 29
+      }
+    },
+    {
+      "vname": "signee",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 262,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 262,
+        "column": 37
+      }
+    },
+    {
+      "vname": "t",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 262,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 262,
+        "column": 43
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 265,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 265,
+        "column": 12
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 266,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 266,
+        "column": 18
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 271,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 271,
+        "column": 40
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 271,
+        "column": 52
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 271,
+        "column": 58
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 271,
+        "column": 70
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 271,
+        "column": 73
+      }
+    },
+    {
+      "vname": "sender_is_owner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 273,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 273,
+        "column": 18
+      }
+    },
+    {
+      "vname": "owners",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 273,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 273,
+        "column": 35
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 273,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 273,
+        "column": 43
+      }
+    },
+    {
+      "vname": "sender_is_owner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 274,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 274,
+        "column": 24
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 276,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 276,
+        "column": 12
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 277,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 277,
+        "column": 18
+      }
+    },
+    {
+      "vname": "tc",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 279,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 279,
+        "column": 10
+      }
+    },
+    {
+      "vname": "transactionCount",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 279,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 279,
+        "column": 27
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 280,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 280,
+        "column": 14
+      }
+    },
+    {
+      "vname": "amount_is_zero",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 281,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 281,
+        "column": 34
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 281,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 281,
+        "column": 39
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 281,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 281,
+        "column": 44
+      }
+    },
+    {
+      "vname": "amount_is_zero",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 282,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 282,
+        "column": 25
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 285,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 285,
+        "column": 14
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 286,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 286,
+        "column": 20
+      }
+    },
+    {
+      "vname": "transaction",
+      "type": "Transaction",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 289,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 289,
+        "column": 30
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 289,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 289,
+        "column": 36
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 289,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 289,
+        "column": 43
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 289,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 289,
+        "column": 47
+      }
+    },
+    {
+      "vname": "transactions",
+      "type": "Map (Uint32) (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 291,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 291,
+        "column": 19
+      }
+    },
+    {
+      "vname": "tc",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 291,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 291,
+        "column": 22
+      }
+    },
+    {
+      "vname": "transaction",
+      "type": "Transaction",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 291,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 291,
+        "column": 38
+      }
+    },
+    {
+      "vname": "tc",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 293,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 293,
+        "column": 22
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 293,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 293,
+        "column": 30
+      }
+    },
+    {
+      "vname": "tc_new",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 295,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 295,
+        "column": 20
+      }
+    },
+    {
+      "vname": "tc",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 295,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 295,
+        "column": 30
+      }
+    },
+    {
+      "vname": "transaction_inc",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 295,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 295,
+        "column": 46
+      }
+    },
+    {
+      "vname": "tc_new",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 297,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 297,
+        "column": 33
+      }
+    },
+    {
+      "vname": "transactionCount",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 297,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 297,
+        "column": 40
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 299,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 299,
+        "column": 10
+      }
+    },
+    {
+      "vname": "mk_transaction_added_event",
+      "type": "Uint32 -> Event",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 299,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 299,
+        "column": 37
+      }
+    },
+    {
+      "vname": "tc",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 299,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 299,
+        "column": 40
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 300,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 300,
+        "column": 8
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 306,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 306,
+        "column": 42
+      }
+    },
+    {
+      "vname": "sender_is_owner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 308,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 308,
+        "column": 18
+      }
+    },
+    {
+      "vname": "owners",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 308,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 308,
+        "column": 35
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 308,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 308,
+        "column": 43
+      }
+    },
+    {
+      "vname": "sender_is_owner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 309,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 309,
+        "column": 24
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 311,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 311,
+        "column": 12
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 312,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 312,
+        "column": 18
+      }
+    },
+    {
+      "vname": "transaction",
+      "type": "Option (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 315,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 315,
+        "column": 16
+      }
+    },
+    {
+      "vname": "transactions",
+      "type": "Map (Uint32) (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 315,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 315,
+        "column": 32
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 315,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 315,
+        "column": 46
+      }
+    },
+    {
+      "vname": "transaction",
+      "type": "Option (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 316,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 316,
+        "column": 22
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 318,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 318,
+        "column": 14
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 319,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 319,
+        "column": 20
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 322,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 322,
+        "column": 33
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 322,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 322,
+        "column": 41
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 328,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 328,
+        "column": 43
+      }
+    },
+    {
+      "vname": "transactions",
+      "type": "Map (Uint32) (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 329,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 329,
+        "column": 22
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 329,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 329,
+        "column": 36
+      }
+    },
+    {
+      "vname": "signatures",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 330,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 330,
+        "column": 20
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 330,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 330,
+        "column": 34
+      }
+    },
+    {
+      "vname": "signature_counts",
+      "type": "Map (Uint32) (Uint32)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 331,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 331,
+        "column": 26
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 331,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 331,
+        "column": 40
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 335,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 335,
+        "column": 45
+      }
+    },
+    {
+      "vname": "transaction_opt",
+      "type": "Option (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 336,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 336,
+        "column": 18
+      }
+    },
+    {
+      "vname": "transactions",
+      "type": "Map (Uint32) (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 336,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 336,
+        "column": 34
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 336,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 336,
+        "column": 48
+      }
+    },
+    {
+      "vname": "transaction_opt",
+      "type": "Option (Transaction)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 337,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 337,
+        "column": 24
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 340,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 340,
+        "column": 12
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 341,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 341,
+        "column": 18
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 342,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 342,
+        "column": 37
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 342,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 342,
+        "column": 33
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 342,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 342,
+        "column": 26
+      }
+    },
+    {
+      "vname": "recipient_is_sender",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 344,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 344,
+        "column": 44
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 344,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 344,
+        "column": 47
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 344,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 344,
+        "column": 55
+      }
+    },
+    {
+      "vname": "sender_is_owner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 345,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 345,
+        "column": 20
+      }
+    },
+    {
+      "vname": "owners",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 345,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 345,
+        "column": 37
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 345,
+        "column": 38
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 345,
+        "column": 45
+      }
+    },
+    {
+      "vname": "sender_may_execute",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 346,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 346,
+        "column": 42
+      }
+    },
+    {
+      "vname": "orb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 346,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 346,
+        "column": 29
+      }
+    },
+    {
+      "vname": "recipient_is_sender",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 346,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 346,
+        "column": 49
+      }
+    },
+    {
+      "vname": "sender_is_owner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 346,
+        "column": 50
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 346,
+        "column": 65
+      }
+    },
+    {
+      "vname": "sender_may_execute",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 347,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 347,
+        "column": 29
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 349,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 349,
+        "column": 14
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 350,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 350,
+        "column": 20
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 353,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 353,
+        "column": 14
+      }
+    },
+    {
+      "vname": "_balance",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 353,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 353,
+        "column": 22
+      }
+    },
+    {
+      "vname": "not_enough_money",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 354,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 354,
+        "column": 40
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 354,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 354,
+        "column": 40
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 354,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 354,
+        "column": 47
+      }
+    },
+    {
+      "vname": "not_enough_money",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 355,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 355,
+        "column": 29
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 357,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 357,
+        "column": 16
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 358,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 358,
+        "column": 22
+      }
+    },
+    {
+      "vname": "sig_count_opt",
+      "type": "Option (Uint32)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 360,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 360,
+        "column": 22
+      }
+    },
+    {
+      "vname": "signature_counts",
+      "type": "Map (Uint32) (Uint32)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 360,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 360,
+        "column": 42
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 360,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 360,
+        "column": 56
+      }
+    },
+    {
+      "vname": "sig_count_opt",
+      "type": "Option (Uint32)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 361,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 361,
+        "column": 28
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 364,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 364,
+        "column": 18
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 365,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 365,
+        "column": 24
+      }
+    },
+    {
+      "vname": "sig_count",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 366,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 366,
+        "column": 25
+      }
+    },
+    {
+      "vname": "not_enough_signatures",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 367,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 367,
+        "column": 54
+      }
+    },
+    {
+      "vname": "sig_count",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 367,
+        "column": 46
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 367,
+        "column": 55
+      }
+    },
+    {
+      "vname": "required_signatures",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 367,
+        "column": 56
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 367,
+        "column": 75
+      }
+    },
+    {
+      "vname": "not_enough_signatures",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 368,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 368,
+        "column": 38
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 370,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 370,
+        "column": 20
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 371,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 371,
+        "column": 26
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 375,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 375,
+        "column": 44
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 376,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 376,
+        "column": 22
+      }
+    },
+    {
+      "vname": "transaction_msg_as_list",
+      "type": "ByStr20 -> Uint128 -> String -> List (Message)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 376,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 376,
+        "column": 43
+      }
+    },
+    {
+      "vname": "recipient",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 376,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 376,
+        "column": 53
+      }
+    },
+    {
+      "vname": "amount",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 376,
+        "column": 54
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 376,
+        "column": 60
+      }
+    },
+    {
+      "vname": "tag",
+      "type": "String",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 376,
+        "column": 61
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 376,
+        "column": 64
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 377,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 377,
+        "column": 17
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 378,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 378,
+        "column": 16
+      }
+    },
+    {
+      "vname": "mk_transaction_executed_event",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 378,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 378,
+        "column": 46
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 379,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 379,
+        "column": 14
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 388,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 388,
+        "column": 42
+      }
+    },
+    {
+      "vname": "sig",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 389,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 389,
+        "column": 6
+      }
+    },
+    {
+      "vname": "signatures",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 389,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 389,
+        "column": 27
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 389,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 389,
+        "column": 41
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 389,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 389,
+        "column": 50
+      }
+    },
+    {
+      "vname": "sig",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 390,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 390,
+        "column": 12
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 392,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 392,
+        "column": 12
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 393,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 393,
+        "column": 18
+      }
+    },
+    {
+      "vname": "count",
+      "type": "Option (Uint32)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 395,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 395,
+        "column": 10
+      }
+    },
+    {
+      "vname": "signature_counts",
+      "type": "Map (Uint32) (Uint32)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 395,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 395,
+        "column": 30
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 395,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 395,
+        "column": 44
+      }
+    },
+    {
+      "vname": "count",
+      "type": "Option (Uint32)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 396,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 396,
+        "column": 16
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 398,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 398,
+        "column": 14
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 399,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 399,
+        "column": 20
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 400,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 400,
+        "column": 13
+      }
+    },
+    {
+      "vname": "c_is_zero",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 401,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 401,
+        "column": 26
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 401,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 401,
+        "column": 31
+      }
+    },
+    {
+      "vname": "zero",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 401,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 401,
+        "column": 36
+      }
+    },
+    {
+      "vname": "c_is_zero",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 402,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 402,
+        "column": 22
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 404,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 404,
+        "column": 16
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 405,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 405,
+        "column": 22
+      }
+    },
+    {
+      "vname": "new_c",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 407,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 407,
+        "column": 20
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 407,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 407,
+        "column": 30
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 407,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 407,
+        "column": 34
+      }
+    },
+    {
+      "vname": "signature_counts",
+      "type": "Map (Uint32) (Uint32)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 408,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 408,
+        "column": 25
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 408,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 408,
+        "column": 39
+      }
+    },
+    {
+      "vname": "new_c",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 408,
+        "column": 44
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 408,
+        "column": 49
+      }
+    },
+    {
+      "vname": "signatures",
+      "type": "Map (Uint32) (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 409,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 409,
+        "column": 26
+      }
+    },
+    {
+      "vname": "transactionId",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 409,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 409,
+        "column": 40
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 409,
+        "column": 42
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 409,
+        "column": 49
+      }
+    },
+    {
+      "vname": "validity",
+      "type": "ContractValidity",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 418,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 418,
+        "column": 20
+      }
+    },
+    {
+      "vname": "contract_valid",
+      "type": "ContractValidity",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 418,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 418,
+        "column": 29
+      }
+    },
+    {
+      "vname": "validity",
+      "type": "ContractValidity",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 419,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 419,
+        "column": 17
+      }
+    },
+    {
+      "vname": "owners_map_opt",
+      "type": "Option (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 422,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 422,
+        "column": 34
+      }
+    },
+    {
+      "vname": "check_validity_and_build_owners_map",
+      "type": "List (ByStr20) -> Uint32 -> Option (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 422,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 422,
+        "column": 57
+      }
+    },
+    {
+      "vname": "owners_list",
+      "type": "List (ByStr20)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 422,
+        "column": 58
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 422,
+        "column": 69
+      }
+    },
+    {
+      "vname": "required_signatures",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 422,
+        "column": 70
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 422,
+        "column": 89
+      }
+    },
+    {
+      "vname": "owners_map_opt",
+      "type": "Option (Map (ByStr20) (Bool))",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 423,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 423,
+        "column": 25
+      }
+    },
+    {
+      "vname": "owners_map",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 424,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 424,
+        "column": 22
+      }
+    },
+    {
+      "vname": "valid",
+      "type": "ContractValidity",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 425,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 425,
+        "column": 30
+      }
+    },
+    {
+      "vname": "contract_valid",
+      "type": "ContractValidity",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 425,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 425,
+        "column": 36
+      }
+    },
+    {
+      "vname": "owners_map",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 426,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 426,
+        "column": 27
+      }
+    },
+    {
+      "vname": "owners",
+      "type": "Map (ByStr20) (Bool)",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 426,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 426,
+        "column": 20
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 427,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 427,
+        "column": 10
+      }
+    },
+    {
+      "vname": "mk_contract_initialized_event",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 427,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 427,
+        "column": 40
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 428,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 428,
+        "column": 8
+      }
+    },
+    {
+      "vname": "invalid",
+      "type": "ContractValidity",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 430,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 430,
+        "column": 32
+      }
+    },
+    {
+      "vname": "contract_valid",
+      "type": "ContractValidity",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 430,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 430,
+        "column": 36
+      }
+    },
+    {
+      "vname": "validity",
+      "type": "ContractValidity",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 440,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 440,
+        "column": 20
+      }
+    },
+    {
+      "vname": "contract_valid",
+      "type": "ContractValidity",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 440,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 440,
+        "column": 29
+      }
+    },
+    {
+      "vname": "validity",
+      "type": "ContractValidity",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 441,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 441,
+        "column": 17
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 444,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 444,
+        "column": 12
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 445,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 445,
+        "column": 18
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 447,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 447,
+        "column": 12
+      }
+    },
+    {
+      "vname": "err",
+      "type": "Error",
+      "start_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 448,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/wallet_2.scilla",
+        "line": 448,
+        "column": 18
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "Wallet",

--- a/tests/checker/good/gold/zil-game.scilla.gold
+++ b/tests/checker/good/gold/zil-game.scilla.gold
@@ -11,6 +11,4324 @@
     ],
     "ADT constructors": []
   },
+  "type_info": [
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 11,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 11,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 12,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 12,
+        "column": 6
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 13,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 13,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 14,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 14,
+        "column": 23
+      }
+    },
+    {
+      "vname": "nil_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 14,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 14,
+        "column": 31
+      }
+    },
+    {
+      "vname": "no_msg",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 16,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 16,
+        "column": 11
+      }
+    },
+    {
+      "vname": "hash_dist",
+      "type": "ByStr32 -> ByStr32 -> Uint256",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 18,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 18,
+        "column": 14
+      }
+    },
+    {
+      "vname": "h0",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 19,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 19,
+        "column": 5
+      }
+    },
+    {
+      "vname": "h1",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 20,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 20,
+        "column": 5
+      }
+    },
+    {
+      "vname": "h00",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 21,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 21,
+        "column": 8
+      }
+    },
+    {
+      "vname": "h0",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 21,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 21,
+        "column": 36
+      }
+    },
+    {
+      "vname": "h11",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 22,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 22,
+        "column": 8
+      }
+    },
+    {
+      "vname": "h1",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 22,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 22,
+        "column": 36
+      }
+    },
+    {
+      "vname": "lt",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 23,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 23,
+        "column": 7
+      }
+    },
+    {
+      "vname": "h00",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 23,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 23,
+        "column": 28
+      }
+    },
+    {
+      "vname": "h11",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 23,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 23,
+        "column": 32
+      }
+    },
+    {
+      "vname": "lt",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 24,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 24,
+        "column": 13
+      }
+    },
+    {
+      "vname": "h00",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 26,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 26,
+        "column": 22
+      }
+    },
+    {
+      "vname": "h11",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 26,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 26,
+        "column": 26
+      }
+    },
+    {
+      "vname": "h11",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 28,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 28,
+        "column": 22
+      }
+    },
+    {
+      "vname": "h00",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 28,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 28,
+        "column": 26
+      }
+    },
+    {
+      "vname": "update_hash",
+      "type": "Option (ByStr32) -> ByStr32 -> Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 31,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 31,
+        "column": 16
+      }
+    },
+    {
+      "vname": "oh",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 32,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 32,
+        "column": 5
+      }
+    },
+    {
+      "vname": "h",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 33,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 33,
+        "column": 4
+      }
+    },
+    {
+      "vname": "oh",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 34,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 34,
+        "column": 13
+      }
+    },
+    {
+      "vname": "x",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 35,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 35,
+        "column": 13
+      }
+    },
+    {
+      "vname": "x",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 35,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 35,
+        "column": 33
+      }
+    },
+    {
+      "vname": "h",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 36,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 36,
+        "column": 33
+      }
+    },
+    {
+      "vname": "update_timer",
+      "type": "Option (BNum) -> BNum -> Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 39,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 39,
+        "column": 17
+      }
+    },
+    {
+      "vname": "tm",
+      "type": "Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 40,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 40,
+        "column": 5
+      }
+    },
+    {
+      "vname": "b",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 41,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 41,
+        "column": 4
+      }
+    },
+    {
+      "vname": "tm",
+      "type": "Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 42,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 42,
+        "column": 13
+      }
+    },
+    {
+      "vname": "x",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 43,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 43,
+        "column": 13
+      }
+    },
+    {
+      "vname": "x",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 43,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 43,
+        "column": 30
+      }
+    },
+    {
+      "vname": "window",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 45,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 45,
+        "column": 13
+      }
+    },
+    {
+      "vname": "b1",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 46,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 46,
+        "column": 9
+      }
+    },
+    {
+      "vname": "b",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 46,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 46,
+        "column": 30
+      }
+    },
+    {
+      "vname": "window",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 46,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 46,
+        "column": 37
+      }
+    },
+    {
+      "vname": "b1",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 47,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 47,
+        "column": 21
+      }
+    },
+    {
+      "vname": "can_play",
+      "type": "Option (BNum) -> BNum -> Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 51,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 51,
+        "column": 13
+      }
+    },
+    {
+      "vname": "tm",
+      "type": "Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 52,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 52,
+        "column": 5
+      }
+    },
+    {
+      "vname": "b",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 53,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 53,
+        "column": 4
+      }
+    },
+    {
+      "vname": "tm",
+      "type": "Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 54,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 54,
+        "column": 13
+      }
+    },
+    {
+      "vname": "b1",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 56,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 56,
+        "column": 14
+      }
+    },
+    {
+      "vname": "b",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 56,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 56,
+        "column": 31
+      }
+    },
+    {
+      "vname": "b1",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 56,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 56,
+        "column": 34
+      }
+    },
+    {
+      "vname": "time_to_claim",
+      "type": "Option (BNum) -> BNum -> Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 59,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 59,
+        "column": 18
+      }
+    },
+    {
+      "vname": "tm",
+      "type": "Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 60,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 60,
+        "column": 5
+      }
+    },
+    {
+      "vname": "b",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 61,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 61,
+        "column": 4
+      }
+    },
+    {
+      "vname": "tm",
+      "type": "Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 62,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 62,
+        "column": 13
+      }
+    },
+    {
+      "vname": "b1",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 64,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 64,
+        "column": 14
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 65,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 65,
+        "column": 9
+      }
+    },
+    {
+      "vname": "b",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 65,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 65,
+        "column": 29
+      }
+    },
+    {
+      "vname": "b1",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 65,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 65,
+        "column": 32
+      }
+    },
+    {
+      "vname": "negb",
+      "type": "Bool -> Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 66,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 66,
+        "column": 11
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 66,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 66,
+        "column": 14
+      }
+    },
+    {
+      "vname": "check_validity",
+      "type":
+        "ByStr20 -> Int128 -> ByStr20 -> ByStr20 -> Option (ByStr32) -> Option (ByStr32) -> Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 69,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 69,
+        "column": 19
+      }
+    },
+    {
+      "vname": "a",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 70,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 70,
+        "column": 4
+      }
+    },
+    {
+      "vname": "solution",
+      "type": "Int128",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 71,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 71,
+        "column": 11
+      }
+    },
+    {
+      "vname": "pa",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 72,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 72,
+        "column": 5
+      }
+    },
+    {
+      "vname": "pb",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 73,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 73,
+        "column": 5
+      }
+    },
+    {
+      "vname": "guess_a",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 74,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 74,
+        "column": 10
+      }
+    },
+    {
+      "vname": "guess_b",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 75,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 75,
+        "column": 10
+      }
+    },
+    {
+      "vname": "ca",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 76,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 76,
+        "column": 7
+      }
+    },
+    {
+      "vname": "pa",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 76,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 76,
+        "column": 27
+      }
+    },
+    {
+      "vname": "a",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 76,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 76,
+        "column": 29
+      }
+    },
+    {
+      "vname": "cb",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 77,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 77,
+        "column": 7
+      }
+    },
+    {
+      "vname": "pb",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 77,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 77,
+        "column": 27
+      }
+    },
+    {
+      "vname": "a",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 77,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 77,
+        "column": 29
+      }
+    },
+    {
+      "vname": "xa",
+      "type": "Pair (Bool) (Option (ByStr32))",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 78,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 78,
+        "column": 7
+      }
+    },
+    {
+      "vname": "ca",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 78,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 78,
+        "column": 45
+      }
+    },
+    {
+      "vname": "guess_a",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 78,
+        "column": 46
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 78,
+        "column": 53
+      }
+    },
+    {
+      "vname": "xb",
+      "type": "Pair (Bool) (Option (ByStr32))",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 79,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 79,
+        "column": 7
+      }
+    },
+    {
+      "vname": "cb",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 79,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 79,
+        "column": 45
+      }
+    },
+    {
+      "vname": "guess_b",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 79,
+        "column": 46
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 79,
+        "column": 53
+      }
+    },
+    {
+      "vname": "xa",
+      "type": "Pair (Bool) (Option (ByStr32))",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 80,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 80,
+        "column": 13
+      }
+    },
+    {
+      "vname": "g",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 81,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 81,
+        "column": 24
+      }
+    },
+    {
+      "vname": "h",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 82,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 82,
+        "column": 8
+      }
+    },
+    {
+      "vname": "solution",
+      "type": "Int128",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 82,
+        "column": 34
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 82,
+        "column": 42
+      }
+    },
+    {
+      "vname": "h",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 83,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 83,
+        "column": 19
+      }
+    },
+    {
+      "vname": "g",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 83,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 83,
+        "column": 21
+      }
+    },
+    {
+      "vname": "xb",
+      "type": "Pair (Bool) (Option (ByStr32))",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 85,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 85,
+        "column": 15
+      }
+    },
+    {
+      "vname": "g",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 86,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 86,
+        "column": 26
+      }
+    },
+    {
+      "vname": "h",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 87,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 87,
+        "column": 10
+      }
+    },
+    {
+      "vname": "solution",
+      "type": "Int128",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 87,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 87,
+        "column": 44
+      }
+    },
+    {
+      "vname": "h",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 88,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 88,
+        "column": 21
+      }
+    },
+    {
+      "vname": "g",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 88,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 88,
+        "column": 23
+      }
+    },
+    {
+      "vname": "can_withdraw",
+      "type": "BNum -> BNum -> Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 94,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 94,
+        "column": 17
+      }
+    },
+    {
+      "vname": "tm",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 95,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 95,
+        "column": 5
+      }
+    },
+    {
+      "vname": "b",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 96,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 96,
+        "column": 4
+      }
+    },
+    {
+      "vname": "window",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 97,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 97,
+        "column": 11
+      }
+    },
+    {
+      "vname": "deadline",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 98,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 98,
+        "column": 13
+      }
+    },
+    {
+      "vname": "tm",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 98,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 98,
+        "column": 35
+      }
+    },
+    {
+      "vname": "window",
+      "type": "Uint32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 98,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 98,
+        "column": 42
+      }
+    },
+    {
+      "vname": "deadline",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 99,
+        "column": 19
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 99,
+        "column": 27
+      }
+    },
+    {
+      "vname": "b",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 99,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 99,
+        "column": 29
+      }
+    },
+    {
+      "vname": "determine_winner",
+      "type":
+        "ByStr32 -> Option (ByStr32) -> Option (ByStr32) -> ByStr20 -> ByStr20 -> ByStr20 -> ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 102,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 102,
+        "column": 21
+      }
+    },
+    {
+      "vname": "puzzle",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 103,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 103,
+        "column": 9
+      }
+    },
+    {
+      "vname": "guess_a",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 104,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 104,
+        "column": 10
+      }
+    },
+    {
+      "vname": "guess_b",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 105,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 105,
+        "column": 10
+      }
+    },
+    {
+      "vname": "pa",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 106,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 106,
+        "column": 5
+      }
+    },
+    {
+      "vname": "pb",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 107,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 107,
+        "column": 5
+      }
+    },
+    {
+      "vname": "oa",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 108,
+        "column": 3
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 108,
+        "column": 5
+      }
+    },
+    {
+      "vname": "gab",
+      "type": "Pair (Option (ByStr32)) (Option (ByStr32))",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 109,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 109,
+        "column": 8
+      }
+    },
+    {
+      "vname": "guess_a",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 109,
+        "column": 58
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 109,
+        "column": 65
+      }
+    },
+    {
+      "vname": "guess_b",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 109,
+        "column": 66
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 109,
+        "column": 73
+      }
+    },
+    {
+      "vname": "gab",
+      "type": "Pair (Option (ByStr32)) (Option (ByStr32))",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 110,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 110,
+        "column": 14
+      }
+    },
+    {
+      "vname": "gb",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 111,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 111,
+        "column": 30
+      }
+    },
+    {
+      "vname": "ga",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 111,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 111,
+        "column": 20
+      }
+    },
+    {
+      "vname": "d1",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 112,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 112,
+        "column": 9
+      }
+    },
+    {
+      "vname": "hash_dist",
+      "type": "ByStr32 -> ByStr32 -> Uint256",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 112,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 112,
+        "column": 25
+      }
+    },
+    {
+      "vname": "puzzle",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 112,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 112,
+        "column": 32
+      }
+    },
+    {
+      "vname": "ga",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 112,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 112,
+        "column": 35
+      }
+    },
+    {
+      "vname": "d2",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 113,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 113,
+        "column": 9
+      }
+    },
+    {
+      "vname": "hash_dist",
+      "type": "ByStr32 -> ByStr32 -> Uint256",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 113,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 113,
+        "column": 25
+      }
+    },
+    {
+      "vname": "puzzle",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 113,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 113,
+        "column": 32
+      }
+    },
+    {
+      "vname": "gb",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 113,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 113,
+        "column": 35
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 114,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 114,
+        "column": 9
+      }
+    },
+    {
+      "vname": "d1",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 114,
+        "column": 27
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 114,
+        "column": 29
+      }
+    },
+    {
+      "vname": "d2",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 114,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 114,
+        "column": 32
+      }
+    },
+    {
+      "vname": "c1",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 115,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 115,
+        "column": 15
+      }
+    },
+    {
+      "vname": "pa",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 116,
+        "column": 17
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 116,
+        "column": 19
+      }
+    },
+    {
+      "vname": "c2",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 118,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 118,
+        "column": 11
+      }
+    },
+    {
+      "vname": "d1",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 118,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 118,
+        "column": 31
+      }
+    },
+    {
+      "vname": "d2",
+      "type": "Uint256",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 118,
+        "column": 32
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 118,
+        "column": 34
+      }
+    },
+    {
+      "vname": "c2",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 119,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 119,
+        "column": 17
+      }
+    },
+    {
+      "vname": "pb",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 120,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 120,
+        "column": 22
+      }
+    },
+    {
+      "vname": "oa",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 121,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 121,
+        "column": 22
+      }
+    },
+    {
+      "vname": "pa",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 124,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 124,
+        "column": 31
+      }
+    },
+    {
+      "vname": "pb",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 125,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 125,
+        "column": 31
+      }
+    },
+    {
+      "vname": "oa",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 126,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 126,
+        "column": 31
+      }
+    },
+    {
+      "vname": "solution_submitted",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 129,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 129,
+        "column": 23
+      }
+    },
+    {
+      "vname": "time_window_missed",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 130,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 130,
+        "column": 23
+      }
+    },
+    {
+      "vname": "not_a_player",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 131,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 131,
+        "column": 17
+      }
+    },
+    {
+      "vname": "too_early_to_claim",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 132,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 132,
+        "column": 23
+      }
+    },
+    {
+      "vname": "wrong__sender_or_solution",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 133,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 133,
+        "column": 30
+      }
+    },
+    {
+      "vname": "here_is_the_reward",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 134,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 134,
+        "column": 23
+      }
+    },
+    {
+      "vname": "cannot_withdraw",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 135,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 135,
+        "column": 20
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 142,
+        "column": 1
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 142,
+        "column": 6
+      }
+    },
+    {
+      "vname": "player_a",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 143,
+        "column": 1
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 143,
+        "column": 9
+      }
+    },
+    {
+      "vname": "player_b",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 144,
+        "column": 1
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 144,
+        "column": 9
+      }
+    },
+    {
+      "vname": "puzzle",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 145,
+        "column": 1
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 145,
+        "column": 7
+      }
+    },
+    {
+      "vname": "player_a_hash",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 150,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 150,
+        "column": 20
+      }
+    },
+    {
+      "vname": "player_b_hash",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 151,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 151,
+        "column": 20
+      }
+    },
+    {
+      "vname": "timer",
+      "type": "Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 152,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 152,
+        "column": 12
+      }
+    },
+    {
+      "vname": "guess",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 154,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 154,
+        "column": 23
+      }
+    },
+    {
+      "vname": "tm_opt",
+      "type": "Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 155,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 155,
+        "column": 16
+      }
+    },
+    {
+      "vname": "timer",
+      "type": "Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 155,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 155,
+        "column": 18
+      }
+    },
+    {
+      "vname": "b",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 156,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 156,
+        "column": 6
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 158,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 158,
+        "column": 6
+      }
+    },
+    {
+      "vname": "can_play",
+      "type": "Option (BNum) -> BNum -> Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 158,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 158,
+        "column": 15
+      }
+    },
+    {
+      "vname": "tm_opt",
+      "type": "Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 158,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 158,
+        "column": 22
+      }
+    },
+    {
+      "vname": "b",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 158,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 158,
+        "column": 24
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 159,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 159,
+        "column": 10
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 161,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 161,
+        "column": 13
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 161,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 161,
+        "column": 44
+      }
+    },
+    {
+      "vname": "time_window_missed",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 162,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 162,
+        "column": 38
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 163,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 163,
+        "column": 14
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 163,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 163,
+        "column": 19
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 163,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 163,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 164,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 164,
+        "column": 9
+      }
+    },
+    {
+      "vname": "isa",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 166,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 166,
+        "column": 12
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 166,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 166,
+        "column": 29
+      }
+    },
+    {
+      "vname": "player_a",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 166,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 166,
+        "column": 38
+      }
+    },
+    {
+      "vname": "isb",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 167,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 167,
+        "column": 12
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 167,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 167,
+        "column": 29
+      }
+    },
+    {
+      "vname": "player_b",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 167,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 167,
+        "column": 38
+      }
+    },
+    {
+      "vname": "tt",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 168,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 168,
+        "column": 10
+      }
+    },
+    {
+      "vname": "isa",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 169,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 169,
+        "column": 14
+      }
+    },
+    {
+      "vname": "ah",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 171,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 171,
+        "column": 12
+      }
+    },
+    {
+      "vname": "player_a_hash",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 171,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 171,
+        "column": 26
+      }
+    },
+    {
+      "vname": "hopt",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 172,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 172,
+        "column": 16
+      }
+    },
+    {
+      "vname": "update_hash",
+      "type": "Option (ByStr32) -> ByStr32 -> Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 172,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 172,
+        "column": 25
+      }
+    },
+    {
+      "vname": "ah",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 172,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 172,
+        "column": 28
+      }
+    },
+    {
+      "vname": "guess",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 172,
+        "column": 29
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 172,
+        "column": 34
+      }
+    },
+    {
+      "vname": "hopt",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 173,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 173,
+        "column": 28
+      }
+    },
+    {
+      "vname": "player_a_hash",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 173,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 173,
+        "column": 34
+      }
+    },
+    {
+      "vname": "tm1",
+      "type": "Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 174,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 174,
+        "column": 14
+      }
+    },
+    {
+      "vname": "update_timer",
+      "type": "Option (BNum) -> BNum -> Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 174,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 174,
+        "column": 25
+      }
+    },
+    {
+      "vname": "tm_opt",
+      "type": "Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 174,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 174,
+        "column": 32
+      }
+    },
+    {
+      "vname": "b",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 174,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 174,
+        "column": 34
+      }
+    },
+    {
+      "vname": "tm1",
+      "type": "Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 175,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 175,
+        "column": 19
+      }
+    },
+    {
+      "vname": "timer",
+      "type": "Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 175,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 175,
+        "column": 18
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 176,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 176,
+        "column": 15
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 176,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 176,
+        "column": 46
+      }
+    },
+    {
+      "vname": "solution_submitted",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 177,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 177,
+        "column": 40
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 178,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 178,
+        "column": 16
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 178,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 178,
+        "column": 21
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 178,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 178,
+        "column": 25
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 179,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 179,
+        "column": 11
+      }
+    },
+    {
+      "vname": "isb",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 181,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 181,
+        "column": 16
+      }
+    },
+    {
+      "vname": "bh",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 183,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 183,
+        "column": 14
+      }
+    },
+    {
+      "vname": "player_b_hash",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 183,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 183,
+        "column": 28
+      }
+    },
+    {
+      "vname": "hopt",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 184,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 184,
+        "column": 18
+      }
+    },
+    {
+      "vname": "update_hash",
+      "type": "Option (ByStr32) -> ByStr32 -> Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 184,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 184,
+        "column": 27
+      }
+    },
+    {
+      "vname": "bh",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 184,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 184,
+        "column": 30
+      }
+    },
+    {
+      "vname": "guess",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 184,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 184,
+        "column": 36
+      }
+    },
+    {
+      "vname": "hopt",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 185,
+        "column": 26
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 185,
+        "column": 30
+      }
+    },
+    {
+      "vname": "player_b_hash",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 185,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 185,
+        "column": 36
+      }
+    },
+    {
+      "vname": "tm1",
+      "type": "Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 186,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 186,
+        "column": 16
+      }
+    },
+    {
+      "vname": "update_timer",
+      "type": "Option (BNum) -> BNum -> Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 186,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 186,
+        "column": 27
+      }
+    },
+    {
+      "vname": "tm_opt",
+      "type": "Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 186,
+        "column": 28
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 186,
+        "column": 34
+      }
+    },
+    {
+      "vname": "b",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 186,
+        "column": 35
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 186,
+        "column": 36
+      }
+    },
+    {
+      "vname": "tm1",
+      "type": "Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 187,
+        "column": 18
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 187,
+        "column": 21
+      }
+    },
+    {
+      "vname": "timer",
+      "type": "Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 187,
+        "column": 15
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 187,
+        "column": 20
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 188,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 188,
+        "column": 17
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 188,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 188,
+        "column": 48
+      }
+    },
+    {
+      "vname": "solution_submitted",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 189,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 189,
+        "column": 42
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 190,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 190,
+        "column": 18
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 190,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 190,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 190,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 190,
+        "column": 27
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 191,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 191,
+        "column": 13
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 193,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 193,
+        "column": 17
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 193,
+        "column": 41
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 193,
+        "column": 48
+      }
+    },
+    {
+      "vname": "not_a_player",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 194,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 194,
+        "column": 36
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 195,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 195,
+        "column": 18
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 195,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 195,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 195,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 195,
+        "column": 27
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 196,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 196,
+        "column": 13
+      }
+    },
+    {
+      "vname": "solution",
+      "type": "Int128",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 202,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 202,
+        "column": 32
+      }
+    },
+    {
+      "vname": "tm_opt",
+      "type": "Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 203,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 203,
+        "column": 16
+      }
+    },
+    {
+      "vname": "timer",
+      "type": "Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 203,
+        "column": 13
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 203,
+        "column": 18
+      }
+    },
+    {
+      "vname": "b",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 204,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 204,
+        "column": 6
+      }
+    },
+    {
+      "vname": "ttc",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 206,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 206,
+        "column": 10
+      }
+    },
+    {
+      "vname": "time_to_claim",
+      "type": "Option (BNum) -> BNum -> Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 206,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 206,
+        "column": 22
+      }
+    },
+    {
+      "vname": "tm_opt",
+      "type": "Option (BNum)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 206,
+        "column": 23
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 206,
+        "column": 29
+      }
+    },
+    {
+      "vname": "b",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 206,
+        "column": 30
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 206,
+        "column": 31
+      }
+    },
+    {
+      "vname": "ttc",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 207,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 207,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 209,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 209,
+        "column": 13
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 209,
+        "column": 37
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 209,
+        "column": 44
+      }
+    },
+    {
+      "vname": "too_early_to_claim",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 210,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 210,
+        "column": 38
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 211,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 211,
+        "column": 14
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 211,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 211,
+        "column": 19
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 211,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 211,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 212,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 212,
+        "column": 9
+      }
+    },
+    {
+      "vname": "pa",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 214,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 214,
+        "column": 10
+      }
+    },
+    {
+      "vname": "player_a_hash",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 214,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 214,
+        "column": 24
+      }
+    },
+    {
+      "vname": "pb",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 215,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 215,
+        "column": 10
+      }
+    },
+    {
+      "vname": "player_b_hash",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 215,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 215,
+        "column": 24
+      }
+    },
+    {
+      "vname": "is_valid",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 216,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 216,
+        "column": 22
+      }
+    },
+    {
+      "vname": "check_validity",
+      "type":
+        "ByStr20 -> Int128 -> ByStr20 -> ByStr20 -> Option (ByStr32) -> Option (ByStr32) -> Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 216,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 216,
+        "column": 30
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 216,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 216,
+        "column": 38
+      }
+    },
+    {
+      "vname": "solution",
+      "type": "Int128",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 216,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 216,
+        "column": 47
+      }
+    },
+    {
+      "vname": "player_a",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 216,
+        "column": 48
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 216,
+        "column": 56
+      }
+    },
+    {
+      "vname": "player_b",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 216,
+        "column": 57
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 216,
+        "column": 65
+      }
+    },
+    {
+      "vname": "pa",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 216,
+        "column": 66
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 216,
+        "column": 68
+      }
+    },
+    {
+      "vname": "pb",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 216,
+        "column": 69
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 216,
+        "column": 71
+      }
+    },
+    {
+      "vname": "is_valid",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 217,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 217,
+        "column": 19
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 219,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 219,
+        "column": 15
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 219,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 219,
+        "column": 46
+      }
+    },
+    {
+      "vname": "wrong__sender_or_solution",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 220,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 220,
+        "column": 47
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 221,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 221,
+        "column": 16
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 221,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 221,
+        "column": 21
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 221,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 221,
+        "column": 25
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 222,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 222,
+        "column": 11
+      }
+    },
+    {
+      "vname": "winner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 224,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 224,
+        "column": 20
+      }
+    },
+    {
+      "vname": "determine_winner",
+      "type":
+        "ByStr32 -> Option (ByStr32) -> Option (ByStr32) -> ByStr20 -> ByStr20 -> ByStr20 -> ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 224,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 224,
+        "column": 32
+      }
+    },
+    {
+      "vname": "puzzle",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 224,
+        "column": 33
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 224,
+        "column": 39
+      }
+    },
+    {
+      "vname": "pa",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 224,
+        "column": 40
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 224,
+        "column": 42
+      }
+    },
+    {
+      "vname": "pb",
+      "type": "Option (ByStr32)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 224,
+        "column": 43
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 224,
+        "column": 45
+      }
+    },
+    {
+      "vname": "player_a",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 224,
+        "column": 46
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 224,
+        "column": 54
+      }
+    },
+    {
+      "vname": "player_b",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 224,
+        "column": 55
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 224,
+        "column": 63
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 224,
+        "column": 64
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 224,
+        "column": 69
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 225,
+        "column": 11
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 225,
+        "column": 14
+      }
+    },
+    {
+      "vname": "_balance",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 225,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 225,
+        "column": 22
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 226,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 226,
+        "column": 15
+      }
+    },
+    {
+      "vname": "winner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 226,
+        "column": 39
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 226,
+        "column": 45
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 226,
+        "column": 57
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 226,
+        "column": 60
+      }
+    },
+    {
+      "vname": "here_is_the_reward",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 227,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 227,
+        "column": 40
+      }
+    },
+    {
+      "vname": "ff",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 228,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 228,
+        "column": 12
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 229,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 229,
+        "column": 16
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 229,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 229,
+        "column": 21
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 229,
+        "column": 22
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 229,
+        "column": 25
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 230,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 230,
+        "column": 11
+      }
+    },
+    {
+      "vname": "tm",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 236,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 236,
+        "column": 8
+      }
+    },
+    {
+      "vname": "_creation_block",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 236,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 236,
+        "column": 22
+      }
+    },
+    {
+      "vname": "b",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 237,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 237,
+        "column": 6
+      }
+    },
+    {
+      "vname": "cw",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 238,
+        "column": 6
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 238,
+        "column": 8
+      }
+    },
+    {
+      "vname": "can_withdraw",
+      "type": "BNum -> BNum -> Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 238,
+        "column": 8
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 238,
+        "column": 20
+      }
+    },
+    {
+      "vname": "tm",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 238,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 238,
+        "column": 23
+      }
+    },
+    {
+      "vname": "b",
+      "type": "BNum",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 238,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 238,
+        "column": 25
+      }
+    },
+    {
+      "vname": "is_owner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 239,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 239,
+        "column": 20
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 239,
+        "column": 25
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 239,
+        "column": 30
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 239,
+        "column": 31
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 239,
+        "column": 38
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 240,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 240,
+        "column": 10
+      }
+    },
+    {
+      "vname": "_balance",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 240,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 240,
+        "column": 18
+      }
+    },
+    {
+      "vname": "good_to_go",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 241,
+        "column": 14
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 241,
+        "column": 24
+      }
+    },
+    {
+      "vname": "andb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 241,
+        "column": 16
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 241,
+        "column": 20
+      }
+    },
+    {
+      "vname": "cw",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 241,
+        "column": 21
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 241,
+        "column": 23
+      }
+    },
+    {
+      "vname": "is_owner",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 241,
+        "column": 24
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 241,
+        "column": 32
+      }
+    },
+    {
+      "vname": "good_to_go",
+      "type": "Bool",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 242,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 242,
+        "column": 19
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 244,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 244,
+        "column": 12
+      }
+    },
+    {
+      "vname": "owner",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 244,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 244,
+        "column": 41
+      }
+    },
+    {
+      "vname": "bal",
+      "type": "Uint128",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 244,
+        "column": 53
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 244,
+        "column": 56
+      }
+    },
+    {
+      "vname": "here_is_the_reward",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 244,
+        "column": 65
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 244,
+        "column": 83
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 245,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 245,
+        "column": 14
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 245,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 245,
+        "column": 19
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 245,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 245,
+        "column": 23
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 246,
+        "column": 7
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 246,
+        "column": 8
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Event",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 247,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 247,
+        "column": 6
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 248,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 248,
+        "column": 9
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 250,
+        "column": 9
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 250,
+        "column": 12
+      }
+    },
+    {
+      "vname": "_sender",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 250,
+        "column": 36
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 250,
+        "column": 43
+      }
+    },
+    {
+      "vname": "cannot_withdraw",
+      "type": "Int32",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 250,
+        "column": 73
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 250,
+        "column": 88
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 251,
+        "column": 10
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 251,
+        "column": 14
+      }
+    },
+    {
+      "vname": "one_msg",
+      "type": "Message -> List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 251,
+        "column": 12
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 251,
+        "column": 19
+      }
+    },
+    {
+      "vname": "msg",
+      "type": "Message",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 251,
+        "column": 20
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 251,
+        "column": 23
+      }
+    },
+    {
+      "vname": "msgs",
+      "type": "List (Message)",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 252,
+        "column": 5
+      },
+      "end_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 252,
+        "column": 9
+      }
+    }
+  ],
   "contract_info": {
     "scilla_major_version": "0",
     "vname": "ZilGame",

--- a/tests/typecheck/good/Testtypes.ml
+++ b/tests/typecheck/good/Testtypes.ml
@@ -122,7 +122,7 @@ module Tests = TestUtil.DiffBasedTests(
     let test_path f = ["typecheck"; "good"; f]
     let runner = "type-checker"
     let gas_limit = Stdint.Uint64.of_int 4002000
-    let custom_args = []
+    let custom_args = ["-typeinfo"]
     let additional_libdirs = []
     let tests = [
       "branch-match.scilexp";

--- a/tests/typecheck/good/gold/addr.scilexp.gold
+++ b/tests/typecheck/good/gold/addr.scilexp.gold
@@ -1,1 +1,61 @@
-Bool
+{
+  "type_info": [
+    {
+      "vname": "a",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "typecheck/good/addr.scilexp",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/addr.scilexp",
+        "line": 1,
+        "column": 2
+      }
+    },
+    {
+      "vname": "b",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "typecheck/good/addr.scilexp",
+        "line": 2,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/addr.scilexp",
+        "line": 2,
+        "column": 2
+      }
+    },
+    {
+      "vname": "a",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "typecheck/good/addr.scilexp",
+        "line": 3,
+        "column": 12
+      },
+      "end_location": {
+        "file": "typecheck/good/addr.scilexp",
+        "line": 3,
+        "column": 13
+      }
+    },
+    {
+      "vname": "b",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "typecheck/good/addr.scilexp",
+        "line": 3,
+        "column": 14
+      },
+      "end_location": {
+        "file": "typecheck/good/addr.scilexp",
+        "line": 3,
+        "column": 15
+      }
+    }
+  ],
+  "type": "Bool"
+}

--- a/tests/typecheck/good/gold/app.scilexp.gold
+++ b/tests/typecheck/good/gold/app.scilexp.gold
@@ -1,1 +1,159 @@
-Int32 -> Int32
+{
+  "type_info": [
+    {
+      "vname": "x",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/app.scilexp",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/app.scilexp",
+        "line": 1,
+        "column": 2
+      }
+    },
+    {
+      "vname": "f",
+      "type": "Int32 -> Int32 -> Int32",
+      "start_location": {
+        "file": "typecheck/good/app.scilexp",
+        "line": 2,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/app.scilexp",
+        "line": 2,
+        "column": 2
+      }
+    },
+    {
+      "vname": "z",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/app.scilexp",
+        "line": 2,
+        "column": 9
+      },
+      "end_location": {
+        "file": "typecheck/good/app.scilexp",
+        "line": 2,
+        "column": 10
+      }
+    },
+    {
+      "vname": "b",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/app.scilexp",
+        "line": 3,
+        "column": 5
+      },
+      "end_location": {
+        "file": "typecheck/good/app.scilexp",
+        "line": 3,
+        "column": 6
+      }
+    },
+    {
+      "vname": "x",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/app.scilexp",
+        "line": 3,
+        "column": 13
+      },
+      "end_location": {
+        "file": "typecheck/good/app.scilexp",
+        "line": 3,
+        "column": 14
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/app.scilexp",
+        "line": 4,
+        "column": 5
+      },
+      "end_location": {
+        "file": "typecheck/good/app.scilexp",
+        "line": 4,
+        "column": 6
+      }
+    },
+    {
+      "vname": "z",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/app.scilexp",
+        "line": 4,
+        "column": 24
+      },
+      "end_location": {
+        "file": "typecheck/good/app.scilexp",
+        "line": 4,
+        "column": 25
+      }
+    },
+    {
+      "vname": "a",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/app.scilexp",
+        "line": 6,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/app.scilexp",
+        "line": 6,
+        "column": 2
+      }
+    },
+    {
+      "vname": "d",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/app.scilexp",
+        "line": 7,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/app.scilexp",
+        "line": 7,
+        "column": 2
+      }
+    },
+    {
+      "vname": "f",
+      "type": "Int32 -> Int32 -> Int32",
+      "start_location": {
+        "file": "typecheck/good/app.scilexp",
+        "line": 8,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/app.scilexp",
+        "line": 8,
+        "column": 2
+      }
+    },
+    {
+      "vname": "d",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/app.scilexp",
+        "line": 8,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/app.scilexp",
+        "line": 8,
+        "column": 4
+      }
+    }
+  ],
+  "type": "Int32 -> Int32"
+}

--- a/tests/typecheck/good/gold/branch-match.scilexp.gold
+++ b/tests/typecheck/good/gold/branch-match.scilexp.gold
@@ -1,1 +1,160 @@
-forall 'X. forall 'A. ('A -> 'X) -> ('A -> 'X) -> 'A -> Bool -> 'X
+{
+  "type_info": [
+    {
+      "vname": "'X",
+      "type": "forall 'A. ('A -> 'X) -> ('A -> 'X) -> 'A -> Bool -> 'X",
+      "start_location": {
+        "file": "typecheck/good/branch-match.scilexp",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/branch-match.scilexp",
+        "line": 1,
+        "column": 3
+      }
+    },
+    {
+      "vname": "'A",
+      "type": "('A -> 'X) -> ('A -> 'X) -> 'A -> Bool -> 'X",
+      "start_location": {
+        "file": "typecheck/good/branch-match.scilexp",
+        "line": 2,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/branch-match.scilexp",
+        "line": 2,
+        "column": 3
+      }
+    },
+    {
+      "vname": "f",
+      "type": "'A -> 'X",
+      "start_location": {
+        "file": "typecheck/good/branch-match.scilexp",
+        "line": 3,
+        "column": 2
+      },
+      "end_location": {
+        "file": "typecheck/good/branch-match.scilexp",
+        "line": 3,
+        "column": 3
+      }
+    },
+    {
+      "vname": "g",
+      "type": "'A -> 'X",
+      "start_location": {
+        "file": "typecheck/good/branch-match.scilexp",
+        "line": 4,
+        "column": 2
+      },
+      "end_location": {
+        "file": "typecheck/good/branch-match.scilexp",
+        "line": 4,
+        "column": 3
+      }
+    },
+    {
+      "vname": "a",
+      "type": "'A",
+      "start_location": {
+        "file": "typecheck/good/branch-match.scilexp",
+        "line": 5,
+        "column": 2
+      },
+      "end_location": {
+        "file": "typecheck/good/branch-match.scilexp",
+        "line": 5,
+        "column": 3
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/branch-match.scilexp",
+        "line": 6,
+        "column": 2
+      },
+      "end_location": {
+        "file": "typecheck/good/branch-match.scilexp",
+        "line": 6,
+        "column": 3
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/branch-match.scilexp",
+        "line": 7,
+        "column": 8
+      },
+      "end_location": {
+        "file": "typecheck/good/branch-match.scilexp",
+        "line": 7,
+        "column": 9
+      }
+    },
+    {
+      "vname": "f",
+      "type": "'A -> 'X",
+      "start_location": {
+        "file": "typecheck/good/branch-match.scilexp",
+        "line": 8,
+        "column": 13
+      },
+      "end_location": {
+        "file": "typecheck/good/branch-match.scilexp",
+        "line": 8,
+        "column": 14
+      }
+    },
+    {
+      "vname": "a",
+      "type": "'A",
+      "start_location": {
+        "file": "typecheck/good/branch-match.scilexp",
+        "line": 8,
+        "column": 15
+      },
+      "end_location": {
+        "file": "typecheck/good/branch-match.scilexp",
+        "line": 8,
+        "column": 16
+      }
+    },
+    {
+      "vname": "g",
+      "type": "'A -> 'X",
+      "start_location": {
+        "file": "typecheck/good/branch-match.scilexp",
+        "line": 9,
+        "column": 13
+      },
+      "end_location": {
+        "file": "typecheck/good/branch-match.scilexp",
+        "line": 9,
+        "column": 14
+      }
+    },
+    {
+      "vname": "a",
+      "type": "'A",
+      "start_location": {
+        "file": "typecheck/good/branch-match.scilexp",
+        "line": 9,
+        "column": 15
+      },
+      "end_location": {
+        "file": "typecheck/good/branch-match.scilexp",
+        "line": 9,
+        "column": 16
+      }
+    }
+  ],
+  "type":
+    "forall 'X. forall 'A. ('A -> 'X) -> ('A -> 'X) -> 'A -> Bool -> 'X"
+}

--- a/tests/typecheck/good/gold/builtin-alt-bn128.scilexp.gold
+++ b/tests/typecheck/good/gold/builtin-alt-bn128.scilexp.gold
@@ -1,1 +1,1439 @@
-String
+{
+  "type_info": [
+    {
+      "vname": "p1x",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 1,
+        "column": 4
+      }
+    },
+    {
+      "vname": "p1y",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 2,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 2,
+        "column": 4
+      }
+    },
+    {
+      "vname": "p2x",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 3,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 3,
+        "column": 4
+      }
+    },
+    {
+      "vname": "p2y",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 4,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 4,
+        "column": 4
+      }
+    },
+    {
+      "vname": "sum_x",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 6,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 6,
+        "column": 6
+      }
+    },
+    {
+      "vname": "sum_y",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 7,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 7,
+        "column": 6
+      }
+    },
+    {
+      "vname": "p1",
+      "type": "Pair (ByStr32) (ByStr32)",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 9,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 9,
+        "column": 3
+      }
+    },
+    {
+      "vname": "p1x",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 9,
+        "column": 33
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 9,
+        "column": 36
+      }
+    },
+    {
+      "vname": "p1y",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 9,
+        "column": 37
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 9,
+        "column": 40
+      }
+    },
+    {
+      "vname": "p2",
+      "type": "Pair (ByStr32) (ByStr32)",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 10,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 10,
+        "column": 3
+      }
+    },
+    {
+      "vname": "p2x",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 10,
+        "column": 33
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 10,
+        "column": 36
+      }
+    },
+    {
+      "vname": "p2y",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 10,
+        "column": 37
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 10,
+        "column": 40
+      }
+    },
+    {
+      "vname": "sum",
+      "type": "Option (Pair (ByStr32) (ByStr32))",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 12,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 12,
+        "column": 4
+      }
+    },
+    {
+      "vname": "p1",
+      "type": "Pair (ByStr32) (ByStr32)",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 12,
+        "column": 36
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 12,
+        "column": 38
+      }
+    },
+    {
+      "vname": "p2",
+      "type": "Pair (ByStr32) (ByStr32)",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 12,
+        "column": 39
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 12,
+        "column": 41
+      }
+    },
+    {
+      "vname": "sum_test",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 13,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 13,
+        "column": 9
+      }
+    },
+    {
+      "vname": "sum",
+      "type": "Option (Pair (ByStr32) (ByStr32))",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 14,
+        "column": 9
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 14,
+        "column": 12
+      }
+    },
+    {
+      "vname": "sumy",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 15,
+        "column": 21
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 15,
+        "column": 25
+      }
+    },
+    {
+      "vname": "sumx",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 15,
+        "column": 16
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 15,
+        "column": 20
+      }
+    },
+    {
+      "vname": "xeq",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 16,
+        "column": 5
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 16,
+        "column": 8
+      }
+    },
+    {
+      "vname": "sum_x",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 16,
+        "column": 26
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 16,
+        "column": 31
+      }
+    },
+    {
+      "vname": "sumx",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 16,
+        "column": 32
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 16,
+        "column": 36
+      }
+    },
+    {
+      "vname": "yeq",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 17,
+        "column": 5
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 17,
+        "column": 8
+      }
+    },
+    {
+      "vname": "sum_y",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 17,
+        "column": 26
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 17,
+        "column": 31
+      }
+    },
+    {
+      "vname": "sumy",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 17,
+        "column": 32
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 17,
+        "column": 36
+      }
+    },
+    {
+      "vname": "andb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 18,
+        "column": 5
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 18,
+        "column": 9
+      }
+    },
+    {
+      "vname": "xeq",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 18,
+        "column": 10
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 18,
+        "column": 13
+      }
+    },
+    {
+      "vname": "yeq",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 18,
+        "column": 14
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 18,
+        "column": 17
+      }
+    },
+    {
+      "vname": "px",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 23,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 23,
+        "column": 3
+      }
+    },
+    {
+      "vname": "py",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 24,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 24,
+        "column": 3
+      }
+    },
+    {
+      "vname": "s",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 25,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 25,
+        "column": 2
+      }
+    },
+    {
+      "vname": "p",
+      "type": "Pair (ByStr32) (ByStr32)",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 27,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 27,
+        "column": 2
+      }
+    },
+    {
+      "vname": "px",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 27,
+        "column": 32
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 27,
+        "column": 34
+      }
+    },
+    {
+      "vname": "py",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 27,
+        "column": 35
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 27,
+        "column": 37
+      }
+    },
+    {
+      "vname": "mul_x",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 29,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 29,
+        "column": 6
+      }
+    },
+    {
+      "vname": "mul_y",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 30,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 30,
+        "column": 6
+      }
+    },
+    {
+      "vname": "mul",
+      "type": "Option (Pair (ByStr32) (ByStr32))",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 32,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 32,
+        "column": 4
+      }
+    },
+    {
+      "vname": "p",
+      "type": "Pair (ByStr32) (ByStr32)",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 32,
+        "column": 36
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 32,
+        "column": 37
+      }
+    },
+    {
+      "vname": "s",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 32,
+        "column": 38
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 32,
+        "column": 39
+      }
+    },
+    {
+      "vname": "mul_test",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 33,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 33,
+        "column": 9
+      }
+    },
+    {
+      "vname": "mul",
+      "type": "Option (Pair (ByStr32) (ByStr32))",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 34,
+        "column": 9
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 34,
+        "column": 12
+      }
+    },
+    {
+      "vname": "muly",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 35,
+        "column": 21
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 35,
+        "column": 25
+      }
+    },
+    {
+      "vname": "mulx",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 35,
+        "column": 16
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 35,
+        "column": 20
+      }
+    },
+    {
+      "vname": "xeq",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 36,
+        "column": 5
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 36,
+        "column": 8
+      }
+    },
+    {
+      "vname": "mul_x",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 36,
+        "column": 26
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 36,
+        "column": 31
+      }
+    },
+    {
+      "vname": "mulx",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 36,
+        "column": 32
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 36,
+        "column": 36
+      }
+    },
+    {
+      "vname": "yeq",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 37,
+        "column": 5
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 37,
+        "column": 8
+      }
+    },
+    {
+      "vname": "mul_y",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 37,
+        "column": 26
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 37,
+        "column": 31
+      }
+    },
+    {
+      "vname": "muly",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 37,
+        "column": 32
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 37,
+        "column": 36
+      }
+    },
+    {
+      "vname": "andb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 38,
+        "column": 5
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 38,
+        "column": 9
+      }
+    },
+    {
+      "vname": "xeq",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 38,
+        "column": 10
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 38,
+        "column": 13
+      }
+    },
+    {
+      "vname": "yeq",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 38,
+        "column": 14
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 38,
+        "column": 17
+      }
+    },
+    {
+      "vname": "proof_Ax",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 43,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 43,
+        "column": 9
+      }
+    },
+    {
+      "vname": "proof_Ay",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 44,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 44,
+        "column": 9
+      }
+    },
+    {
+      "vname": "proof_A",
+      "type": "Pair (ByStr32) (ByStr32)",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 45,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 45,
+        "column": 8
+      }
+    },
+    {
+      "vname": "proof_Ax",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 45,
+        "column": 38
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 45,
+        "column": 46
+      }
+    },
+    {
+      "vname": "proof_Ay",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 45,
+        "column": 47
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 45,
+        "column": 55
+      }
+    },
+    {
+      "vname": "vk_Ax",
+      "type": "ByStr64",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 46,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 46,
+        "column": 6
+      }
+    },
+    {
+      "vname": "vk_Ay",
+      "type": "ByStr64",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 47,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 47,
+        "column": 6
+      }
+    },
+    {
+      "vname": "vk_A",
+      "type": "Pair (ByStr64) (ByStr64)",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 48,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 48,
+        "column": 5
+      }
+    },
+    {
+      "vname": "vk_Ax",
+      "type": "ByStr64",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 48,
+        "column": 35
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 48,
+        "column": 40
+      }
+    },
+    {
+      "vname": "vk_Ay",
+      "type": "ByStr64",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 48,
+        "column": 41
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 48,
+        "column": 46
+      }
+    },
+    {
+      "vname": "pair1",
+      "type": "Pair (Pair (ByStr32) (ByStr32)) (Pair (ByStr64) (ByStr64))",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 50,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 50,
+        "column": 6
+      }
+    },
+    {
+      "vname": "proof_A",
+      "type": "Pair (ByStr32) (ByStr32)",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 50,
+        "column": 67
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 50,
+        "column": 74
+      }
+    },
+    {
+      "vname": "vk_A",
+      "type": "Pair (ByStr64) (ByStr64)",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 50,
+        "column": 75
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 50,
+        "column": 79
+      }
+    },
+    {
+      "vname": "proof_Apx",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 52,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 52,
+        "column": 10
+      }
+    },
+    {
+      "vname": "proof_Apy",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 53,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 53,
+        "column": 10
+      }
+    },
+    {
+      "vname": "proof_Ap",
+      "type": "Pair (ByStr32) (ByStr32)",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 54,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 54,
+        "column": 9
+      }
+    },
+    {
+      "vname": "proof_Apx",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 54,
+        "column": 39
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 54,
+        "column": 48
+      }
+    },
+    {
+      "vname": "proof_Apy",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 54,
+        "column": 49
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 54,
+        "column": 58
+      }
+    },
+    {
+      "vname": "p2x",
+      "type": "ByStr64",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 55,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 55,
+        "column": 4
+      }
+    },
+    {
+      "vname": "p2y",
+      "type": "ByStr64",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 56,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 56,
+        "column": 4
+      }
+    },
+    {
+      "vname": "p2",
+      "type": "Pair (ByStr64) (ByStr64)",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 57,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 57,
+        "column": 3
+      }
+    },
+    {
+      "vname": "p2x",
+      "type": "ByStr64",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 57,
+        "column": 33
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 57,
+        "column": 36
+      }
+    },
+    {
+      "vname": "p2y",
+      "type": "ByStr64",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 57,
+        "column": 37
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 57,
+        "column": 40
+      }
+    },
+    {
+      "vname": "pair2",
+      "type": "Pair (Pair (ByStr32) (ByStr32)) (Pair (ByStr64) (ByStr64))",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 59,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 59,
+        "column": 6
+      }
+    },
+    {
+      "vname": "proof_Ap",
+      "type": "Pair (ByStr32) (ByStr32)",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 59,
+        "column": 66
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 59,
+        "column": 74
+      }
+    },
+    {
+      "vname": "p2",
+      "type": "Pair (ByStr64) (ByStr64)",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 59,
+        "column": 75
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 59,
+        "column": 77
+      }
+    },
+    {
+      "vname": "nil",
+      "type":
+        "List (Pair (Pair (ByStr32) (ByStr32)) (Pair (ByStr64) (ByStr64)))",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 61,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 61,
+        "column": 4
+      }
+    },
+    {
+      "vname": "l1",
+      "type":
+        "List (Pair (Pair (ByStr32) (ByStr32)) (Pair (ByStr64) (ByStr64)))",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 62,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 62,
+        "column": 3
+      }
+    },
+    {
+      "vname": "pair2",
+      "type": "Pair (Pair (ByStr32) (ByStr32)) (Pair (ByStr64) (ByStr64))",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 62,
+        "column": 70
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 62,
+        "column": 75
+      }
+    },
+    {
+      "vname": "nil",
+      "type":
+        "List (Pair (Pair (ByStr32) (ByStr32)) (Pair (ByStr64) (ByStr64)))",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 62,
+        "column": 76
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 62,
+        "column": 79
+      }
+    },
+    {
+      "vname": "l",
+      "type":
+        "List (Pair (Pair (ByStr32) (ByStr32)) (Pair (ByStr64) (ByStr64)))",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 63,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 63,
+        "column": 2
+      }
+    },
+    {
+      "vname": "pair1",
+      "type": "Pair (Pair (ByStr32) (ByStr32)) (Pair (ByStr64) (ByStr64))",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 63,
+        "column": 69
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 63,
+        "column": 74
+      }
+    },
+    {
+      "vname": "l1",
+      "type":
+        "List (Pair (Pair (ByStr32) (ByStr32)) (Pair (ByStr64) (ByStr64)))",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 63,
+        "column": 75
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 63,
+        "column": 77
+      }
+    },
+    {
+      "vname": "paired",
+      "type": "Option (Bool)",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 65,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 65,
+        "column": 7
+      }
+    },
+    {
+      "vname": "l",
+      "type":
+        "List (Pair (Pair (ByStr32) (ByStr32)) (Pair (ByStr64) (ByStr64)))",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 65,
+        "column": 48
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 65,
+        "column": 49
+      }
+    },
+    {
+      "vname": "paired_test",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 66,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 66,
+        "column": 12
+      }
+    },
+    {
+      "vname": "paired",
+      "type": "Option (Bool)",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 67,
+        "column": 9
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 67,
+        "column": 15
+      }
+    },
+    {
+      "vname": "succm",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 73,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 73,
+        "column": 6
+      }
+    },
+    {
+      "vname": "failm",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 74,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 74,
+        "column": 6
+      }
+    },
+    {
+      "vname": "succ",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 76,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 76,
+        "column": 5
+      }
+    },
+    {
+      "vname": "b1",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 77,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 77,
+        "column": 5
+      }
+    },
+    {
+      "vname": "andb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 77,
+        "column": 12
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 77,
+        "column": 16
+      }
+    },
+    {
+      "vname": "sum_test",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 77,
+        "column": 17
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 77,
+        "column": 25
+      }
+    },
+    {
+      "vname": "mul_test",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 77,
+        "column": 26
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 77,
+        "column": 34
+      }
+    },
+    {
+      "vname": "andb",
+      "type": "Bool -> Bool -> Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 78,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 78,
+        "column": 7
+      }
+    },
+    {
+      "vname": "paired_test",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 78,
+        "column": 8
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 78,
+        "column": 19
+      }
+    },
+    {
+      "vname": "b1",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 78,
+        "column": 20
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 78,
+        "column": 22
+      }
+    },
+    {
+      "vname": "succ",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 81,
+        "column": 7
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 81,
+        "column": 11
+      }
+    },
+    {
+      "vname": "succm",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 82,
+        "column": 11
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 82,
+        "column": 16
+      }
+    },
+    {
+      "vname": "failm",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 83,
+        "column": 12
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-alt-bn128.scilexp",
+        "line": 83,
+        "column": 17
+      }
+    }
+  ],
+  "type": "String"
+}

--- a/tests/typecheck/good/gold/builtin-bech32-1.scilexp.gold
+++ b/tests/typecheck/good/gold/builtin-bech32-1.scilexp.gold
@@ -1,1 +1,61 @@
-Option (ByStr20)
+{
+  "type_info": [
+    {
+      "vname": "bech32str",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-bech32-1.scilexp",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-bech32-1.scilexp",
+        "line": 1,
+        "column": 10
+      }
+    },
+    {
+      "vname": "prefix",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-bech32-1.scilexp",
+        "line": 2,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-bech32-1.scilexp",
+        "line": 2,
+        "column": 7
+      }
+    },
+    {
+      "vname": "prefix",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-bech32-1.scilexp",
+        "line": 3,
+        "column": 27
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-bech32-1.scilexp",
+        "line": 3,
+        "column": 33
+      }
+    },
+    {
+      "vname": "bech32str",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-bech32-1.scilexp",
+        "line": 3,
+        "column": 34
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-bech32-1.scilexp",
+        "line": 3,
+        "column": 43
+      }
+    }
+  ],
+  "type": "Option (ByStr20)"
+}

--- a/tests/typecheck/good/gold/builtin-bech32-2.scilexp.gold
+++ b/tests/typecheck/good/gold/builtin-bech32-2.scilexp.gold
@@ -1,1 +1,61 @@
-Option (String)
+{
+  "type_info": [
+    {
+      "vname": "bystr20_addr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "typecheck/good/builtin-bech32-2.scilexp",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-bech32-2.scilexp",
+        "line": 1,
+        "column": 13
+      }
+    },
+    {
+      "vname": "prefix",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-bech32-2.scilexp",
+        "line": 2,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-bech32-2.scilexp",
+        "line": 2,
+        "column": 7
+      }
+    },
+    {
+      "vname": "prefix",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-bech32-2.scilexp",
+        "line": 3,
+        "column": 27
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-bech32-2.scilexp",
+        "line": 3,
+        "column": 33
+      }
+    },
+    {
+      "vname": "bystr20_addr",
+      "type": "ByStr20",
+      "start_location": {
+        "file": "typecheck/good/builtin-bech32-2.scilexp",
+        "line": 3,
+        "column": 34
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-bech32-2.scilexp",
+        "line": 3,
+        "column": 46
+      }
+    }
+  ],
+  "type": "Option (String)"
+}

--- a/tests/typecheck/good/gold/builtin-strings.scilexp.gold
+++ b/tests/typecheck/good/gold/builtin-strings.scilexp.gold
@@ -1,1 +1,887 @@
-String
+{
+  "type_info": [
+    {
+      "vname": "feq",
+      "type": "String -> String -> Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 2,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 2,
+        "column": 4
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 3,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 3,
+        "column": 4
+      }
+    },
+    {
+      "vname": "b",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 4,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 4,
+        "column": 4
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 5,
+        "column": 16
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 5,
+        "column": 17
+      }
+    },
+    {
+      "vname": "b",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 5,
+        "column": 18
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 5,
+        "column": 19
+      }
+    },
+    {
+      "vname": "fconcat",
+      "type": "String -> String -> String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 7,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 7,
+        "column": 8
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 8,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 8,
+        "column": 4
+      }
+    },
+    {
+      "vname": "b",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 9,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 9,
+        "column": 4
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 10,
+        "column": 20
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 10,
+        "column": 21
+      }
+    },
+    {
+      "vname": "b",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 10,
+        "column": 22
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 10,
+        "column": 23
+      }
+    },
+    {
+      "vname": "fsubstr",
+      "type": "String -> Uint32 -> Uint32 -> String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 12,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 12,
+        "column": 8
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 13,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 13,
+        "column": 4
+      }
+    },
+    {
+      "vname": "s",
+      "type": "Uint32",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 14,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 14,
+        "column": 4
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Uint32",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 15,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 15,
+        "column": 4
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 16,
+        "column": 20
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 16,
+        "column": 21
+      }
+    },
+    {
+      "vname": "s",
+      "type": "Uint32",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 16,
+        "column": 22
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 16,
+        "column": 23
+      }
+    },
+    {
+      "vname": "e",
+      "type": "Uint32",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 16,
+        "column": 24
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 16,
+        "column": 25
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 18,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 18,
+        "column": 2
+      }
+    },
+    {
+      "vname": "b",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 19,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 19,
+        "column": 2
+      }
+    },
+    {
+      "vname": "sep",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 20,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 20,
+        "column": 4
+      }
+    },
+    {
+      "vname": "res1",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 21,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 21,
+        "column": 5
+      }
+    },
+    {
+      "vname": "feq",
+      "type": "String -> String -> Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 21,
+        "column": 12
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 21,
+        "column": 15
+      }
+    },
+    {
+      "vname": "a",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 21,
+        "column": 16
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 21,
+        "column": 17
+      }
+    },
+    {
+      "vname": "b",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 21,
+        "column": 18
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 21,
+        "column": 19
+      }
+    },
+    {
+      "vname": "c",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 22,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 22,
+        "column": 2
+      }
+    },
+    {
+      "vname": "d",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 23,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 23,
+        "column": 2
+      }
+    },
+    {
+      "vname": "res2",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 24,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 24,
+        "column": 5
+      }
+    },
+    {
+      "vname": "feq",
+      "type": "String -> String -> Bool",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 24,
+        "column": 12
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 24,
+        "column": 15
+      }
+    },
+    {
+      "vname": "c",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 24,
+        "column": 16
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 24,
+        "column": 17
+      }
+    },
+    {
+      "vname": "d",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 24,
+        "column": 18
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 24,
+        "column": 19
+      }
+    },
+    {
+      "vname": "s1",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 25,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 25,
+        "column": 3
+      }
+    },
+    {
+      "vname": "s2",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 26,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 26,
+        "column": 3
+      }
+    },
+    {
+      "vname": "fconcat",
+      "type": "String -> String -> String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 26,
+        "column": 10
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 26,
+        "column": 17
+      }
+    },
+    {
+      "vname": "s1",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 26,
+        "column": 18
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 26,
+        "column": 20
+      }
+    },
+    {
+      "vname": "sep",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 26,
+        "column": 21
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 26,
+        "column": 24
+      }
+    },
+    {
+      "vname": "s3",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 27,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 27,
+        "column": 3
+      }
+    },
+    {
+      "vname": "fconcat",
+      "type": "String -> String -> String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 27,
+        "column": 10
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 27,
+        "column": 17
+      }
+    },
+    {
+      "vname": "s2",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 27,
+        "column": 18
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 27,
+        "column": 20
+      }
+    },
+    {
+      "vname": "b",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 27,
+        "column": 21
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 27,
+        "column": 22
+      }
+    },
+    {
+      "vname": "startp",
+      "type": "Uint32",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 28,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 28,
+        "column": 7
+      }
+    },
+    {
+      "vname": "endp",
+      "type": "Uint32",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 29,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 29,
+        "column": 5
+      }
+    },
+    {
+      "vname": "res",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 30,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 30,
+        "column": 4
+      }
+    },
+    {
+      "vname": "fsubstr",
+      "type": "String -> Uint32 -> Uint32 -> String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 30,
+        "column": 11
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 30,
+        "column": 18
+      }
+    },
+    {
+      "vname": "s3",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 30,
+        "column": 19
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 30,
+        "column": 21
+      }
+    },
+    {
+      "vname": "startp",
+      "type": "Uint32",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 30,
+        "column": 22
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 30,
+        "column": 28
+      }
+    },
+    {
+      "vname": "endp",
+      "type": "Uint32",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 30,
+        "column": 29
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 30,
+        "column": 33
+      }
+    },
+    {
+      "vname": "bs",
+      "type": "ByStr3",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 32,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 32,
+        "column": 3
+      }
+    },
+    {
+      "vname": "bsx",
+      "type": "ByStr",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 33,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 33,
+        "column": 4
+      }
+    },
+    {
+      "vname": "bs",
+      "type": "ByStr3",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 33,
+        "column": 28
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 33,
+        "column": 30
+      }
+    },
+    {
+      "vname": "bss",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 34,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 34,
+        "column": 4
+      }
+    },
+    {
+      "vname": "bs",
+      "type": "ByStr3",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 34,
+        "column": 29
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 34,
+        "column": 31
+      }
+    },
+    {
+      "vname": "bsxs",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 35,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 35,
+        "column": 5
+      }
+    },
+    {
+      "vname": "bsx",
+      "type": "ByStr",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 35,
+        "column": 30
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 35,
+        "column": 33
+      }
+    },
+    {
+      "vname": "i",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 37,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 37,
+        "column": 2
+      }
+    },
+    {
+      "vname": "j",
+      "type": "Uint128",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 38,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 38,
+        "column": 2
+      }
+    },
+    {
+      "vname": "k",
+      "type": "Int64",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 39,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 39,
+        "column": 2
+      }
+    },
+    {
+      "vname": "is",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 40,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 40,
+        "column": 3
+      }
+    },
+    {
+      "vname": "i",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 40,
+        "column": 28
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 40,
+        "column": 29
+      }
+    },
+    {
+      "vname": "js",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 41,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 41,
+        "column": 3
+      }
+    },
+    {
+      "vname": "j",
+      "type": "Uint128",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 41,
+        "column": 28
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 41,
+        "column": 29
+      }
+    },
+    {
+      "vname": "ks",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 42,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 42,
+        "column": 3
+      }
+    },
+    {
+      "vname": "k",
+      "type": "Int64",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 42,
+        "column": 28
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 42,
+        "column": 29
+      }
+    },
+    {
+      "vname": "res",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 44,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/builtin-strings.scilexp",
+        "line": 44,
+        "column": 4
+      }
+    }
+  ],
+  "type": "String"
+}

--- a/tests/typecheck/good/gold/fun.scilexp.gold
+++ b/tests/typecheck/good/gold/fun.scilexp.gold
@@ -1,1 +1,33 @@
-Int32 -> Int32
+{
+  "type_info": [
+    {
+      "vname": "x",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/fun.scilexp",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/fun.scilexp",
+        "line": 1,
+        "column": 2
+      }
+    },
+    {
+      "vname": "x",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/fun.scilexp",
+        "line": 1,
+        "column": 20
+      },
+      "end_location": {
+        "file": "typecheck/good/fun.scilexp",
+        "line": 1,
+        "column": 21
+      }
+    }
+  ],
+  "type": "Int32 -> Int32"
+}

--- a/tests/typecheck/good/gold/fun1.scilexp.gold
+++ b/tests/typecheck/good/gold/fun1.scilexp.gold
@@ -1,1 +1,61 @@
-Int32 -> Int32 -> Int32
+{
+  "type_info": [
+    {
+      "vname": "x",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/fun1.scilexp",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/fun1.scilexp",
+        "line": 1,
+        "column": 2
+      }
+    },
+    {
+      "vname": "y",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/fun1.scilexp",
+        "line": 2,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/fun1.scilexp",
+        "line": 2,
+        "column": 2
+      }
+    },
+    {
+      "vname": "x",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/fun1.scilexp",
+        "line": 2,
+        "column": 32
+      },
+      "end_location": {
+        "file": "typecheck/good/fun1.scilexp",
+        "line": 2,
+        "column": 33
+      }
+    },
+    {
+      "vname": "y",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/fun1.scilexp",
+        "line": 2,
+        "column": 34
+      },
+      "end_location": {
+        "file": "typecheck/good/fun1.scilexp",
+        "line": 2,
+        "column": 35
+      }
+    }
+  ],
+  "type": "Int32 -> Int32 -> Int32"
+}

--- a/tests/typecheck/good/gold/hash1.scilexp.gold
+++ b/tests/typecheck/good/gold/hash1.scilexp.gold
@@ -1,1 +1,271 @@
-ByStr64
+{
+  "type_info": [
+    {
+      "vname": "k1",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 1,
+        "column": 3
+      }
+    },
+    {
+      "vname": "k2",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 2,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 2,
+        "column": 3
+      }
+    },
+    {
+      "vname": "v1",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 3,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 3,
+        "column": 3
+      }
+    },
+    {
+      "vname": "v2",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 4,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 4,
+        "column": 3
+      }
+    },
+    {
+      "vname": "m0",
+      "type": "Map (Int32) (Int32)",
+      "start_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 6,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 6,
+        "column": 3
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (Int32) (Int32)",
+      "start_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 7,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 7,
+        "column": 3
+      }
+    },
+    {
+      "vname": "m0",
+      "type": "Map (Int32) (Int32)",
+      "start_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 7,
+        "column": 22
+      },
+      "end_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 7,
+        "column": 24
+      }
+    },
+    {
+      "vname": "k1",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 7,
+        "column": 25
+      },
+      "end_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 7,
+        "column": 27
+      }
+    },
+    {
+      "vname": "v1",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 7,
+        "column": 28
+      },
+      "end_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 7,
+        "column": 30
+      }
+    },
+    {
+      "vname": "m2",
+      "type": "Map (Int32) (Int32)",
+      "start_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 8,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 8,
+        "column": 3
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (Int32) (Int32)",
+      "start_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 8,
+        "column": 22
+      },
+      "end_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 8,
+        "column": 24
+      }
+    },
+    {
+      "vname": "k2",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 8,
+        "column": 25
+      },
+      "end_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 8,
+        "column": 27
+      }
+    },
+    {
+      "vname": "v2",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 8,
+        "column": 28
+      },
+      "end_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 8,
+        "column": 30
+      }
+    },
+    {
+      "vname": "b1",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 10,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 10,
+        "column": 3
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (Int32) (Int32)",
+      "start_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 10,
+        "column": 29
+      },
+      "end_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 10,
+        "column": 31
+      }
+    },
+    {
+      "vname": "b2",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 11,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 11,
+        "column": 3
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "Map (Int32) (Int32)",
+      "start_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 11,
+        "column": 29
+      },
+      "end_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 11,
+        "column": 31
+      }
+    },
+    {
+      "vname": "b1",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 12,
+        "column": 16
+      },
+      "end_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 12,
+        "column": 18
+      }
+    },
+    {
+      "vname": "b2",
+      "type": "ByStr32",
+      "start_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 12,
+        "column": 19
+      },
+      "end_location": {
+        "file": "typecheck/good/hash1.scilexp",
+        "line": 12,
+        "column": 21
+      }
+    }
+  ],
+  "type": "ByStr64"
+}

--- a/tests/typecheck/good/gold/list1.scilexp.gold
+++ b/tests/typecheck/good/gold/list1.scilexp.gold
@@ -1,1 +1,481 @@
-List (Pair (String) (Int64))
+{
+  "type_info": [
+    {
+      "vname": "one",
+      "type": "Int64",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 1,
+        "column": 4
+      }
+    },
+    {
+      "vname": "two",
+      "type": "Int64",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 2,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 2,
+        "column": 4
+      }
+    },
+    {
+      "vname": "three",
+      "type": "Int64",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 3,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 3,
+        "column": 6
+      }
+    },
+    {
+      "vname": "four",
+      "type": "Int64",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 4,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 4,
+        "column": 5
+      }
+    },
+    {
+      "vname": "ones",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 6,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 6,
+        "column": 5
+      }
+    },
+    {
+      "vname": "twos",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 7,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 7,
+        "column": 5
+      }
+    },
+    {
+      "vname": "threes",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 8,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 8,
+        "column": 7
+      }
+    },
+    {
+      "vname": "fours",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 9,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 9,
+        "column": 6
+      }
+    },
+    {
+      "vname": "pair1",
+      "type": "Pair (String) (Int64)",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 11,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 11,
+        "column": 6
+      }
+    },
+    {
+      "vname": "ones",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 11,
+        "column": 33
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 11,
+        "column": 37
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Int64",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 11,
+        "column": 38
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 11,
+        "column": 41
+      }
+    },
+    {
+      "vname": "pair2",
+      "type": "Pair (String) (Int64)",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 12,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 12,
+        "column": 6
+      }
+    },
+    {
+      "vname": "twos",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 12,
+        "column": 33
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 12,
+        "column": 37
+      }
+    },
+    {
+      "vname": "two",
+      "type": "Int64",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 12,
+        "column": 38
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 12,
+        "column": 41
+      }
+    },
+    {
+      "vname": "pair3",
+      "type": "Pair (String) (Int64)",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 13,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 13,
+        "column": 6
+      }
+    },
+    {
+      "vname": "threes",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 13,
+        "column": 33
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 13,
+        "column": 39
+      }
+    },
+    {
+      "vname": "three",
+      "type": "Int64",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 13,
+        "column": 40
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 13,
+        "column": 45
+      }
+    },
+    {
+      "vname": "pair4",
+      "type": "Pair (String) (Int64)",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 14,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 14,
+        "column": 6
+      }
+    },
+    {
+      "vname": "fours",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 14,
+        "column": 33
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 14,
+        "column": 38
+      }
+    },
+    {
+      "vname": "four",
+      "type": "Int64",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 14,
+        "column": 39
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 14,
+        "column": 43
+      }
+    },
+    {
+      "vname": "nil",
+      "type": "List (Pair (String) (Int64))",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 16,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 16,
+        "column": 4
+      }
+    },
+    {
+      "vname": "l1",
+      "type": "List (Pair (String) (Int64))",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 17,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 17,
+        "column": 3
+      }
+    },
+    {
+      "vname": "pair4",
+      "type": "Pair (String) (Int64)",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 17,
+        "column": 37
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 17,
+        "column": 42
+      }
+    },
+    {
+      "vname": "nil",
+      "type": "List (Pair (String) (Int64))",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 17,
+        "column": 43
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 17,
+        "column": 46
+      }
+    },
+    {
+      "vname": "l2",
+      "type": "List (Pair (String) (Int64))",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 18,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 18,
+        "column": 3
+      }
+    },
+    {
+      "vname": "pair3",
+      "type": "Pair (String) (Int64)",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 18,
+        "column": 37
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 18,
+        "column": 42
+      }
+    },
+    {
+      "vname": "l1",
+      "type": "List (Pair (String) (Int64))",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 18,
+        "column": 43
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 18,
+        "column": 45
+      }
+    },
+    {
+      "vname": "l3",
+      "type": "List (Pair (String) (Int64))",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 19,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 19,
+        "column": 3
+      }
+    },
+    {
+      "vname": "pair2",
+      "type": "Pair (String) (Int64)",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 19,
+        "column": 37
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 19,
+        "column": 42
+      }
+    },
+    {
+      "vname": "l2",
+      "type": "List (Pair (String) (Int64))",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 19,
+        "column": 43
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 19,
+        "column": 45
+      }
+    },
+    {
+      "vname": "l4",
+      "type": "List (Pair (String) (Int64))",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 20,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 20,
+        "column": 3
+      }
+    },
+    {
+      "vname": "pair1",
+      "type": "Pair (String) (Int64)",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 20,
+        "column": 37
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 20,
+        "column": 42
+      }
+    },
+    {
+      "vname": "l3",
+      "type": "List (Pair (String) (Int64))",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 20,
+        "column": 43
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 20,
+        "column": 45
+      }
+    },
+    {
+      "vname": "l4",
+      "type": "List (Pair (String) (Int64))",
+      "start_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 21,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/list1.scilexp",
+        "line": 21,
+        "column": 3
+      }
+    }
+  ],
+  "type": "List (Pair (String) (Int64))"
+}

--- a/tests/typecheck/good/gold/nat_to_int.scilexp.gold
+++ b/tests/typecheck/good/gold/nat_to_int.scilexp.gold
@@ -1,1 +1,103 @@
-Uint32
+{
+  "type_info": [
+    {
+      "vname": "z",
+      "type": "Nat",
+      "start_location": {
+        "file": "typecheck/good/nat_to_int.scilexp",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/nat_to_int.scilexp",
+        "line": 1,
+        "column": 2
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Nat",
+      "start_location": {
+        "file": "typecheck/good/nat_to_int.scilexp",
+        "line": 2,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/nat_to_int.scilexp",
+        "line": 2,
+        "column": 4
+      }
+    },
+    {
+      "vname": "z",
+      "type": "Nat",
+      "start_location": {
+        "file": "typecheck/good/nat_to_int.scilexp",
+        "line": 2,
+        "column": 16
+      },
+      "end_location": {
+        "file": "typecheck/good/nat_to_int.scilexp",
+        "line": 2,
+        "column": 17
+      }
+    },
+    {
+      "vname": "two",
+      "type": "Nat",
+      "start_location": {
+        "file": "typecheck/good/nat_to_int.scilexp",
+        "line": 3,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/nat_to_int.scilexp",
+        "line": 3,
+        "column": 4
+      }
+    },
+    {
+      "vname": "one",
+      "type": "Nat",
+      "start_location": {
+        "file": "typecheck/good/nat_to_int.scilexp",
+        "line": 3,
+        "column": 16
+      },
+      "end_location": {
+        "file": "typecheck/good/nat_to_int.scilexp",
+        "line": 3,
+        "column": 19
+      }
+    },
+    {
+      "vname": "nat_to_int",
+      "type": "Nat -> Uint32",
+      "start_location": {
+        "file": "typecheck/good/nat_to_int.scilexp",
+        "line": 4,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/nat_to_int.scilexp",
+        "line": 4,
+        "column": 11
+      }
+    },
+    {
+      "vname": "two",
+      "type": "Nat",
+      "start_location": {
+        "file": "typecheck/good/nat_to_int.scilexp",
+        "line": 4,
+        "column": 12
+      },
+      "end_location": {
+        "file": "typecheck/good/nat_to_int.scilexp",
+        "line": 4,
+        "column": 15
+      }
+    }
+  ],
+  "type": "Uint32"
+}

--- a/tests/typecheck/good/gold/pair.scilexp.gold
+++ b/tests/typecheck/good/gold/pair.scilexp.gold
@@ -1,1 +1,47 @@
-Map (Int32) (Pair (BNum) (Uint128)) -> Uint128
+{
+  "type_info": [
+    {
+      "vname": "f",
+      "type": "Map (Int32) (Pair (BNum) (Uint128)) -> Uint128",
+      "start_location": {
+        "file": "typecheck/good/pair.scilexp",
+        "line": 2,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/pair.scilexp",
+        "line": 2,
+        "column": 2
+      }
+    },
+    {
+      "vname": "a",
+      "type": "Map (Int32) (Pair (BNum) (Uint128))",
+      "start_location": {
+        "file": "typecheck/good/pair.scilexp",
+        "line": 3,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/pair.scilexp",
+        "line": 3,
+        "column": 4
+      }
+    },
+    {
+      "vname": "f",
+      "type": "Map (Int32) (Pair (BNum) (Uint128)) -> Uint128",
+      "start_location": {
+        "file": "typecheck/good/pair.scilexp",
+        "line": 6,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/pair.scilexp",
+        "line": 6,
+        "column": 2
+      }
+    }
+  ],
+  "type": "Map (Int32) (Pair (BNum) (Uint128)) -> Uint128"
+}

--- a/tests/typecheck/good/gold/pm1.scilexp.gold
+++ b/tests/typecheck/good/gold/pm1.scilexp.gold
@@ -1,1 +1,117 @@
-Bool -> Int32
+{
+  "type_info": [
+    {
+      "vname": "x",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/pm1.scilexp",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/pm1.scilexp",
+        "line": 1,
+        "column": 2
+      }
+    },
+    {
+      "vname": "y",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/pm1.scilexp",
+        "line": 2,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/pm1.scilexp",
+        "line": 2,
+        "column": 2
+      }
+    },
+    {
+      "vname": "f",
+      "type": "Bool -> Int32",
+      "start_location": {
+        "file": "typecheck/good/pm1.scilexp",
+        "line": 3,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/pm1.scilexp",
+        "line": 3,
+        "column": 2
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/pm1.scilexp",
+        "line": 3,
+        "column": 9
+      },
+      "end_location": {
+        "file": "typecheck/good/pm1.scilexp",
+        "line": 3,
+        "column": 10
+      }
+    },
+    {
+      "vname": "c",
+      "type": "Bool",
+      "start_location": {
+        "file": "typecheck/good/pm1.scilexp",
+        "line": 4,
+        "column": 9
+      },
+      "end_location": {
+        "file": "typecheck/good/pm1.scilexp",
+        "line": 4,
+        "column": 10
+      }
+    },
+    {
+      "vname": "x",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/pm1.scilexp",
+        "line": 5,
+        "column": 13
+      },
+      "end_location": {
+        "file": "typecheck/good/pm1.scilexp",
+        "line": 5,
+        "column": 14
+      }
+    },
+    {
+      "vname": "y",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/pm1.scilexp",
+        "line": 6,
+        "column": 10
+      },
+      "end_location": {
+        "file": "typecheck/good/pm1.scilexp",
+        "line": 6,
+        "column": 11
+      }
+    },
+    {
+      "vname": "f",
+      "type": "Bool -> Int32",
+      "start_location": {
+        "file": "typecheck/good/pm1.scilexp",
+        "line": 8,
+        "column": 4
+      },
+      "end_location": {
+        "file": "typecheck/good/pm1.scilexp",
+        "line": 8,
+        "column": 5
+      }
+    }
+  ],
+  "type": "Bool -> Int32"
+}

--- a/tests/typecheck/good/gold/pm2.scilexp.gold
+++ b/tests/typecheck/good/gold/pm2.scilexp.gold
@@ -1,1 +1,145 @@
-Option (Option (Int32)) -> Int32
+{
+  "type_info": [
+    {
+      "vname": "x",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/pm2.scilexp",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/pm2.scilexp",
+        "line": 1,
+        "column": 2
+      }
+    },
+    {
+      "vname": "y",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/pm2.scilexp",
+        "line": 2,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/pm2.scilexp",
+        "line": 2,
+        "column": 2
+      }
+    },
+    {
+      "vname": "f",
+      "type": "Option (Option (Int32)) -> Int32",
+      "start_location": {
+        "file": "typecheck/good/pm2.scilexp",
+        "line": 3,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/pm2.scilexp",
+        "line": 3,
+        "column": 2
+      }
+    },
+    {
+      "vname": "o",
+      "type": "Option (Option (Int32))",
+      "start_location": {
+        "file": "typecheck/good/pm2.scilexp",
+        "line": 3,
+        "column": 9
+      },
+      "end_location": {
+        "file": "typecheck/good/pm2.scilexp",
+        "line": 3,
+        "column": 10
+      }
+    },
+    {
+      "vname": "o",
+      "type": "Option (Option (Int32))",
+      "start_location": {
+        "file": "typecheck/good/pm2.scilexp",
+        "line": 4,
+        "column": 9
+      },
+      "end_location": {
+        "file": "typecheck/good/pm2.scilexp",
+        "line": 4,
+        "column": 10
+      }
+    },
+    {
+      "vname": "x",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/pm2.scilexp",
+        "line": 5,
+        "column": 13
+      },
+      "end_location": {
+        "file": "typecheck/good/pm2.scilexp",
+        "line": 5,
+        "column": 14
+      }
+    },
+    {
+      "vname": "y",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/pm2.scilexp",
+        "line": 6,
+        "column": 18
+      },
+      "end_location": {
+        "file": "typecheck/good/pm2.scilexp",
+        "line": 6,
+        "column": 19
+      }
+    },
+    {
+      "vname": "z",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/pm2.scilexp",
+        "line": 7,
+        "column": 16
+      },
+      "end_location": {
+        "file": "typecheck/good/pm2.scilexp",
+        "line": 7,
+        "column": 17
+      }
+    },
+    {
+      "vname": "z",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/pm2.scilexp",
+        "line": 7,
+        "column": 22
+      },
+      "end_location": {
+        "file": "typecheck/good/pm2.scilexp",
+        "line": 7,
+        "column": 23
+      }
+    },
+    {
+      "vname": "f",
+      "type": "Option (Option (Int32)) -> Int32",
+      "start_location": {
+        "file": "typecheck/good/pm2.scilexp",
+        "line": 9,
+        "column": 4
+      },
+      "end_location": {
+        "file": "typecheck/good/pm2.scilexp",
+        "line": 9,
+        "column": 5
+      }
+    }
+  ],
+  "type": "Option (Option (Int32)) -> Int32"
+}

--- a/tests/typecheck/good/gold/pm3.scilexp.gold
+++ b/tests/typecheck/good/gold/pm3.scilexp.gold
@@ -1,1 +1,117 @@
-Pair (Option (Int32)) (Int32) -> Int32
+{
+  "type_info": [
+    {
+      "vname": "f",
+      "type": "Pair (Option (Int32)) (Int32) -> Int32",
+      "start_location": {
+        "file": "typecheck/good/pm3.scilexp",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/pm3.scilexp",
+        "line": 1,
+        "column": 2
+      }
+    },
+    {
+      "vname": "p",
+      "type": "Pair (Option (Int32)) (Int32)",
+      "start_location": {
+        "file": "typecheck/good/pm3.scilexp",
+        "line": 1,
+        "column": 9
+      },
+      "end_location": {
+        "file": "typecheck/good/pm3.scilexp",
+        "line": 1,
+        "column": 10
+      }
+    },
+    {
+      "vname": "p",
+      "type": "Pair (Option (Int32)) (Int32)",
+      "start_location": {
+        "file": "typecheck/good/pm3.scilexp",
+        "line": 2,
+        "column": 9
+      },
+      "end_location": {
+        "file": "typecheck/good/pm3.scilexp",
+        "line": 2,
+        "column": 10
+      }
+    },
+    {
+      "vname": "z",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/pm3.scilexp",
+        "line": 3,
+        "column": 16
+      },
+      "end_location": {
+        "file": "typecheck/good/pm3.scilexp",
+        "line": 3,
+        "column": 17
+      }
+    },
+    {
+      "vname": "z",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/pm3.scilexp",
+        "line": 3,
+        "column": 24
+      },
+      "end_location": {
+        "file": "typecheck/good/pm3.scilexp",
+        "line": 3,
+        "column": 25
+      }
+    },
+    {
+      "vname": "i",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/pm3.scilexp",
+        "line": 4,
+        "column": 12
+      },
+      "end_location": {
+        "file": "typecheck/good/pm3.scilexp",
+        "line": 4,
+        "column": 13
+      }
+    },
+    {
+      "vname": "i",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/pm3.scilexp",
+        "line": 4,
+        "column": 17
+      },
+      "end_location": {
+        "file": "typecheck/good/pm3.scilexp",
+        "line": 4,
+        "column": 18
+      }
+    },
+    {
+      "vname": "f",
+      "type": "Pair (Option (Int32)) (Int32) -> Int32",
+      "start_location": {
+        "file": "typecheck/good/pm3.scilexp",
+        "line": 6,
+        "column": 4
+      },
+      "end_location": {
+        "file": "typecheck/good/pm3.scilexp",
+        "line": 6,
+        "column": 5
+      }
+    }
+  ],
+  "type": "Pair (Option (Int32)) (Int32) -> Int32"
+}

--- a/tests/typecheck/good/gold/pm4.scilexp.gold
+++ b/tests/typecheck/good/gold/pm4.scilexp.gold
@@ -1,1 +1,145 @@
-List (Option (Int32)) -> Int32
+{
+  "type_info": [
+    {
+      "vname": "z",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/pm4.scilexp",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/pm4.scilexp",
+        "line": 1,
+        "column": 2
+      }
+    },
+    {
+      "vname": "f",
+      "type": "List (Option (Int32)) -> Int32",
+      "start_location": {
+        "file": "typecheck/good/pm4.scilexp",
+        "line": 2,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/pm4.scilexp",
+        "line": 2,
+        "column": 2
+      }
+    },
+    {
+      "vname": "p",
+      "type": "List (Option (Int32))",
+      "start_location": {
+        "file": "typecheck/good/pm4.scilexp",
+        "line": 2,
+        "column": 9
+      },
+      "end_location": {
+        "file": "typecheck/good/pm4.scilexp",
+        "line": 2,
+        "column": 10
+      }
+    },
+    {
+      "vname": "p",
+      "type": "List (Option (Int32))",
+      "start_location": {
+        "file": "typecheck/good/pm4.scilexp",
+        "line": 3,
+        "column": 9
+      },
+      "end_location": {
+        "file": "typecheck/good/pm4.scilexp",
+        "line": 3,
+        "column": 10
+      }
+    },
+    {
+      "vname": "z",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/pm4.scilexp",
+        "line": 4,
+        "column": 12
+      },
+      "end_location": {
+        "file": "typecheck/good/pm4.scilexp",
+        "line": 4,
+        "column": 13
+      }
+    },
+    {
+      "vname": "xs",
+      "type": "List (Option (Int32))",
+      "start_location": {
+        "file": "typecheck/good/pm4.scilexp",
+        "line": 5,
+        "column": 19
+      },
+      "end_location": {
+        "file": "typecheck/good/pm4.scilexp",
+        "line": 5,
+        "column": 21
+      }
+    },
+    {
+      "vname": "x",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/pm4.scilexp",
+        "line": 5,
+        "column": 16
+      },
+      "end_location": {
+        "file": "typecheck/good/pm4.scilexp",
+        "line": 5,
+        "column": 17
+      }
+    },
+    {
+      "vname": "x",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/pm4.scilexp",
+        "line": 5,
+        "column": 25
+      },
+      "end_location": {
+        "file": "typecheck/good/pm4.scilexp",
+        "line": 5,
+        "column": 26
+      }
+    },
+    {
+      "vname": "z",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/pm4.scilexp",
+        "line": 6,
+        "column": 17
+      },
+      "end_location": {
+        "file": "typecheck/good/pm4.scilexp",
+        "line": 6,
+        "column": 18
+      }
+    },
+    {
+      "vname": "f",
+      "type": "List (Option (Int32)) -> Int32",
+      "start_location": {
+        "file": "typecheck/good/pm4.scilexp",
+        "line": 8,
+        "column": 4
+      },
+      "end_location": {
+        "file": "typecheck/good/pm4.scilexp",
+        "line": 8,
+        "column": 5
+      }
+    }
+  ],
+  "type": "List (Option (Int32)) -> Int32"
+}

--- a/tests/typecheck/good/gold/str-nonprint-char-1.scilexp.gold
+++ b/tests/typecheck/good/gold/str-nonprint-char-1.scilexp.gold
@@ -1,1 +1,33 @@
-String
+{
+  "type_info": [
+    {
+      "vname": "s",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/str-nonprint-char-1.scilexp",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/str-nonprint-char-1.scilexp",
+        "line": 1,
+        "column": 2
+      }
+    },
+    {
+      "vname": "s",
+      "type": "String",
+      "start_location": {
+        "file": "typecheck/good/str-nonprint-char-1.scilexp",
+        "line": 2,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/str-nonprint-char-1.scilexp",
+        "line": 2,
+        "column": 2
+      }
+    }
+  ],
+  "type": "String"
+}

--- a/tests/typecheck/good/gold/subst.scilexp.gold
+++ b/tests/typecheck/good/gold/subst.scilexp.gold
@@ -1,1 +1,476 @@
-forall 'A. forall 'B. List (Pair ('A) ('B)) -> Pair (List ('A)) (List ('B))
+{
+  "type_info": [
+    {
+      "vname": "list_unzip",
+      "type":
+        "forall 'A. forall 'B. List (Pair ('A) ('B)) -> Pair (List ('A)) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 1,
+        "column": 11
+      }
+    },
+    {
+      "vname": "'A",
+      "type":
+        "forall 'B. List (Pair ('A) ('B)) -> Pair (List ('A)) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 2,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 2,
+        "column": 5
+      }
+    },
+    {
+      "vname": "'B",
+      "type": "List (Pair ('A) ('B)) -> Pair (List ('A)) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 3,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 3,
+        "column": 5
+      }
+    },
+    {
+      "vname": "l",
+      "type": "List (Pair ('A) ('B))",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 4,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 4,
+        "column": 4
+      }
+    },
+    {
+      "vname": "folder",
+      "type":
+        "(Pair ('A) ('B) -> Pair (List ('A)) (List ('B)) -> Pair (List ('A)) (List ('B))) -> Pair (List ('A)) (List ('B)) -> List (Pair ('A) ('B)) -> Pair (List ('A)) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 5,
+        "column": 5
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 5,
+        "column": 11
+      }
+    },
+    {
+      "vname": "list_foldr",
+      "type":
+        "forall 'A. forall 'B. ('A -> 'B -> 'B) -> 'B -> List ('A) -> 'B",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 5,
+        "column": 18
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 5,
+        "column": 28
+      }
+    },
+    {
+      "vname": "nil1",
+      "type": "List ('A)",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 6,
+        "column": 5
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 6,
+        "column": 9
+      }
+    },
+    {
+      "vname": "nil2",
+      "type": "List ('B)",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 7,
+        "column": 5
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 7,
+        "column": 9
+      }
+    },
+    {
+      "vname": "init",
+      "type": "Pair (List ('A)) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 8,
+        "column": 5
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 8,
+        "column": 9
+      }
+    },
+    {
+      "vname": "nil1",
+      "type": "List ('A)",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 8,
+        "column": 43
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 8,
+        "column": 47
+      }
+    },
+    {
+      "vname": "nil2",
+      "type": "List ('B)",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 8,
+        "column": 48
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 8,
+        "column": 52
+      }
+    },
+    {
+      "vname": "iter",
+      "type":
+        "Pair ('A) ('B) -> Pair (List ('A)) (List ('B)) -> Pair (List ('A)) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 9,
+        "column": 5
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 9,
+        "column": 9
+      }
+    },
+    {
+      "vname": "h",
+      "type": "Pair ('A) ('B)",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 10,
+        "column": 7
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 10,
+        "column": 8
+      }
+    },
+    {
+      "vname": "z",
+      "type": "Pair (List ('A)) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 11,
+        "column": 7
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 11,
+        "column": 8
+      }
+    },
+    {
+      "vname": "h",
+      "type": "Pair ('A) ('B)",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 12,
+        "column": 15
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 12,
+        "column": 16
+      }
+    },
+    {
+      "vname": "b",
+      "type": "'B",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 13,
+        "column": 18
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 13,
+        "column": 19
+      }
+    },
+    {
+      "vname": "a",
+      "type": "'A",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 13,
+        "column": 16
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 13,
+        "column": 17
+      }
+    },
+    {
+      "vname": "z",
+      "type": "Pair (List ('A)) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 14,
+        "column": 17
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 14,
+        "column": 18
+      }
+    },
+    {
+      "vname": "lb",
+      "type": "List ('B)",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 15,
+        "column": 21
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 15,
+        "column": 23
+      }
+    },
+    {
+      "vname": "la",
+      "type": "List ('A)",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 15,
+        "column": 18
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 15,
+        "column": 20
+      }
+    },
+    {
+      "vname": "nla",
+      "type": "List ('A)",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 16,
+        "column": 13
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 16,
+        "column": 16
+      }
+    },
+    {
+      "vname": "a",
+      "type": "'A",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 16,
+        "column": 33
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 16,
+        "column": 34
+      }
+    },
+    {
+      "vname": "la",
+      "type": "List ('A)",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 16,
+        "column": 35
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 16,
+        "column": 37
+      }
+    },
+    {
+      "vname": "nlb",
+      "type": "List ('B)",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 17,
+        "column": 13
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 17,
+        "column": 16
+      }
+    },
+    {
+      "vname": "b",
+      "type": "'B",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 17,
+        "column": 33
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 17,
+        "column": 34
+      }
+    },
+    {
+      "vname": "lb",
+      "type": "List ('B)",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 17,
+        "column": 35
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 17,
+        "column": 37
+      }
+    },
+    {
+      "vname": "nla",
+      "type": "List ('A)",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 18,
+        "column": 39
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 18,
+        "column": 42
+      }
+    },
+    {
+      "vname": "nlb",
+      "type": "List ('B)",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 18,
+        "column": 43
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 18,
+        "column": 46
+      }
+    },
+    {
+      "vname": "folder",
+      "type":
+        "(Pair ('A) ('B) -> Pair (List ('A)) (List ('B)) -> Pair (List ('A)) (List ('B))) -> Pair (List ('A)) (List ('B)) -> List (Pair ('A) ('B)) -> Pair (List ('A)) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 22,
+        "column": 7
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 22,
+        "column": 13
+      }
+    },
+    {
+      "vname": "iter",
+      "type":
+        "Pair ('A) ('B) -> Pair (List ('A)) (List ('B)) -> Pair (List ('A)) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 22,
+        "column": 14
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 22,
+        "column": 18
+      }
+    },
+    {
+      "vname": "init",
+      "type": "Pair (List ('A)) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 22,
+        "column": 19
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 22,
+        "column": 23
+      }
+    },
+    {
+      "vname": "l",
+      "type": "List (Pair ('A) ('B))",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 22,
+        "column": 24
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 22,
+        "column": 25
+      }
+    },
+    {
+      "vname": "list_unzip",
+      "type":
+        "forall 'A. forall 'B. List (Pair ('A) ('B)) -> Pair (List ('A)) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 23,
+        "column": 4
+      },
+      "end_location": {
+        "file": "typecheck/good/subst.scilexp",
+        "line": 23,
+        "column": 14
+      }
+    }
+  ],
+  "type":
+    "forall 'A. forall 'B. List (Pair ('A) ('B)) -> Pair (List ('A)) (List ('B))"
+}

--- a/tests/typecheck/good/gold/to_int.scilexp.gold
+++ b/tests/typecheck/good/gold/to_int.scilexp.gold
@@ -1,1 +1,117 @@
-Bool
+{
+  "type_info": [
+    {
+      "vname": "x",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/to_int.scilexp",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/to_int.scilexp",
+        "line": 1,
+        "column": 2
+      }
+    },
+    {
+      "vname": "y",
+      "type": "Int64",
+      "start_location": {
+        "file": "typecheck/good/to_int.scilexp",
+        "line": 2,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/to_int.scilexp",
+        "line": 2,
+        "column": 2
+      }
+    },
+    {
+      "vname": "o",
+      "type": "Option (Int64)",
+      "start_location": {
+        "file": "typecheck/good/to_int.scilexp",
+        "line": 3,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/to_int.scilexp",
+        "line": 3,
+        "column": 2
+      }
+    },
+    {
+      "vname": "x",
+      "type": "Int32",
+      "start_location": {
+        "file": "typecheck/good/to_int.scilexp",
+        "line": 3,
+        "column": 26
+      },
+      "end_location": {
+        "file": "typecheck/good/to_int.scilexp",
+        "line": 3,
+        "column": 27
+      }
+    },
+    {
+      "vname": "o",
+      "type": "Option (Int64)",
+      "start_location": {
+        "file": "typecheck/good/to_int.scilexp",
+        "line": 4,
+        "column": 7
+      },
+      "end_location": {
+        "file": "typecheck/good/to_int.scilexp",
+        "line": 4,
+        "column": 8
+      }
+    },
+    {
+      "vname": "x1",
+      "type": "Int64",
+      "start_location": {
+        "file": "typecheck/good/to_int.scilexp",
+        "line": 5,
+        "column": 8
+      },
+      "end_location": {
+        "file": "typecheck/good/to_int.scilexp",
+        "line": 5,
+        "column": 10
+      }
+    },
+    {
+      "vname": "x1",
+      "type": "Int64",
+      "start_location": {
+        "file": "typecheck/good/to_int.scilexp",
+        "line": 5,
+        "column": 25
+      },
+      "end_location": {
+        "file": "typecheck/good/to_int.scilexp",
+        "line": 5,
+        "column": 27
+      }
+    },
+    {
+      "vname": "y",
+      "type": "Int64",
+      "start_location": {
+        "file": "typecheck/good/to_int.scilexp",
+        "line": 5,
+        "column": 28
+      },
+      "end_location": {
+        "file": "typecheck/good/to_int.scilexp",
+        "line": 5,
+        "column": 29
+      }
+    }
+  ],
+  "type": "Bool"
+}

--- a/tests/typecheck/good/gold/type-subst-avoids-capture-1.scilexp.gold
+++ b/tests/typecheck/good/gold/type-subst-avoids-capture-1.scilexp.gold
@@ -1,1 +1,145 @@
-forall 'A. forall 'B. ('B -> 'A) -> 'B -> 'A
+{
+  "type_info": [
+    {
+      "vname": "id_with_dummy",
+      "type": "forall 'A. forall 'B. 'A -> 'A",
+      "start_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-1.scilexp",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-1.scilexp",
+        "line": 1,
+        "column": 14
+      }
+    },
+    {
+      "vname": "'A",
+      "type": "forall 'B. 'A -> 'A",
+      "start_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-1.scilexp",
+        "line": 1,
+        "column": 21
+      },
+      "end_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-1.scilexp",
+        "line": 1,
+        "column": 23
+      }
+    },
+    {
+      "vname": "'B",
+      "type": "'A -> 'A",
+      "start_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-1.scilexp",
+        "line": 1,
+        "column": 32
+      },
+      "end_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-1.scilexp",
+        "line": 1,
+        "column": 34
+      }
+    },
+    {
+      "vname": "x",
+      "type": "'A",
+      "start_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-1.scilexp",
+        "line": 1,
+        "column": 43
+      },
+      "end_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-1.scilexp",
+        "line": 1,
+        "column": 44
+      }
+    },
+    {
+      "vname": "x",
+      "type": "'A",
+      "start_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-1.scilexp",
+        "line": 1,
+        "column": 59
+      },
+      "end_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-1.scilexp",
+        "line": 1,
+        "column": 60
+      }
+    },
+    {
+      "vname": "try_to_capture_type_var",
+      "type": "forall 'A. forall 'B. ('B -> 'A) -> 'B -> 'A",
+      "start_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-1.scilexp",
+        "line": 2,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-1.scilexp",
+        "line": 2,
+        "column": 24
+      }
+    },
+    {
+      "vname": "'A",
+      "type": "forall 'B. ('B -> 'A) -> 'B -> 'A",
+      "start_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-1.scilexp",
+        "line": 2,
+        "column": 31
+      },
+      "end_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-1.scilexp",
+        "line": 2,
+        "column": 33
+      }
+    },
+    {
+      "vname": "'B",
+      "type": "('B -> 'A) -> 'B -> 'A",
+      "start_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-1.scilexp",
+        "line": 2,
+        "column": 42
+      },
+      "end_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-1.scilexp",
+        "line": 2,
+        "column": 44
+      }
+    },
+    {
+      "vname": "id_with_dummy",
+      "type": "forall 'A. forall 'B. 'A -> 'A",
+      "start_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-1.scilexp",
+        "line": 3,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-1.scilexp",
+        "line": 3,
+        "column": 16
+      }
+    },
+    {
+      "vname": "try_to_capture_type_var",
+      "type": "forall 'A. forall 'B. ('B -> 'A) -> 'B -> 'A",
+      "start_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-1.scilexp",
+        "line": 4,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-1.scilexp",
+        "line": 4,
+        "column": 24
+      }
+    }
+  ],
+  "type": "forall 'A. forall 'B. ('B -> 'A) -> 'B -> 'A"
+}

--- a/tests/typecheck/good/gold/type-subst-avoids-capture-2.scilexp.gold
+++ b/tests/typecheck/good/gold/type-subst-avoids-capture-2.scilexp.gold
@@ -1,1 +1,145 @@
-forall 'A. forall 'B. ('A -> 'B) -> 'A -> 'B
+{
+  "type_info": [
+    {
+      "vname": "id_with_dummy",
+      "type": "forall 'A. forall 'B. 'A -> 'A",
+      "start_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-2.scilexp",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-2.scilexp",
+        "line": 1,
+        "column": 14
+      }
+    },
+    {
+      "vname": "'A",
+      "type": "forall 'B. 'A -> 'A",
+      "start_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-2.scilexp",
+        "line": 1,
+        "column": 21
+      },
+      "end_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-2.scilexp",
+        "line": 1,
+        "column": 23
+      }
+    },
+    {
+      "vname": "'B",
+      "type": "'A -> 'A",
+      "start_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-2.scilexp",
+        "line": 1,
+        "column": 32
+      },
+      "end_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-2.scilexp",
+        "line": 1,
+        "column": 34
+      }
+    },
+    {
+      "vname": "x",
+      "type": "'A",
+      "start_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-2.scilexp",
+        "line": 1,
+        "column": 43
+      },
+      "end_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-2.scilexp",
+        "line": 1,
+        "column": 44
+      }
+    },
+    {
+      "vname": "x",
+      "type": "'A",
+      "start_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-2.scilexp",
+        "line": 1,
+        "column": 59
+      },
+      "end_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-2.scilexp",
+        "line": 1,
+        "column": 60
+      }
+    },
+    {
+      "vname": "try_to_capture_type_var",
+      "type": "forall 'A. forall 'B. ('A -> 'B) -> 'A -> 'B",
+      "start_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-2.scilexp",
+        "line": 2,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-2.scilexp",
+        "line": 2,
+        "column": 24
+      }
+    },
+    {
+      "vname": "'A",
+      "type": "forall 'B. ('A -> 'B) -> 'A -> 'B",
+      "start_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-2.scilexp",
+        "line": 2,
+        "column": 31
+      },
+      "end_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-2.scilexp",
+        "line": 2,
+        "column": 33
+      }
+    },
+    {
+      "vname": "'B",
+      "type": "('A -> 'B) -> 'A -> 'B",
+      "start_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-2.scilexp",
+        "line": 2,
+        "column": 42
+      },
+      "end_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-2.scilexp",
+        "line": 2,
+        "column": 44
+      }
+    },
+    {
+      "vname": "id_with_dummy",
+      "type": "forall 'A. forall 'B. 'A -> 'A",
+      "start_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-2.scilexp",
+        "line": 3,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-2.scilexp",
+        "line": 3,
+        "column": 16
+      }
+    },
+    {
+      "vname": "try_to_capture_type_var",
+      "type": "forall 'A. forall 'B. ('A -> 'B) -> 'A -> 'B",
+      "start_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-2.scilexp",
+        "line": 4,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/type-subst-avoids-capture-2.scilexp",
+        "line": 4,
+        "column": 24
+      }
+    }
+  ],
+  "type": "forall 'A. forall 'B. ('A -> 'B) -> 'A -> 'B"
+}

--- a/tests/typecheck/good/gold/zip.scilexp.gold
+++ b/tests/typecheck/good/gold/zip.scilexp.gold
@@ -1,1 +1,1366 @@
-forall 'A. forall 'B. List ('A) -> List ('B) -> List (Pair ('A) ('B))
+{
+  "type_info": [
+    {
+      "vname": "list_head",
+      "type": "forall 'A. List ('A) -> Option ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 1,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 1,
+        "column": 10
+      }
+    },
+    {
+      "vname": "'A",
+      "type": "List ('A) -> Option ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 2,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 2,
+        "column": 5
+      }
+    },
+    {
+      "vname": "l",
+      "type": "List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 3,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 3,
+        "column": 4
+      }
+    },
+    {
+      "vname": "l",
+      "type": "List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 4,
+        "column": 11
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 4,
+        "column": 12
+      }
+    },
+    {
+      "vname": "t",
+      "type": "List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 5,
+        "column": 14
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 5,
+        "column": 15
+      }
+    },
+    {
+      "vname": "h",
+      "type": "'A",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 5,
+        "column": 12
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 5,
+        "column": 13
+      }
+    },
+    {
+      "vname": "h",
+      "type": "'A",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 6,
+        "column": 17
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 6,
+        "column": 18
+      }
+    },
+    {
+      "vname": "list_tail",
+      "type": "forall 'A. List ('A) -> Option (List ('A))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 13,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 13,
+        "column": 10
+      }
+    },
+    {
+      "vname": "'A",
+      "type": "List ('A) -> Option (List ('A))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 14,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 14,
+        "column": 5
+      }
+    },
+    {
+      "vname": "l",
+      "type": "List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 15,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 15,
+        "column": 4
+      }
+    },
+    {
+      "vname": "l",
+      "type": "List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 16,
+        "column": 11
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 16,
+        "column": 12
+      }
+    },
+    {
+      "vname": "t",
+      "type": "List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 17,
+        "column": 14
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 17,
+        "column": 15
+      }
+    },
+    {
+      "vname": "h",
+      "type": "'A",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 17,
+        "column": 12
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 17,
+        "column": 13
+      }
+    },
+    {
+      "vname": "t",
+      "type": "List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 18,
+        "column": 24
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 18,
+        "column": 25
+      }
+    },
+    {
+      "vname": "list_reverse",
+      "type": "forall 'A. List ('A) -> List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 25,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 25,
+        "column": 13
+      }
+    },
+    {
+      "vname": "'A",
+      "type": "List ('A) -> List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 26,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 26,
+        "column": 5
+      }
+    },
+    {
+      "vname": "l",
+      "type": "List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 27,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 27,
+        "column": 4
+      }
+    },
+    {
+      "vname": "folder",
+      "type":
+        "(List ('A) -> 'A -> List ('A)) -> List ('A) -> List ('A) -> List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 28,
+        "column": 5
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 28,
+        "column": 11
+      }
+    },
+    {
+      "vname": "list_foldl",
+      "type":
+        "forall 'A. forall 'B. ('B -> 'A -> 'B) -> 'B -> List ('A) -> 'B",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 28,
+        "column": 18
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 28,
+        "column": 28
+      }
+    },
+    {
+      "vname": "init",
+      "type": "List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 29,
+        "column": 5
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 29,
+        "column": 9
+      }
+    },
+    {
+      "vname": "iter",
+      "type": "List ('A) -> 'A -> List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 30,
+        "column": 5
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 30,
+        "column": 9
+      }
+    },
+    {
+      "vname": "z",
+      "type": "List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 31,
+        "column": 7
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 31,
+        "column": 8
+      }
+    },
+    {
+      "vname": "h",
+      "type": "'A",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 32,
+        "column": 7
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 32,
+        "column": 8
+      }
+    },
+    {
+      "vname": "h",
+      "type": "'A",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 33,
+        "column": 19
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 33,
+        "column": 20
+      }
+    },
+    {
+      "vname": "z",
+      "type": "List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 33,
+        "column": 21
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 33,
+        "column": 22
+      }
+    },
+    {
+      "vname": "folder",
+      "type":
+        "(List ('A) -> 'A -> List ('A)) -> List ('A) -> List ('A) -> List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 35,
+        "column": 7
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 35,
+        "column": 13
+      }
+    },
+    {
+      "vname": "iter",
+      "type": "List ('A) -> 'A -> List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 35,
+        "column": 14
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 35,
+        "column": 18
+      }
+    },
+    {
+      "vname": "init",
+      "type": "List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 35,
+        "column": 19
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 35,
+        "column": 23
+      }
+    },
+    {
+      "vname": "l",
+      "type": "List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 35,
+        "column": 24
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 35,
+        "column": 25
+      }
+    },
+    {
+      "vname": "list_zip",
+      "type":
+        "forall 'A. forall 'B. List ('A) -> List ('B) -> List (Pair ('A) ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 39,
+        "column": 1
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 39,
+        "column": 9
+      }
+    },
+    {
+      "vname": "'A",
+      "type": "forall 'B. List ('A) -> List ('B) -> List (Pair ('A) ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 40,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 40,
+        "column": 5
+      }
+    },
+    {
+      "vname": "'B",
+      "type": "List ('A) -> List ('B) -> List (Pair ('A) ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 41,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 41,
+        "column": 5
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 42,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 42,
+        "column": 5
+      }
+    },
+    {
+      "vname": "m2",
+      "type": "List ('B)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 43,
+        "column": 3
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 43,
+        "column": 5
+      }
+    },
+    {
+      "vname": "list_zip_helper",
+      "type":
+        "forall 'A. forall 'B. List ('A) -> List ('B) -> Pair (List (Pair ('A) ('B))) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 44,
+        "column": 5
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 44,
+        "column": 20
+      }
+    },
+    {
+      "vname": "'A",
+      "type":
+        "forall 'B. List ('A) -> List ('B) -> Pair (List (Pair ('A) ('B))) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 45,
+        "column": 7
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 45,
+        "column": 9
+      }
+    },
+    {
+      "vname": "'B",
+      "type":
+        "List ('A) -> List ('B) -> Pair (List (Pair ('A) ('B))) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 46,
+        "column": 7
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 46,
+        "column": 9
+      }
+    },
+    {
+      "vname": "l1",
+      "type": "List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 47,
+        "column": 7
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 47,
+        "column": 9
+      }
+    },
+    {
+      "vname": "l2",
+      "type": "List ('B)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 48,
+        "column": 7
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 48,
+        "column": 9
+      }
+    },
+    {
+      "vname": "folder",
+      "type":
+        "(Pair (List (Pair ('A) ('B))) (List ('B)) -> 'A -> Pair (List (Pair ('A) ('B))) (List ('B))) -> Pair (List (Pair ('A) ('B))) (List ('B)) -> List ('A) -> Pair (List (Pair ('A) ('B))) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 49,
+        "column": 9
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 49,
+        "column": 15
+      }
+    },
+    {
+      "vname": "list_foldl",
+      "type":
+        "forall 'A. forall 'B. ('B -> 'A -> 'B) -> 'B -> List ('A) -> 'B",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 49,
+        "column": 22
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 49,
+        "column": 32
+      }
+    },
+    {
+      "vname": "nil",
+      "type": "List (Pair ('A) ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 50,
+        "column": 9
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 50,
+        "column": 12
+      }
+    },
+    {
+      "vname": "init",
+      "type": "Pair (List (Pair ('A) ('B))) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 51,
+        "column": 9
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 51,
+        "column": 13
+      }
+    },
+    {
+      "vname": "nil",
+      "type": "List (Pair ('A) ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 51,
+        "column": 57
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 51,
+        "column": 60
+      }
+    },
+    {
+      "vname": "l2",
+      "type": "List ('B)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 51,
+        "column": 61
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 51,
+        "column": 63
+      }
+    },
+    {
+      "vname": "iter",
+      "type":
+        "Pair (List (Pair ('A) ('B))) (List ('B)) -> 'A -> Pair (List (Pair ('A) ('B))) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 52,
+        "column": 9
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 52,
+        "column": 13
+      }
+    },
+    {
+      "vname": "z",
+      "type": "Pair (List (Pair ('A) ('B))) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 53,
+        "column": 11
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 53,
+        "column": 12
+      }
+    },
+    {
+      "vname": "h",
+      "type": "'A",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 54,
+        "column": 11
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 54,
+        "column": 12
+      }
+    },
+    {
+      "vname": "z",
+      "type": "Pair (List (Pair ('A) ('B))) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 55,
+        "column": 19
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 55,
+        "column": 20
+      }
+    },
+    {
+      "vname": "b",
+      "type": "List ('B)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 56,
+        "column": 22
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 56,
+        "column": 23
+      }
+    },
+    {
+      "vname": "r",
+      "type": "List (Pair ('A) ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 56,
+        "column": 20
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 56,
+        "column": 21
+      }
+    },
+    {
+      "vname": "header",
+      "type": "List ('B) -> Option ('B)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 58,
+        "column": 15
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 58,
+        "column": 21
+      }
+    },
+    {
+      "vname": "list_head",
+      "type": "forall 'A. List ('A) -> Option ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 58,
+        "column": 28
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 58,
+        "column": 37
+      }
+    },
+    {
+      "vname": "tailer",
+      "type": "List ('B) -> Option (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 59,
+        "column": 15
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 59,
+        "column": 21
+      }
+    },
+    {
+      "vname": "list_tail",
+      "type": "forall 'A. List ('A) -> Option (List ('A))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 59,
+        "column": 28
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 59,
+        "column": 37
+      }
+    },
+    {
+      "vname": "bhead",
+      "type": "Option ('B)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 60,
+        "column": 15
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 60,
+        "column": 20
+      }
+    },
+    {
+      "vname": "header",
+      "type": "List ('B) -> Option ('B)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 60,
+        "column": 27
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 60,
+        "column": 33
+      }
+    },
+    {
+      "vname": "b",
+      "type": "List ('B)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 60,
+        "column": 34
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 60,
+        "column": 35
+      }
+    },
+    {
+      "vname": "bhead",
+      "type": "Option ('B)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 61,
+        "column": 21
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 61,
+        "column": 26
+      }
+    },
+    {
+      "vname": "bel",
+      "type": "'B",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 62,
+        "column": 22
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 62,
+        "column": 25
+      }
+    },
+    {
+      "vname": "newp",
+      "type": "Pair ('A) ('B)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 63,
+        "column": 17
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 63,
+        "column": 21
+      }
+    },
+    {
+      "vname": "h",
+      "type": "'A",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 63,
+        "column": 41
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 63,
+        "column": 42
+      }
+    },
+    {
+      "vname": "bel",
+      "type": "'B",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 63,
+        "column": 43
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 63,
+        "column": 46
+      }
+    },
+    {
+      "vname": "newp_concat",
+      "type": "List (Pair ('A) ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 64,
+        "column": 17
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 64,
+        "column": 28
+      }
+    },
+    {
+      "vname": "newp",
+      "type": "Pair ('A) ('B)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 64,
+        "column": 55
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 64,
+        "column": 59
+      }
+    },
+    {
+      "vname": "r",
+      "type": "List (Pair ('A) ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 64,
+        "column": 60
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 64,
+        "column": 61
+      }
+    },
+    {
+      "vname": "btail",
+      "type": "Option (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 65,
+        "column": 17
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 65,
+        "column": 22
+      }
+    },
+    {
+      "vname": "tailer",
+      "type": "List ('B) -> Option (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 65,
+        "column": 29
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 65,
+        "column": 35
+      }
+    },
+    {
+      "vname": "b",
+      "type": "List ('B)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 65,
+        "column": 36
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 65,
+        "column": 37
+      }
+    },
+    {
+      "vname": "newb",
+      "type": "List ('B)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 66,
+        "column": 17
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 66,
+        "column": 21
+      }
+    },
+    {
+      "vname": "btail",
+      "type": "Option (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 67,
+        "column": 25
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 67,
+        "column": 30
+      }
+    },
+    {
+      "vname": "t",
+      "type": "List ('B)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 68,
+        "column": 26
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 68,
+        "column": 27
+      }
+    },
+    {
+      "vname": "t",
+      "type": "List ('B)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 69,
+        "column": 21
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 69,
+        "column": 22
+      }
+    },
+    {
+      "vname": "nilb",
+      "type": "List ('B)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 71,
+        "column": 21
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 71,
+        "column": 25
+      }
+    },
+    {
+      "vname": "nilb",
+      "type": "List ('B)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 72,
+        "column": 21
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 72,
+        "column": 25
+      }
+    },
+    {
+      "vname": "newp_concat",
+      "type": "List (Pair ('A) ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 75,
+        "column": 54
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 75,
+        "column": 65
+      }
+    },
+    {
+      "vname": "newb",
+      "type": "List ('B)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 75,
+        "column": 66
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 75,
+        "column": 70
+      }
+    },
+    {
+      "vname": "z",
+      "type": "Pair (List (Pair ('A) ('B))) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 77,
+        "column": 17
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 77,
+        "column": 18
+      }
+    },
+    {
+      "vname": "folder",
+      "type":
+        "(Pair (List (Pair ('A) ('B))) (List ('B)) -> 'A -> Pair (List (Pair ('A) ('B))) (List ('B))) -> Pair (List (Pair ('A) ('B))) (List ('B)) -> List ('A) -> Pair (List (Pair ('A) ('B))) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 81,
+        "column": 13
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 81,
+        "column": 19
+      }
+    },
+    {
+      "vname": "iter",
+      "type":
+        "Pair (List (Pair ('A) ('B))) (List ('B)) -> 'A -> Pair (List (Pair ('A) ('B))) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 81,
+        "column": 20
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 81,
+        "column": 24
+      }
+    },
+    {
+      "vname": "init",
+      "type": "Pair (List (Pair ('A) ('B))) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 81,
+        "column": 25
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 81,
+        "column": 29
+      }
+    },
+    {
+      "vname": "l1",
+      "type": "List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 81,
+        "column": 30
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 81,
+        "column": 32
+      }
+    },
+    {
+      "vname": "zipper",
+      "type":
+        "List ('A) -> List ('B) -> Pair (List (Pair ('A) ('B))) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 83,
+        "column": 7
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 83,
+        "column": 13
+      }
+    },
+    {
+      "vname": "list_zip_helper",
+      "type":
+        "forall 'A. forall 'B. List ('A) -> List ('B) -> Pair (List (Pair ('A) ('B))) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 83,
+        "column": 20
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 83,
+        "column": 35
+      }
+    },
+    {
+      "vname": "res",
+      "type": "Pair (List (Pair ('A) ('B))) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 84,
+        "column": 7
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 84,
+        "column": 10
+      }
+    },
+    {
+      "vname": "zipper",
+      "type":
+        "List ('A) -> List ('B) -> Pair (List (Pair ('A) ('B))) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 84,
+        "column": 17
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 84,
+        "column": 23
+      }
+    },
+    {
+      "vname": "m1",
+      "type": "List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 84,
+        "column": 24
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 84,
+        "column": 26
+      }
+    },
+    {
+      "vname": "m2",
+      "type": "List ('B)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 84,
+        "column": 27
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 84,
+        "column": 29
+      }
+    },
+    {
+      "vname": "res",
+      "type": "Pair (List (Pair ('A) ('B))) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 85,
+        "column": 13
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 85,
+        "column": 16
+      }
+    },
+    {
+      "vname": "y",
+      "type": "List ('B)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 86,
+        "column": 16
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 86,
+        "column": 17
+      }
+    },
+    {
+      "vname": "x",
+      "type": "List (Pair ('A) ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 86,
+        "column": 14
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 86,
+        "column": 15
+      }
+    },
+    {
+      "vname": "reverser",
+      "type": "List (Pair ('A) ('B)) -> List (Pair ('A) ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 87,
+        "column": 9
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 87,
+        "column": 17
+      }
+    },
+    {
+      "vname": "list_reverse",
+      "type": "forall 'A. List ('A) -> List ('A)",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 87,
+        "column": 24
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 87,
+        "column": 36
+      }
+    },
+    {
+      "vname": "reverser",
+      "type": "List (Pair ('A) ('B)) -> List (Pair ('A) ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 88,
+        "column": 11
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 88,
+        "column": 19
+      }
+    },
+    {
+      "vname": "x",
+      "type": "List (Pair ('A) ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 88,
+        "column": 20
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 88,
+        "column": 21
+      }
+    },
+    {
+      "vname": "list_zip",
+      "type":
+        "forall 'A. forall 'B. List ('A) -> List ('B) -> List (Pair ('A) ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 90,
+        "column": 4
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 90,
+        "column": 12
+      }
+    }
+  ],
+  "type":
+    "forall 'A. forall 'B. List ('A) -> List ('B) -> List (Pair ('A) ('B))"
+}


### PR DESCRIPTION
This PR provides a new flag to the checker, under which it prints an output JSON with the type-information for all variables. This allows IDEs to report types of variables when the user requests for it.

The PR also updates our Emacs mode by providing a new key binding `C-c C-t` (which is the default binding used by [Tuareg](https://www.ocamlpro.com/files/tuareg-mode.pdf)).

Resolves #336 . 

This should ideally be done via a full LSP implementation, but that's a longer term goal and this particular feature can be useful as it is now. 