### PR TITLE
Fix Schnorr

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,7 +6,7 @@ The recommended installation process is comprised of two separate steps:
 
 Please make sure you install opam v2.0 or greater (this can be checked by running `opam --version`).
 
-Scilla requires OpenSSL 1.0.2 and if your platform does not have packages for this, you may need to build OpenSSL
+Scilla requires OpenSSL 1.1.1 and if your platform does not have packages for this, you may need to build OpenSSL
 yourself and set `PKG_CONFIG_PATH` environment variable accordingly
 (if you install OpenSSL in a non-default path):
 ```shell

--- a/scripts/build_openssl.sh
+++ b/scripts/build_openssl.sh
@@ -8,7 +8,7 @@ fi
 
 git clone https://github.com/openssl/openssl.git ~/openssl/src
 cd ~/openssl/src
-git checkout tags/OpenSSL_1_0_2n
+git checkout tags/OpenSSL_1_1_1
 ./config --prefix=${HOME}/openssl/install --openssldir=${HOME}/openssl/ssl
 make -j4
 make install

--- a/src/base/cpp/Schnorr.cpp
+++ b/src/base/cpp/Schnorr.cpp
@@ -196,7 +196,7 @@ bool Schnorr::Sign(const bytes& message, unsigned int offset, unsigned int size,
       }
 
       err = (BN_nnmod(result.m_r.get(), result.m_r.get(), m_curve.m_order.get(),
-                      NULL) == 0);
+                      ctx.get()) == 0);
       if (err) {
         LOG_GENERAL(WARNING, "BIGNUM NNmod failed");
         return false;
@@ -370,7 +370,7 @@ bool Schnorr::Verify(const bytes& message, unsigned int offset,
       }
 
       err2 = (BN_nnmod(challenge_built.get(), challenge_built.get(),
-                       m_curve.m_order.get(), NULL) == 0);
+                       m_curve.m_order.get(), ctx.get()) == 0);
       err = err || err2;
       if (err2) {
         LOG_GENERAL(WARNING, "Challenge rebuild mod failed");


### PR DESCRIPTION
Fixes compilation with OpenSSL 1.1.1 on macOS (see https://github.com/Zilliqa/scilla/issues/745#issuecomment-571716107).