### PR TITLE
Port Scilla to Core v0.12 and OCaml 4.07 - 4.09

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,13 @@ matrix:
   include:
     - os: linux
       dist: xenial
-      env: OCAML_VERSION=4.07.1
+      env: OCAML_VERSION=4.09.0
     - os: linux
       dist: xenial
-      env: OCAML_VERSION=4.06.1
+      env: OCAML_VERSION=4.08.1
+    - os: linux
+      dist: xenial
+      env: OCAML_VERSION=4.07.1
     # - os: osx
     #  osx_image: xcode10.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
     libpcre3-dev \
     && rm -rf /var/lib/apt/lists/*
 
-ENV OCAML_VERSION 4.06.1
+ENV OCAML_VERSION 4.07.1
 
 RUN cd /scilla/${MAJOR_VERSION} && make opamdep-ci \
     && echo '. ~/.opam/opam-init/init.sh > /dev/null 2> /dev/null || true ' >> ~/.bashrc \

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -29,7 +29,7 @@ RUN apt-get update \
     libpcre3-dev \
     && rm -rf /var/lib/apt/lists/*
 
-ENV OCAML_VERSION 4.06.1
+ENV OCAML_VERSION 4.07.1
 
 RUN cd /scilla/${MAJOR_VERSION} && make opamdep-ci \
     && echo '. ~/.opam/opam-init/init.sh > /dev/null 2> /dev/null || true ' >> ~/.bashrc \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -132,7 +132,7 @@ Disabling sandboxing is required since [WSL does not support Sandboxing](https:/
 To disable sandboxing, simply run:
 
 ```shell
-opam init --disable-sandboxing --compiler=4.06.1 --yes
+opam init --disable-sandboxing --compiler=4.07.1 --yes
 ```
 
 7. Set up current shell to work with opam
@@ -152,7 +152,7 @@ opam install ./scilla.opam --deps-only --with-test
 then
 
 ```shell
-opam switch create ./ --deps-only --with-test --yes ocaml-base-compiler.4.06.1
+opam switch create ./ --deps-only --with-test --yes ocaml-base-compiler.4.07.1
 ```
 
 9. Build the binaries
@@ -185,7 +185,7 @@ The binaries (`eval-runner`, `scilla-checker`, `scilla-runner` & `type-checker`)
 
 #### Initialize opam
 ```shell
-opam init --compiler=4.06.1 --yes
+opam init --compiler=4.07.1 --yes
 ```
 Note: the initializer will change your shell configuration to setup the environment opam needs to work.
 You can remove `--yes` from the above command to manually control that process.
@@ -214,7 +214,7 @@ This is like a standard opam switch but instead of `$HOME/.opam`, it will reside
 This lets us to avoid dependency conflict and changing our switches back and forth when working on different projects.
 To create a local opam switch and install all the Scilla dependencies, `cd` into project root and execute:
 ```shell
-opam switch create ./ --deps-only --with-test --yes ocaml-base-compiler.4.06.1
+opam switch create ./ --deps-only --with-test --yes ocaml-base-compiler.4.07.1
 ```
 Now, whenever you are inside the project directory, opam will prefer the local switch to any globally installed switches,
 unless being told explicitly which one to use.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Invoke `make` to build, `make clean` to clean up, etc.
 
-OCAML_VERSION_RECOMMENDED=4.06.1
+OCAML_VERSION_RECOMMENDED=4.07.1
 IPC_SOCK_PATH="/tmp/zilliqa.sock"
 
 .PHONY: default all utop dev clean docker zilliqa-docker

--- a/scilla.opam
+++ b/scilla.opam
@@ -6,11 +6,11 @@ bug-reports: "https://github.com/Zilliqa/scilla/issues"
 dev-repo: "git+https://github.com/Zilliqa/scilla.git"
 license: "GPL-3.0"
 depends: [
-  "ocaml" {>= "4.06.1" & < "4.08~"}
+  "ocaml" {>= "4.07.1" & < "4.10~"}
   "dune" {build & >= "2.0"}
   "menhir"
-  "core" {>= "v0.11" & < "v0.12~"}
-  "batteries" {>= "2.9.0" & < "2.11~"}
+  "core" {>= "v0.12.4" & < "v0.13~"}
+  "batteries" {>= "2.10.0" & < "2.11~"}
   "bitstring" {>= "3.1.0" & < "3.2~"}
   "angstrom" {>= "0.11.0" & < "0.13~"}
   "bisect_ppx" {>= "1.4.0" & < "1.5~"}
@@ -22,12 +22,12 @@ depends: [
   "yojson" {>= "1.7.0" & < "1.8~"}
   "ocaml-protoc" {>= "1.2.0" & < "2.1~"}
   "ppx_deriving" {>= "4.2.1" & < "4.5~"}
-  "ppx_sexp_conv" {>= "v0.11.2" & < "v0.12~"}
-  "ppx_deriving_rpc" {>= "5.9.0" & < "5.10~"}
+  "ppx_sexp_conv" {>= "v0.12.0" & < "v0.13~"}
+  "ppx_deriving_rpc" {>= "6.0.0" & < "7.0~"}
   "secp256k1" {>= "0.4.0" & < "0.5~"}
-  "stdint" {>= "0.5.1" & < "0.6~"}
+  "stdint" {>= "0.5.1" & < "0.7~"}
   "ounit" {with-test & (>= "2.0.8" & < "2.3~")}
-  "patdiff" {with-test & (>= "v0.11" & < "v0.12~")}
+  "patdiff" {with-test & (>= "v0.12.1" & < "v0.13~")}
 ]
 build: [
   [ "dune" "build" "-j" jobs "@install" ]

--- a/src/lang/base/TypeChecker.ml
+++ b/src/lang/base/TypeChecker.ml
@@ -317,8 +317,8 @@ module ScillaTypechecker
     let targs = List.map tqargs ~f:(fun rr -> rr.tp) in
     let actuals_with_types =
       match List.zip actuals tqargs with
-      | Some l -> l
-      | None -> raise (mk_internal_error "Different number of actuals and Types of actuals")  in
+      | Ok l -> l
+      | Unequal_lengths -> raise (mk_internal_error "Different number of actuals and Types of actuals")  in
     let typed_actuals = List.map actuals_with_types ~f:(fun (a, t) -> add_type_to_ident a t) in
     pure @@ (targs, typed_actuals, remaining_gas)
 

--- a/src/lang/base/TypeUtil.ml
+++ b/src/lang/base/TypeUtil.ml
@@ -371,10 +371,10 @@ module TypeUtilities = struct
 
   let proc_type_applies formals actuals =
     match List.zip formals actuals with
-    | Some arg_pairs ->
+    | Ok arg_pairs ->
        mapM arg_pairs ~f:(fun (formal, actual) ->
             assert_type_equiv formal actual)
-    | None -> fail0 "Incorrect number of arguments to procedure"
+    | Unequal_lengths -> fail0 "Incorrect number of arguments to procedure"
 
   let rec elab_tfun_with_args_no_gas tf args = match tf, args with
     | PolyFun _ as pf, a :: args' ->

--- a/src/lang/checkers/Cashflow.ml
+++ b/src/lang/checkers/Cashflow.ml
@@ -436,15 +436,15 @@ module ScillaCashflowChecker
                 | NoInfo (* Nothing known *)
                 | Money (* Nat case *)
                 | NotMoney (* Nat case *)
-                  -> Some (List.map adt.tparams ~f:(fun tparam -> (tparam, expected_tag)))
+                  -> Ok (List.map adt.tparams ~f:(fun tparam -> (tparam, expected_tag)))
                 | _ ->
                     (* Don't let inconsistent tags infect subpatterns *)
-                    Some (List.map adt.tparams ~f:(fun tparam -> (tparam, NoInfo))) in
+                    Ok (List.map adt.tparams ~f:(fun tparam -> (tparam, NoInfo))) in
               match zipped_tvar_tags with
-              | None ->
+              | Unequal_lengths ->
                   (* Can only happen if arg_tags in Adt case has wrong length *)
                   List.map adt.tparams ~f:(fun tparam -> (tparam, Inconsistent))
-              | Some map -> map in
+              | Ok map -> map in
             let rec tag_tmap t =
               match t with
               | PrimType _ ->
@@ -1070,8 +1070,8 @@ module ScillaCashflowChecker
             match ctr_pattern_to_subtags s expected_tag with
             | Some ts -> ts
             | None -> List.map ps ~f:(fun _ -> NoInfo) in
-          let new_subpatterns_with_tags =
-            List.zip ps expected_subtags |> Option.value ~default:[] in
+          let (new_subpatterns_with_tags,_) =
+            List.zip_with_remainder ps expected_subtags in
           let (new_ps, changes) =
             List.fold_right new_subpatterns_with_tags
               ~init:([], false)
@@ -1183,8 +1183,8 @@ module ScillaCashflowChecker
           let (final_args, final_param_env, final_local_env, changes) =
             let tags_list =
               match List.zip args args_tags_usage with
-              | None -> []
-              | Some res -> res in
+              | Unequal_lengths -> []
+              | Ok res -> res in
             List.fold_right tags_list ~init:([], param_env, local_env, false) 
               ~f:(fun (arg, arg_tag) (acc_args, acc_param_env, acc_local_env, acc_changes) ->
                  let (new_local_env, new_param_env) =

--- a/src/lang/eval/EvalUtil.ml
+++ b/src/lang/eval/EvalUtil.ml
@@ -221,8 +221,8 @@ module Configuration = struct
   let bind_all st ks vs =
     let e = st.env in
     match List.zip ks vs with
-    | None -> fail0 "Attempting to bind different number of keys and values in environment"
-    | Some kvs ->
+    | Unequal_lengths -> fail0 "Attempting to bind different number of keys and values in environment"
+    | Ok kvs ->
         let filtered_env =
           List.filter e ~f:(fun z ->
               not (

--- a/src/lang/eval/PatternMatching.ml
+++ b/src/lang/eval/PatternMatching.ml
@@ -42,8 +42,8 @@ let rec match_with_pattern v p = match p with
                  (List.length ls') = ctr.arity  ->
               (* The value structure matches the pattern *)
               (match List.zip ls' ps with
-               | None -> fail0 "Pattern and value lists have different length"
-               | Some sub_matches ->
+               | Unequal_lengths -> fail0 "Pattern and value lists have different length"
+               | Ok sub_matches ->
                    let%bind res_list =
                      mapM sub_matches
                        ~f:(fun (w, q) -> match_with_pattern w q) in

--- a/tests/eval/TestSyntax.ml
+++ b/tests/eval/TestSyntax.ml
@@ -11,8 +11,8 @@ let parse_expr_wrapper exprstr =
   | Ok expr -> expr
   | Error _ -> assert_failure ("Error parsing test expression:\n" ^ exprstr ^ "\n")
 
-let ident_list_cmp lsa lsb =
-  List.equal ~equal:(fun a b -> (get_id a) = (get_id b)) lsa lsb
+let ident_list_cmp =
+  List.equal (fun a b -> (get_id a) = (get_id b))
 
 let ident_list_printer =
   (fun ls -> String.concat ~sep:";" (List.map ~f:get_id ls))

--- a/tests/util/TestUtil.ml
+++ b/tests/util/TestUtil.ml
@@ -42,7 +42,7 @@ let output_verifier goldoutput_file msg print_diff output =
     let gold = {Patdiff_core.name = goldoutput_file; text = gold_output} in
     let out = {Patdiff_core.name = "test output"; text = output} in
     let open Patdiff_lib.Compare_core in
-    match diff_strings config ~old:gold ~new_:out with
+    match diff_strings config ~prev:gold ~next:out with
     | `Same -> ()
     | `Different s ->  (* s contains ANSI color codes *)
         Format.pp_force_newline fmt ();


### PR DESCRIPTION
Cancel OCaml 4.06 support, because Core v0.12 requires OCaml 4.07 or a later version.
And also bump several dependencies' upper bounds.
Here is a PR for `ppx_deriving_rpc` v6.0.0 that makes this upgrade possible : https://github.com/ocaml/opam-repository/pull/15436