### PR TITLE
Mandate specifying scilla_version in libraries

### DIFF
--- a/src/lang/base/ParserFaults.messages
+++ b/src/lang/base/ParserFaults.messages
@@ -11,7 +11,7 @@ type_term: CID LPAREN TID WITH
 ##
 ## Ends in an error in state: 71.
 ##
-## targ -> LPAREN typ . RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ]
+## targ -> LPAREN typ . RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ## typ -> typ . TARROW typ [ TARROW RPAREN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -25,7 +25,7 @@ type_term: CID LPAREN WITH
 ##
 ## Ends in an error in state: 52.
 ##
-## targ -> LPAREN . typ RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ]
+## targ -> LPAREN . typ RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -38,7 +38,7 @@ type_term: CID MAP CID UNDERSCORE
 ##
 ## Ends in an error in state: 27.
 ##
-## targ -> MAP t_map_key . t_map_value [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ]
+## targ -> MAP t_map_key . t_map_value [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## MAP t_map_key
@@ -58,7 +58,7 @@ type_term: CID MAP WITH
 ##
 ## Ends in an error in state: 20.
 ##
-## targ -> MAP . t_map_key t_map_value [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ]
+## targ -> MAP . t_map_key t_map_value [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## MAP
@@ -210,7 +210,7 @@ type_term: MAP CID CID CID UNDERSCORE
 ##
 ## Ends in an error in state: 41.
 ##
-## list(t_map_value_args) -> t_map_value_args . list(t_map_value_args) [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ]
+## list(t_map_value_args) -> t_map_value_args . list(t_map_value_args) [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## t_map_value_args
@@ -230,7 +230,7 @@ type_term: MAP CID CID LPAREN CID UNDERSCORE
 ##
 ## Ends in an error in state: 38.
 ##
-## t_map_value_args -> LPAREN t_map_value_args . RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ]
+## t_map_value_args -> LPAREN t_map_value_args . RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN t_map_value_args
@@ -250,7 +250,7 @@ type_term: MAP CID CID LPAREN WITH
 ##
 ## Ends in an error in state: 37.
 ##
-## t_map_value_args -> LPAREN . t_map_value_args RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ]
+## t_map_value_args -> LPAREN . t_map_value_args RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -263,7 +263,7 @@ type_term: MAP CID CID MAP CID UNDERSCORE
 ##
 ## Ends in an error in state: 34.
 ##
-## t_map_value_args -> MAP t_map_key . t_map_value [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ]
+## t_map_value_args -> MAP t_map_key . t_map_value [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## MAP t_map_key
@@ -283,7 +283,7 @@ type_term: MAP CID CID MAP WITH
 ##
 ## Ends in an error in state: 33.
 ##
-## t_map_value_args -> MAP . t_map_key t_map_value [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ]
+## t_map_value_args -> MAP . t_map_key t_map_value [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## MAP
@@ -296,7 +296,7 @@ type_term: MAP CID CID UNDERSCORE
 ##
 ## Ends in an error in state: 36.
 ##
-## t_map_value -> scid . list(t_map_value_args) [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ]
+## t_map_value -> scid . list(t_map_value_args) [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## scid
@@ -315,7 +315,7 @@ type_term: MAP CID LPAREN CID CID TYPE
 ##
 ## Ends in an error in state: 48.
 ##
-## t_map_value -> LPAREN scid list(t_map_value_args) . RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ]
+## t_map_value -> LPAREN scid list(t_map_value_args) . RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN scid list(t_map_value_args)
@@ -337,7 +337,7 @@ type_term: MAP CID LPAREN CID UNDERSCORE
 ##
 ## Ends in an error in state: 47.
 ##
-## t_map_value -> LPAREN scid . list(t_map_value_args) RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ]
+## t_map_value -> LPAREN scid . list(t_map_value_args) RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN scid
@@ -357,7 +357,7 @@ type_term: MAP CID LPAREN MAP CID CID UNDERSCORE
 ##
 ## Ends in an error in state: 45.
 ##
-## t_map_value -> LPAREN MAP t_map_key t_map_value_args . RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ]
+## t_map_value -> LPAREN MAP t_map_key t_map_value_args . RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN MAP t_map_key t_map_value_args
@@ -377,7 +377,7 @@ type_term: MAP CID LPAREN MAP CID UNDERSCORE
 ##
 ## Ends in an error in state: 32.
 ##
-## t_map_value -> LPAREN MAP t_map_key . t_map_value_args RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ]
+## t_map_value -> LPAREN MAP t_map_key . t_map_value_args RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN MAP t_map_key
@@ -397,7 +397,7 @@ type_term: MAP CID LPAREN MAP WITH
 ##
 ## Ends in an error in state: 31.
 ##
-## t_map_value -> LPAREN MAP . t_map_key t_map_value_args RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ]
+## t_map_value -> LPAREN MAP . t_map_key t_map_value_args RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN MAP
@@ -410,8 +410,8 @@ type_term: MAP CID LPAREN WITH
 ##
 ## Ends in an error in state: 30.
 ##
-## t_map_value -> LPAREN . scid list(t_map_value_args) RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ]
-## t_map_value -> LPAREN . MAP t_map_key t_map_value_args RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ]
+## t_map_value -> LPAREN . scid list(t_map_value_args) RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+## t_map_value -> LPAREN . MAP t_map_key t_map_value_args RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -424,7 +424,7 @@ type_term: MAP CID MAP CID UNDERSCORE
 ##
 ## Ends in an error in state: 29.
 ##
-## t_map_value -> MAP t_map_key . t_map_value [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ]
+## t_map_value -> MAP t_map_key . t_map_value [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## MAP t_map_key
@@ -444,7 +444,7 @@ type_term: MAP CID MAP WITH
 ##
 ## Ends in an error in state: 28.
 ##
-## t_map_value -> MAP . t_map_key t_map_value [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ]
+## t_map_value -> MAP . t_map_key t_map_value [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## MAP
@@ -547,7 +547,7 @@ This function type lacks a result type.
 
 type_term: TID WITH
 ##
-## Ends in an error in state: 304.
+## Ends in an error in state: 312.
 ##
 ## typ -> typ . TARROW typ [ TARROW EOF ]
 ## type_term -> typ . EOF [ # ]
@@ -561,7 +561,7 @@ This is an invalid type term, following the type it is complete and may only be 
 
 type_term: WITH
 ##
-## Ends in an error in state: 302.
+## Ends in an error in state: 310.
 ##
 ## type_term' -> . type_term [ # ]
 ##
@@ -574,7 +574,7 @@ This is an invalid type term.
 
 stmts_term: ACCEPT WITH
 ##
-## Ends in an error in state: 259.
+## Ends in an error in state: 263.
 ##
 ## separated_nonempty_list(SEMICOLON,stmt) -> stmt . [ EOF END BAR ]
 ## separated_nonempty_list(SEMICOLON,stmt) -> stmt . SEMICOLON separated_nonempty_list(SEMICOLON,stmt) [ EOF END BAR ]
@@ -589,7 +589,7 @@ This is likely an improperly terminated statement (lacking the semicolon).
 
 stmts_term: CID WITH
 ##
-## Ends in an error in state: 262.
+## Ends in an error in state: 266.
 ##
 ## stmt -> component_id . list(sident) [ SEMICOLON EOF END BAR ]
 ##
@@ -602,7 +602,7 @@ This is an invalid statements term.
 
 stmts_term: DELETE ID WITH
 ##
-## Ends in an error in state: 256.
+## Ends in an error in state: 260.
 ##
 ## stmt -> DELETE ID . nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ##
@@ -615,7 +615,7 @@ This is an invalid delete statement, it lacks the keys to delete.
 
 stmts_term: DELETE WITH
 ##
-## Ends in an error in state: 255.
+## Ends in an error in state: 259.
 ##
 ## stmt -> DELETE . ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ##
@@ -628,7 +628,7 @@ This is an invalid delete statement, it lacks a map to delete from.
 
 stmts_term: EVENT WITH
 ##
-## Ends in an error in state: 253.
+## Ends in an error in state: 257.
 ##
 ## stmt -> EVENT . sid [ SEMICOLON EOF END BAR ]
 ##
@@ -641,7 +641,7 @@ This is an invalid event statement, it lacks a separated identifier for the even
 
 stmts_term: ID ASSIGN WITH
 ##
-## Ends in an error in state: 248.
+## Ends in an error in state: 252.
 ##
 ## stmt -> ID ASSIGN . sid [ SEMICOLON EOF END BAR ]
 ##
@@ -654,7 +654,7 @@ This is an invalid assign statement, it lacks a separated identifier.
 
 stmts_term: ID FETCH AND WITH
 ##
-## Ends in an error in state: 245.
+## Ends in an error in state: 247.
 ##
 ## stmt -> ID FETCH AND . CID [ SEMICOLON EOF END BAR ]
 ##
@@ -667,7 +667,7 @@ This is an invalid bind and statement. The parser expects a capital identifier a
 
 stmts_term: ID FETCH EXISTS ID WITH
 ##
-## Ends in an error in state: 243.
+## Ends in an error in state: 245.
 ##
 ## stmt -> ID FETCH EXISTS ID . nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ##
@@ -680,7 +680,7 @@ This is an invalid existence bind statement. It lacks a non-empty list of access
 
 stmts_term: ID FETCH EXISTS WITH
 ##
-## Ends in an error in state: 242.
+## Ends in an error in state: 244.
 ##
 ## stmt -> ID FETCH EXISTS . ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ##
@@ -693,7 +693,7 @@ This is an invalid existence bind statement. It lacks a map to check existence o
 
 stmts_term: ID FETCH ID WITH
 ##
-## Ends in an error in state: 238.
+## Ends in an error in state: 240.
 ##
 ## sid -> ID . [ SEMICOLON EOF END BAR ]
 ## stmt -> ID FETCH ID . nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
@@ -707,7 +707,7 @@ This is an invalid bind statement, it is lacking a non empty list of map accesse
 
 stmts_term: ID FETCH WITH
 ##
-## Ends in an error in state: 237.
+## Ends in an error in state: 239.
 ##
 ## stmt -> ID FETCH . sid [ SEMICOLON EOF END BAR ]
 ## stmt -> ID FETCH . AND CID [ SEMICOLON EOF END BAR ]
@@ -723,7 +723,7 @@ This is an invalid bind statement, the bind can be followed by '&', 'exists' or 
 
 stmts_term: ID EQ WITH
 ##
-## Ends in an error in state: 235.
+## Ends in an error in state: 250.
 ##
 ## stmt -> ID EQ . exp [ SEMICOLON EOF END BAR ]
 ##
@@ -736,7 +736,7 @@ This is an invalid equal statement, it is lacking a valid expression on the righ
 
 stmts_term: ID LSQB SPID RSQB ASSIGN WITH
 ##
-## Ends in an error in state: 251.
+## Ends in an error in state: 255.
 ##
 ## stmt -> ID nonempty_list(map_access) ASSIGN . sid [ SEMICOLON EOF END BAR ]
 ##
@@ -749,7 +749,7 @@ The map key must be assigned to some separated identifier.
 
 stmts_term: ID LSQB SPID RSQB SEMICOLON
 ##
-## Ends in an error in state: 250.
+## Ends in an error in state: 254.
 ##
 ## stmt -> ID nonempty_list(map_access) . ASSIGN sid [ SEMICOLON EOF END BAR ]
 ##
@@ -760,7 +760,7 @@ stmts_term: ID LSQB SPID RSQB SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 240, spurious reduction of production nonempty_list(map_access) -> map_access 
+## In state 242, spurious reduction of production nonempty_list(map_access) -> map_access 
 ##
 # see tests/parser/bad/stmts_t-id-lsqb-spid-rsqb-semicolon.scilla
 
@@ -768,7 +768,7 @@ This is likely an invalid map assign statement, it lacks the assign.
 
 stmts_term: ID LSQB SPID RSQB WITH
 ##
-## Ends in an error in state: 240.
+## Ends in an error in state: 242.
 ##
 ## nonempty_list(map_access) -> map_access . [ SEMICOLON EOF END BAR ASSIGN ]
 ## nonempty_list(map_access) -> map_access . nonempty_list(map_access) [ SEMICOLON EOF END BAR ASSIGN ]
@@ -782,7 +782,7 @@ This is an invalid statements term. A possible continuation may be assigning a m
 
 stmts_term: ID LSQB SPID WITH
 ##
-## Ends in an error in state: 233.
+## Ends in an error in state: 237.
 ##
 ## map_access -> LSQB sident . RSQB [ SEMICOLON LSQB EOF END BAR ASSIGN ]
 ##
@@ -795,7 +795,7 @@ This is an invalid statements term. A possible continuation may be accessing a k
 
 stmts_term: ID LSQB WITH
 ##
-## Ends in an error in state: 232.
+## Ends in an error in state: 236.
 ##
 ## map_access -> LSQB . sident RSQB [ SEMICOLON LSQB EOF END BAR ASSIGN ]
 ##
@@ -810,7 +810,7 @@ stmts_term: ID SPID WITH
 ##
 ## Ends in an error in state: 162.
 ##
-## list(sident) -> sident . list(sident) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## list(sident) -> sident . list(sident) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## sident
@@ -821,7 +821,7 @@ This is an invalid statements term, likely a bad procedure call with faulty argu
 
 stmts_term: ID WITH
 ##
-## Ends in an error in state: 231.
+## Ends in an error in state: 235.
 ##
 ## component_id -> ID . [ SPID SEMICOLON ID EOF END CID BAR ]
 ## stmt -> ID . FETCH sid [ SEMICOLON EOF END BAR ]
@@ -841,7 +841,7 @@ This is an invalid statements term. Scilla expects to do something with the iden
 
 stmts_term: MATCH SPID UNDERSCORE
 ##
-## Ends in an error in state: 226.
+## Ends in an error in state: 230.
 ##
 ## stmt -> MATCH sid . WITH list(stmt_pm_clause) END [ SEMICOLON EOF END BAR ]
 ##
@@ -854,7 +854,7 @@ This is an invalid match statement, 'with' is expected after what is specified t
 
 stmts_term: MATCH SPID WITH BAR UNDERSCORE ARROW ACCEPT EOF
 ##
-## Ends in an error in state: 266.
+## Ends in an error in state: 270.
 ##
 ## list(stmt_pm_clause) -> stmt_pm_clause . list(stmt_pm_clause) [ END ]
 ##
@@ -865,9 +865,9 @@ stmts_term: MATCH SPID WITH BAR UNDERSCORE ARROW ACCEPT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 259, spurious reduction of production separated_nonempty_list(SEMICOLON,stmt) -> stmt 
-## In state 264, spurious reduction of production loption(separated_nonempty_list(SEMICOLON,stmt)) -> separated_nonempty_list(SEMICOLON,stmt) 
-## In state 265, spurious reduction of production stmt_pm_clause -> BAR pattern ARROW loption(separated_nonempty_list(SEMICOLON,stmt)) 
+## In state 263, spurious reduction of production separated_nonempty_list(SEMICOLON,stmt) -> stmt 
+## In state 268, spurious reduction of production loption(separated_nonempty_list(SEMICOLON,stmt)) -> separated_nonempty_list(SEMICOLON,stmt) 
+## In state 269, spurious reduction of production stmt_pm_clause -> BAR pattern ARROW loption(separated_nonempty_list(SEMICOLON,stmt)) 
 ##
 # see tests/parser/bad/stmts_t-match-spid-with-bar-underscore-arrow-accept-eof.scilla
 
@@ -875,7 +875,7 @@ When the match statement is finished, the parser expects 'end'.
 
 stmts_term: MATCH SPID WITH BAR UNDERSCORE ARROW WITH
 ##
-## Ends in an error in state: 230.
+## Ends in an error in state: 234.
 ##
 ## stmt_pm_clause -> BAR pattern ARROW . loption(separated_nonempty_list(SEMICOLON,stmt)) [ END BAR ]
 ##
@@ -888,7 +888,7 @@ This is an invalid statements term. In the match expression, after an arrow the 
 
 stmts_term: MATCH SPID WITH BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 229.
+## Ends in an error in state: 233.
 ##
 ## stmt_pm_clause -> BAR pattern . ARROW loption(separated_nonempty_list(SEMICOLON,stmt)) [ END BAR ]
 ##
@@ -901,7 +901,7 @@ This is an invalid statements term. In the match expression, after a pattern is 
 
 stmts_term: MATCH SPID WITH BAR WITH
 ##
-## Ends in an error in state: 228.
+## Ends in an error in state: 232.
 ##
 ## stmt_pm_clause -> BAR . pattern ARROW loption(separated_nonempty_list(SEMICOLON,stmt)) [ END BAR ]
 ##
@@ -914,7 +914,7 @@ In the match statement there is a malformed pattern.
 
 stmts_term: MATCH SPID WITH WITH
 ##
-## Ends in an error in state: 227.
+## Ends in an error in state: 231.
 ##
 ## stmt -> MATCH sid WITH . list(stmt_pm_clause) END [ SEMICOLON EOF END BAR ]
 ##
@@ -927,7 +927,7 @@ There is a malformed pattern matching clause, the bar is likely missing.
 
 stmts_term: MATCH WITH
 ##
-## Ends in an error in state: 225.
+## Ends in an error in state: 229.
 ##
 ## stmt -> MATCH . sid WITH list(stmt_pm_clause) END [ SEMICOLON EOF END BAR ]
 ##
@@ -966,7 +966,7 @@ This send statement is either unfinished or not properly terminated.
 
 stmts_term: SEND WITH
 ##
-## Ends in an error in state: 223.
+## Ends in an error in state: 227.
 ##
 ## stmt -> SEND . sid [ SEMICOLON EOF END BAR ]
 ##
@@ -979,7 +979,7 @@ It is expected to send to a separated identifier.
 
 stmts_term: THROW END
 ##
-## Ends in an error in state: 300.
+## Ends in an error in state: 308.
 ##
 ## stmts_term -> stmts . EOF [ # ]
 ##
@@ -990,11 +990,11 @@ stmts_term: THROW END
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 220, spurious reduction of production option(sid) -> 
-## In state 222, spurious reduction of production stmt -> THROW option(sid) 
-## In state 259, spurious reduction of production separated_nonempty_list(SEMICOLON,stmt) -> stmt 
-## In state 264, spurious reduction of production loption(separated_nonempty_list(SEMICOLON,stmt)) -> separated_nonempty_list(SEMICOLON,stmt) 
-## In state 272, spurious reduction of production stmts -> loption(separated_nonempty_list(SEMICOLON,stmt)) 
+## In state 224, spurious reduction of production option(sid) -> 
+## In state 226, spurious reduction of production stmt -> THROW option(sid) 
+## In state 263, spurious reduction of production separated_nonempty_list(SEMICOLON,stmt) -> stmt 
+## In state 268, spurious reduction of production loption(separated_nonempty_list(SEMICOLON,stmt)) -> separated_nonempty_list(SEMICOLON,stmt) 
+## In state 276, spurious reduction of production stmts -> loption(separated_nonempty_list(SEMICOLON,stmt)) 
 ##
 # special case, only via stmts_term entry point should never happen
 # throw itself is a valid statement term and a procedure or transition
@@ -1004,7 +1004,7 @@ This is an invalid statements term, bad throw.
 
 stmts_term: THROW SEMICOLON WITH
 ##
-## Ends in an error in state: 260.
+## Ends in an error in state: 264.
 ##
 ## separated_nonempty_list(SEMICOLON,stmt) -> stmt SEMICOLON . separated_nonempty_list(SEMICOLON,stmt) [ EOF END BAR ]
 ##
@@ -1019,7 +1019,7 @@ What follows the statement was unexpected, for example possibly a statement or t
 
 stmts_term: THROW WITH
 ##
-## Ends in an error in state: 220.
+## Ends in an error in state: 224.
 ##
 ## stmt -> THROW . option(sid) [ SEMICOLON EOF END BAR ]
 ##
@@ -1032,7 +1032,7 @@ This throw does not throw a valid exception or is not properly terminated.
 
 stmts_term: WITH
 ##
-## Ends in an error in state: 298.
+## Ends in an error in state: 306.
 ##
 ## stmts_term' -> . stmts_term [ # ]
 ##
@@ -1085,12 +1085,12 @@ To import another library mention the new library name directly after the previo
 
 lmodule: SCILLA_VERSION NUMLIT IMPORT CONTRACT
 ##
-## Ends in an error in state: 295.
+## Ends in an error in state: 302.
 ##
-## lmodule -> imports . library EOF [ # ]
+## lmodule -> SCILLA_VERSION NUMLIT imports . library EOF [ # ]
 ##
 ## The known suffix of the stack is as follows:
-## imports
+## SCILLA_VERSION NUMLIT imports
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
@@ -1118,12 +1118,12 @@ If import is mentioned there must be one or more imported libraries with capital
 
 lmodule: SCILLA_VERSION NUMLIT LIBRARY CID CONTRACT
 ##
-## Ends in an error in state: 296.
+## Ends in an error in state: 303.
 ##
-## lmodule -> imports library . EOF [ # ]
+## lmodule -> SCILLA_VERSION NUMLIT imports library . EOF [ # ]
 ##
 ## The known suffix of the stack is as follows:
-## imports library
+## SCILLA_VERSION NUMLIT imports library
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
@@ -1336,12 +1336,12 @@ This is an invalid library module because it lacks a capital identifier for a na
 
 lmodule: SCILLA_VERSION NUMLIT WITH
 ##
-## Ends in an error in state: 293.
+## Ends in an error in state: 301.
 ##
-## lmodule' -> . lmodule [ # ]
+## lmodule -> SCILLA_VERSION NUMLIT . imports library EOF [ # ]
 ##
 ## The known suffix of the stack is as follows:
-##
+## SCILLA_VERSION NUMLIT
 ##
 # see tests/parser/bad/lmodule-version-with.scillib
 
@@ -1351,8 +1351,8 @@ exp_term: AT SPID TID WITH
 ##
 ## Ends in an error in state: 73.
 ##
-## nonempty_list(targ) -> targ . [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
-## nonempty_list(targ) -> targ . nonempty_list(targ) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## nonempty_list(targ) -> targ . [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
+## nonempty_list(targ) -> targ . nonempty_list(targ) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## targ
@@ -1365,7 +1365,7 @@ exp_term: AT SPID WITH
 ##
 ## Ends in an error in state: 152.
 ##
-## simple_exp -> AT sid . nonempty_list(targ) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> AT sid . nonempty_list(targ) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## AT sid
@@ -1378,7 +1378,7 @@ exp_term: AT WITH
 ##
 ## Ends in an error in state: 151.
 ##
-## simple_exp -> AT . sid nonempty_list(targ) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> AT . sid nonempty_list(targ) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## AT
@@ -1391,7 +1391,7 @@ exp_term: BUILTIN ID LPAREN WITH
 ##
 ## Ends in an error in state: 141.
 ##
-## builtin_args -> LPAREN . RPAREN [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## builtin_args -> LPAREN . RPAREN [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -1404,7 +1404,7 @@ exp_term: BUILTIN ID WITH
 ##
 ## Ends in an error in state: 139.
 ##
-## simple_exp -> BUILTIN ID . builtin_args [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> BUILTIN ID . builtin_args [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## BUILTIN ID
@@ -1417,7 +1417,7 @@ exp_term: BUILTIN WITH
 ##
 ## Ends in an error in state: 138.
 ##
-## simple_exp -> BUILTIN . ID builtin_args [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> BUILTIN . ID builtin_args [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## BUILTIN
@@ -1430,7 +1430,7 @@ exp_term: CID LBRACE TID EQ
 ##
 ## Ends in an error in state: 159.
 ##
-## ctargs -> LBRACE list(targ) . RBRACE [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET IN ID FIELD EOF END CONTRACT CID BAR ]
+## ctargs -> LBRACE list(targ) . RBRACE [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LBRACE list(targ)
@@ -1450,7 +1450,7 @@ exp_term: CID LBRACE WITH
 ##
 ## Ends in an error in state: 158.
 ##
-## ctargs -> LBRACE . list(targ) RBRACE [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET IN ID FIELD EOF END CONTRACT CID BAR ]
+## ctargs -> LBRACE . list(targ) RBRACE [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LBRACE
@@ -1463,7 +1463,7 @@ exp_term: CID PERIOD CID WITH
 ##
 ## Ends in an error in state: 157.
 ##
-## simple_exp -> scid . option(ctargs) list(sident) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> scid . option(ctargs) list(sident) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## scid
@@ -1476,8 +1476,8 @@ exp_term: CID PERIOD WITH
 ##
 ## Ends in an error in state: 137.
 ##
-## scid -> CID PERIOD . CID [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET LBRACE IN ID FIELD EOF END CONTRACT CID BAR ]
-## sid -> CID PERIOD . ID [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET IN ID FIELD EOF END CONTRACT CID BAR ]
+## scid -> CID PERIOD . CID [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET LBRACE IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
+## sid -> CID PERIOD . ID [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## CID PERIOD
@@ -1490,10 +1490,10 @@ exp_term: CID WITH
 ##
 ## Ends in an error in state: 136.
 ##
-## lit -> CID . NUMLIT [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
-## scid -> CID . [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET LBRACE IN ID FIELD EOF END CONTRACT CID BAR ]
-## scid -> CID . PERIOD CID [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET LBRACE IN ID FIELD EOF END CONTRACT CID BAR ]
-## sid -> CID . PERIOD ID [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET IN ID FIELD EOF END CONTRACT CID BAR ]
+## lit -> CID . NUMLIT [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
+## scid -> CID . [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET LBRACE IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
+## scid -> CID . PERIOD CID [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET LBRACE IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
+## sid -> CID . PERIOD ID [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## CID
@@ -1506,7 +1506,7 @@ exp_term: EMP CID UNDERSCORE
 ##
 ## Ends in an error in state: 117.
 ##
-## lit -> EMP t_map_key . t_map_value [ TYPE TRANSITION SEMICOLON RBRACE PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## lit -> EMP t_map_key . t_map_value [ TYPE TRANSITION SEMICOLON RBRACE PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## EMP t_map_key
@@ -1526,7 +1526,7 @@ exp_term: EMP WITH
 ##
 ## Ends in an error in state: 116.
 ##
-## lit -> EMP . t_map_key t_map_value [ TYPE TRANSITION SEMICOLON RBRACE PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## lit -> EMP . t_map_key t_map_value [ TYPE TRANSITION SEMICOLON RBRACE PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## EMP
@@ -1539,7 +1539,7 @@ exp_term: FUN LPAREN ID COLON TID RPAREN ARROW WITH
 ##
 ## Ends in an error in state: 135.
 ##
-## simple_exp -> FUN LPAREN ID COLON typ RPAREN ARROW . exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> FUN LPAREN ID COLON typ RPAREN ARROW . exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## FUN LPAREN ID COLON typ RPAREN ARROW
@@ -1552,7 +1552,7 @@ exp_term: FUN LPAREN ID COLON TID RPAREN WITH
 ##
 ## Ends in an error in state: 134.
 ##
-## simple_exp -> FUN LPAREN ID COLON typ RPAREN . ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> FUN LPAREN ID COLON typ RPAREN . ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## FUN LPAREN ID COLON typ RPAREN
@@ -1565,7 +1565,7 @@ exp_term: FUN LPAREN ID COLON TID WITH
 ##
 ## Ends in an error in state: 133.
 ##
-## simple_exp -> FUN LPAREN ID COLON typ . RPAREN ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> FUN LPAREN ID COLON typ . RPAREN ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ## typ -> typ . TARROW typ [ TARROW RPAREN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -1579,7 +1579,7 @@ exp_term: FUN LPAREN ID COLON WITH
 ##
 ## Ends in an error in state: 132.
 ##
-## simple_exp -> FUN LPAREN ID COLON . typ RPAREN ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> FUN LPAREN ID COLON . typ RPAREN ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## FUN LPAREN ID COLON
@@ -1592,7 +1592,7 @@ exp_term: FUN LPAREN ID WITH
 ##
 ## Ends in an error in state: 131.
 ##
-## simple_exp -> FUN LPAREN ID . COLON typ RPAREN ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> FUN LPAREN ID . COLON typ RPAREN ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## FUN LPAREN ID
@@ -1605,7 +1605,7 @@ exp_term: FUN LPAREN WITH
 ##
 ## Ends in an error in state: 130.
 ##
-## simple_exp -> FUN LPAREN . ID COLON typ RPAREN ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> FUN LPAREN . ID COLON typ RPAREN ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## FUN LPAREN
@@ -1618,7 +1618,7 @@ exp_term: FUN WITH
 ##
 ## Ends in an error in state: 129.
 ##
-## simple_exp -> FUN . LPAREN ID COLON typ RPAREN ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> FUN . LPAREN ID COLON typ RPAREN ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## FUN
@@ -1700,7 +1700,7 @@ exp_term: LBRACE WITH
 ##
 ## Ends in an error in state: 112.
 ##
-## simple_exp -> LBRACE . loption(separated_nonempty_list(SEMICOLON,msg_entry)) RBRACE [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> LBRACE . loption(separated_nonempty_list(SEMICOLON,msg_entry)) RBRACE [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LBRACE
@@ -1714,7 +1714,7 @@ exp_term: LET ID COLON TID EQ STRING IN WITH
 ##
 ## Ends in an error in state: 177.
 ##
-## simple_exp -> LET ID type_annot EQ simple_exp IN . exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> LET ID type_annot EQ simple_exp IN . exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET ID type_annot EQ simple_exp IN
@@ -1756,7 +1756,7 @@ exp_term: LET ID EQ STRING IN WITH
 ##
 ## Ends in an error in state: 170.
 ##
-## simple_exp -> LET ID EQ simple_exp IN . exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> LET ID EQ simple_exp IN . exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET ID EQ simple_exp IN
@@ -1769,7 +1769,7 @@ exp_term: LET ID EQ STRING WITH
 ##
 ## Ends in an error in state: 169.
 ##
-## simple_exp -> LET ID EQ simple_exp . IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> LET ID EQ simple_exp . IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET ID EQ simple_exp
@@ -1782,7 +1782,7 @@ exp_term: LET ID EQ WITH
 ##
 ## Ends in an error in state: 111.
 ##
-## simple_exp -> LET ID EQ . simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> LET ID EQ . simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET ID EQ
@@ -1795,8 +1795,8 @@ exp_term: LET ID WITH
 ##
 ## Ends in an error in state: 110.
 ##
-## simple_exp -> LET ID . EQ simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
-## simple_exp -> LET ID . type_annot EQ simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> LET ID . EQ simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
+## simple_exp -> LET ID . type_annot EQ simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET ID
@@ -1809,8 +1809,8 @@ exp_term: LET WITH
 ##
 ## Ends in an error in state: 109.
 ##
-## simple_exp -> LET . ID EQ simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
-## simple_exp -> LET . ID type_annot EQ simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> LET . ID EQ simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
+## simple_exp -> LET . ID type_annot EQ simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET
@@ -1824,7 +1824,7 @@ exp_term: MATCH SPID UNDERSCORE
 ##
 ## Ends in an error in state: 92.
 ##
-## simple_exp -> MATCH sid . WITH list(exp_pm_clause) END [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> MATCH sid . WITH list(exp_pm_clause) END [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## MATCH sid
@@ -1948,7 +1948,7 @@ exp_term: MATCH SPID WITH WITH
 ##
 ## Ends in an error in state: 93.
 ##
-## simple_exp -> MATCH sid WITH . list(exp_pm_clause) END [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> MATCH sid WITH . list(exp_pm_clause) END [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## MATCH sid WITH
@@ -1961,7 +1961,7 @@ exp_term: MATCH WITH
 ##
 ## Ends in an error in state: 87.
 ##
-## simple_exp -> MATCH . sid WITH list(exp_pm_clause) END [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> MATCH . sid WITH list(exp_pm_clause) END [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## MATCH
@@ -1974,7 +1974,7 @@ exp_term: SPID CID PERIOD WITH
 ##
 ## Ends in an error in state: 145.
 ##
-## sident -> CID PERIOD . ID [ TYPE TRANSITION SPID SEMICOLON RSQB PROCEDURE LET IN ID FIELD EOF END CONTRACT CID BAR ]
+## sident -> CID PERIOD . ID [ TYPE TRANSITION SPID SEMICOLON RSQB PROCEDURE LET IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## CID PERIOD
@@ -1987,7 +1987,7 @@ exp_term: SPID CID WITH
 ##
 ## Ends in an error in state: 144.
 ##
-## sident -> CID . PERIOD ID [ TYPE TRANSITION SPID SEMICOLON RSQB PROCEDURE LET IN ID FIELD EOF END CONTRACT CID BAR ]
+## sident -> CID . PERIOD ID [ TYPE TRANSITION SPID SEMICOLON RSQB PROCEDURE LET IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## CID
@@ -2000,8 +2000,8 @@ exp_term: SPID SPID WITH
 ##
 ## Ends in an error in state: 147.
 ##
-## nonempty_list(sident) -> sident . [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
-## nonempty_list(sident) -> sident . nonempty_list(sident) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## nonempty_list(sident) -> sident . [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
+## nonempty_list(sident) -> sident . nonempty_list(sident) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## sident
@@ -2016,8 +2016,8 @@ exp_term: SPID WITH
 ##
 ## Ends in an error in state: 155.
 ##
-## atomic_exp -> sid . [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
-## simple_exp -> sid . nonempty_list(sident) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## atomic_exp -> sid . [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
+## simple_exp -> sid . nonempty_list(sident) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## sid
@@ -2028,7 +2028,7 @@ This is an invalid expression. If it is an application of a function, it is nece
 
 exp_term: STRING WITH
 ##
-## Ends in an error in state: 291.
+## Ends in an error in state: 297.
 ##
 ## exp_term -> exp . EOF [ # ]
 ##
@@ -2043,7 +2043,7 @@ exp_term: TFUN TID ARROW WITH
 ##
 ## Ends in an error in state: 84.
 ##
-## simple_exp -> TFUN TID ARROW . exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> TFUN TID ARROW . exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## TFUN TID ARROW
@@ -2056,7 +2056,7 @@ exp_term: TFUN TID WITH
 ##
 ## Ends in an error in state: 83.
 ##
-## simple_exp -> TFUN TID . ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> TFUN TID . ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## TFUN TID
@@ -2069,7 +2069,7 @@ exp_term: TFUN WITH
 ##
 ## Ends in an error in state: 82.
 ##
-## simple_exp -> TFUN . TID ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> TFUN . TID ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## TFUN
@@ -2080,7 +2080,7 @@ Type functions expect a type id (e.g. 'A).
 
 exp_term: WITH
 ##
-## Ends in an error in state: 289.
+## Ends in an error in state: 295.
 ##
 ## exp_term' -> . exp_term [ # ]
 ##
@@ -2147,7 +2147,7 @@ In an immutable field declaration, the parser expects a colon following the name
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD ID COLON CID EQ HEXLIT WITH
 ##
-## Ends in an error in state: 283.
+## Ends in an error in state: 287.
 ##
 ## list(field) -> field . list(field) [ TRANSITION PROCEDURE EOF ]
 ##
@@ -2160,7 +2160,7 @@ Following a field definition, the parser expects another field definition, trans
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD ID COLON TID EQ WITH
 ##
-## Ends in an error in state: 209.
+## Ends in an error in state: 212.
 ##
 ## field -> FIELD ID COLON typ EQ . exp [ TRANSITION PROCEDURE FIELD EOF ]
 ##
@@ -2173,7 +2173,7 @@ In a mutable field declaration, it is expected that the field is initialised to 
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD ID COLON TID WITH
 ##
-## Ends in an error in state: 208.
+## Ends in an error in state: 211.
 ##
 ## field -> FIELD ID COLON typ . EQ exp [ TRANSITION PROCEDURE FIELD EOF ]
 ## typ -> typ . TARROW typ [ TARROW EQ ]
@@ -2187,7 +2187,7 @@ In a mutable field declaration, after the type is specified an equals is expecte
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD ID COLON WITH
 ##
-## Ends in an error in state: 207.
+## Ends in an error in state: 210.
 ##
 ## field -> FIELD ID COLON . typ EQ exp [ TRANSITION PROCEDURE FIELD EOF ]
 ##
@@ -2200,7 +2200,7 @@ In a mutable field declaration, following the colon after the naming, a type is 
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD ID WITH
 ##
-## Ends in an error in state: 206.
+## Ends in an error in state: 209.
 ##
 ## field -> FIELD ID . COLON typ EQ exp [ TRANSITION PROCEDURE FIELD EOF ]
 ##
@@ -2213,7 +2213,7 @@ In a mutable field declaration, following the naming a colon is expected. This c
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD WITH
 ##
-## Ends in an error in state: 205.
+## Ends in an error in state: 208.
 ##
 ## field -> FIELD . ID COLON typ EQ exp [ TRANSITION PROCEDURE FIELD EOF ]
 ##
@@ -2227,7 +2227,7 @@ For a mutable field declaration, the parser expects a valid lower case beginning
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN PROCEDURE ID LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 276.
+## Ends in an error in state: 280.
 ##
 ## procedure -> PROCEDURE component_id component_params . component_body [ TRANSITION PROCEDURE EOF ]
 ##
@@ -2240,7 +2240,7 @@ In the transition body the parser expects a list of semi-colon separated stateme
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN PROCEDURE ID WITH
 ##
-## Ends in an error in state: 275.
+## Ends in an error in state: 279.
 ##
 ## procedure -> PROCEDURE component_id . component_params component_body [ TRANSITION PROCEDURE EOF ]
 ##
@@ -2254,7 +2254,7 @@ be a left parenthesis.
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN PROCEDURE WITH
 ##
-## Ends in an error in state: 274.
+## Ends in an error in state: 278.
 ##
 ## procedure -> PROCEDURE . component_id component_params component_body [ TRANSITION PROCEDURE EOF ]
 ##
@@ -2267,7 +2267,7 @@ A procedure requires a valid name.
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN TRANSITION ID LPAREN RPAREN END WITH
 ##
-## Ends in an error in state: 281.
+## Ends in an error in state: 285.
 ##
 ## list(component) -> component . list(component) [ EOF ]
 ##
@@ -2280,7 +2280,7 @@ Following a transition definition, the parser expects a transition or a procedur
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN TRANSITION ID LPAREN RPAREN THROW BAR
 ##
-## Ends in an error in state: 270.
+## Ends in an error in state: 274.
 ##
 ## component_body -> stmts . END [ TRANSITION PROCEDURE EOF ]
 ##
@@ -2291,11 +2291,11 @@ cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN TRANSITION ID LPAREN R
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 220, spurious reduction of production option(sid) -> 
-## In state 222, spurious reduction of production stmt -> THROW option(sid) 
-## In state 259, spurious reduction of production separated_nonempty_list(SEMICOLON,stmt) -> stmt 
-## In state 264, spurious reduction of production loption(separated_nonempty_list(SEMICOLON,stmt)) -> separated_nonempty_list(SEMICOLON,stmt) 
-## In state 272, spurious reduction of production stmts -> loption(separated_nonempty_list(SEMICOLON,stmt)) 
+## In state 224, spurious reduction of production option(sid) -> 
+## In state 226, spurious reduction of production stmt -> THROW option(sid) 
+## In state 263, spurious reduction of production separated_nonempty_list(SEMICOLON,stmt) -> stmt 
+## In state 268, spurious reduction of production loption(separated_nonempty_list(SEMICOLON,stmt)) -> separated_nonempty_list(SEMICOLON,stmt) 
+## In state 276, spurious reduction of production stmts -> loption(separated_nonempty_list(SEMICOLON,stmt)) 
 ##
 # see tests/parser/cmodule-transition-id-lparen-rparen-throw-bar.scilla
 
@@ -2303,7 +2303,7 @@ Possible typo.
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN TRANSITION ID LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 219.
+## Ends in an error in state: 223.
 ##
 ## transition -> TRANSITION component_id component_params . component_body [ TRANSITION PROCEDURE EOF ]
 ##
@@ -2316,7 +2316,7 @@ After a transition has the parameters defined, we expect a semi-colon separated 
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN TRANSITION ID LPAREN WITH
 ##
-## Ends in an error in state: 216.
+## Ends in an error in state: 220.
 ##
 ## component_params -> LPAREN . loption(separated_nonempty_list(COMMA,param_pair)) RPAREN [ THROW SEND MATCH ID EVENT END DELETE CID ACCEPT ]
 ##
@@ -2330,7 +2330,7 @@ The transition parameter name is invalid. This should start with a lower case le
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN TRANSITION ID WITH
 ##
-## Ends in an error in state: 215.
+## Ends in an error in state: 219.
 ##
 ## transition -> TRANSITION component_id . component_params component_body [ TRANSITION PROCEDURE EOF ]
 ##
@@ -2343,7 +2343,7 @@ After a transition has been named, the parameters must be specified in brackets.
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN TRANSITION WITH
 ##
-## Ends in an error in state: 212.
+## Ends in an error in state: 216.
 ##
 ## transition -> TRANSITION . component_id component_params component_body [ TRANSITION PROCEDURE EOF ]
 ##
@@ -2373,6 +2373,7 @@ cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN WITH
 ## Ends in an error in state: 195.
 ##
 ## contract -> CONTRACT CID LPAREN . loption(separated_nonempty_list(COMMA,param_pair)) RPAREN list(field) list(component) [ EOF ]
+## contract -> CONTRACT CID LPAREN . loption(separated_nonempty_list(COMMA,param_pair)) RPAREN with_constraint list(field) list(component) [ EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## CONTRACT CID LPAREN
@@ -2387,6 +2388,7 @@ cmodule: SCILLA_VERSION NUMLIT CONTRACT CID WITH
 ## Ends in an error in state: 194.
 ##
 ## contract -> CONTRACT CID . LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN list(field) list(component) [ EOF ]
+## contract -> CONTRACT CID . LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN with_constraint list(field) list(component) [ EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## CONTRACT CID
@@ -2400,6 +2402,7 @@ cmodule: SCILLA_VERSION NUMLIT CONTRACT WITH
 ## Ends in an error in state: 193.
 ##
 ## contract -> CONTRACT . CID LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN list(field) list(component) [ EOF ]
+## contract -> CONTRACT . CID LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN with_constraint list(field) list(component) [ EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## CONTRACT
@@ -2423,7 +2426,7 @@ cmodule: SCILLA_VERSION NUMLIT LIBRARY CID EOF
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 12, spurious reduction of production list(libentry) -> 
 ## In state 189, spurious reduction of production library -> LIBRARY CID list(libentry) 
-## In state 287, spurious reduction of production option(library) -> library 
+## In state 293, spurious reduction of production option(library) -> library 
 ##
 # see tests/parser/bad/cmodule-version-number-library-name
 
@@ -2472,7 +2475,7 @@ exp_term: CID LBRACE RBRACE AT
 ##
 ## Ends in an error in state: 161.
 ##
-## simple_exp -> scid option(ctargs) . list(sident) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> scid option(ctargs) . list(sident) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## scid option(ctargs)
@@ -2485,7 +2488,7 @@ exp_term: LET ID COLON TID EQ STRING WITH
 ##
 ## Ends in an error in state: 176.
 ##
-## simple_exp -> LET ID type_annot EQ simple_exp . IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> LET ID type_annot EQ simple_exp . IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET ID type_annot EQ simple_exp
@@ -2498,7 +2501,7 @@ exp_term: LET ID COLON TID EQ WITH
 ##
 ## Ends in an error in state: 175.
 ##
-## simple_exp -> LET ID type_annot EQ . simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ]
+## simple_exp -> LET ID type_annot EQ . simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET ID type_annot EQ

--- a/src/lang/base/ParserFaults.messages
+++ b/src/lang/base/ParserFaults.messages
@@ -1347,6 +1347,19 @@ lmodule: SCILLA_VERSION NUMLIT WITH
 
 This is an invalid library module, Scilla version must be followed by 'library' or 'import'.
 
+lmodule: WITH
+##
+## Ends in an error in state: 299.
+##
+## lmodule' -> . lmodule [ # ]
+##
+## The known suffix of the stack is as follows:
+##
+##
+# see tests/parser/bad/lmodule-with.scillib
+
+Scilla version number unspecified.
+
 exp_term: AT SPID TID WITH
 ##
 ## Ends in an error in state: 73.

--- a/src/lang/base/ParserFaults.messages
+++ b/src/lang/base/ParserFaults.messages
@@ -1043,7 +1043,7 @@ stmts_term: WITH
 
 This is not a statement.
 
-lmodule: IMPORT CID AS CID WITH
+lmodule: SCILLA_VERSION NUMLIT IMPORT CID AS CID WITH
 ##
 ## Ends in an error in state: 8.
 ##
@@ -1056,7 +1056,7 @@ lmodule: IMPORT CID AS CID WITH
 
 This is an invalid library module. Following an import, the parser expects another import or the library definition.
 
-lmodule: IMPORT CID AS WITH
+lmodule: SCILLA_VERSION NUMLIT IMPORT CID AS WITH
 ##
 ## Ends in an error in state: 5.
 ##
@@ -1069,7 +1069,7 @@ lmodule: IMPORT CID AS WITH
 
 This is an invalid library module. When importing a library under another name, the parser requires the other name to be given as a capital identifier.
 
-lmodule: IMPORT CID WITH
+lmodule: SCILLA_VERSION NUMLIT IMPORT CID WITH
 ##
 ## Ends in an error in state: 4.
 ##
@@ -1083,7 +1083,7 @@ lmodule: IMPORT CID WITH
 
 To import another library mention the new library name directly after the previous one, alternatively following the name of the imported library there can be a library defintion or sometimes a contract.
 
-lmodule: IMPORT CONTRACT
+lmodule: SCILLA_VERSION NUMLIT IMPORT CONTRACT
 ##
 ## Ends in an error in state: 295.
 ##
@@ -1103,7 +1103,7 @@ lmodule: IMPORT CONTRACT
 
 The parser does not expect contracts when loading imports for libraries.
 
-lmodule: IMPORT WITH
+lmodule: SCILLA_VERSION NUMLIT IMPORT WITH
 ##
 ## Ends in an error in state: 3.
 ##
@@ -1116,7 +1116,7 @@ lmodule: IMPORT WITH
 
 If import is mentioned there must be one or more imported libraries with capital identifiers.
 
-lmodule: LIBRARY CID CONTRACT
+lmodule: SCILLA_VERSION NUMLIT LIBRARY CID CONTRACT
 ##
 ## Ends in an error in state: 296.
 ##
@@ -1136,7 +1136,7 @@ lmodule: LIBRARY CID CONTRACT
 
 When writing solely Scilla libraries, there is no need for a contract.
 
-lmodule: LIBRARY CID LET ID COLON TID EQ WITH
+lmodule: SCILLA_VERSION NUMLIT LIBRARY CID LET ID COLON TID EQ WITH
 ##
 ## Ends in an error in state: 187.
 ##
@@ -1149,7 +1149,7 @@ lmodule: LIBRARY CID LET ID COLON TID EQ WITH
 
 This (type-annotated) let expression is missing an expression to assign to an identifier.
 
-lmodule: LIBRARY CID LET ID EQ HEXLIT WITH
+lmodule: SCILLA_VERSION NUMLIT LIBRARY CID LET ID EQ HEXLIT WITH
 ##
 ## Ends in an error in state: 190.
 ##
@@ -1162,7 +1162,7 @@ lmodule: LIBRARY CID LET ID EQ HEXLIT WITH
 
 This is an invalid library module, a possible continuation would be another valid library entry.
 
-lmodule: LIBRARY CID LET ID EQ WITH
+lmodule: SCILLA_VERSION NUMLIT LIBRARY CID LET ID EQ WITH
 ##
 ## Ends in an error in state: 81.
 ##
@@ -1175,7 +1175,7 @@ lmodule: LIBRARY CID LET ID EQ WITH
 
 This library let expression is missing a valid expression to assign to the identifier.
 
-lmodule: LIBRARY CID LET ID WITH
+lmodule: SCILLA_VERSION NUMLIT LIBRARY CID LET ID WITH
 ##
 ## Ends in an error in state: 80.
 ##
@@ -1189,7 +1189,7 @@ lmodule: LIBRARY CID LET ID WITH
 
 This library let expression is missing an equals, '='.
 
-lmodule: LIBRARY CID LET WITH
+lmodule: SCILLA_VERSION NUMLIT LIBRARY CID LET WITH
 ##
 ## Ends in an error in state: 79.
 ##
@@ -1203,7 +1203,7 @@ lmodule: LIBRARY CID LET WITH
 
 The let expression is missing an identifier to assign an expression to.
 
-lmodule: LIBRARY CID TYPE CID EQ BAR CID OF CID TRANSITION
+lmodule: SCILLA_VERSION NUMLIT LIBRARY CID TYPE CID EQ BAR CID OF CID TRANSITION
 ##
 ## Ends in an error in state: 76.
 ##
@@ -1226,7 +1226,7 @@ lmodule: LIBRARY CID TYPE CID EQ BAR CID OF CID TRANSITION
 
 The type definition has a type constructor containing malformed type arguments. Do note that there are no transitions or procedures in libraries.
 
-lmodule: LIBRARY CID TYPE CID EQ BAR CID OF WITH
+lmodule: SCILLA_VERSION NUMLIT LIBRARY CID TYPE CID EQ BAR CID OF WITH
 ##
 ## Ends in an error in state: 18.
 ##
@@ -1239,7 +1239,7 @@ lmodule: LIBRARY CID TYPE CID EQ BAR CID OF WITH
 
 This library type entry expects a non-empty list of type arguments.
 
-lmodule: LIBRARY CID TYPE CID EQ BAR CID WITH
+lmodule: SCILLA_VERSION NUMLIT LIBRARY CID TYPE CID EQ BAR CID WITH
 ##
 ## Ends in an error in state: 17.
 ##
@@ -1253,7 +1253,7 @@ lmodule: LIBRARY CID TYPE CID EQ BAR CID WITH
 
 This type constructor is missing the word 'of'.
 
-lmodule: LIBRARY CID TYPE CID EQ BAR WITH
+lmodule: SCILLA_VERSION NUMLIT LIBRARY CID TYPE CID EQ BAR WITH
 ##
 ## Ends in an error in state: 16.
 ##
@@ -1267,7 +1267,7 @@ lmodule: LIBRARY CID TYPE CID EQ BAR WITH
 
 This library type entry has an invalid type constructor name.
 
-lmodule: LIBRARY CID TYPE CID EQ WITH
+lmodule: SCILLA_VERSION NUMLIT LIBRARY CID TYPE CID EQ WITH
 ##
 ## Ends in an error in state: 15.
 ##
@@ -1280,7 +1280,7 @@ lmodule: LIBRARY CID TYPE CID EQ WITH
 
 This library type entry is lacking a valid non-empty list of type constructors. Possibly the bar is missing.
 
-lmodule: LIBRARY CID TYPE CID WITH
+lmodule: SCILLA_VERSION NUMLIT LIBRARY CID TYPE CID WITH
 ##
 ## Ends in an error in state: 14.
 ##
@@ -1294,7 +1294,7 @@ lmodule: LIBRARY CID TYPE CID WITH
 
 This library type entry is likely missing an equals, '='.
 
-lmodule: LIBRARY CID TYPE WITH
+lmodule: SCILLA_VERSION NUMLIT LIBRARY CID TYPE WITH
 ##
 ## Ends in an error in state: 13.
 ##
@@ -1308,7 +1308,7 @@ lmodule: LIBRARY CID TYPE WITH
 
 This library type entry is missing a name (should begin with a capital letter).
 
-lmodule: LIBRARY CID WITH
+lmodule: SCILLA_VERSION NUMLIT LIBRARY CID WITH
 ##
 ## Ends in an error in state: 12.
 ##
@@ -1321,7 +1321,7 @@ lmodule: LIBRARY CID WITH
 
 This is an invalid library entry.
 
-lmodule: LIBRARY WITH
+lmodule: SCILLA_VERSION NUMLIT LIBRARY WITH
 ##
 ## Ends in an error in state: 11.
 ##
@@ -1334,7 +1334,7 @@ lmodule: LIBRARY WITH
 
 This is an invalid library module because it lacks a capital identifier for a name.
 
-lmodule: WITH
+lmodule: SCILLA_VERSION NUMLIT WITH
 ##
 ## Ends in an error in state: 293.
 ##
@@ -1343,9 +1343,9 @@ lmodule: WITH
 ## The known suffix of the stack is as follows:
 ##
 ##
-# see tests/parser/bad/lmodule-with.scillib
+# see tests/parser/bad/lmodule-version-with.scillib
 
-This is an invalid library module, libraries start with 'library' or 'import'.
+This is an invalid library module, Scilla version must be followed by 'library' or 'import'.
 
 exp_term: AT SPID TID WITH
 ##

--- a/src/lang/base/Recursion.ml
+++ b/src/lang/base/Recursion.ml
@@ -374,7 +374,8 @@ module ScillaRecursion
 
     if emsgs = [] then
       pure @@ (
-        { RecursionSyntax.libs = recursion_md_libs';
+        { RecursionSyntax.smver = md.smver;
+          RecursionSyntax.libs = recursion_md_libs';
           RecursionSyntax.elibs = md.elibs },
         recursion_rprins,
         recursion_elibs)

--- a/src/lang/base/ScillaParser.mly
+++ b/src/lang/base/ScillaParser.mly
@@ -433,7 +433,9 @@ library :
      lentries = ls } }
 
 lmodule :
-| SCILLA_VERSION; cver = NUMLIT; els = imports; l = library; EOF { { elibs = els; libs = l } }
+| SCILLA_VERSION; cver = NUMLIT; els = imports; l = library; EOF 
+  { { smver = Big_int.int_of_big_int cver;
+      elibs = els; libs = l } }
 
 importname :
 | c = CID { Ident(c, toLoc $startpos), None }

--- a/src/lang/base/ScillaParser.mly
+++ b/src/lang/base/ScillaParser.mly
@@ -433,7 +433,7 @@ library :
      lentries = ls } }
 
 lmodule :
-| els = imports; l = library; EOF { { elibs = els; libs = l } }
+| SCILLA_VERSION; cver = NUMLIT; els = imports; l = library; EOF { { elibs = els; libs = l } }
 
 importname :
 | c = CID { Ident(c, toLoc $startpos), None }

--- a/src/lang/base/Syntax.ml
+++ b/src/lang/base/Syntax.ml
@@ -698,7 +698,8 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
 
   (* Library module *)
   type lmodule =
-    { 
+    {
+      smver : int;                (* Scilla major version of the library. *)
       (* List of imports / external libs with an optional namespace. *)
       elibs : (SR.rep ident * SR.rep ident option) list;
       libs : library; (* lib functions defined in the module *)

--- a/src/lang/base/TypeChecker.ml
+++ b/src/lang/base/TypeChecker.ml
@@ -796,7 +796,11 @@ module ScillaTypechecker
     (* Type the library of this module. *)
     let%bind ((typed_mlib, _), remaining_gas) = type_library elibs_env md.libs remaining_gas in
       
-    let typed_lmodule = { TypedSyntax.elibs = md.elibs; TypedSyntax.libs = typed_mlib } in
+    let typed_lmodule = { 
+      TypedSyntax.smver = md.smver;
+      TypedSyntax.elibs = md.elibs;
+      TypedSyntax.libs = typed_mlib
+    } in
     pure ((typed_lmodule, typed_rlib, typed_elibs), remaining_gas)
 
   let type_module

--- a/src/lang/checkers/PatternChecker.ml
+++ b/src/lang/checkers/PatternChecker.ml
@@ -256,12 +256,13 @@ module ScillaPatternchecker
               CheckedPatternSyntax.ccomps = checked_comp }
 
   let pm_check_lmodule lm rlibs elibs =
-    let {elibs = mod_elibs; libs} = lm in
+    let { smver; elibs = mod_elibs; libs} = lm in
     let%bind checked_rlibs = pm_check_libentries rlibs in
     let%bind checked_elibs = mapM elibs ~f:pm_check_libtree in
 
     let%bind checked_libs = pm_check_library libs in
-    pure ({ CheckedPatternSyntax.elibs = mod_elibs;
+    pure ({ CheckedPatternSyntax.smver = smver;
+            CheckedPatternSyntax.elibs = mod_elibs;
             CheckedPatternSyntax.libs = checked_libs},
           checked_rlibs, checked_elibs)
 

--- a/src/stdlib/BoolUtils.scillib
+++ b/src/stdlib/BoolUtils.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library BoolUtils
 
 let andb : Bool -> Bool -> Bool = 

--- a/src/stdlib/IntUtils.scillib
+++ b/src/stdlib/IntUtils.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library IntUtils
 
 let int_neq : forall 'A. ('A -> 'A -> Bool) -> 'A -> 'A -> Bool =

--- a/src/stdlib/ListUtils.scillib
+++ b/src/stdlib/ListUtils.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library ListUtils
 
 (* list_foldl with early termination. Continues recursing as long as f returns Some _.

--- a/src/stdlib/NatUtils.scillib
+++ b/src/stdlib/NatUtils.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library NatUtils
 
 let nat_prev : Nat -> Option Nat =

--- a/src/stdlib/PairUtils.scillib
+++ b/src/stdlib/PairUtils.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library PairUtils
 
 let fst : forall 'A. forall 'B. Pair 'A 'B -> 'A =

--- a/tests/checker/bad/BadPMLib.scillib
+++ b/tests/checker/bad/BadPMLib.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library BadPMLib
 
 let badpm =

--- a/tests/checker/bad/TestLibNS1.scillib
+++ b/tests/checker/bad/TestLibNS1.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 (* importing the a (non-empty) library into same namespace is a name conflict *)
 import TestLibNS1 as Foo
        TestLibNS1 as Foo

--- a/tests/checker/bad/gold/BadPMLib.scillib.gold
+++ b/tests/checker/bad/gold/BadPMLib.scillib.gold
@@ -6,7 +6,7 @@
         "Error during pattern-match checking of library badpm:\n",
       "start_location": {
         "file": "checker/bad/BadPMLib.scillib",
-        "line": 3,
+        "line": 5,
         "column": 5
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
@@ -16,7 +16,7 @@
         "Type error in pattern matching on `b` of type Bool (or one of its branches):\nNon-exhaustive pattern match.",
       "start_location": {
         "file": "checker/bad/BadPMLib.scillib",
-        "line": 5,
+        "line": 7,
         "column": 5
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/checker/bad/gold/TestLibNS1.scillib.gold
+++ b/tests/checker/bad/gold/TestLibNS1.scillib.gold
@@ -5,7 +5,7 @@
       "error_message": "Type error(s) in contract TestLibNS1:\n",
       "start_location": {
         "file": "checker/bad/TestLibNS1.scillib",
-        "line": 5,
+        "line": 7,
         "column": 1
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
@@ -15,7 +15,7 @@
         "Entry Foo.foo in library TestLibNS1 conflicts with entry in library TestLibNS1",
       "start_location": {
         "file": "checker/bad/lib/TestLibNS1.scillib",
-        "line": 3,
+        "line": 5,
         "column": 5
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/checker/bad/gold/bad_adt_lib_1.scilla.gold
+++ b/tests/checker/bad/gold/bad_adt_lib_1.scilla.gold
@@ -14,7 +14,7 @@
       "error_message": "Multiple declarations of type BadType",
       "start_location": {
         "file": "checker/bad/lib/BadADTLib1.scillib",
-        "line": 7,
+        "line": 9,
         "column": 1
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/checker/bad/gold/bad_adt_lib_2.scilla.gold
+++ b/tests/checker/bad/gold/bad_adt_lib_2.scilla.gold
@@ -14,7 +14,7 @@
       "error_message": "Multiple declarations of type constructor Item1",
       "start_location": {
         "file": "checker/bad/lib/BadADTLib2.scillib",
-        "line": 7,
+        "line": 9,
         "column": 1
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/checker/bad/gold/bad_adt_lib_3.scilla.gold
+++ b/tests/checker/bad/gold/bad_adt_lib_3.scilla.gold
@@ -14,7 +14,7 @@
       "error_message": "Multiple declarations of type TestType1",
       "start_location": {
         "file": "checker/bad/lib/BadADTLib3b.scillib",
-        "line": 3,
+        "line": 5,
         "column": 1
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/checker/bad/gold/bad_adt_lib_4.scilla.gold
+++ b/tests/checker/bad/gold/bad_adt_lib_4.scilla.gold
@@ -14,7 +14,7 @@
       "error_message": "Multiple declarations of type constructor Item1",
       "start_location": {
         "file": "checker/bad/lib/BadADTLib3c.scillib",
-        "line": 3,
+        "line": 5,
         "column": 1
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/checker/bad/gold/bad_lib_pm_import.scilla.gold
+++ b/tests/checker/bad/gold/bad_lib_pm_import.scilla.gold
@@ -11,7 +11,7 @@
         "Error during pattern-match checking of library badpm:\n",
       "start_location": {
         "file": "checker/bad/lib/BadPMLib.scillib",
-        "line": 3,
+        "line": 5,
         "column": 5
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
@@ -21,7 +21,7 @@
         "Type error in pattern matching on `b` of type Bool (or one of its branches):\nNon-exhaustive pattern match.",
       "start_location": {
         "file": "checker/bad/lib/BadPMLib.scillib",
-        "line": 5,
+        "line": 7,
         "column": 5
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/checker/bad/gold/libchaincycle.scilla.gold
+++ b/tests/checker/bad/gold/libchaincycle.scilla.gold
@@ -5,7 +5,7 @@
         "Cyclic dependence found when importing TestLibCycle1.",
       "start_location": {
         "file": "checker/bad/lib/TestLibCycle2.scillib",
-        "line": 1,
+        "line": 3,
         "column": 8
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/checker/bad/gold/libdiamondcycle.scilla.gold
+++ b/tests/checker/bad/gold/libdiamondcycle.scilla.gold
@@ -5,7 +5,7 @@
         "Cyclic dependence found when importing TestLibDiamondTopCycle.",
       "start_location": {
         "file": "checker/bad/lib/TestLibDiamondBottomCycle.scillib",
-        "line": 1,
+        "line": 3,
         "column": 8
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/checker/bad/gold/libdup1.scilla.gold
+++ b/tests/checker/bad/gold/libdup1.scilla.gold
@@ -15,7 +15,7 @@
         "Entry sort_uint32 in library TestLib1 conflicts with entry in library TestLib1",
       "start_location": {
         "file": "checker/bad/lib/TestLib1.scillib",
-        "line": 5,
+        "line": 7,
         "column": 5
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/checker/bad/gold/libdup2.scilla.gold
+++ b/tests/checker/bad/gold/libdup2.scilla.gold
@@ -15,7 +15,7 @@
         "Entry sort_uint32 in library TestLib3 conflicts with entry in library TestLib1",
       "start_location": {
         "file": "checker/bad/lib/TestLib3.scillib",
-        "line": 5,
+        "line": 7,
         "column": 5
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/checker/bad/gold/libindirect.scilla.gold
+++ b/tests/checker/bad/gold/libindirect.scilla.gold
@@ -14,7 +14,7 @@
       "error_message": "Type error in library TestLib2:\n\n",
       "start_location": {
         "file": "checker/bad/lib/TestLib2.scillib",
-        "line": 3,
+        "line": 5,
         "column": 1
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
@@ -23,7 +23,7 @@
       "error_message": "Type error in library variable sort_uint32:\n\n",
       "start_location": {
         "file": "checker/bad/lib/TestLib2.scillib",
-        "line": 3,
+        "line": 5,
         "column": 1
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
@@ -32,7 +32,7 @@
       "error_message": "Couldn't resolve the identifier \"list_sort\".\n",
       "start_location": {
         "file": "checker/bad/lib/TestLib2.scillib",
-        "line": 5,
+        "line": 7,
         "column": 20
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/checker/bad/lib/BadADTLib1.scillib
+++ b/tests/checker/bad/lib/BadADTLib1.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library BadADTLib1
 
 type BadType =

--- a/tests/checker/bad/lib/BadADTLib2.scillib
+++ b/tests/checker/bad/lib/BadADTLib2.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library BadADTLib2
 
 type TestType1 =

--- a/tests/checker/bad/lib/BadADTLib3a.scillib
+++ b/tests/checker/bad/lib/BadADTLib3a.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library BadADTLib3a
 
 type TestType1 =

--- a/tests/checker/bad/lib/BadADTLib3b.scillib
+++ b/tests/checker/bad/lib/BadADTLib3b.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library BadADTLib3b
 
 type TestType1 =

--- a/tests/checker/bad/lib/BadADTLib3c.scillib
+++ b/tests/checker/bad/lib/BadADTLib3c.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library BadADTLib3a
 
 type TestType2 =

--- a/tests/checker/bad/lib/BadPMLib.scillib
+++ b/tests/checker/bad/lib/BadPMLib.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library BadPMLib
 
 let badpm =

--- a/tests/checker/bad/lib/TestLib1.scillib
+++ b/tests/checker/bad/lib/TestLib1.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 import ListUtils
 
 library TestLib1

--- a/tests/checker/bad/lib/TestLib2.scillib
+++ b/tests/checker/bad/lib/TestLib2.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 import TestLib1
 
 library TestLib2

--- a/tests/checker/bad/lib/TestLib3.scillib
+++ b/tests/checker/bad/lib/TestLib3.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 import ListUtils
 
 library TestLib3

--- a/tests/checker/bad/lib/TestLibCycle1.scillib
+++ b/tests/checker/bad/lib/TestLibCycle1.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 import TestLibCycle2
 
 library TestLibCycle1

--- a/tests/checker/bad/lib/TestLibCycle2.scillib
+++ b/tests/checker/bad/lib/TestLibCycle2.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 import TestLibCycle1 ListUtils
 
 library TestLibCycle2

--- a/tests/checker/bad/lib/TestLibDiamondBottomCycle.scillib
+++ b/tests/checker/bad/lib/TestLibDiamondBottomCycle.scillib
@@ -1,2 +1,4 @@
+scilla_version 0
+
 import TestLibDiamondTopCycle
 library TestLibDiamondBottomCycle

--- a/tests/checker/bad/lib/TestLibDiamondLeftCycle.scillib
+++ b/tests/checker/bad/lib/TestLibDiamondLeftCycle.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 import TestLibDiamondBottomCycle
 
 library TestLibDiamondLeftCycle

--- a/tests/checker/bad/lib/TestLibDiamondRightCycle.scillib
+++ b/tests/checker/bad/lib/TestLibDiamondRightCycle.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 import TestLibDiamondBottomCycle
 
 library TestLibDiamondRightCycle

--- a/tests/checker/bad/lib/TestLibDiamondTopCycle.scillib
+++ b/tests/checker/bad/lib/TestLibDiamondTopCycle.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 import TestLibDiamondLeftCycle TestLibDiamondRightCycle
 
 library TestLibDiamondTopCycle

--- a/tests/checker/bad/lib/TestLibNS1.scillib
+++ b/tests/checker/bad/lib/TestLibNS1.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library TestLibNS1
 
 let foo = Uint32 57

--- a/tests/checker/good/InstantiatedListUtils.scillib
+++ b/tests/checker/good/InstantiatedListUtils.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 import ListUtils
 
 library InstantiatedListUtils

--- a/tests/checker/good/TestLibNS1.scillib
+++ b/tests/checker/good/TestLibNS1.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 import BoolUtils as Foo
 
 library TestLibNS1

--- a/tests/checker/good/TestLibNS2.scillib
+++ b/tests/checker/good/TestLibNS2.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 import TestLibNS1 as Foo
 
 library TestLibNS2

--- a/tests/checker/good/TestLibNS3.scillib
+++ b/tests/checker/good/TestLibNS3.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 (* importing the same library into two different namespaces should be fine *)
 import BoolUtils as Foo
        BoolUtils as Bar

--- a/tests/checker/good/TestLibNS4.scillib
+++ b/tests/checker/good/TestLibNS4.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 (* importing two disjoint libraries into the same namespace is fine *)
 import TestLibNS2 as Foo
        BoolUtils  as Foo

--- a/tests/checker/good/lib/TestLib1.scillib
+++ b/tests/checker/good/lib/TestLib1.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 import ListUtils
 
 library TestLib1

--- a/tests/checker/good/lib/TestLib2.scillib
+++ b/tests/checker/good/lib/TestLib2.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 import TestLib1 ListUtils
 
 library TestLib2

--- a/tests/checker/good/lib/TestLibDiamondBottom.scillib
+++ b/tests/checker/good/lib/TestLibDiamondBottom.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library TestLibDiamondBottom
 
 let bot_int = Uint32 1

--- a/tests/checker/good/lib/TestLibDiamondLeft.scillib
+++ b/tests/checker/good/lib/TestLibDiamondLeft.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 import TestLibDiamondBottom
 
 library TestLibDiamondLeft

--- a/tests/checker/good/lib/TestLibDiamondRight.scillib
+++ b/tests/checker/good/lib/TestLibDiamondRight.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 import TestLibDiamondBottom
 
 library TestLibDiamondRight

--- a/tests/checker/good/lib/TestLibDiamondTop.scillib
+++ b/tests/checker/good/lib/TestLibDiamondTop.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 import TestLibDiamondLeft as LeftFoo
        TestLibDiamondRight as RightFoo
 

--- a/tests/checker/good/lib/TestLibNS1.scillib
+++ b/tests/checker/good/lib/TestLibNS1.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 import BoolUtils as Foo
 
 library TestLibNS1

--- a/tests/checker/good/lib/TestLibNS2.scillib
+++ b/tests/checker/good/lib/TestLibNS2.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library TestLibNS2
 
 let foo = Uint32 57

--- a/tests/contracts/0x565556789012345678901234567890123456abcd.scillib
+++ b/tests/contracts/0x565556789012345678901234567890123456abcd.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 (* The filename of this file is the address specified in runner/TestLib2/init.json for TestLib1 *)
 import TestLib1
 

--- a/tests/contracts/0x986556789012345678901234567890123456abcd.scillib
+++ b/tests/contracts/0x986556789012345678901234567890123456abcd.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 (* The filename of this file is the address specified in runner/TestLib2/init.json for TestLib1 *)
 import ListUtils
 

--- a/tests/contracts/TestLib2.scillib
+++ b/tests/contracts/TestLib2.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 import ListUtils TestLib1
 
 library TestLib2

--- a/tests/contracts/shogi_lib/ShogiLib.scillib
+++ b/tests/contracts/shogi_lib/ShogiLib.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library ShogiLib
 
 (* Pieces in the game *)

--- a/tests/parser/bad/TestParserFail.ml
+++ b/tests/parser/bad/TestParserFail.ml
@@ -150,6 +150,7 @@ module LibTests = TestUtil.DiffBasedTests(
         "lmodule-library-cid-type-with.scillib";
         "lmodule-library-cid-with.scillib";
         "lmodule-library-with.scillib";
+        "lmodule-version-with.scillib";
         "lmodule-with.scillib";
     ]
     let exit_code : Unix.process_status = WEXITED 1

--- a/tests/parser/bad/gold/lmodule-import-contract.scillib.gold
+++ b/tests/parser/bad/gold/lmodule-import-contract.scillib.gold
@@ -6,7 +6,7 @@
         "The parser does not expect contracts when loading imports for libraries.\n",
       "start_location": {
         "file": "parser/bad/lib/lmodule-import-contract.scillib",
-        "line": 1,
+        "line": 3,
         "column": 16
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/parser/bad/gold/lmodule-import-with.scillib.gold
+++ b/tests/parser/bad/gold/lmodule-import-with.scillib.gold
@@ -6,7 +6,7 @@
         "If import is mentioned there must be one or more imported libraries with capital identifiers.\n",
       "start_location": {
         "file": "parser/bad/lib/lmodule-import-with.scillib",
-        "line": 1,
+        "line": 3,
         "column": 17
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/parser/bad/gold/lmodule-library-cid-let-id-colon-tid-eq-with.scillib.gold
+++ b/tests/parser/bad/gold/lmodule-library-cid-let-id-colon-tid-eq-with.scillib.gold
@@ -7,7 +7,7 @@
       "start_location": {
         "file":
           "parser/bad/lib/lmodule-library-cid-let-id-colon-tid-eq-with.scillib",
-        "line": 4,
+        "line": 6,
         "column": 21
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/parser/bad/gold/lmodule-library-cid-let-id-eq-hexlit-with.scillib.gold
+++ b/tests/parser/bad/gold/lmodule-library-cid-let-id-eq-hexlit-with.scillib.gold
@@ -7,7 +7,7 @@
       "start_location": {
         "file":
           "parser/bad/lib/lmodule-library-cid-let-id-eq-hexlit-with.scillib",
-        "line": 5,
+        "line": 7,
         "column": 2
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/parser/bad/gold/lmodule-library-cid-let-id-eq-with.scillib.gold
+++ b/tests/parser/bad/gold/lmodule-library-cid-let-id-eq-with.scillib.gold
@@ -6,7 +6,7 @@
         "This library let expression is missing a valid expression to assign to the identifier.\n",
       "start_location": {
         "file": "parser/bad/lib/lmodule-library-cid-let-id-eq-with.scillib",
-        "line": 4,
+        "line": 6,
         "column": 12
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/parser/bad/gold/lmodule-library-cid-let-id-with.scillib.gold
+++ b/tests/parser/bad/gold/lmodule-library-cid-let-id-with.scillib.gold
@@ -6,7 +6,7 @@
         "This library let expression is missing an equals, '='.\n",
       "start_location": {
         "file": "parser/bad/lib/lmodule-library-cid-let-id-with.scillib",
-        "line": 4,
+        "line": 6,
         "column": 13
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/parser/bad/gold/lmodule-library-cid-let-with.scillib.gold
+++ b/tests/parser/bad/gold/lmodule-library-cid-let-with.scillib.gold
@@ -6,7 +6,7 @@
         "The let expression is missing an identifier to assign an expression to.\n",
       "start_location": {
         "file": "parser/bad/lib/lmodule-library-cid-let-with.scillib",
-        "line": 4,
+        "line": 6,
         "column": 6
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/parser/bad/gold/lmodule-library-cid-type-cid-eq-bar-cid-of-cid-transition.scillib.gold
+++ b/tests/parser/bad/gold/lmodule-library-cid-type-cid-eq-bar-cid-of-cid-transition.scillib.gold
@@ -7,7 +7,7 @@
       "start_location": {
         "file":
           "parser/bad/lib/lmodule-library-cid-type-cid-eq-bar-cid-of-cid-transition.scillib",
-        "line": 8,
+        "line": 10,
         "column": 11
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/parser/bad/gold/lmodule-library-cid-type-cid-eq-bar-cid-of-with.scillib.gold
+++ b/tests/parser/bad/gold/lmodule-library-cid-type-cid-eq-bar-cid-of-with.scillib.gold
@@ -7,7 +7,7 @@
       "start_location": {
         "file":
           "parser/bad/lib/lmodule-library-cid-type-cid-eq-bar-cid-of-with.scillib",
-        "line": 5,
+        "line": 7,
         "column": 17
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/parser/bad/gold/lmodule-library-cid-type-cid-eq-bar-cid-with.scillib.gold
+++ b/tests/parser/bad/gold/lmodule-library-cid-type-cid-eq-bar-cid-with.scillib.gold
@@ -6,7 +6,7 @@
       "start_location": {
         "file":
           "parser/bad/lib/lmodule-library-cid-type-cid-eq-bar-cid-with.scillib",
-        "line": 4,
+        "line": 6,
         "column": 14
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/parser/bad/gold/lmodule-library-cid-type-cid-eq-bar-with.scillib.gold
+++ b/tests/parser/bad/gold/lmodule-library-cid-type-cid-eq-bar-with.scillib.gold
@@ -7,7 +7,7 @@
       "start_location": {
         "file":
           "parser/bad/lib/lmodule-library-cid-type-cid-eq-bar-with.scillib",
-        "line": 6,
+        "line": 8,
         "column": 7
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/parser/bad/gold/lmodule-library-cid-type-cid-eq-with.scillib.gold
+++ b/tests/parser/bad/gold/lmodule-library-cid-type-cid-eq-with.scillib.gold
@@ -6,7 +6,7 @@
         "This library type entry is lacking a valid non-empty list of type constructors. Possibly the bar is missing.\n",
       "start_location": {
         "file": "parser/bad/lib/lmodule-library-cid-type-cid-eq-with.scillib",
-        "line": 5,
+        "line": 7,
         "column": 5
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/parser/bad/gold/lmodule-library-cid-type-cid-with.scillib.gold
+++ b/tests/parser/bad/gold/lmodule-library-cid-type-cid-with.scillib.gold
@@ -6,7 +6,7 @@
         "This library type entry is likely missing an equals, '='.\n",
       "start_location": {
         "file": "parser/bad/lib/lmodule-library-cid-type-cid-with.scillib",
-        "line": 5,
+        "line": 7,
         "column": 18
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/parser/bad/gold/lmodule-library-cid-type-with.scillib.gold
+++ b/tests/parser/bad/gold/lmodule-library-cid-type-with.scillib.gold
@@ -6,7 +6,7 @@
         "This library type entry is missing a name (should begin with a capital letter).\n",
       "start_location": {
         "file": "parser/bad/lib/lmodule-library-cid-type-with.scillib",
-        "line": 5,
+        "line": 7,
         "column": 8
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/parser/bad/gold/lmodule-library-cid-with.scillib.gold
+++ b/tests/parser/bad/gold/lmodule-library-cid-with.scillib.gold
@@ -5,7 +5,7 @@
       "error_message": "This is an invalid library entry.\n",
       "start_location": {
         "file": "parser/bad/lib/lmodule-library-cid-with.scillib",
-        "line": 5,
+        "line": 7,
         "column": 5
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/parser/bad/gold/lmodule-library-with.scillib.gold
+++ b/tests/parser/bad/gold/lmodule-library-with.scillib.gold
@@ -6,7 +6,7 @@
         "This is an invalid library module because it lacks a capital identifier for a name.\n",
       "start_location": {
         "file": "parser/bad/lib/lmodule-library-with.scillib",
-        "line": 2,
+        "line": 4,
         "column": 17
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/parser/bad/gold/lmodule-version-with.scillib.gold
+++ b/tests/parser/bad/gold/lmodule-version-with.scillib.gold
@@ -3,11 +3,11 @@
   "errors": [
     {
       "error_message":
-        "When writing solely Scilla libraries, there is no need for a contract.\n",
+        "This is an invalid library module, Scilla version must be followed by 'library' or 'import'.\n",
       "start_location": {
-        "file": "parser/bad/lib/lmodule-library-cid-contract.scillib",
+        "file": "parser/bad/lib/lmodule-version-with.scillib",
         "line": 5,
-        "column": 9
+        "column": 5
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/parser/bad/gold/lmodule-with.scillib.gold
+++ b/tests/parser/bad/gold/lmodule-with.scillib.gold
@@ -2,7 +2,7 @@
   "gas_remaining": "8000",
   "errors": [
     {
-      "error_message": "Syntax error, state number 299",
+      "error_message": "Scilla version number unspecified.\n",
       "start_location": {
         "file": "parser/bad/lib/lmodule-with.scillib",
         "line": 2,

--- a/tests/parser/bad/gold/lmodule-with.scillib.gold
+++ b/tests/parser/bad/gold/lmodule-with.scillib.gold
@@ -2,12 +2,11 @@
   "gas_remaining": "8000",
   "errors": [
     {
-      "error_message":
-        "This is an invalid library module, libraries start with 'library' or 'import'.\n",
+      "error_message": "Syntax error, state number 299",
       "start_location": {
         "file": "parser/bad/lib/lmodule-with.scillib",
-        "line": 3,
-        "column": 5
+        "line": 2,
+        "column": 16
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/parser/bad/lib/lmodule-import-contract.scillib
+++ b/tests/parser/bad/lib/lmodule-import-contract.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 import contract
 
 library TestLib

--- a/tests/parser/bad/lib/lmodule-import-with.scillib
+++ b/tests/parser/bad/lib/lmodule-import-with.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 import boolutils
 
 library TestLib

--- a/tests/parser/bad/lib/lmodule-library-cid-contract.scillib
+++ b/tests/parser/bad/lib/lmodule-library-cid-contract.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library TestLib
 
 contract Test

--- a/tests/parser/bad/lib/lmodule-library-cid-let-id-colon-tid-eq-with.scillib
+++ b/tests/parser/bad/lib/lmodule-library-cid-let-id-colon-tid-eq-with.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library TestLib
 
 (* field is always an incorrect expression *)

--- a/tests/parser/bad/lib/lmodule-library-cid-let-id-eq-hexlit-with.scillib
+++ b/tests/parser/bad/lib/lmodule-library-cid-let-id-eq-hexlit-with.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library TestLib
 
 (* Typo | instead of l *)

--- a/tests/parser/bad/lib/lmodule-library-cid-let-id-eq-with.scillib
+++ b/tests/parser/bad/lib/lmodule-library-cid-let-id-eq-with.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library TestLib
 
 (* can't assign types to variables *)

--- a/tests/parser/bad/lib/lmodule-library-cid-let-id-with.scillib
+++ b/tests/parser/bad/lib/lmodule-library-cid-let-id-with.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library TestLib
 
 (* equals should be '=' *)

--- a/tests/parser/bad/lib/lmodule-library-cid-let-with.scillib
+++ b/tests/parser/bad/lib/lmodule-library-cid-let-with.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library TestLib
 
 (* missing some constant name *)

--- a/tests/parser/bad/lib/lmodule-library-cid-type-cid-eq-bar-cid-of-cid-transition.scillib
+++ b/tests/parser/bad/lib/lmodule-library-cid-type-cid-eq-bar-cid-of-cid-transition.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library TestLib
 
 type House =

--- a/tests/parser/bad/lib/lmodule-library-cid-type-cid-eq-bar-cid-of-with.scillib
+++ b/tests/parser/bad/lib/lmodule-library-cid-type-cid-eq-bar-cid-of-with.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library TestLib
 
 (* Should have a capital letter *)

--- a/tests/parser/bad/lib/lmodule-library-cid-type-cid-eq-bar-cid-with.scillib
+++ b/tests/parser/bad/lib/lmodule-library-cid-type-cid-eq-bar-cid-with.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library TestLib
 
 type House =

--- a/tests/parser/bad/lib/lmodule-library-cid-type-cid-eq-bar-with.scillib
+++ b/tests/parser/bad/lib/lmodule-library-cid-type-cid-eq-bar-with.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library TestLib
 
 (* 'kind' should start with a capital *)

--- a/tests/parser/bad/lib/lmodule-library-cid-type-cid-eq-with.scillib
+++ b/tests/parser/bad/lib/lmodule-library-cid-type-cid-eq-with.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library TestLib
 
 (* missing bar *)

--- a/tests/parser/bad/lib/lmodule-library-cid-type-cid-with.scillib
+++ b/tests/parser/bad/lib/lmodule-library-cid-type-cid-with.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library TestLib
 
 (* 'equals' should be '=' *)

--- a/tests/parser/bad/lib/lmodule-library-cid-type-with.scillib
+++ b/tests/parser/bad/lib/lmodule-library-cid-type-with.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library TestLib
 
 (* Missing 'House' *)

--- a/tests/parser/bad/lib/lmodule-library-cid-with.scillib
+++ b/tests/parser/bad/lib/lmodule-library-cid-with.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 library TestLib
 
 (* Should be 'type' *)

--- a/tests/parser/bad/lib/lmodule-library-with.scillib
+++ b/tests/parser/bad/lib/lmodule-library-with.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 (* should be 'TestLib' instead*)
 library _TestLib
 

--- a/tests/parser/bad/lib/lmodule-version-with.scillib
+++ b/tests/parser/bad/lib/lmodule-version-with.scillib
@@ -1,0 +1,6 @@
+scilla_version 0
+
+(* missing library declaration *)
+
+type House =
+| Kind of String

--- a/tests/parser/bad/lib/lmodule-with.scillib
+++ b/tests/parser/bad/lib/lmodule-with.scillib
@@ -1,6 +1,7 @@
-scilla_version 0
+(* Typo *)
+scilla_verrsion 0
 
-(* missing library declaration *)
+library Mylib
 
 type House =
 | Kind of String

--- a/tests/parser/bad/lib/lmodule-with.scillib
+++ b/tests/parser/bad/lib/lmodule-with.scillib
@@ -1,3 +1,5 @@
+scilla_version 0
+
 (* missing library declaration *)
 
 type House =

--- a/tests/runner/0x565556789012345678901234567890123456abcd/init_output.json
+++ b/tests/runner/0x565556789012345678901234567890123456abcd/init_output.json
@@ -6,7 +6,7 @@
       "start_location": {
         "file":
           "tests/contracts/0x565556789012345678901234567890123456abcd.scillib",
-        "line": 2,
+        "line": 4,
         "column": 8
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/runner/TestLib2/init_output.json
+++ b/tests/runner/TestLib2/init_output.json
@@ -1,1 +1,1 @@
-{ "gas_remaining": "7554" }
+{ "gas_remaining": "7536" }


### PR DESCRIPTION
This is backwards compatible since the blockchain doesn't yet support deploying libraries.