### PR TITLE
Define Address type

### DIFF
--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -525,8 +525,7 @@ let rename_bound_vars mk_new_name update_taken =
         let bt2 = recursor bt1 (update_taken arg' taken) in
         PolyFun (arg', bt2)
     | Address fts ->
-        let fts' = List.map fts ~f:(fun (f, t) -> (f, recursor t taken)) in
-        Address fts'
+        Address (List.map fts ~f:(fun (f, t) -> (f, recursor t taken)))
   in
   recursor
 

--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -94,6 +94,7 @@ type typ =
   | TypeVar of string
   | PolyFun of string * typ
   | Unit
+  | Address of (string * typ) list
 [@@deriving sexp]
 
 let int_bit_width_to_string = function
@@ -125,6 +126,11 @@ let rec pp_typ = function
   | TypeVar tv -> tv
   | PolyFun (tv, bt) -> sprintf "forall %s. %s" tv (pp_typ bt)
   | Unit -> sprintf "()"
+  | Address fts ->
+      let elems = List.map fts ~f:(fun (f, t) -> sprintf "%s : %s" f (pp_typ t)) |>
+                  String.concat ~sep:", "
+      in
+      sprintf "ByStr20 with %s end" elems
 
 and with_paren t =
   match t with
@@ -461,6 +467,8 @@ let free_tvars tp =
     | PolyFun (arg, bt) ->
         let acc' = go bt acc in
         rem acc' arg
+    | Address fts ->
+        List.fold_left fts ~init:acc ~f:(fun acc (_, t) -> go t acc)
   in
   go tp []
 
@@ -492,6 +500,8 @@ let rec subst_type_in_type tvar tp tm =
       ADT (s, ts')
   | PolyFun (arg, t) ->
       if tvar = arg then tm else PolyFun (arg, subst_type_in_type tvar tp t)
+  | Address fts ->
+      Address (List.map fts ~f:(fun (f, t) -> (f, subst_type_in_type tvar tp t)))
 
 (* note: this is sequential substitution of multiple variables,
           _not_ simultaneous substitution *)
@@ -514,6 +524,9 @@ let rename_bound_vars mk_new_name update_taken =
         let bt1 = subst_type_in_type arg tv_new bt in
         let bt2 = recursor bt1 (update_taken arg' taken) in
         PolyFun (arg', bt2)
+    | Address fts ->
+        let fts' = List.map fts ~f:(fun (f, t) -> (f, recursor t taken)) in
+        Address fts'
   in
   recursor
 

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -390,7 +390,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
               let%bind _ =
                 mark_error_as_type_error remaining_gas @@ check_field_type rtp
               in
-              if is_serializable_type rtp then
+              if is_legal_message_field_type rtp then
                 pure @@ (TypedSyntax.MVar (add_type_to_ident i t), remaining_gas)
               else
                 Error
@@ -838,7 +838,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
     @@
     let param_checker =
       match comp_type with
-      | CompTrans -> is_serializable_type
+      | CompTrans -> is_legal_parameter_type
       | CompProc -> is_non_map_ground_type
     in
     let%bind typed_cparams =
@@ -896,7 +896,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
                @@ assert_type_equiv ft actual
              in
              let typed_fs = add_type_to_ident fn ar in
-             if is_storable_type ft then
+             if is_legal_field_type ft then
                pure
                @@ ( ( (typed_fs, ft, typed_expr) :: acc,
                       TEnv.addT (TEnv.copy fenv) fn actual ),

--- a/src/base/TypeUtil.mli
+++ b/src/base/TypeUtil.mli
@@ -120,9 +120,11 @@ module TypeUtilities : sig
   (*                       Type sanitization                      *)
   (****************************************************************)
 
-  val is_storable_type : typ -> bool
+  val is_legal_message_field_type : typ -> bool
 
-  val is_serializable_type : typ -> bool
+  val is_legal_parameter_type : typ -> bool
+  
+  val is_legal_field_type : typ -> bool
 
   val is_ground_type : typ -> bool
 

--- a/src/checkers/Cashflow.ml
+++ b/src/checkers/Cashflow.ml
@@ -385,6 +385,7 @@ struct
                           new_map
                       | _ -> targ_tag_map )
                   | PrimType _ | PolyFun (_, _) | Unit -> targ_tag_map
+                  | Address _ -> targ_tag_map
                 in
                 let tvar_tag_map, _ =
                   List.fold_left arg_typs ~init:(init_targ_to_tag_map, arg_tags)
@@ -461,6 +462,7 @@ struct
     | Unit ->
         (* Ignore *)
         false
+    | Address _ -> (* TODO *) false
 
   let init_ctr_tag_map () =
     let open DataTypeDictionary in

--- a/src/checkers/Cashflow.ml
+++ b/src/checkers/Cashflow.ml
@@ -385,7 +385,7 @@ struct
                           new_map
                       | _ -> targ_tag_map )
                   | PrimType _ | PolyFun (_, _) | Unit -> targ_tag_map
-                  | Address _ -> targ_tag_map
+                  | Address _ -> (* TODO *) targ_tag_map
                 in
                 let tvar_tag_map, _ =
                   List.fold_left arg_typs ~init:(init_targ_to_tag_map, arg_tags)

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -70,7 +70,7 @@ let rec is_pure_literal l =
 (* Sanitize before storing into a message *)
 let sanitize_literal l =
   let%bind t = fromR @@ literal_type l in
-  if is_serializable_type t then pure l
+  if is_legal_message_field_type t then pure l
   else fail0 @@ sprintf "Cannot serialize literal %s" (pp_literal l)
 
 (*******************************************************)

--- a/src/runners/RunnerUtil.ml
+++ b/src/runners/RunnerUtil.ml
@@ -109,6 +109,8 @@ let eliminate_namespaces lib_tree ns_tree =
                   let tname' = check_and_prefix_string env tname in
                   let tlist' = List.map tlist ~f:(fun t -> recurser t) in
                   ADT (tname', tlist')
+              | Address fts ->
+                  Address (List.map fts ~f:(fun (f, t) -> (f, recurser t)))
             in
             recurser t
           in


### PR DESCRIPTION
This PR introduces the new address type, and implements the minimum features to make Scilla compile.

Two important design points:

1. Polymorphic addresses are allowed, i.e., we allow stuff like

```
let f =
  tfun 'A =>
  fun (other : ByStr20 with x : 'A end)
  ...
end
```

Since the pure part of Scilla won't be able to read the remote field (seen from the pure part of Scilla all addresses are just `ByStr20`s) I don't see any use for this feature, but it's easier to implement than to prohibit, and I don't see any problems with it either.

2. Legal address types.
- Addresses may be used as message field initialisers, in which case they are considered `ByStr20`.
- Addresses may be used as field types, provided that all fields declared in the type have legal field types themselves (i.e., they must be storable by the remote contract).
- Addresses may be used as contract/transition parameter types, provided that all fields declared in the type have legal field types.

Since polymorphic types are neither serialisable nor storable these restrictions ensure that the type of a remote state read is always known statically.


I have postponed the cashflow analysis implementation until I have a better feel for how remote state reads are to function.

I am merging this PR to the `remote_state_reads` branch, which will function as the temporary master branch for this feature. I don't want `master` to be cluttered with a partial implementation, but I also want to avoid a big, monolithic PR to be merged all at once without regular reviews along the way.