### PR TITLE
Remove unused ppx_deriving_protobuf dependency

### DIFF
--- a/src/lang/eval/dune
+++ b/src/lang/eval/dune
@@ -11,6 +11,5 @@
                     ppx_let
                     bisect_ppx -conditional
                     ppx_deriving_rpc
-                    ppx_deriving.show
-                    ppx_deriving_protobuf))
+                    ppx_deriving.show))
   (synopsis "Scilla workbench implementation."))


### PR DESCRIPTION
ocaml-protoc >= 2.0 does not require ppx_deriving_protobuf, causing Travis builds to fail (since a `dune` file requires it)