### PR TITLE
Change fold_over_messages to pass a location rather than an identifier

### DIFF
--- a/src/lang/checkers/EventInfo.ml
+++ b/src/lang/checkers/EventInfo.ml
@@ -27,8 +27,7 @@ module ScillaEventInfo
 
     (* Given a message and a current list of event info, extract
      * info from message and append to the list. *)
-    let extract_from_message b m acc =
-      let bloc = (ER.get_loc (get_rep b)) in
+    let extract_from_message bloc m acc =
       (* Check if this is for an event. *)
       (match (List.find_opt (fun (label, _) -> label = eventname_label) m) with
        | Some (_, epld) ->

--- a/src/lang/checkers/SanityChecker.ml
+++ b/src/lang/checkers/SanityChecker.ml
@@ -84,10 +84,7 @@ module ScillaSanityChecker
     in
 
     (* Message literals must either be for "send" or "event" and well formed. *)
-    let check_message b msg e =
-      (* Use location of "b" to represent the location of msg. *)
-      let eloc = ER.get_loc @@ get_rep b in
-
+    let check_message eloc msg e =
       (* No repeating message field. *)
       let e = e @ check_duplicate_ident (fun _ -> eloc) (List.map (fun (s, _) -> SR.mk_id_string s) msg) in
 


### PR DESCRIPTION
`fold_over_messages` passes an identifier through the fold, but the identifier is only ever used to specify the location of whatever message has been found.

`fold_over_messages` needs to analyse the contract constraint, but there i don't have an identifier with the correct annotation, so I have changed the function to pass the location directly instead.