### PR TITLE
Typechecker gas errors no longer reported as type errors

### DIFF
--- a/src/lang/base/ErrorUtils.ml
+++ b/src/lang/base/ErrorUtils.ml
@@ -84,7 +84,3 @@ let get_warnings () =
 
 exception Invalid_json of scilla_error list
 let mk_invalid_json msg = Invalid_json (mk_error0 msg)
-
-let wrap_error_with_gas gas res = match res with
-  | Ok r -> Ok r
-  | Error e -> Error (e, gas)

--- a/src/lang/base/ErrorUtils.mli
+++ b/src/lang/base/ErrorUtils.mli
@@ -60,5 +60,3 @@ val get_warnings : unit -> scilla_warning list
 
 exception Invalid_json of scilla_error list
 val mk_invalid_json : string -> exn
-
-val wrap_error_with_gas : Stdint.uint64 -> ('a, 'b) result -> ('a, 'b * Stdint.uint64) result

--- a/src/lang/base/TypeChecker.ml
+++ b/src/lang/base/TypeChecker.ml
@@ -81,9 +81,15 @@ module ScillaTypechecker
   open TypeEnv
   open UntypedSyntax
       
-  let wrap_with_info_and_gas (msg, sloc) res = match res with
+  let wrap_error_with_info (msg, sloc) res = match res with
     | Ok (r, g) -> Ok (r, g)
-    | Error (e, g) -> Error ({emsg = msg; startl = sloc; endl = dummy_loc}::e, g)
+    | Error (errorType, e, g) ->
+        Error (errorType, {emsg = msg; startl = sloc; endl = dummy_loc}::e, g)
+
+  let wrap_info_and_strip_error_type (msg, sloc) res =
+    match wrap_error_with_info (msg, sloc) res with
+    | Ok (r, g) -> Ok (r, g)
+    | Error (errorType, e, g) -> Error (e, g)
 
   let wrap_with_gas gas res = match res with
     | Ok r -> Ok r
@@ -91,12 +97,18 @@ module ScillaTypechecker
   
   let wrap_type_err erep ?opt:(opt = "") res = match res with
     | Ok r -> Ok r
-    | Error (e, g) -> wrap_error_with_gas g (wrap_err erep "typechecking" ~opt:opt (Error e))
-                        
+    | Error (error_type, e, g) -> mark_error_as_type_error g (wrap_err erep "typechecking" ~opt:opt (Error e))
+
   let wrap_type_serr s ?opt:(opt = "") res = match res with
     | Ok r -> Ok r
-    | Error (e, g) -> wrap_error_with_gas g (wrap_serr s "typechecking" ~opt:opt (Error e))
-      
+    | Error (TypeError, e, g) ->
+        (* Wrap type errors *)
+        let wrapped_error = wrap_serr s "typechecking" ~opt:opt (Error e) in
+        wrap_error_with_errortype_and_gas TypeError g wrapped_error
+    | Error (GasError, e, g) ->
+        (* Do not wrap gas errors *)
+        res
+        
   (*****************************************************************)
   (*               Blockchain component typing                     *)
   (*****************************************************************)
@@ -148,29 +160,29 @@ module ScillaTypechecker
     let (e, rep) = erep in
     match e with
     | Literal l ->
-        let%bind lt = wrap_error_with_gas remaining_gas @@ literal_type l in
+        let%bind lt = mark_error_as_type_error remaining_gas @@ literal_type l in
         pure @@ ((TypedSyntax.Literal l, (mk_qual_tp lt, rep)), remaining_gas)
     | Var i ->
-        let%bind r = wrap_error_with_gas remaining_gas @@ TEnv.resolveT tenv (get_id i) ~lopt:(Some (get_rep i)) in
+        let%bind r = mark_error_as_type_error remaining_gas @@ TEnv.resolveT tenv (get_id i) ~lopt:(Some (get_rep i)) in
         let typ = rr_typ r in
         pure @@ ((TypedSyntax.Var (add_type_to_ident i typ), (typ, rep)), remaining_gas)
     |  Fun (arg, t, body) ->
-        let%bind _ = wrap_error_with_gas remaining_gas @@ TEnv.is_wf_type tenv t in
+        let%bind _ = mark_error_as_type_error remaining_gas @@ TEnv.is_wf_type tenv t in
         let tenv' = TEnv.addT (TEnv.copy tenv) arg t in
         let%bind ((_, (bt, _)) as b, remaining_gas) = type_expr tenv' body remaining_gas in
         let typed_arg = add_type_to_ident arg (mk_qual_tp t) in
         pure @@ ((TypedSyntax.Fun (typed_arg, t, b), (mk_qual_tp (FunType (t, bt.tp)), rep)), remaining_gas)
     | App (f, actuals) ->
         wrap_type_err erep @@ 
-        let%bind fres = wrap_error_with_gas remaining_gas @@ TEnv.resolveT tenv (get_id f) ~lopt:(Some (get_rep f)) in
+        let%bind fres = mark_error_as_type_error remaining_gas @@ TEnv.resolveT tenv (get_id f) ~lopt:(Some (get_rep f)) in
         let%bind (typed_actuals, apptyp, remaining_gas) = app_type tenv (rr_typ fres).tp actuals remaining_gas in
         let typed_f = add_type_to_ident f (rr_typ fres) in
         pure @@ ((TypedSyntax.App (typed_f, typed_actuals), (apptyp, rep)), remaining_gas)
     | Builtin (b, actuals) ->
         wrap_type_err erep @@ 
         let%bind (targs, typed_actuals, remaining_gas) = type_actuals tenv actuals remaining_gas in
-        let%bind (_, ret_typ, _) = wrap_error_with_gas remaining_gas @@ BuiltInDictionary.find_builtin_op b targs in
-        let%bind _ = wrap_error_with_gas remaining_gas @@ TEnv.is_wf_type tenv ret_typ in
+        let%bind (_, ret_typ, _) = mark_error_as_type_error remaining_gas @@ BuiltInDictionary.find_builtin_op b targs in
+        let%bind _ = mark_error_as_type_error remaining_gas @@ TEnv.is_wf_type tenv ret_typ in
         let q_ret_typ = mk_qual_tp ret_typ in
         let q_ret_tag = ETR.mk_rep rep q_ret_typ in
         pure @@ ((TypedSyntax.Builtin ((fst b, q_ret_tag), typed_actuals), (q_ret_typ, rep)), remaining_gas)
@@ -178,32 +190,34 @@ module ScillaTypechecker
         (* Poor man's error reporting *)
         let%bind ((_, (ityp, _)) as checked_lhs, remaining_gas) = wrap_type_err erep @@ type_expr tenv lhs remaining_gas in
         let%bind () = match topt with
-          | Some tannot -> wrap_error_with_gas remaining_gas @@ assert_type_equiv tannot ityp.tp
+          | Some tannot -> mark_error_as_type_error remaining_gas @@ assert_type_equiv tannot ityp.tp
           | None -> pure () in
         let tenv' = TEnv.addT (TEnv.copy tenv) i ityp.tp in
         let typed_i = add_type_to_ident i ityp in
         let%bind ((_, (rhstyp, _)) as checked_rhs, remaining_gas) = type_expr tenv' rhs remaining_gas in
         pure @@ ((TypedSyntax.Let (typed_i, topt, checked_lhs, checked_rhs), (rhstyp, rep)), remaining_gas)
     | Constr (cname, ts, actuals) ->
-        let%bind _ = wrap_error_with_gas remaining_gas @@ mapM ts ~f:(TEnv.is_wf_type tenv) in
+        let%bind _ = mark_error_as_type_error remaining_gas @@ mapM ts ~f:(TEnv.is_wf_type tenv) in
         let open Datatypes.DataTypeDictionary in 
-        let%bind (_, constr) = wrap_error_with_gas remaining_gas @@ lookup_constructor cname in
+        let%bind (_, constr) = mark_error_as_type_error remaining_gas @@ lookup_constructor cname in
         let alen = List.length actuals in
         if (constr.arity <> alen)
-        then Error (mk_error0 @@ sprintf
-            "Constructor %s expects %d arguments, but got %d."
-            cname constr.arity alen, remaining_gas)
+        then Error (mk_type_error0
+                    (sprintf
+                       "Constructor %s expects %d arguments, but got %d."
+                       cname constr.arity alen)
+                     remaining_gas)
         else
-          let%bind ftyp = wrap_error_with_gas remaining_gas @@ elab_constr_type cname ts in
+          let%bind ftyp = mark_error_as_type_error remaining_gas @@ elab_constr_type cname ts in
           (* Now type-check as a function application *)
           let%bind (typed_actuals, apptyp, remaining_gas) = app_type tenv ftyp actuals remaining_gas in
           pure @@ ((TypedSyntax.Constr (cname, ts, typed_actuals), (apptyp, rep)), remaining_gas)
     | MatchExpr (x, clauses) ->
         if List.is_empty clauses
-        then wrap_error_with_gas remaining_gas @@ fail0 @@ sprintf
+        then mark_error_as_type_error remaining_gas @@ fail0 @@ sprintf
             "List of pattern matching clauses is empty:\n%s" (pp_expr e)
         else
-          let%bind sctyp = wrap_error_with_gas remaining_gas @@ TEnv.resolveT tenv (get_id x)
+          let%bind sctyp = mark_error_as_type_error remaining_gas @@ TEnv.resolveT tenv (get_id x)
               ~lopt:(Some (get_rep x)) in
           let sct = (rr_typ sctyp).tp in
           let msg = sprintf " of type %s" (pp_typ sct) in
@@ -215,7 +229,7 @@ module ScillaTypechecker
                     pure (typed_clause :: typed_clauses_acc, remaining_gas')) in
             let typed_clauses = List.rev typed_clauses_rev in
             let cl_types = List.map typed_clauses ~f:(fun (_, (_, (t, _))) -> t) in
-            let%bind _ = wrap_error_with_gas remaining_gas @@
+            let%bind _ = mark_error_as_type_error remaining_gas @@
               assert_all_same_type (List.map ~f:(fun it -> it.tp) cl_types) in
             (* Return the first type since all they are the same *)
             pure @@ ((TypedSyntax.MatchExpr
@@ -227,7 +241,7 @@ module ScillaTypechecker
         wrap_type_err erep @@ 
         let tenv' = TEnv.addT (TEnv.copy tenv) f t in
         let%bind ((_, (bt, _)) as typed_b, remaining_gas) = type_expr tenv' body remaining_gas in
-        let%bind _ = wrap_error_with_gas remaining_gas @@ assert_type_equiv t bt.tp in
+        let%bind _ = mark_error_as_type_error remaining_gas @@ assert_type_equiv t bt.tp in
         pure @@ ((TypedSyntax.Fixpoint (add_type_to_ident f (mk_qual_tp t), t, typed_b), (mk_qual_tp t, rep)), remaining_gas)
     | TFun (tvar, body) ->
         let tenv' = TEnv.addV (TEnv.copy tenv) tvar in
@@ -235,16 +249,16 @@ module ScillaTypechecker
         let typed_tvar = add_type_to_ident tvar bt in
         pure @@ ((TypedSyntax.TFun (typed_tvar, typed_b), (mk_qual_tp (PolyFun ((get_id tvar), bt.tp)), rep)), remaining_gas)
     | TApp (tf, arg_types) ->
-        let%bind _ = wrap_error_with_gas remaining_gas @@ mapM arg_types ~f:(TEnv.is_wf_type tenv) in
-        let%bind tfres = wrap_error_with_gas remaining_gas @@ TEnv.resolveT tenv (get_id tf)
+        let%bind _ = mark_error_as_type_error remaining_gas @@ mapM arg_types ~f:(TEnv.is_wf_type tenv) in
+        let%bind tfres = mark_error_as_type_error remaining_gas @@ TEnv.resolveT tenv (get_id tf)
             ~lopt:(Some (get_rep tf)) in
         let tf_rr = rr_typ tfres in
         let tftyp = tf_rr.tp in
         let%bind (res_type, remaining_gas) = elab_tfun_with_args tftyp arg_types remaining_gas in
-        let%bind _ = wrap_error_with_gas remaining_gas @@ TEnv.is_wf_type tenv res_type in
+        let%bind _ = mark_error_as_type_error remaining_gas @@ TEnv.is_wf_type tenv res_type in
         pure @@ ((TypedSyntax.TApp (add_type_to_ident tf tf_rr, arg_types), (mk_qual_tp res_type, rep)), remaining_gas)
     | Message bs ->
-        let%bind msg_typ = wrap_error_with_gas remaining_gas @@ get_msgevnt_type bs in
+        let%bind msg_typ = mark_error_as_type_error remaining_gas @@ get_msgevnt_type bs in
         let payload_type fld pld remaining_gas =
           let check_field_type seen_type =
             match Caml.List.assoc_opt fld CU.msg_mandatory_field_types with
@@ -256,19 +270,20 @@ module ScillaTypechecker
           (match pld with
            | MLit l ->
                let%bind ((_, (lt, _)), remaining_gas) = type_expr tenv (Literal l, rep) remaining_gas in
-               let%bind _ = wrap_error_with_gas remaining_gas @@ check_field_type lt.tp in
+               let%bind _ = mark_error_as_type_error remaining_gas @@ check_field_type lt.tp in
                pure @@ (TypedSyntax.MLit l, remaining_gas)
            | MVar i ->
-               let%bind r = wrap_error_with_gas remaining_gas @@ TEnv.resolveT tenv (get_id i)
+               let%bind r = mark_error_as_type_error remaining_gas @@ TEnv.resolveT tenv (get_id i)
                    ~lopt:(Some (get_rep i)) in
                let t = rr_typ r in
                let rtp = t.tp in
-               let%bind _ = wrap_error_with_gas remaining_gas @@ check_field_type rtp in
+               let%bind _ = mark_error_as_type_error remaining_gas @@ check_field_type rtp in
                if is_serializable_type rtp
                then pure @@ (TypedSyntax.MVar (add_type_to_ident i t), remaining_gas)
-               else Error (mk_error1
+               else Error (mk_type_error1
                              (sprintf "Cannot serialize values of type %s." (pp_typ rtp))
-                             (ER.get_loc (get_rep i)), remaining_gas))
+                             (ER.get_loc (get_rep i))
+                             remaining_gas))
         in
         let%bind (typed_bs_rev, remaining_gas) =
           (* Make sure we resolve all the payload *)
@@ -282,21 +297,21 @@ module ScillaTypechecker
 
   and app_type tenv ftyp actuals remaining_gas =
     (* Type-check function application *)  
-    let%bind _ = wrap_error_with_gas remaining_gas @@ TEnv.is_wf_type tenv ftyp in
+    let%bind _ = mark_error_as_type_error remaining_gas @@ TEnv.is_wf_type tenv ftyp in
     let%bind (targs, typed_actuals, remaining_gas) = type_actuals tenv actuals remaining_gas in
-    let%bind res_type = wrap_error_with_gas remaining_gas @@ fun_type_applies ftyp targs in
-    let%bind _ = wrap_error_with_gas remaining_gas @@ TEnv.is_wf_type tenv res_type in
+    let%bind res_type = mark_error_as_type_error remaining_gas @@ fun_type_applies ftyp targs in
+    let%bind _ = mark_error_as_type_error remaining_gas @@ TEnv.is_wf_type tenv res_type in
     pure @@ (typed_actuals, mk_qual_tp res_type, remaining_gas)
 
   and type_check_match_branch tenv styp ptrn e remaining_gas =
-    let%bind (new_p, new_typings) = wrap_error_with_gas remaining_gas @@ assign_types_for_pattern styp ptrn in
+    let%bind (new_p, new_typings) = mark_error_as_type_error remaining_gas @@ assign_types_for_pattern styp ptrn in
     let tenv' = TEnv.addTs (TEnv.copy tenv) new_typings in
     let%bind ((_ as typed_e), remaining_gas) = type_expr tenv' e remaining_gas in
     pure @@ ((new_p, typed_e), remaining_gas)
 
   and type_actuals tenv actuals remaining_gas =
     let%bind tresults = mapM actuals
-        ~f:(fun arg -> wrap_error_with_gas remaining_gas @@ TEnv.resolveT tenv (get_id arg)
+        ~f:(fun arg -> mark_error_as_type_error remaining_gas @@ TEnv.resolveT tenv (get_id arg)
                ~lopt:(Some (get_rep arg))) in
     let tqargs = List.map tresults ~f:rr_typ in
     let targs = List.map tqargs ~f:(fun rr -> rr.tp) in
@@ -321,7 +336,7 @@ module ScillaTypechecker
   (* Return typed map accesses and the accessed value's type. *)
   (* (m[k1][k2]... -> (typed_m, typed_k_list, type_of_accessed_value) *)
   let type_map_access env m' keys' remaining_gas =
-    let%bind t' = wrap_error_with_gas remaining_gas @@
+    let%bind t' = mark_error_as_type_error remaining_gas @@
       TEnv.resolveT env.fields (get_id m') ~lopt:(Some (get_rep m'))  in
     let rec helper t keys =
       match t, keys with
@@ -336,7 +351,7 @@ module ScillaTypechecker
       | _ , k :: _ -> fail1 (sprintf "Type failure in map access. Cannot index into key %s" (get_id k))
                         (ER.get_loc (get_rep k))
     in
-      let%bind (typed_keys, res) = wrap_error_with_gas remaining_gas @@ helper (rr_typ t').tp keys' in
+      let%bind (typed_keys, res) = mark_error_as_type_error remaining_gas @@ helper (rr_typ t').tp keys' in
       let typed_m = add_type_to_ident m' (rr_typ t') in
       pure (typed_m, typed_keys, res, remaining_gas)
 
@@ -353,7 +368,7 @@ module ScillaTypechecker
         (match s with
          | Load (x, f) ->
              let%bind (next_env, ident_type) = wrap_type_serr stmt (
-                 let%bind fr = wrap_error_with_gas remaining_gas @@ TEnv.resolveT env.fields (get_id f) ~lopt:(Some (get_rep f)) in
+                 let%bind fr = mark_error_as_type_error remaining_gas @@ TEnv.resolveT env.fields (get_id f) ~lopt:(Some (get_rep f)) in
                  let pure' = TEnv.addT (TEnv.copy env.pure) x (rr_typ fr).tp in
                  let next_env = {env with pure = pure'} in
                  pure @@ (next_env, rr_typ fr)
@@ -366,13 +381,15 @@ module ScillaTypechecker
              if List.mem ~equal:(fun s1 s2 -> s1 = s2)
                  no_store_fields (get_id f) then
                wrap_type_serr stmt (
-                 Error (mk_error0 (sprintf
-                                     "Writing to the field `%s` is prohibited." (get_id f)), remaining_gas))
+                 Error (mk_type_error0
+                          (sprintf
+                             "Writing to the field `%s` is prohibited." (get_id f))
+                          remaining_gas))
              else
                let%bind (checked_stmts, f_type, r_type, remaining_gas) = wrap_type_serr stmt (
-                   let%bind fr = wrap_error_with_gas remaining_gas @@ TEnv.resolveT env.fields (get_id f) ~lopt:(Some (get_rep f)) in
-                   let%bind r = wrap_error_with_gas remaining_gas @@ TEnv.resolveT env.pure (get_id r) ~lopt:(Some (get_rep r)) in
-                   let%bind _ = wrap_error_with_gas remaining_gas @@ assert_type_equiv (rr_typ fr).tp (rr_typ r).tp in
+                   let%bind fr = mark_error_as_type_error remaining_gas @@ TEnv.resolveT env.fields (get_id f) ~lopt:(Some (get_rep f)) in
+                   let%bind r = mark_error_as_type_error remaining_gas @@ TEnv.resolveT env.pure (get_id r) ~lopt:(Some (get_rep r)) in
+                   let%bind _ = mark_error_as_type_error remaining_gas @@ assert_type_equiv (rr_typ fr).tp (rr_typ r).tp in
                    let%bind (checked_stmts, remaining_gas) = type_stmts env sts get_loc remaining_gas in
                    pure @@ (checked_stmts, rr_typ fr, rr_typ r, remaining_gas)
                  ) in
@@ -392,9 +409,9 @@ module ScillaTypechecker
                 let%bind typed_v = 
                   (match vopt with
                    | Some v -> (* This is adding/replacing the value for a key. *) 
-                      let%bind v_resolv = wrap_error_with_gas remaining_gas @@ TEnv.resolveT env.pure (get_id v) ~lopt:(Some (get_rep v)) in
+                      let%bind v_resolv = mark_error_as_type_error remaining_gas @@ TEnv.resolveT env.pure (get_id v) ~lopt:(Some (get_rep v)) in
                       let typed_v = rr_typ v_resolv in
-                      let%bind _ = wrap_error_with_gas remaining_gas @@ assert_type_equiv v_type typed_v.tp in
+                      let%bind _ = mark_error_as_type_error remaining_gas @@ assert_type_equiv v_type typed_v.tp in
                       let typed_v' = add_type_to_ident v typed_v in
                       pure @@ Some typed_v'
                    | None -> pure None (* This is deleting a key from the map. *)
@@ -422,7 +439,7 @@ module ScillaTypechecker
              (* Update annotations. *)
              pure @@ add_stmt_to_stmts_env_gas (TypedSyntax.MapGet(typed_v, typed_m, typed_klist, valfetch), rep) checked_stmts remaining_gas
          | ReadFromBC (x, bf) ->
-             let%bind bt = wrap_type_serr stmt @@ wrap_error_with_gas remaining_gas @@ lookup_bc_type bf in
+             let%bind bt = wrap_type_serr stmt @@ mark_error_as_type_error remaining_gas @@ lookup_bc_type bf in
              let pure' = TEnv.addT (TEnv.copy env.pure) x bt in
              let env' = {env with pure = pure'} in
              let%bind (checked_stmts, remaining_gas) = type_stmts env' sts get_loc remaining_gas in
@@ -430,10 +447,13 @@ module ScillaTypechecker
              pure @@ add_stmt_to_stmts_env_gas (TypedSyntax.ReadFromBC (typed_x, bf), rep) checked_stmts remaining_gas
          | MatchStmt (x, clauses) ->
              if List.is_empty clauses
-             then wrap_type_serr stmt @@ Error (mk_error0 @@ sprintf
-                 "List of pattern matching clauses is empty:\n%s" (pp_stmt s), remaining_gas)
+             then wrap_type_serr stmt @@
+               Error (mk_type_error0
+                        (sprintf
+                           "List of pattern matching clauses is empty:\n%s" (pp_stmt s))
+                        remaining_gas)
              else
-               let%bind sctyp = wrap_error_with_gas remaining_gas @@
+               let%bind sctyp = mark_error_as_type_error remaining_gas @@
                  TEnv.resolveT env.pure (get_id x)
                    ~lopt:(Some (get_rep x)) in
                let sctype = rr_typ sctyp in
@@ -442,7 +462,7 @@ module ScillaTypechecker
                let sloc = ER.get_loc (get_rep x) in
                let typed_x = add_type_to_ident x sctype in
                let%bind (checked_clauses_rev, remaining_gas) =
-                 wrap_with_info_and_gas (msg, sloc) @@ 
+                 wrap_error_with_info (msg, sloc) @@ 
                  foldM clauses ~init:([], remaining_gas)
                    ~f:(fun (checked_clauses_acc, remaining_gas) (ptrn, ex) ->
                        let%bind (typed_clause, remaining_gas') = type_match_stmt_branch env sct ptrn ex get_loc remaining_gas in
@@ -454,39 +474,40 @@ module ScillaTypechecker
              let%bind (checked_stmts, remaining_gas) = type_stmts env sts get_loc remaining_gas in
              pure @@ add_stmt_to_stmts_env_gas (TypedSyntax.AcceptPayment, rep) checked_stmts remaining_gas
          | SendMsgs i ->
-             let%bind r = wrap_error_with_gas remaining_gas @@
+             let%bind r = mark_error_as_type_error remaining_gas @@
                TEnv.resolveT env.pure (get_id i)
                  ~lopt:(Some (get_rep i)) in
              let i_type = rr_typ r in
              let expected = list_typ msg_typ in
              let%bind _ = wrap_type_serr stmt @@
-               wrap_error_with_gas remaining_gas @@ assert_type_equiv expected i_type.tp in
+               mark_error_as_type_error remaining_gas @@ assert_type_equiv expected i_type.tp in
              let typed_i = add_type_to_ident i i_type in
              let%bind (checked_stmts, remaining_gas) = type_stmts env sts get_loc remaining_gas in
              pure @@ add_stmt_to_stmts_env_gas (TypedSyntax.SendMsgs typed_i, rep) checked_stmts remaining_gas
          | CreateEvnt i ->
             (* Same as SendMsgs except that this takes a single message instead of a list. *)
-             let%bind r = wrap_error_with_gas remaining_gas @@
+             let%bind r = mark_error_as_type_error remaining_gas @@
                TEnv.resolveT env.pure (get_id i)
                  ~lopt:(Some (get_rep i)) in
              let i_type = rr_typ r in
              let%bind _ = wrap_type_serr stmt @@
-               wrap_error_with_gas remaining_gas @@ assert_type_equiv event_typ i_type.tp in
+               mark_error_as_type_error remaining_gas @@ assert_type_equiv event_typ i_type.tp in
              let typed_i = add_type_to_ident i i_type in
              let%bind (checked_stmts, remaining_gas) = type_stmts env sts get_loc remaining_gas in
              pure @@ add_stmt_to_stmts_env_gas (TypedSyntax.CreateEvnt typed_i, rep) checked_stmts remaining_gas
          | CallProc (p, args) ->
              let msg = sprintf "Type error(s) in procedure call %s:\n" (get_id p) in
              let%bind (typed_args, remaining_gas) =
-               wrap_with_info_and_gas (msg, SR.get_loc (get_rep p)) @@
+               wrap_error_with_info (msg, SR.get_loc (get_rep p)) @@
                let%bind (targs, typed_actuals, remaining_gas) = type_actuals env.pure args remaining_gas in
                match List.Assoc.find env.procedures ~equal:(=) (get_id p) with
                | Some arg_typs ->
-                   let%bind _ = wrap_error_with_gas remaining_gas @@ proc_type_applies arg_typs targs in
+                   let%bind _ = mark_error_as_type_error remaining_gas @@ proc_type_applies arg_typs targs in
                    pure @@ (typed_actuals, remaining_gas)
                | None -> 
-                   Error (mk_error0 @@ sprintf
-                     "Procedure %s not found." (get_id p), remaining_gas) in
+                   Error (mk_type_error0
+                            (sprintf "Procedure %s not found." (get_id p))
+                         remaining_gas) in
              let%bind (checked_stmts, remaining_gas) = type_stmts env sts get_loc remaining_gas in
              pure @@ add_stmt_to_stmts_env_gas (TypedSyntax.CallProc (p, typed_args), rep) checked_stmts remaining_gas
          | Throw iopt ->
@@ -494,12 +515,12 @@ module ScillaTypechecker
             (match iopt with
             | Some i ->
               (* Same as CreateEvent. *)
-                let%bind r = wrap_error_with_gas remaining_gas @@
+                let%bind r = mark_error_as_type_error remaining_gas @@
                   TEnv.resolveT env.pure (get_id i)
                   ~lopt:(Some (get_rep i)) in
                 let i_type = rr_typ r in
                 let%bind _ = wrap_type_serr stmt @@
-                  wrap_error_with_gas remaining_gas @@
+                  mark_error_as_type_error remaining_gas @@
                   assert_type_equiv exception_typ i_type.tp in
                 let typed_i = add_type_to_ident i i_type in
                 pure @@ add_stmt_to_stmts_env_gas (TypedSyntax.Throw (Some typed_i), rep) checked_stmts remaining_gas
@@ -509,26 +530,26 @@ module ScillaTypechecker
         )
         
   and type_match_stmt_branch env styp ptrn sts get_loc remaining_gas =
-    let%bind (new_p, new_typings) = wrap_error_with_gas remaining_gas @@
+    let%bind (new_p, new_typings) = mark_error_as_type_error remaining_gas @@
       assign_types_for_pattern styp ptrn in
     let pure' = TEnv.addTs (TEnv.copy env.pure) new_typings in
     let env' = {env with pure = pure'} in
     let%bind ((new_stmts, _), remaining_gas) = type_stmts env' sts get_loc remaining_gas in
     pure @@ ((new_p, new_stmts), remaining_gas)
 
-  let type_component env0 tr remaining_gas : ((TypedSyntax.component * (string * typ list) list) * Stdint.uint64, scilla_error list * Stdint.uint64) result  =
+  let type_component env0 tr remaining_gas : ((TypedSyntax.component * (string * typ list) list) * Stdint.uint64, typeCheckerErrorType * scilla_error list * Stdint.uint64) result  =
     let {comp_type; comp_name; comp_params; comp_body} = tr in
     let tenv0 = env0.pure in
     let procedures = env0.procedures in
     let component_type_string = component_type_to_string comp_type in
     let msg = sprintf "Type error(s) in %s %s:\n" component_type_string (get_id comp_name) in
-    wrap_with_info_and_gas (msg, SR.get_loc (get_rep comp_name)) @@
+    wrap_error_with_info (msg, SR.get_loc (get_rep comp_name)) @@
     let param_checker =
       match comp_type with
       | CompTrans -> is_serializable_type
       | CompProc -> is_non_map_ground_type in
     let%bind typed_cparams =
-      wrap_error_with_gas remaining_gas @@
+      mark_error_as_type_error remaining_gas @@
       mapM ~f:(fun (param, t) ->
           if param_checker t
           then pure (add_type_to_ident param (mk_qual_tp t), t)
@@ -560,15 +581,17 @@ module ScillaTypechecker
         ~f:(fun ((acc, fenv), remaining_gas) (fn, ft, fe) ->
             let msg = sprintf
                 "Type error in field %s:\n" (get_id fn) in
-            wrap_with_info_and_gas (msg, ER.get_loc (get_rep fn)) @@
+            wrap_error_with_info (msg, ER.get_loc (get_rep fn)) @@
             let%bind ((_, (ar, _)) as typed_expr, remaining_gas') = type_expr tenv fe remaining_gas in
             let actual = ar.tp in
-            let%bind _ = wrap_error_with_gas remaining_gas' @@ assert_type_equiv ft actual in
+            let%bind _ = mark_error_as_type_error remaining_gas' @@ assert_type_equiv ft actual in
             let typed_fs = add_type_to_ident fn ar in
             if is_storable_type ft then
               pure @@ (((typed_fs, ft, typed_expr) :: acc,
                        TEnv.addT (TEnv.copy fenv) fn actual), remaining_gas')
-            else Error (mk_error0 @@ sprintf "Values of the type \"%s\" cannot be stored." (pp_typ ft), remaining_gas')) in
+            else Error (mk_type_error0
+                          (sprintf "Values of the type \"%s\" cannot be stored." (pp_typ ft))
+                          remaining_gas')) in
         pure @@ (List.rev typed_flds, new_env, remaining_gas)
 
   (**************************************************************)
@@ -583,17 +606,17 @@ module ScillaTypechecker
     (* recursion primitives must not contain type declarations *)
     let%bind _ =
       match lib_types with
-      | _ :: _ -> Error (mk_error0 "Type declarations not allowed in recursion primitives", remaining_gas)
+      | _ :: _ -> Error (mk_type_error0 "Type declarations not allowed in recursion primitives" remaining_gas)
       | [] -> pure () in
     let env0 = TEnv.copy TEnv.mk in
     foldM lib_vars ~init:(([], env0), remaining_gas)
       ~f:(fun ((entry_acc, env_acc), remaining_gas) (rn, topt, body) ->
-          wrap_with_info_and_gas
+          wrap_error_with_info
             (sprintf "Type error when checking recursion primitive %s:\n"
                (get_id rn), dummy_loc) @@
           let%bind ((_, (ar, _)) as typed_body, remaining_gas') = type_expr env0 body remaining_gas in
           let%bind _ = match topt with
-            | Some tannot -> wrap_error_with_gas remaining_gas' @@ assert_type_equiv tannot ar.tp
+            | Some tannot -> mark_error_as_type_error remaining_gas' @@ assert_type_equiv tannot ar.tp
             | None -> pure () in
           let typed_rn = add_type_to_ident rn ar in
           let new_entries = (TypedSyntax.LibVar (typed_rn, topt, typed_body)) :: entry_acc in
@@ -617,7 +640,7 @@ module ScillaTypechecker
   let type_library env0 { lname ; lentries = ents } remaining_gas =
     let msg = sprintf
         "Type error in library %s:\n\n" (get_id lname) in
-    wrap_with_info_and_gas (msg, SR.get_loc (get_rep lname)) @@
+    wrap_error_with_info (msg, SR.get_loc (get_rep lname)) @@
     let%bind ((typed_entries, new_tenv, errs, _), remaining_gas) =
       foldM ~init:(([], env0, [], []), remaining_gas) ents
         ~f:(fun ((acc, env, errs, blist), remaining_gas) lib_entry ->
@@ -625,8 +648,8 @@ module ScillaTypechecker
             | LibTyp (tname, ctr_defs) ->
                 let msg = sprintf
                     "Type error in library type %s:\n\n" (get_id tname) in
-                wrap_with_info_and_gas (msg, ER.get_loc (get_rep tname)) @@
-                let%bind _ = wrap_error_with_gas remaining_gas @@ type_lib_typ_ctrs env ctr_defs in
+                wrap_error_with_info (msg, ER.get_loc (get_rep tname)) @@
+                let%bind _ = mark_error_as_type_error remaining_gas @@ type_lib_typ_ctrs env ctr_defs in
                 pure @@ ((acc, env, errs, blist), remaining_gas)
             | LibVar (ln, ltopt, le) ->
                 let msg = sprintf
@@ -634,16 +657,16 @@ module ScillaTypechecker
                 let dep_on_blist = free_vars_dep_check le blist in
                 (* If exp depends on a blacklisted exp, then let's ignore it. *)
                 if dep_on_blist then pure @@ ((acc, env, errs, ln :: blist), remaining_gas) else
-                  let res = wrap_with_info_and_gas (msg, SR.get_loc (get_rep lname)) (type_expr env le remaining_gas) in
+                  let res = wrap_error_with_info (msg, SR.get_loc (get_rep lname)) (type_expr env le remaining_gas) in
                   match res with
-                  | Error (e, remaining_gas) ->
+                  | Error (_, e, remaining_gas) ->
                       (* A new original failure. Add to blocklist and move on. *)
                       pure @@ ((acc, env, errs @ e, ln :: blist), remaining_gas)
                   | Ok (res', remaining_gas) ->
                       (* This went good. *)
                       let (_, (tr, _)) as typed_e = res' in
                       let%bind _ = match ltopt with
-                        | Some tannot -> wrap_error_with_gas remaining_gas @@ assert_type_equiv tannot tr.tp
+                        | Some tannot -> mark_error_as_type_error remaining_gas @@ assert_type_equiv tannot tr.tp
                         | None -> pure () in
                       let typed_ln = add_type_to_ident ln tr in
                       pure @@ ((TypedSyntax.LibVar (typed_ln, ltopt, typed_e) :: acc,
@@ -754,7 +777,7 @@ module ScillaTypechecker
     : ((TypedSyntax.lmodule * TypedSyntax.lib_entry list * TypedSyntax.libtree list) * Stdint.uint64, scilla_error list * Stdint.uint64) result =
 
     let msg = sprintf "Type error(s) in contract %s:\n" (get_id md.libs.lname) in
-    wrap_with_info_and_gas (msg, SR.get_loc (get_rep md.libs.lname)) @@
+    wrap_error_with_info (msg, SR.get_loc (get_rep md.libs.lname)) @@
 
     (* Step 0: Type check recursion principles *)
     let%bind ((typed_rlib, tenv0), remaining_gas) = type_rec_libs rec_libs gas in
@@ -779,7 +802,7 @@ module ScillaTypechecker
     let {smver = mod_smver;cname = mod_cname; libs; elibs = mod_elibs; contr} = md in
     let {cname = ctr_cname; cparams; cfields; ccomps} = contr in
     let msg = sprintf "Type error(s) in contract %s:\n" (get_id ctr_cname) in
-    wrap_with_info_and_gas (msg, SR.get_loc (get_rep ctr_cname)) @@
+    wrap_error_with_info (msg, SR.get_loc (get_rep ctr_cname)) @@
 
     (* Step 0: Type check recursion principles *)
     let%bind ((typed_rlib, tenv0), remaining_gas) = type_rec_libs rec_libs gas in

--- a/src/lang/base/TypeUtil.mli
+++ b/src/lang/base/TypeUtil.mli
@@ -114,8 +114,17 @@ module TypeUtilities : sig
   val type_equiv : typ -> typ -> bool
   val type_equiv_list : typ list -> typ list -> bool
 
+  type typeCheckerErrorType =
+    | TypeError
+    | GasError
+
+  val mk_type_error0 : string -> Stdint.uint64 -> (typeCheckerErrorType * scilla_error list * Stdint.uint64) 
+  val mk_type_error1 : string -> loc -> Stdint.uint64 -> (typeCheckerErrorType * scilla_error list * Stdint.uint64)
+  val wrap_error_with_errortype_and_gas : typeCheckerErrorType -> Stdint.uint64 -> ('a, 'b) result -> ('a, typeCheckerErrorType * 'b * Stdint.uint64) result
+  val mark_error_as_type_error : Stdint.uint64 -> ('a, 'b) result -> ('a, typeCheckerErrorType * 'b * Stdint.uint64) result
+  
   val assert_type_equiv : typ -> typ -> (unit, scilla_error list) result
-  val assert_type_equiv_with_gas : typ -> typ -> Stdint.uint64 -> ((Stdint.uint64, scilla_error list * Stdint.uint64) result)
+  val assert_type_equiv_with_gas : typ -> typ -> Stdint.uint64 -> ((Stdint.uint64, typeCheckerErrorType * scilla_error list * Stdint.uint64) result)
 
   (* Applying a function type *)
   val fun_type_applies : typ -> typ list -> (typ, scilla_error list) result
@@ -125,7 +134,7 @@ module TypeUtilities : sig
   (* Applying a type function without gas charge (for builtins) *)
   val elab_tfun_with_args_no_gas : typ -> typ list -> (typ, scilla_error list) result
   (* Applying a type function *)
-  val elab_tfun_with_args : typ -> typ list -> Stdint.uint64 -> (typ * Stdint.uint64, scilla_error list * Stdint.uint64) result
+  val elab_tfun_with_args : typ -> typ list -> Stdint.uint64 -> (typ * Stdint.uint64, typeCheckerErrorType * scilla_error list * Stdint.uint64) result
 
   val pp_typ_list : typ list -> string  
 

--- a/src/runners/scilla_checker.ml
+++ b/src/runners/scilla_checker.ml
@@ -94,6 +94,7 @@ let check_typing cmod rprin elibs gas =
 (* Type check the contract with external libraries *)
 let check_typing_lmod lmod rprin elibs gas =
   let open TC in
+  strip_error_type @@
   let res = type_lmodule lmod rprin elibs gas in
   let _ = match res with
     | Ok (_, remaining_gas) ->
@@ -153,6 +154,10 @@ let check_version vernum =
   then
     let emsg =  sprintf "Scilla version mismatch. Expected %d vs Contract %d\n" mver vernum in
     fatal_error (mk_error0 emsg)
+
+let wrap_error_with_gas gas res = match res with
+  | Ok r -> Ok r
+  | Error e -> Error (e, gas)
 
 (* Check a library module. *)
 let check_lmodule cli =

--- a/src/runners/type_checker.ml
+++ b/src/runners/type_checker.ml
@@ -90,5 +90,5 @@ let () =
                  | Ok _ -> ()
                  | Error el -> fatal_error el)
               | Error el -> fatal_error el)
-         | Error (el, _remaining_gas) -> fatal_error el)
+         | Error (_, el, _remaining_gas) -> fatal_error el)
     | Error e -> fatal_error e

--- a/tests/checker/bad/gold/blowup.scilla.gold
+++ b/tests/checker/bad/gold/blowup.scilla.gold
@@ -2,54 +2,8 @@
   "gas_remaining": "2",
   "errors": [
     {
-      "error_message": "Type error(s) in contract Blowup:\n",
-      "start_location": {
-        "file": "checker/bad/blowup.scilla",
-        "line": 32,
-        "column": 10
-      },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Type error in library Blowup:\n\n",
-      "start_location": {
-        "file": "checker/bad/blowup.scilla",
-        "line": 3,
-        "column": 1
-      },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Type error in library variable bar8:\n\n",
-      "start_location": {
-        "file": "checker/bad/blowup.scilla",
-        "line": 3,
-        "column": 1
-      },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
       "error_message": "Ran out of gas",
       "start_location": { "file": "", "line": 0, "column": 0 },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message": "Type error(s) in transition setHello:\n",
-      "start_location": {
-        "file": "checker/bad/blowup.scilla",
-        "line": 34,
-        "column": 12
-      },
-      "end_location": { "file": "", "line": 0, "column": 0 }
-    },
-    {
-      "error_message":
-        "Type error in the binding to into `e`:\nCouldn't resolve the identifier \"not_owner_code\".\n",
-      "start_location": {
-        "file": "checker/bad/blowup.scilla",
-        "line": 35,
-        "column": 42
-      },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ],


### PR DESCRIPTION
Fixes #649.

When the typechecker runs out of gas the "Out of gas" error message was wrapped in information where in the code the typechecker ran out of gas. This was counter-intuitive and probably not all that useful to the developer.

I have fixed it so that only type errors are wrapped with information about the location and surrounding constructs, whereas gas errors are no longer wrapped and now causes us to bail out of typechecking completely.