### PR TITLE
Fix scoping issue in cashflow

### DIFF
--- a/tests/checker/good/gold/inplace-map.scilla.gold
+++ b/tests/checker/good/gold/inplace-map.scilla.gold
@@ -2,8 +2,8 @@
   "cashflow_tags": {
     "State variables": [
       { "field": "owner", "tag": "NotMoney" },
-      { "field": "gmap", "tag": "(Map NoInfo)" },
-      { "field": "gmap3", "tag": "(Map (Map (Map NoInfo)))" }
+      { "field": "gmap", "tag": "(Map NotMoney)" },
+      { "field": "gmap3", "tag": "(Map (Map (Map NotMoney)))" }
     ],
     "ADT constructors": []
   },

--- a/tests/checker/good/gold/nonfungible-token.scilla.gold
+++ b/tests/checker/good/gold/nonfungible-token.scilla.gold
@@ -4,7 +4,7 @@
       { "field": "contractOwner", "tag": "NoInfo" },
       { "field": "name", "tag": "NoInfo" },
       { "field": "symbol", "tag": "NoInfo" },
-      { "field": "tokenOwnerMap", "tag": "(Map NoInfo)" },
+      { "field": "tokenOwnerMap", "tag": "(Map NotMoney)" },
       { "field": "ownedTokenCount", "tag": "(Map NoInfo)" },
       { "field": "tokenApprovals", "tag": "(Map NoInfo)" },
       { "field": "operatorApprovals", "tag": "(Map (Map NoInfo))" }

--- a/tests/checker/good/gold/shogi_proc.scilla.gold
+++ b/tests/checker/good/gold/shogi_proc.scilla.gold
@@ -1,7 +1,7 @@
 {
   "cashflow_tags": {
     "State variables": [
-      { "field": "player1", "tag": "NoInfo" },
+      { "field": "player1", "tag": "NotMoney" },
       { "field": "player2", "tag": "NoInfo" },
       { "field": "board", "tag": "(Map (Map (SquareContents )))" },
       { "field": "captured_pieces", "tag": "(Map (Map NoInfo))" },

--- a/tests/checker/good/gold/simple-dex-shadowwarn.scilla.gold
+++ b/tests/checker/good/gold/simple-dex-shadowwarn.scilla.gold
@@ -11,7 +11,7 @@
         "Order": [
           {
             "constructor": "Order",
-            "tags": [ "NoInfo", "NoInfo", "NoInfo", "NoInfo" ]
+            "tags": [ "NotMoney", "NoInfo", "NotMoney", "NoInfo" ]
           }
         ]
       }

--- a/tests/checker/good/gold/simple-dex.scilla.gold
+++ b/tests/checker/good/gold/simple-dex.scilla.gold
@@ -11,7 +11,7 @@
         "Order": [
           {
             "constructor": "Order",
-            "tags": [ "NoInfo", "NoInfo", "NoInfo", "NoInfo" ]
+            "tags": [ "NotMoney", "NoInfo", "NotMoney", "NoInfo" ]
           }
         ]
       }

--- a/tests/checker/good/gold/ud-registry.scilla.gold
+++ b/tests/checker/good/gold/ud-registry.scilla.gold
@@ -12,7 +12,7 @@
     "ADT constructors": [
       {
         "Record": [
-          { "constructor": "Record", "tags": [ "NoInfo", "NotMoney" ] }
+          { "constructor": "Record", "tags": [ "NotMoney", "NotMoney" ] }
         ]
       }
     ]

--- a/tests/checker/good/gold/wallet_2.scilla.gold
+++ b/tests/checker/good/gold/wallet_2.scilla.gold
@@ -5,7 +5,7 @@
       { "field": "required_signatures", "tag": "NoInfo" },
       { "field": "contract_valid", "tag": "NotMoney" },
       { "field": "owners", "tag": "(Map NoInfo)" },
-      { "field": "transactionCount", "tag": "NoInfo" },
+      { "field": "transactionCount", "tag": "NotMoney" },
       { "field": "signatures", "tag": "(Map (Map NoInfo))" },
       { "field": "signature_counts", "tag": "(Map NoInfo)" },
       { "field": "transactions", "tag": "(Map (Transaction ))" }


### PR DESCRIPTION
The cashflow analyser has so far used incorrect scoping rules for contract parameters and fields.

The rules have been that contract parameters are treated as fields, and that fields are in scope in pure expressions. This is incorrect, since fields are not in scope in pure expressions. However, contract parameters are in scope.

To make the separation clear, we now thread three different environments through the cashflow analyser, namely the local environment, the field environment, and the parameter environment.

I have also fixed a couple bugs that I have discovered along the way. In particular, the keys used for map accesses were not being updated with the `NotMoney` tag, even though this is an assumption we make about map keys.

Note also that the `shogi_proc` contract appears to treat `player1` and `player2` differently, because they get different tags. This is in fact expected, since `player1` is used to initialise `player_in_turn`, which is known to be `NotMoney`, whereas `player2` is only ever used as a parameter to a library function, which are not analysed by the cashflow analyser.