### PR TITLE
Switch to Dune 2.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -225,6 +225,17 @@ We suggest using `make clean` command or keeping `_opam` directory like so:
 git clean -dfX --exclude=\!_opam/**
 ```
 
+To get rid of Dune warnings like the following one
+```shell
+File "/path/to/scilla/_opam/lib/expect_test_helpers_kernel/expect_test_helpers_kernel.dune", line 1, characters 0-0:
+Warning: .dune files are ignored since 2.0. Reinstall the library with dune
+>= 2.0 to get rid of this warning and enable support for the subsystem this
+library provides.
+```
+simply delete all the `.dune` files in the local opam switch:
+```shell
+find ./_opam/ -type f -iname '*.dune' | xargs rm
+```
 
 ## Using OCaml with Emacs
 

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,5 @@
-(lang dune 1.5)
+(lang dune 2.0)
 (using menhir 2.0)
+; use `dune build @fmt` to autoformat all the dune files within the project
+(formatting
+ (enabled_for dune))

--- a/scilla.opam
+++ b/scilla.opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/Zilliqa/scilla.git"
 license: "GPL-3.0"
 depends: [
   "ocaml" {>= "4.06.1" & < "4.08~"}
-  "dune" {build & >= "1.5"}
+  "dune" {build & >= "2.0"}
   "menhir"
   "core" {>= "v0.11" & < "v0.12~"}
   "batteries" {>= "2.9.0" & < "2.11~"}

--- a/src/cpp/dune
+++ b/src/cpp/dune
@@ -1,17 +1,20 @@
 (library
  (name scilla_cpp_deps)
-  (wrapped false)
-  (libraries ctypes ctypes.foreign cryptokit)
-  (c_names generate_dsa_nonce)
-  (cxx_names
-      c_schnorr DataConversion Schnorr PrivKey PubKey
-      Signature BIGNUMSerialize ECPOINTSerialize Snark c_snark)
-  (c_flags (:include c_flags.sexp))
-  (cxx_flags -std=c++11 -fPIC (:include c_flags.sexp))
-  ;;; -lstdc++ is not portable, it can be e.g. -lc++
-  (c_library_flags -lstdc++ (:include c_library_flags.sexp) -lff)
-  (library_flags (:include library_flags.sexp))
-  )
+ (wrapped false)
+ (libraries ctypes ctypes.foreign cryptokit)
+ (foreign_stubs (language c)
+  (names generate_dsa_nonce)
+  (flags (:include c_flags.sexp)))
+ (foreign_stubs (language cxx)
+  (names
+   c_schnorr DataConversion Schnorr PrivKey PubKey
+   Signature BIGNUMSerialize ECPOINTSerialize Snark c_snark)
+   ;;; -lstdc++ is not portable, it can be e.g. -lc++
+  (flags -std=c++11 -fPIC (:include c_flags.sexp))
+ )
+ (c_library_flags -lstdc++ (:include c_library_flags.sexp) -lff)
+ (library_flags (:include library_flags.sexp))
+)
 
 (rule
  (targets c_flags.sexp c_library_flags.sexp library_flags.sexp)

--- a/src/cpp/dune
+++ b/src/cpp/dune
@@ -2,21 +2,30 @@
  (name scilla_cpp_deps)
  (wrapped false)
  (libraries ctypes ctypes.foreign cryptokit)
- (foreign_stubs (language c)
+ (foreign_stubs
+  (language c)
   (names generate_dsa_nonce)
-  (flags (:include c_flags.sexp)))
- (foreign_stubs (language cxx)
-  (names
-   c_schnorr DataConversion Schnorr PrivKey PubKey
-   Signature BIGNUMSerialize ECPOINTSerialize Snark c_snark)
-   ;;; -lstdc++ is not portable, it can be e.g. -lc++
-  (flags -std=c++11 -fPIC (:include c_flags.sexp))
- )
- (c_library_flags -lstdc++ (:include c_library_flags.sexp) -lff)
- (library_flags (:include library_flags.sexp))
-)
+  (flags
+   (:include c_flags.sexp)))
+ (foreign_stubs
+  (language cxx)
+  (names c_schnorr DataConversion Schnorr PrivKey PubKey Signature
+    BIGNUMSerialize ECPOINTSerialize Snark c_snark)
+  ;;; -lstdc++ is not portable, it can be e.g. -lc++
+  (flags
+   -std=c++11
+   -fPIC
+   (:include c_flags.sexp)))
+ (c_library_flags
+  -lstdc++
+  (:include c_library_flags.sexp)
+  -lff)
+ (library_flags
+  (:include library_flags.sexp)))
 
 (rule
  (targets c_flags.sexp c_library_flags.sexp library_flags.sexp)
- (deps    (:discover config/discover.exe))
- (action  (run %{discover})))
+ (deps
+  (:discover config/discover.exe))
+ (action
+  (run %{discover})))

--- a/src/lang/base/dune
+++ b/src/lang/base/dune
@@ -6,26 +6,20 @@
  (modules ScillaParser))
 
 ;; Generate ParserFaults module (to make parsing messages more user-friendly)
+
 (rule
  (targets ParserFaults.ml)
  (deps ParserFaults.messages ScillaParser.mly)
  (action
-  (with-stdout-to ParserFaults.ml
+  (with-stdout-to
+   ParserFaults.ml
    (run %{bin:menhir} --compile-errors ParserFaults.messages ScillaParser.mly))))
-
 
 (library
  (name scilla_base)
  (wrapped false)
- (libraries core ppx_sexp_conv
-            num hex stdint batteries
-            ppx_deriving.show
-            cryptokit secp256k1 bitstring
-            yojson scilla_cpp_deps scilla_util
-            menhirLib)
+ (libraries core ppx_sexp_conv num hex stdint batteries ppx_deriving.show
+   cryptokit secp256k1 bitstring yojson scilla_cpp_deps scilla_util menhirLib)
  (preprocess
-  (pps ppx_sexp_conv
-       ppx_let
-       ppx_deriving.show
-       bisect_ppx -conditional))
+  (pps ppx_sexp_conv ppx_let ppx_deriving.show bisect_ppx -conditional))
  (synopsis "Scilla workbench implementation."))

--- a/src/lang/checkers/dune
+++ b/src/lang/checkers/dune
@@ -1,12 +1,8 @@
 (library
  (name scilla_checkers)
-  (wrapped false)
-  (libraries core
-              angstrom stdint polynomials
-              ppx_sexp_conv ppx_deriving batteries
-              ppx_let yojson cryptokit scilla_base)
-  (preprocess (pps ppx_sexp_conv
-                    ppx_let
-                    bisect_ppx -conditional
-                    ppx_deriving.show))
-  (synopsis "Custom Scilla checkers"))
+ (wrapped false)
+ (libraries core angstrom stdint polynomials ppx_sexp_conv ppx_deriving
+   batteries ppx_let yojson cryptokit scilla_base)
+ (preprocess
+  (pps ppx_sexp_conv ppx_let bisect_ppx -conditional ppx_deriving.show))
+ (synopsis "Custom Scilla checkers"))

--- a/src/lang/eval/dune
+++ b/src/lang/eval/dune
@@ -1,15 +1,9 @@
 (library
  (name scilla_eval)
-  (wrapped false)
-  (libraries core
-              angstrom stdint
-              ppx_sexp_conv ppx_deriving batteries
-              ppx_let yojson cryptokit scilla_base
-              rpclib unix rpclib.json rresult
-              ocaml-protoc)
-  (preprocess (pps ppx_sexp_conv
-                    ppx_let
-                    bisect_ppx -conditional
-                    ppx_deriving_rpc
-                    ppx_deriving.show))
-  (synopsis "Scilla workbench implementation."))
+ (wrapped false)
+ (libraries core angstrom stdint ppx_sexp_conv ppx_deriving batteries ppx_let
+   yojson cryptokit scilla_base rpclib unix rpclib.json rresult ocaml-protoc)
+ (preprocess
+  (pps ppx_sexp_conv ppx_let bisect_ppx -conditional ppx_deriving_rpc
+    ppx_deriving.show))
+ (synopsis "Scilla workbench implementation."))

--- a/src/runners/dune
+++ b/src/runners/dune
@@ -1,16 +1,10 @@
 (executables
  (names scilla_runner eval_runner type_checker scilla_checker)
-  (public_names scilla-runner eval-runner type-checker scilla-checker)
-  (package scilla)
-  (modules scilla_runner
-            eval_runner
-            type_checker
-            scilla_checker
-            cli RunnerUtil)
-  (libraries core
-              angstrom
-              ppx_sexp_conv ppx_deriving
-              ppx_let yojson cryptokit
-              fileutils
-              scilla_base scilla_eval scilla_checkers scilla_cpp_deps)
-  (preprocess (pps ppx_sexp_conv ppx_let ppx_deriving.show bisect_ppx -conditional)))
+ (public_names scilla-runner eval-runner type-checker scilla-checker)
+ (package scilla)
+ (modules scilla_runner eval_runner type_checker scilla_checker cli
+   RunnerUtil)
+ (libraries core angstrom ppx_sexp_conv ppx_deriving ppx_let yojson cryptokit
+   fileutils scilla_base scilla_eval scilla_checkers scilla_cpp_deps)
+ (preprocess
+  (pps ppx_sexp_conv ppx_let ppx_deriving.show bisect_ppx -conditional)))

--- a/tests/checker/bad/dune
+++ b/tests/checker/bad/dune
@@ -1,5 +1,4 @@
 (library
-  (name testcheckerfail)
-  (wrapped false)
-  (libraries core oUnit testutil)
-)
+ (name testcheckerfail)
+ (wrapped false)
+ (libraries core oUnit testutil))

--- a/tests/checker/dune
+++ b/tests/checker/dune
@@ -1,5 +1,4 @@
 (library
-  (name testchecker)
-  (wrapped false)
-  (libraries core oUnit testutil testcheckersuccess testcheckerfail)
-)
+ (name testchecker)
+ (wrapped false)
+ (libraries core oUnit testutil testcheckersuccess testcheckerfail))

--- a/tests/checker/good/dune
+++ b/tests/checker/good/dune
@@ -1,5 +1,4 @@
 (library
-  (name testcheckersuccess)
-  (wrapped false)
-  (libraries core oUnit testutil)
-)
+ (name testcheckersuccess)
+ (wrapped false)
+ (libraries core oUnit testutil))

--- a/tests/dune
+++ b/tests/dune
@@ -1,10 +1,7 @@
 (executable
-  (name testsuite)
-  (preprocess (pps ppx_sexp_conv ppx_let ppx_deriving.show))
-  (libraries core oUnit scilla_util testcontracts
-             testexps testexpsfail
-             testtypes testtypefail
-             testpmfail testgasexpr testgascontracts
-             testparser
-             testchecker testinteger256)
-)
+ (name testsuite)
+ (preprocess
+  (pps ppx_sexp_conv ppx_let ppx_deriving.show))
+ (libraries core oUnit scilla_util testcontracts testexps testexpsfail
+   testtypes testtypefail testpmfail testgasexpr testgascontracts testparser
+   testchecker testinteger256))

--- a/tests/eval/dune
+++ b/tests/eval/dune
@@ -1,6 +1,6 @@
 (library
-  (name testinteger256)
-  (wrapped false)
-  (libraries core oUnit testutil scilla_base scilla_cpp_deps polynomials)
-  (preprocess (pps ppx_sexp_conv))
-)
+ (name testinteger256)
+ (wrapped false)
+ (libraries core oUnit testutil scilla_base scilla_cpp_deps polynomials)
+ (preprocess
+  (pps ppx_sexp_conv)))

--- a/tests/eval/exp/bad/dune
+++ b/tests/eval/exp/bad/dune
@@ -1,5 +1,4 @@
 (library
-  (name testexpsfail)
-  (wrapped false)
-  (libraries core oUnit testutil)
-)
+ (name testexpsfail)
+ (wrapped false)
+ (libraries core oUnit testutil))

--- a/tests/eval/exp/good/dune
+++ b/tests/eval/exp/good/dune
@@ -1,5 +1,4 @@
 (library
-  (name testexps)
-  (wrapped false)
-  (libraries core oUnit testutil)
-)
+ (name testexps)
+ (wrapped false)
+ (libraries core oUnit testutil))

--- a/tests/gas_use_analysis/contracts/dune
+++ b/tests/gas_use_analysis/contracts/dune
@@ -1,5 +1,4 @@
 (library
-  (name testgascontracts)
-  (wrapped false)
-  (libraries core oUnit testutil scilla_base)
-)
+ (name testgascontracts)
+ (wrapped false)
+ (libraries core oUnit testutil scilla_base))

--- a/tests/gas_use_analysis/expr/dune
+++ b/tests/gas_use_analysis/expr/dune
@@ -1,5 +1,4 @@
 (library
-  (name testgasexpr)
-  (wrapped false)
-  (libraries core oUnit testutil scilla_base)
-)
+ (name testgasexpr)
+ (wrapped false)
+ (libraries core oUnit testutil scilla_base))

--- a/tests/ipc/dune
+++ b/tests/ipc/dune
@@ -1,6 +1,6 @@
 (library
-  (name stateIPCTest)
-  (preprocess (pps ppx_sexp_conv ppx_let ppx_deriving.show))
-  (libraries core scilla_base oUnit
-             rpclib unix rpclib.json rresult
-             ocaml-protoc scilla_eval))
+ (name stateIPCTest)
+ (preprocess
+  (pps ppx_sexp_conv ppx_let ppx_deriving.show))
+ (libraries core scilla_base oUnit rpclib unix rpclib.json rresult
+   ocaml-protoc scilla_eval))

--- a/tests/parser/bad/dune
+++ b/tests/parser/bad/dune
@@ -1,5 +1,4 @@
 (library
-  (name testparserfail)
-  (wrapped false)
-  (libraries core oUnit testutil)
-)
+ (name testparserfail)
+ (wrapped false)
+ (libraries core oUnit testutil))

--- a/tests/parser/dune
+++ b/tests/parser/dune
@@ -1,5 +1,4 @@
 (library
-  (name testparser)
-  (wrapped false)
-  (libraries core oUnit testutil testparserfail)
-)
+ (name testparser)
+ (wrapped false)
+ (libraries core oUnit testutil testparserfail))

--- a/tests/pm_check/bad/dune
+++ b/tests/pm_check/bad/dune
@@ -1,5 +1,4 @@
 (library
-  (name testpmfail)
-  (wrapped false)
-  (libraries core oUnit testutil scilla_base)
-)
+ (name testpmfail)
+ (wrapped false)
+ (libraries core oUnit testutil scilla_base))

--- a/tests/runner/dune
+++ b/tests/runner/dune
@@ -1,5 +1,4 @@
 (library
-  (name testcontracts)
-  (wrapped false)
-  (libraries core oUnit testutil stateIPCTest)
-)
+ (name testcontracts)
+ (wrapped false)
+ (libraries core oUnit testutil stateIPCTest))

--- a/tests/typecheck/bad/dune
+++ b/tests/typecheck/bad/dune
@@ -1,5 +1,4 @@
 (library
-  (name testtypefail)
-  (wrapped false)
-  (libraries core oUnit testutil scilla_base)
-)
+ (name testtypefail)
+ (wrapped false)
+ (libraries core oUnit testutil scilla_base))

--- a/tests/typecheck/good/dune
+++ b/tests/typecheck/good/dune
@@ -1,5 +1,4 @@
 (library
-  (name testtypes)
-  (wrapped false)
-  (libraries core oUnit testutil scilla_base)
-)
+ (name testtypes)
+ (wrapped false)
+ (libraries core oUnit testutil scilla_base))

--- a/tests/util/dune
+++ b/tests/util/dune
@@ -1,6 +1,5 @@
 (library
-  (name testutil)
-  (wrapped false)
-  (libraries core batteries oUnit fileutils scilla_base patdiff.lib scilla_util)
-)
-
+ (name testutil)
+ (wrapped false)
+ (libraries core batteries oUnit fileutils scilla_base patdiff.lib
+   scilla_util))


### PR DESCRIPTION
Dune 2.0 provides a number of useful features, e.g. improvements in building foreign libraries. Also, Travis CI already uses Dune 2.0 (in 1.x compatibility mode).
There is one issue, though -- https://github.com/ocaml/dune/issues/2917
If one uses a local opam switch then after `opam upgrade`, one needs to do something like this to get rid of dune warnings (once per each (infrequent) upgrade):
```shell
find _opam -type f -iname '*.dune' | xargs rm
```
This will eventually go away once all the dependencies update to dune 2.0 (or dune will learn to ignore local opam switches).
PS Travis CI also shows errors from global opam installation.