### PR TITLE
Switch from Core to Core_kernel in most places

### DIFF
--- a/src/lang/base/Bech32.ml
+++ b/src/lang/base/Bech32.ml
@@ -16,7 +16,7 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Core
+open Core_kernel
 open Bitstring
 open Utils
 

--- a/src/lang/base/BuiltIns.ml
+++ b/src/lang/base/BuiltIns.ml
@@ -17,7 +17,7 @@
 *)
 
 open Syntax
-open Core
+open Core_kernel
 open ErrorUtils
 open MonadUtil
 open Result.Let_syntax

--- a/src/lang/base/BuiltIns.mli
+++ b/src/lang/base/BuiltIns.mli
@@ -18,7 +18,7 @@
 
 open Syntax
 open ErrorUtils
-open Core
+open Core_kernel
 
 module UsefulLiterals : sig
   val true_lit : literal

--- a/src/lang/base/ContractUtil.ml
+++ b/src/lang/base/ContractUtil.ml
@@ -16,11 +16,11 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Core
+open Core_kernel
 open Syntax
 open MonadUtil
 open Stdint
-open Core.Result.Let_syntax
+open Core_kernel.Result.Let_syntax
 open PrettyPrinters
 
 (*****************************************************)

--- a/src/lang/base/Datatypes.ml
+++ b/src/lang/base/Datatypes.ml
@@ -17,7 +17,7 @@
 *)
 
 open Syntax
-open Core
+open Core_kernel
 open MonadUtil
 open Result.Let_syntax
 

--- a/src/lang/base/Datatypes.mli
+++ b/src/lang/base/Datatypes.mli
@@ -18,7 +18,7 @@
 
 open Syntax
 open ErrorUtils
-open Core
+open Core_kernel
 
 (**********************************************************)
 (*                 Built-in Algebraic Data Types          *)

--- a/src/lang/base/DebugMessage.ml
+++ b/src/lang/base/DebugMessage.ml
@@ -18,7 +18,7 @@
 
 
 open GlobalConfig
-open Core
+open Core_kernel
 
 (* Prints to log file *)
 let plog msg =

--- a/src/lang/base/FrontEndParser.ml
+++ b/src/lang/base/FrontEndParser.ml
@@ -17,7 +17,7 @@
 *)
 
 
-open Core
+open Core_kernel
 open Lexing
 open ErrorUtils
 open MonadUtil

--- a/src/lang/base/Gas.ml
+++ b/src/lang/base/Gas.ml
@@ -16,7 +16,7 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Core
+open Core_kernel
 open ErrorUtils
 open Result.Let_syntax
 open MonadUtil

--- a/src/lang/base/GlobalConfig.ml
+++ b/src/lang/base/GlobalConfig.ml
@@ -16,7 +16,7 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Core
+open Core_kernel
 open ScillaUtil.FilePathInfix
 
 (* Available debug levels for functions in DbgMsg *)
@@ -50,7 +50,7 @@ let create_log_filename dir =
   if not (Caml.Sys.file_exists dir) ||
      not (Caml.Sys.is_directory dir)
   then
-    Caml.Unix.mkdir dir 0o766; (* Arbitrary *)
+    Unix.mkdir dir 0o766; (* Arbitrary *)
   let files = Sys.readdir dir in
   let num = get_highest_numbered_log (Array.to_list files) in
   dir ^/ "scilla-runner-" ^ Int.to_string (num+1) ^. "log"

--- a/src/lang/base/JSON.ml
+++ b/src/lang/base/JSON.ml
@@ -20,7 +20,7 @@
 open Syntax
 open ErrorUtils
 open ParserUtil
-open Core
+open Core_kernel
 open Yojson
 open ContractUtil.MessagePayload
 open Datatypes

--- a/src/lang/base/JSONParser.ml
+++ b/src/lang/base/JSONParser.ml
@@ -22,7 +22,7 @@
 open Yojson
 open Syntax
 open ErrorUtils
-open Core
+open Core_kernel
 open PrimTypes
 open TypeUtil
 open Datatypes

--- a/src/lang/base/MonadUtil.ml
+++ b/src/lang/base/MonadUtil.ml
@@ -16,7 +16,7 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Core
+open Core_kernel
 open Result.Let_syntax
 open ErrorUtils
 open Stdint

--- a/src/lang/base/PatternUtil.ml
+++ b/src/lang/base/PatternUtil.ml
@@ -16,7 +16,7 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Core
+open Core_kernel
 open ErrorUtils
 
 (****************************************************************)

--- a/src/lang/base/PatternUtil.mli
+++ b/src/lang/base/PatternUtil.mli
@@ -16,7 +16,7 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Core
+open Core_kernel
 
 (* Pattern match expression descriptions *)
 module Exp_descriptions : sig

--- a/src/lang/base/PrettyPrinters.ml
+++ b/src/lang/base/PrettyPrinters.ml
@@ -17,7 +17,7 @@
 *)
 
 
-open Core
+open Core_kernel
 open Syntax
 open Yojson
 open PrimTypes

--- a/src/lang/base/PrimTypes.ml
+++ b/src/lang/base/PrimTypes.ml
@@ -17,7 +17,7 @@
 *)
 
 
-open Core
+open Core_kernel
 open Syntax
 open Stdint
 open Integer256

--- a/src/lang/base/Recursion.ml
+++ b/src/lang/base/Recursion.ml
@@ -17,7 +17,7 @@
 *)
 
 open Syntax
-open Core
+open Core_kernel
 open ErrorUtils
 open MonadUtil
 open Result.Let_syntax

--- a/src/lang/base/RecursionPrinciples.ml
+++ b/src/lang/base/RecursionPrinciples.ml
@@ -17,7 +17,7 @@
 *)
 
 open Syntax
-open Core
+open Core_kernel
 open ParserUtil
 open FrontEndParser
 

--- a/src/lang/base/Secp256k1Wrapper.ml
+++ b/src/lang/base/Secp256k1Wrapper.ml
@@ -17,8 +17,8 @@
 *)
 
 open Secp256k1
-open Core.Result
-open Core.Result.Let_syntax
+open Core_kernel.Result
+open Core_kernel.Result.Let_syntax
 open MonadUtil
 
 let ctx = Context.create [ Sign ; Verify ]

--- a/src/lang/base/Syntax.ml
+++ b/src/lang/base/Syntax.ml
@@ -17,7 +17,7 @@
 *)
 
 
-open Core
+open Core_kernel
 open Sexplib.Std
 open MonadUtil
 open ErrorUtils

--- a/src/lang/base/TypeCache.ml
+++ b/src/lang/base/TypeCache.ml
@@ -16,7 +16,7 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Core
+open Core_kernel
 open Syntax
 open ErrorUtils
 open TypeUtil

--- a/src/lang/base/TypeChecker.ml
+++ b/src/lang/base/TypeChecker.ml
@@ -17,7 +17,7 @@
 *)
 
 open Syntax
-open Core
+open Core_kernel
 open ErrorUtils
 open MonadUtil
 open Result.Let_syntax

--- a/src/lang/base/TypeUtil.ml
+++ b/src/lang/base/TypeUtil.ml
@@ -16,7 +16,7 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Core
+open Core_kernel
 open ErrorUtils
 open Sexplib.Std
 open Syntax

--- a/src/lang/base/TypeUtil.mli
+++ b/src/lang/base/TypeUtil.mli
@@ -16,7 +16,7 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Core
+open Core_kernel
 open ErrorUtils
 open Syntax
 

--- a/src/lang/base/Utils.mli
+++ b/src/lang/base/Utils.mli
@@ -16,7 +16,7 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Core
+open Core_kernel
 
 (* Add to list only if unique considering equal *)
 val list_add_unique :

--- a/src/lang/checkers/Cashflow.ml
+++ b/src/lang/checkers/Cashflow.ml
@@ -15,7 +15,7 @@
   You should have received a copy of the GNU General Public License along with
 *)
 
-open Core
+open Core_kernel
 open Sexplib.Std
 open Syntax
 open Datatypes

--- a/src/lang/checkers/EventInfo.ml
+++ b/src/lang/checkers/EventInfo.ml
@@ -2,7 +2,7 @@ open TypeUtil
 open Syntax
 open ContractUtil.MessagePayload
 open MonadUtil
-open Core.Result.Let_syntax
+open Core_kernel.Result.Let_syntax
 
 module ScillaEventInfo
     (SR : Rep)

--- a/src/lang/checkers/GasUseAnalysis.ml
+++ b/src/lang/checkers/GasUseAnalysis.ml
@@ -22,7 +22,7 @@ open Syntax
 open ErrorUtils
 open MonadUtil
 open Polynomial
-open Core.Result.Let_syntax
+open Core_kernel.Result.Let_syntax
 
 module ScillaGUA
     (SR : Rep)

--- a/src/lang/checkers/PatternChecker.ml
+++ b/src/lang/checkers/PatternChecker.ml
@@ -15,7 +15,7 @@
  *)
 
 open Syntax
-open Core
+open Core_kernel
 open ErrorUtils
 open MonadUtil
 open Result.Let_syntax

--- a/src/lang/checkers/SanityChecker.ml
+++ b/src/lang/checkers/SanityChecker.ml
@@ -21,7 +21,7 @@ open ErrorUtils
 open MonadUtil
 
 open ContractUtil.MessagePayload
-open Core.Result.Let_syntax
+open Core_kernel.Result.Let_syntax
 
 module ScillaSanityChecker
     (SR : Rep)

--- a/src/lang/checkers/TypeInfo.ml
+++ b/src/lang/checkers/TypeInfo.ml
@@ -16,7 +16,7 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Core
+open Core_kernel
 open TypeUtil
 open Syntax
 open ErrorUtils

--- a/src/lang/eval/Eval.ml
+++ b/src/lang/eval/Eval.ml
@@ -17,7 +17,7 @@
 *)
 
 open Syntax
-open Core
+open Core_kernel
 open ErrorUtils
 open EvalUtil
 open MonadUtil

--- a/src/lang/eval/EvalUtil.ml
+++ b/src/lang/eval/EvalUtil.ml
@@ -17,7 +17,7 @@
 *)
 
 open Syntax
-open Core
+open Core_kernel
 open ErrorUtils
 open MonadUtil
 open EvalMonad

--- a/src/lang/eval/PatternMatching.ml
+++ b/src/lang/eval/PatternMatching.ml
@@ -16,7 +16,7 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Core
+open Core_kernel
 open Datatypes
 open Syntax
 open EvalUtil

--- a/src/lang/eval/StateService.ml
+++ b/src/lang/eval/StateService.ml
@@ -16,7 +16,7 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Core
+open Core_kernel
 open Result.Let_syntax
 open MonadUtil
 open TypeUtil

--- a/src/polynomials/Polynomial.ml
+++ b/src/polynomials/Polynomial.ml
@@ -18,7 +18,7 @@
 
 (* Library to create and operate on multivariate polynomials *)
 
-open Core
+open Core_kernel
 
 exception Polynomial_error of string
 

--- a/src/runners/RunnerUtil.ml
+++ b/src/runners/RunnerUtil.ml
@@ -17,7 +17,7 @@
 *)
 
 
-open Core
+open Core_kernel
 open Printf
 open Syntax
 open GlobalConfig

--- a/src/runners/eval_runner.ml
+++ b/src/runners/eval_runner.ml
@@ -23,7 +23,7 @@ open ParserUtil
 open RunnerUtil
 open GlobalConfig
 open PrettyPrinters
-open Core
+open Core_kernel
 
 module ParsedSyntax = ParserUtil.ParsedSyntax
 module PSRep = ParserRep

--- a/src/runners/scilla_checker.ml
+++ b/src/runners/scilla_checker.ml
@@ -18,7 +18,7 @@
 
 
 open Syntax
-open Core
+open Core_kernel
 open ErrorUtils
 open PrettyPrinters
 open ParserUtil

--- a/src/runners/scilla_module_parse.ml
+++ b/src/runners/scilla_module_parse.ml
@@ -21,7 +21,7 @@
 open Printf
 open Sexplib.Std
 open Syntax
-open Core
+open Core_kernel
 
 let () =
   let filename = Sys.argv.(1) in

--- a/src/runners/type_checker.ml
+++ b/src/runners/type_checker.ml
@@ -16,7 +16,7 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Core
+open Core_kernel
 open Printf
 open Syntax
 open ParserUtil

--- a/tests/eval/TestBech32.ml
+++ b/tests/eval/TestBech32.ml
@@ -20,7 +20,7 @@ open OUnit2
 open Bech32
 open Syntax
 open Utils
-open Core
+open Core_kernel
 
 let hex_to_raw_bytes h = Bystr.parse_hex h |> Bystr.to_raw_bytes
 

--- a/tests/eval/TestSafeArith.ml
+++ b/tests/eval/TestSafeArith.ml
@@ -1,4 +1,4 @@
-open Core
+open Core_kernel
 open Stdint
 open OUnit2
 open SafeArith

--- a/tests/eval/TestSignatures.ml
+++ b/tests/eval/TestSignatures.ml
@@ -1,5 +1,5 @@
 open OUnit2
-open Core.Result
+open Core_kernel.Result
 
 let t1 = test_case (fun _ ->
   let open Schnorr in

--- a/tests/eval/TestSnark.ml
+++ b/tests/eval/TestSnark.ml
@@ -19,7 +19,7 @@
 (* The tests in this file are modelled after Ethereum's unit tests for zkSNARKs.
    https://github.com/ethereum/aleth/blob/master/test/unittests/libdevcrypto/LibSnark.cpp *)
 
-open Core
+open Core_kernel
 open OUnit2
 open Snark
 open Integer256

--- a/tests/eval/TestSyntax.ml
+++ b/tests/eval/TestSyntax.ml
@@ -1,4 +1,4 @@
-open Core
+open Core_kernel
 open Stdint
 open OUnit2
 open Syntax

--- a/tests/ipc/StateIPCTest.ml
+++ b/tests/ipc/StateIPCTest.ml
@@ -20,7 +20,7 @@
  * and initializing it with some initial data. *)
 
 open OUnit2
-open Core
+open Core_kernel
 open Syntax
 open Yojson
 

--- a/tests/runner/Testcontracts.ml
+++ b/tests/runner/Testcontracts.ml
@@ -17,7 +17,7 @@
 *)
 
 
-open Core
+open Core_kernel
 open OUnit2
 open ScillaUtil.FilePathInfix
 open TestUtil
@@ -26,8 +26,8 @@ open OUnitTest
 let testsuit_gas_limit = "8000"
 let ipc_socket_addr = Filename.temp_dir_name ^/ "scillaipcsocket"
 
-let succ_code : Caml.Unix.process_status = WEXITED 0
-let fail_code : Caml.Unix.process_status = WEXITED 1
+let succ_code : Unix.process_status = WEXITED 0
+let fail_code : Unix.process_status = WEXITED 1
 
 (*
  * Build tests to invoke scilla-runner with the right arguments, for


### PR DESCRIPTION
We cut down on the dependencies here to help with using js_of_ocaml on our codebase, e.g. on the parser.