### PR TITLE
deprecate pattern bind shadowing

### DIFF
--- a/src/lang/checkers/Cashflow.ml
+++ b/src/lang/checkers/Cashflow.ml
@@ -1012,34 +1012,35 @@ module ScillaCashflowChecker
   (*            Helper functions for patterns            *)
   (*******************************************************)
 
-  let rec get_pattern_vars acc p =
+  let rec get_pattern_vars p acc =
     match p with
     | Wildcard -> acc
     | Binder x -> x :: acc
     | Constructor (_, ps) ->
-        List.fold_left ps ~init:acc ~f:get_pattern_vars
+        List.fold_right ps ~init:acc ~f:get_pattern_vars
 
-  let update_pattern_vars_tags_from_usage p local_env ctr_tag_map =
-    let rec walk p ctr_tag_map =
+  let update_pattern_vars_tags_from_usage_and_remove_from_env p local_env ctr_tag_map =
+    let rec walk p local_env ctr_tag_map =
       match p with
-      | Wildcard -> (Wildcard, NoInfo, ctr_tag_map, false)
+      | Wildcard -> (Wildcard, NoInfo, local_env, ctr_tag_map, false)
       | Binder x ->
           let new_x_tag = lookup_var_tag x local_env in
           let new_x = update_id_tag x new_x_tag in
-          (Binder new_x, new_x_tag, ctr_tag_map, get_id_tag x <> get_id_tag new_x)
+          let new_local_env = AssocDictionary.remove (get_id x) local_env in
+          (Binder new_x, new_x_tag, new_local_env, ctr_tag_map, get_id_tag x <> get_id_tag new_x)
       | Constructor (s, ps) ->
-          let (new_ps, new_ps_tags, ps_ctr_tag_map, ps_changes) =
-            List.fold_right ps ~init:([], [], ctr_tag_map, false)
-              ~f:(fun p (acc_ps, acc_ps_tags, acc_ctr_tag_map, acc_changes) ->
-                 let (new_p, new_p_tag, p_ctr_tag_map, p_changes) = walk p acc_ctr_tag_map in
-                 (new_p :: acc_ps, new_p_tag :: acc_ps_tags, p_ctr_tag_map, acc_changes || p_changes)) in
+          let (new_ps, new_ps_tags, new_local_env, ps_ctr_tag_map, ps_changes) =
+            List.fold_right ps ~init:([], [], local_env, ctr_tag_map, false)
+              ~f:(fun p (acc_ps, acc_ps_tags, acc_local_env, acc_ctr_tag_map, acc_changes) ->
+                 let (new_p, new_p_tag, p_local_env, p_ctr_tag_map, p_changes) = walk p acc_local_env acc_ctr_tag_map in
+                 (new_p :: acc_ps, new_p_tag :: acc_ps_tags, p_local_env, p_ctr_tag_map, acc_changes || p_changes)) in
           let (new_ctr_tag_map, ctr_tag_map_changes) =
             update_ctr_tag_map ps_ctr_tag_map s new_ps_tags |>
             Option.value_map ~default:(ps_ctr_tag_map, false) ~f:(fun map -> (map, true)) in
           let ctr_tag = ctr_to_adt_tag s new_ps_tags in
-          (Constructor (s, new_ps), ctr_tag, new_ctr_tag_map, ctr_tag_map_changes || ps_changes) in
-    let (new_p, _, new_ctr_tag_map, changes) = walk p ctr_tag_map in
-    (new_p, new_ctr_tag_map, changes)
+          (Constructor (s, new_ps), ctr_tag, new_local_env, new_ctr_tag_map, ctr_tag_map_changes || ps_changes) in
+    let (new_p, _, new_local_env, new_ctr_tag_map, changes) = walk p local_env ctr_tag_map in
+    (new_p, new_local_env, new_ctr_tag_map, changes)
 
   let update_pattern_vars_tags_from_scrutinee p scrutinee_tag =
     let rec walk p expected_tag =
@@ -1066,16 +1067,11 @@ module ScillaCashflowChecker
     walk p scrutinee_tag
               
   let insert_pattern_vars_into_env p local_env =
-    let pattern_vars = get_pattern_vars [] p in
+    let pattern_vars = get_pattern_vars p [] in
     List.fold_left pattern_vars ~init:local_env
       ~f:(fun l_env x ->
          AssocDictionary.insert (get_id x) (get_id_tag x) l_env)
       
-  let remove_pattern_vars_from_env p local_env =
-    let pattern_vars = get_pattern_vars [] p in
-    List.fold_left pattern_vars ~init:local_env
-      ~f:(fun l_env x -> AssocDictionary.remove (get_id x) l_env)
-
   (* Find least upper bound of scrutinee based on patterns and pattern tags *)
   let lub_pattern_tags ps =
     let rec walk acc_tag p =
@@ -1235,12 +1231,11 @@ module ScillaCashflowChecker
                    insert_pattern_vars_into_env p acc_local_env in
                  let ((_, (new_e_tag, _)) as new_e, new_field_env, new_local_env, e_ctr_tag_map, new_changes) =
                    cf_tag_expr ep expected_tag acc_field_env sub_local_env acc_ctr_tag_map in
-                 let (new_p, new_ctr_tag_map, p_changes) = update_pattern_vars_tags_from_usage p new_local_env e_ctr_tag_map in
-                 let res_local_env = remove_pattern_vars_from_env p new_local_env in
+                 let (new_p, new_local_env, new_ctr_tag_map, p_changes) = update_pattern_vars_tags_from_usage_and_remove_from_env p new_local_env e_ctr_tag_map in
                  ((new_p, new_e) :: acc_clauses,
                   lub_tags acc_res_tag new_e_tag,
                   new_field_env,
-                  res_local_env,
+                  new_local_env,
                   new_ctr_tag_map,
                   acc_changes || new_changes || p_changes)) in
           let (x_res_clauses, clause_changes) =
@@ -1419,13 +1414,12 @@ module ScillaCashflowChecker
             List.fold_right clauses
               ~init:([], field_env, local_env, ctr_tag_map, false) 
               ~f:(fun (p, sp) (acc_clauses, acc_field_env, acc_local_env, acc_ctr_tag_map, acc_changes) ->
-                 let sub_local_env =
-                   insert_pattern_vars_into_env p acc_local_env in
+                  let sub_local_env =
+                    insert_pattern_vars_into_env p acc_local_env in
                   let (new_stmts, new_field_env, s_local_env, s_ctr_tag_map, s_changes) =
                    cf_tag_stmts sp acc_field_env sub_local_env acc_ctr_tag_map in
-                 let (new_p, new_ctr_tag_map, p_changes) = update_pattern_vars_tags_from_usage p s_local_env s_ctr_tag_map in
-                 let new_local_env = remove_pattern_vars_from_env p s_local_env in
-                 ((new_p, new_stmts) :: acc_clauses,
+                  let (new_p, new_local_env, new_ctr_tag_map, p_changes) = update_pattern_vars_tags_from_usage_and_remove_from_env p s_local_env s_ctr_tag_map in
+                  ((new_p, new_stmts) :: acc_clauses,
                   new_field_env,
                   new_local_env,
                   new_ctr_tag_map,
@@ -1520,7 +1514,7 @@ module ScillaCashflowChecker
         ~init:([], field_env, init_local_env, ctr_tag_map, false)
         ~f:(fun s (acc_ss, acc_field_env, acc_local_env, acc_ctr_tag_map, acc_changes) ->
            let (new_s, new_field_env, new_local_env, new_ctr_tag_map, new_changes) =
-             cf_tag_stmt s acc_field_env acc_local_env acc_ctr_tag_map in
+             cf_tag_stmt s acc_field_env acc_local_env acc_ctr_tag_map in 
            (new_s :: acc_ss,
             new_field_env,
             new_local_env,
@@ -1538,16 +1532,16 @@ module ScillaCashflowChecker
         List.fold_left comp_params ~init:implicit_local_env
           ~f:(fun acc_env (p, _) ->
              AssocDictionary.insert (get_id p) (get_id_tag p) acc_env)
-          in
+      in
       let (new_comp_body, new_field_env, new_local_env, new_ctr_tag_map, body_changes) =
         cf_tag_stmts comp_body field_env param_local_env ctr_tag_map in
       let (new_params, new_changes) =
         List.fold_right comp_params ~init:([], body_changes)
           ~f:(fun (p, typ) (acc_ps, acc_changes) ->
-             let new_tag = lookup_var_tag p new_local_env in
+              let new_tag = lookup_var_tag p new_local_env in
              ((update_id_tag p new_tag, typ) :: acc_ps,
               acc_changes || (get_id_tag p) <> new_tag))
-          in
+      in
       ({ comp_type = comp_type; comp_name = comp_name ; comp_params = new_params ; comp_body = new_comp_body },
        new_field_env,
        new_ctr_tag_map,
@@ -1562,14 +1556,14 @@ module ScillaCashflowChecker
         List.fold_left cparams ~init:implicit_field_env
           ~f:(fun acc_env (p, _) ->
              AssocDictionary.insert (get_id p) (get_id_tag p) acc_env)
-          in
+      in
       let init_field_env =
         List.fold_left cfields ~init:param_field_env
           ~f:(fun acc_env (f, _, e) ->
              let ((_, (e_tag, _)), _, _, _, _) =
                   cf_tag_expr e (lub_tags (get_id_tag f) NoInfo) (AssocDictionary.make_dict ()) (AssocDictionary.make_dict ()) ctr_tag_map in
              AssocDictionary.insert (get_id f) e_tag acc_env)
-          in
+      in
       let rec tagger components field_env ctr_tag_map =
         let (new_ts, new_field_env, tmp_ctr_tag_map, ccomps_changes) =
           List.fold_right components ~init:([], field_env, ctr_tag_map, false) 
@@ -1577,7 +1571,7 @@ module ScillaCashflowChecker
                let (new_t, new_field_env, new_ctr_tag_map, t_changes) =
                  cf_tag_component t acc_field_env acc_ctr_tag_map in
                (new_t :: acc_ts, new_field_env, new_ctr_tag_map, acc_changes || t_changes))
-            in
+        in
         if ccomps_changes
         then
           tagger new_ts new_field_env tmp_ctr_tag_map

--- a/src/runners/scilla_checker.ml
+++ b/src/runners/scilla_checker.ml
@@ -121,6 +121,12 @@ let check_sanity m rlibs elibs =
     plog @@ sprintf "\n[Sanity Check]:\n module [%s] is successfully checked.\n" (get_id m.contr.cname);
   res
 
+let check_sanity_lmod m rlibs elibs =
+  let res = SC.lmod_sanity m rlibs elibs in
+  if Result.is_ok res then
+    plog @@ sprintf "\n[Sanity Check]:\n module [%s] is successfully checked.\n" (get_id m.libs.lname);
+  res
+
 let check_accepts m =AC.contr_sanity m
 
 let analyze_print_gas cmod typed_elibs =
@@ -167,6 +173,7 @@ let check_lmodule cli =
       check_typing_lmod recursion_lmod recursion_rec_principles recursion_elibs initial_gas in
     let%bind _ = wrap_error_with_gas remaining_gas @@ 
       check_patterns_lmodule typed_lmod typed_rlibs typed_elibs in
+    let%bind _ = wrap_error_with_gas remaining_gas @@ check_sanity_lmod typed_lmod typed_rlibs typed_elibs in
     pure ((typed_lmod, typed_rlibs, typed_elibs), remaining_gas)
   ) in
   (match r with

--- a/tests/checker/good/TestCheckerSuccess.ml
+++ b/tests/checker/good/TestCheckerSuccess.ml
@@ -85,6 +85,7 @@ module CheckerTests = TestUtil.DiffBasedTests(
       "map_no_inplace_warn.scilla";
       "shadowwarn1.scilla";
       "shadowwarn2.scilla";
+      (* "shadowwarn3.scilla"; *)
       "simple-dex-shadowwarn.scilla";
       "namespace1.scilla";
       "namespace2.scilla";

--- a/tests/checker/good/TestCheckerSuccess.ml
+++ b/tests/checker/good/TestCheckerSuccess.ml
@@ -85,7 +85,7 @@ module CheckerTests = TestUtil.DiffBasedTests(
       "map_no_inplace_warn.scilla";
       "shadowwarn1.scilla";
       "shadowwarn2.scilla";
-      (* "shadowwarn3.scilla"; *)
+      "shadowwarn3.scilla";
       "simple-dex-shadowwarn.scilla";
       "namespace1.scilla";
       "namespace2.scilla";

--- a/tests/checker/good/gold/shadowwarn3.scilla.gold
+++ b/tests/checker/good/gold/shadowwarn3.scilla.gold
@@ -1,0 +1,82 @@
+{
+  "cashflow_tags": { "State variables": [], "ADT constructors": [] },
+  "contract_info": {
+    "scilla_major_version": "0",
+    "vname": "ShadowWarn3",
+    "params": [],
+    "fields": [],
+    "transitions": [ { "vname": "warn1", "params": [] } ],
+    "events": [],
+    "ADTs": [
+      {
+        "tname": "Option",
+        "tparams": [ "'A" ],
+        "tmap": [
+          { "cname": "Some", "argtypes": [ "'A" ] },
+          { "cname": "None", "argtypes": [] }
+        ]
+      },
+      {
+        "tname": "Bool",
+        "tparams": [],
+        "tmap": [
+          { "cname": "True", "argtypes": [] },
+          { "cname": "False", "argtypes": [] }
+        ]
+      },
+      {
+        "tname": "Nat",
+        "tparams": [],
+        "tmap": [
+          { "cname": "Zero", "argtypes": [] },
+          { "cname": "Succ", "argtypes": [ "Nat" ] }
+        ]
+      },
+      {
+        "tname": "List",
+        "tparams": [ "'A" ],
+        "tmap": [
+          { "cname": "Cons", "argtypes": [ "'A", "List ('A)" ] },
+          { "cname": "Nil", "argtypes": [] }
+        ]
+      },
+      {
+        "tname": "Pair",
+        "tparams": [ "'A", "'B" ],
+        "tmap": [ { "cname": "Pair", "argtypes": [ "'A", "'B" ] } ]
+      }
+    ]
+  },
+  "warnings": [
+    {
+      "warning_message":
+        "Deprecated: variable a shadows a previous binding in the same pattern.",
+      "start_location": {
+        "file": "checker/good/shadowwarn3.scilla",
+        "line": 19,
+        "column": 20
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 2
+    },
+    {
+      "warning_message":
+        "Deprecated: variable a shadows a previous binding in the same pattern.",
+      "start_location": {
+        "file": "checker/good/shadowwarn3.scilla",
+        "line": 11,
+        "column": 20
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 2
+    },
+    {
+      "warning_message":
+        "No transition in contract ShadowWarn3 contains an accept statement\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 1
+    }
+  ],
+  "gas_remaining": "8000"
+}

--- a/tests/checker/good/shadowwarn3.scilla
+++ b/tests/checker/good/shadowwarn3.scilla
@@ -1,0 +1,22 @@
+scilla_version 0
+
+library ShadowWarn3
+
+let i = Int32 0
+let n = Nil {Int32}
+let p = Cons {Int32} i n
+
+let f = 
+  match p with
+  | Cons a (Cons b a) => a
+  | _ => n
+  end
+
+contract ShadowWarn3 ()
+
+transition warn1 ()
+  match p with
+  | Cons a (Cons b a) =>
+  | _ =>
+  end
+end


### PR DESCRIPTION
Issue #687

Warn when a variable binding in a pattern shadows another one in the same pattern. This will later (in the next major release) be modified to be an error.
