### PR TITLE
Rename lexer token from BIND to FETCH

### DIFF
--- a/src/lang/base/ParserFaults.messages
+++ b/src/lang/base/ParserFaults.messages
@@ -652,70 +652,70 @@ stmts_term: ID ASSIGN WITH
 
 This is an invalid assign statement, it lacks a separated identifier.
 
-stmts_term: ID BIND AND WITH
+stmts_term: ID FETCH AND WITH
 ##
 ## Ends in an error in state: 245.
 ##
-## stmt -> ID BIND AND . CID [ SEMICOLON EOF END BAR ]
+## stmt -> ID FETCH AND . CID [ SEMICOLON EOF END BAR ]
 ##
 ## The known suffix of the stack is as follows:
-## ID BIND AND
+## ID FETCH AND
 ##
 # see tests/parser/bad/stmts_t-id-bind-and-with.scilla
 
 This is an invalid bind and statement. The parser expects a capital identifier associated with a block number.
 
-stmts_term: ID BIND EXISTS ID WITH
+stmts_term: ID FETCH EXISTS ID WITH
 ##
 ## Ends in an error in state: 243.
 ##
-## stmt -> ID BIND EXISTS ID . nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
+## stmt -> ID FETCH EXISTS ID . nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ##
 ## The known suffix of the stack is as follows:
-## ID BIND EXISTS ID
+## ID FETCH EXISTS ID
 ##
 # see tests/parser/bad/stmts_t-id-bind-exists-id-with.scilla
 
 This is an invalid existence bind statement. It lacks a non-empty list of accesses.
 
-stmts_term: ID BIND EXISTS WITH
+stmts_term: ID FETCH EXISTS WITH
 ##
 ## Ends in an error in state: 242.
 ##
-## stmt -> ID BIND EXISTS . ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
+## stmt -> ID FETCH EXISTS . ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ##
 ## The known suffix of the stack is as follows:
-## ID BIND EXISTS
+## ID FETCH EXISTS
 ##
 # see tests/parser/bad/stmts_t-id-bind-exists-with.scilla
 
 This is an invalid existence bind statement. It lacks a map to check existence of keys in.
 
-stmts_term: ID BIND ID WITH
+stmts_term: ID FETCH ID WITH
 ##
 ## Ends in an error in state: 238.
 ##
 ## sid -> ID . [ SEMICOLON EOF END BAR ]
-## stmt -> ID BIND ID . nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
+## stmt -> ID FETCH ID . nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ##
 ## The known suffix of the stack is as follows:
-## ID BIND ID
+## ID FETCH ID
 ##
 # see tests/parser/bad/stmts_t-id-bind-id-with.scilla 
 
 This is an invalid bind statement, it is lacking a non empty list of map accesses.
 
-stmts_term: ID BIND WITH
+stmts_term: ID FETCH WITH
 ##
 ## Ends in an error in state: 237.
 ##
-## stmt -> ID BIND . sid [ SEMICOLON EOF END BAR ]
-## stmt -> ID BIND . AND CID [ SEMICOLON EOF END BAR ]
-## stmt -> ID BIND . ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
-## stmt -> ID BIND . EXISTS ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
+## stmt -> ID FETCH . sid [ SEMICOLON EOF END BAR ]
+## stmt -> ID FETCH . AND CID [ SEMICOLON EOF END BAR ]
+## stmt -> ID FETCH . ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
+## stmt -> ID FETCH . EXISTS ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ##
 ## The known suffix of the stack is as follows:
-## ID BIND
+## ID FETCH
 ##
 # see tests/parser/bad/stmts_t-id-bind-with.scilla
 
@@ -824,12 +824,12 @@ stmts_term: ID WITH
 ## Ends in an error in state: 231.
 ##
 ## component_id -> ID . [ SPID SEMICOLON ID EOF END CID BAR ]
-## stmt -> ID . BIND sid [ SEMICOLON EOF END BAR ]
+## stmt -> ID . FETCH sid [ SEMICOLON EOF END BAR ]
 ## stmt -> ID . ASSIGN sid [ SEMICOLON EOF END BAR ]
 ## stmt -> ID . EQ exp [ SEMICOLON EOF END BAR ]
-## stmt -> ID . BIND AND CID [ SEMICOLON EOF END BAR ]
-## stmt -> ID . BIND ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
-## stmt -> ID . BIND EXISTS ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
+## stmt -> ID . FETCH AND CID [ SEMICOLON EOF END BAR ]
+## stmt -> ID . FETCH ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
+## stmt -> ID . FETCH EXISTS ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ## stmt -> ID . nonempty_list(map_access) ASSIGN sid [ SEMICOLON EOF END BAR ]
 ##
 ## The known suffix of the stack is as follows:

--- a/src/lang/base/ScillaLexer.mll
+++ b/src/lang/base/ScillaLexer.mll
@@ -108,7 +108,7 @@ rule read =
   | "->"          { TARROW }                  
   | "="           { EQ }                  
   | "&"           { AND }                  
-  | "<-"          { BIND }                  
+  | "<-"          { FETCH }                  
   | ":="          { ASSIGN }                  
   | "@"           { AT }                  
   | "_"           { UNDERSCORE } 

--- a/src/lang/base/ScillaParser.mly
+++ b/src/lang/base/ScillaParser.mly
@@ -93,7 +93,7 @@
 %token PERIOD
 %token EQ
 %token AND
-%token BIND
+%token FETCH
 %token ASSIGN
 (* %token LANGLE
  * %token RANGLE *)
@@ -313,13 +313,13 @@ type_term :
 (***********************************************)
 
 stmt:
-| l = ID; BIND; r = sid   { (Load (asIdL l (toLoc $startpos($2)), asIdL r (toLoc $startpos(r))), toLoc $startpos) }
+| l = ID; FETCH; r = sid   { (Load (asIdL l (toLoc $startpos($2)), asIdL r (toLoc $startpos(r))), toLoc $startpos) }
 | l = ID; ASSIGN; r = sid { (Store (asIdL l (toLoc $startpos($2)), asIdL r (toLoc $startpos(r))), toLoc $startpos) }
 | l = ID; EQ; r = exp    { (Bind (asIdL l (toLoc $startpos($2)), r), toLoc $startpos) }
-| l = ID; BIND; AND; c = CID { (ReadFromBC (asIdL l (toLoc $startpos($2)), c), toLoc $startpos) }
-| l = ID; BIND; r = ID; keys = nonempty_list(map_access)
+| l = ID; FETCH; AND; c = CID { (ReadFromBC (asIdL l (toLoc $startpos($2)), c), toLoc $startpos) }
+| l = ID; FETCH; r = ID; keys = nonempty_list(map_access)
   { MapGet(asIdL l (toLoc $startpos(l)), asIdL r (toLoc $startpos(r)), keys, true), toLoc $startpos }
-| l = ID; BIND; EXISTS; r = ID; keys = nonempty_list(map_access)
+| l = ID; FETCH; EXISTS; r = ID; keys = nonempty_list(map_access)
   { MapGet(asIdL l (toLoc $startpos(l)), asIdL r (toLoc $startpos(r)), keys, false), toLoc $startpos }
 | l = ID; keys = nonempty_list(map_access); ASSIGN; r = sid
   { MapUpdate(asIdL l (toLoc $startpos(l)), keys, Some (asIdL r (toLoc $startpos(r)))), toLoc $startpos }


### PR DESCRIPTION
This PR fixes a confusing name clash between the `BIND` lexer token (`<-`) and the `Bind` statement (`x = y`). The lexer token gives rise to `Load` and `MapGet` statements, but not `Bind` statements, which I find confusing.