### PR TITLE
Syntax for address types

### DIFF
--- a/src/base/ParserFaults.messages
+++ b/src/base/ParserFaults.messages
@@ -168,7 +168,7 @@ This is an invalid forall type, after the type id (following forall) the parser 
 
 type_term: FORALL WITH
 ##
-## Ends in an error in state: 58.
+## Ends in an error in state: 58 (this isn't true anymore).
 ##
 ## typ -> FORALL . TID PERIOD typ [ TARROW RPAREN EQ EOF COMMA ]
 ##
@@ -1576,43 +1576,72 @@ This function needs an arrow (e.g. '=>') pointing to an expression.
 
 exp_term: FUN LPAREN ID COLON TID WITH
 ##
-## Ends in an error in state: 133.
+## Ends in an error in state: 73.
 ##
-## simple_exp -> FUN LPAREN ID COLON typ . RPAREN ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
-## typ -> typ . TARROW typ [ TARROW RPAREN ]
-##
+## simple_exp -> FUN LPAREN id_with_typ . RPAREN ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
+## typ -> typ . TARROW typ [ TARROW RPAREN EQ COMMA ]
+## type_annot -> COLON typ . [ EQ ]
+## param_pair -> ID COLON typ . [ RPAREN COMMA ]
+## field -> FIELD ID COLON typ . EQ exp [ TRANSITION PROCEDURE FIELD EOF ]
+## 
 ## The known suffix of the stack is as follows:
 ## FUN LPAREN ID COLON typ
+## LET ID COLON typ
+## SCILLA_VERSION NUMLIT CONTRACT CID LPAREN ID COLON TID WITH
+## SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD ID COLON TID WITH
 ##
 # see tests/parser/bad/exps/exp_t-fun-lparen-id-colon-tid-with.scilexp
 
-This function argument and argument type declaration is not closed properly.
+This type annotation is not closed properly, or has a missing or misplaced '='.
 
 exp_term: FUN LPAREN ID COLON WITH
 ##
-## Ends in an error in state: 132.
+## Ends in an error in state: 61.
 ##
 ## simple_exp -> FUN LPAREN ID COLON . typ RPAREN ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
-##
+## type_annot -> COLON . typ [ EQ ]
+## param_pair -> ID COLON . typ [ RPAREN COMMA ]
+## field -> FIELD ID COLON . typ EQ exp [ TRANSITION PROCEDURE FIELD EOF ]
+## 
 ## The known suffix of the stack is as follows:
 ## FUN LPAREN ID COLON
+## LET ID COLON WITH
+## SCILLA_VERSION NUMLIT CONTRACT CID LPAREN ID COLON WITH
+## SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD ID COLON WITH
 ##
 # see tests/parser/bad/exps/exp_t-fun-lparen-id-colon-with.scilexp
 
-This function argument lacks a valid type.
+Missing or invalid type in type annotation.
+
+cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN ID COLON ID RPAREN
+##
+## Ends in an error in state: 58.
+##
+## type_annot -> COLON . typ [ EQ ]
+## 
+## The known suffix of the stack is as follows:
+## SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD ID COLON WITH
+##
+# see tests/parser/bad/exps/exp_t-fun-lparen-id-colon-with.scilexp
+
+Invalid type in type annotation.
 
 exp_term: FUN LPAREN ID WITH
 ##
 ## Ends in an error in state: 131.
 ##
 ## simple_exp -> FUN LPAREN ID . COLON typ RPAREN ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
-##
+## param_pair -> ID . COLON typ [ RPAREN COMMA ]
+## field -> FIELD ID . COLON typ EQ exp [ TRANSITION PROCEDURE FIELD EOF ]
+## 
 ## The known suffix of the stack is as follows:
 ## FUN LPAREN ID
+## SCILLA_VERSION NUMLIT CONTRACT CID LPAREN ID WITH
+## SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD ID WITH
 ##
 # see tests/parser/bad/exps/exp_t-fun-lparen-id-with.scilexp
 
-This function's argument is lacking a colon to associate it with its type.
+Missing type annotation (a colon followed by a legal type).
 
 exp_term: FUN LPAREN WITH
 ##
@@ -1735,35 +1764,6 @@ exp_term: LET ID COLON TID EQ STRING IN WITH
 # see tests/parser/bad/exps/exp_t-let-id-colon-tid-eq-string-in-with.scilexp
 
 This let expression (type-annotated) is likely missing an expression to substitute into.
-
-exp_term: LET ID COLON TID WITH
-##
-## Ends in an error in state: 173.
-##
-## typ -> typ . TARROW typ [ TARROW EQ ]
-## type_annot -> COLON typ . [ EQ ]
-##
-## The known suffix of the stack is as follows:
-## COLON typ
-##
-# see tests/parser/bad/exps/exp_t-let-id-colon-tid-with.scilexp
-# say misplaced not missing because a reduction may not happen
-# as early as the user wanted in some cases
-
-This type-annotated let expression likely has a misplaced equals, '='.
-
-exp_term: LET ID COLON WITH
-##
-## Ends in an error in state: 172.
-##
-## type_annot -> COLON . typ [ EQ ]
-##
-## The known suffix of the stack is as follows:
-## COLON
-##
-# see tests/parser/bad/exps/exp_t-let-id-colon-with.scilexp
-
-This let expression is likely missing a complete type annotation after the colon.
 
 exp_term: LET ID EQ STRING IN WITH
 ##
@@ -2118,46 +2118,6 @@ cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN ID COLON CID COMMA WITH
 
 Following a comma in the list of immutable fields, the parser expects another immutable field.
 
-cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN ID COLON TID WITH
-##
-## Ends in an error in state: 198.
-##
-## param_pair -> ID COLON typ . [ RPAREN COMMA ]
-## typ -> typ . TARROW typ [ TARROW RPAREN COMMA ]
-##
-## The known suffix of the stack is as follows:
-## ID COLON typ
-##
-# see tests/parser/bad/cmodule-contract-cid-lparen-id-colon-tid-with.scilla
-
-Following the declaration of an immutable field, the parser expects another one separated by a comma or the end of the declarations with a right bracket.
-
-cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN ID COLON WITH
-##
-## Ends in an error in state: 197.
-##
-## param_pair -> ID COLON . typ [ RPAREN COMMA ]
-##
-## The known suffix of the stack is as follows:
-## ID COLON
-##
-# see tests/parser/bad/cmodule-contract-cid-lparen-id-colon-with.scilla
-
-In an immutable field declaration the parser expects a valid type name.
-
-cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN ID WITH
-##
-## Ends in an error in state: 196.
-##
-## param_pair -> ID . COLON typ [ RPAREN COMMA ]
-##
-## The known suffix of the stack is as follows:
-## ID
-##
-# see tests/parser/bad/cmodule-contract-cid-lparen-id-with.scilla
-
-In an immutable field declaration, the parser expects a colon following the name to precede the type.
-
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD ID COLON CID EQ HEXLIT WITH
 ##
 ## Ends in an error in state: 287.
@@ -2183,46 +2143,6 @@ cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD ID COLON TID EQ 
 # see tests/parser/bad/cmodule-field-id-colon-tid-eq-with.scilla
 
 In a mutable field declaration, it is expected that the field is initialised to be equal to some valid expression.
-
-cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD ID COLON TID WITH
-##
-## Ends in an error in state: 211.
-##
-## field -> FIELD ID COLON typ . EQ exp [ TRANSITION PROCEDURE FIELD EOF ]
-## typ -> typ . TARROW typ [ TARROW EQ ]
-##
-## The known suffix of the stack is as follows:
-## FIELD ID COLON typ
-##
-# see tests/parser/bad/cmodule-field-id-colon-tid-with.scilla
-
-In a mutable field declaration, after the type is specified an equals is expected.
-
-cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD ID COLON WITH
-##
-## Ends in an error in state: 210.
-##
-## field -> FIELD ID COLON . typ EQ exp [ TRANSITION PROCEDURE FIELD EOF ]
-##
-## The known suffix of the stack is as follows:
-## FIELD ID COLON
-##
-# see tests/parser/bad/cmodule-field-id-colon-with.scilla
-
-In a mutable field declaration, following the colon after the naming, a type is expected.
-
-cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD ID WITH
-##
-## Ends in an error in state: 209.
-##
-## field -> FIELD ID . COLON typ EQ exp [ TRANSITION PROCEDURE FIELD EOF ]
-##
-## The known suffix of the stack is as follows:
-## FIELD ID
-##
-# see tests/parser/bad/cmodule-field-id-with.scilla
-
-In a mutable field declaration, following the naming a colon is expected. This colon separates the name and the type.
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD WITH
 ##

--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -196,6 +196,10 @@ typ :
 | MAP; k=t_map_key; v = t_map_value; { MapType (k, v) }
 | t1 = typ; TARROW; t2 = typ; { FunType (t1, t2) }
 | LPAREN; t = typ; RPAREN; { t }
+| d = ID; WITH; fs = separated_list(COMMA, address_field_type); END;
+    { if d = "ByStr20"
+      then Address fs
+      else raise (SyntaxError ("Invalid primitive type", toLoc $startpos(d))) }
 | FORALL; tv = TID; PERIOD; t = typ; {PolyFun (tv, t)}
 %prec TARROW
 | t = TID; { TypeVar t }
@@ -205,6 +209,10 @@ targ:
 | d = scid; { to_type d }
 | t = TID; { TypeVar t }
 | MAP; k=t_map_key; v = t_map_value; { MapType (k, v) }
+
+address_field_type:
+| f = ID; COLON; t = typ; { (f, t) }
+
 
 (***********************************************)
 (*                 Expressions                 *)

--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -62,10 +62,6 @@
   let build_bool_literal v loc =
     (Literal (BuiltIns.UsefulLiterals.to_Bool v), loc)
 
-  let id_with_typ_to_idl_with_typ iwt loc =
-    match iwt with
-    | (i, t) -> (asIdL i loc, t)
-    
 %}
 
 (* Identifiers *)
@@ -170,7 +166,7 @@ type_annot:
 | COLON; t = typ { t }
 
 id_with_typ :
-| n = ID; t = type_annot { n, t }
+| n = ID; t = type_annot { (asIdL n (toLoc $startpos(n)), t) }
 
 
 (***********************************************)
@@ -240,7 +236,7 @@ simple_exp :
   {(Let ((Ident (x, toLoc $startpos(x))), t, f, e), toLoc $startpos(f)) }
 (* Function *)
 | FUN; LPAREN; iwt = id_with_typ; RPAREN; ARROW; e = exp
-    { match id_with_typ_to_idl_with_typ iwt (toLoc $startpos(iwt)) with
+    { match iwt with
       | (i, t) -> (Fun (i, t, e), toLoc $startpos(e) ) }
 (* Application *)
 | f = sid;
@@ -369,7 +365,7 @@ stmts_term:
 (***********************************************)
 
 param_pair:
-| iwt = id_with_typ { id_with_typ_to_idl_with_typ iwt (toLoc $startpos(iwt)) }
+| iwt = id_with_typ { iwt }
 
 component:
 | t = transition
@@ -410,7 +406,7 @@ component_body:
 field:
 | FIELD; iwt = id_with_typ
   EQ; rhs = exp
-    { match id_with_typ_to_idl_with_typ iwt (toLoc $startpos(iwt)) with
+    { match iwt with
       | (f, t) -> (f, t, rhs) }
 
 with_constraint:

--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -94,7 +94,7 @@ type typ =
   | TypeVar of string
   | PolyFun of string * typ
   | Unit
-  | Address of (string * typ) list
+  | Address of (loc ident * typ) list
 [@@deriving sexp]
 
 let int_bit_width_to_string = function
@@ -127,7 +127,7 @@ let rec pp_typ = function
   | PolyFun (tv, bt) -> sprintf "forall %s. %s" tv (pp_typ bt)
   | Unit -> sprintf "()"
   | Address fts ->
-      let elems = List.map fts ~f:(fun (f, t) -> sprintf "%s : %s" f (pp_typ t)) |>
+      let elems = List.map fts ~f:(fun (f, t) -> sprintf "%s : %s" (get_id f) (pp_typ t)) |>
                   String.concat ~sep:", "
       in
       sprintf "ByStr20 with %s end" elems

--- a/tests/base/parser/bad/gold/cmodule-contract-cid-lparen-id-colon-tid-with.scilla.gold
+++ b/tests/base/parser/bad/gold/cmodule-contract-cid-lparen-id-colon-tid-with.scilla.gold
@@ -2,7 +2,7 @@
   "errors": [
     {
       "error_message":
-        "Following the declaration of an immutable field, the parser expects another one separated by a comma or the end of the declarations with a right bracket.\n",
+        "This type annotation is not closed properly, or has a missing or misplaced '='.\n",
       "start_location": {
         "file":
           "base/parser/bad/cmodule-contract-cid-lparen-id-colon-tid-with.scilla",

--- a/tests/base/parser/bad/gold/cmodule-contract-cid-lparen-id-colon-with.scilla.gold
+++ b/tests/base/parser/bad/gold/cmodule-contract-cid-lparen-id-colon-with.scilla.gold
@@ -1,13 +1,12 @@
 {
   "errors": [
     {
-      "error_message":
-        "In an immutable field declaration the parser expects a valid type name.\n",
+      "error_message": "Invalid type in type annotation.\n",
       "start_location": {
         "file":
           "base/parser/bad/cmodule-contract-cid-lparen-id-colon-with.scilla",
         "line": 5,
-        "column": 19
+        "column": 20
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/base/parser/bad/gold/cmodule-contract-cid-lparen-id-with.scilla.gold
+++ b/tests/base/parser/bad/gold/cmodule-contract-cid-lparen-id-with.scilla.gold
@@ -2,7 +2,7 @@
   "errors": [
     {
       "error_message":
-        "In an immutable field declaration, the parser expects a colon following the name to precede the type.\n",
+        "Missing type annotation (a colon followed by a legal type).\n",
       "start_location": {
         "file": "base/parser/bad/cmodule-contract-cid-lparen-id-with.scilla",
         "line": 5,

--- a/tests/base/parser/bad/gold/cmodule-field-id-colon-tid-with.scilla.gold
+++ b/tests/base/parser/bad/gold/cmodule-field-id-colon-tid-with.scilla.gold
@@ -2,7 +2,7 @@
   "errors": [
     {
       "error_message":
-        "In a mutable field declaration, after the type is specified an equals is expected.\n",
+        "This type annotation is not closed properly, or has a missing or misplaced '='.\n",
       "start_location": {
         "file": "base/parser/bad/cmodule-field-id-colon-tid-with.scilla",
         "line": 7,

--- a/tests/base/parser/bad/gold/cmodule-field-id-colon-with.scilla.gold
+++ b/tests/base/parser/bad/gold/cmodule-field-id-colon-with.scilla.gold
@@ -1,12 +1,11 @@
 {
   "errors": [
     {
-      "error_message":
-        "In a mutable field declaration, following the colon after the naming, a type is expected.\n",
+      "error_message": "Invalid type in type annotation.\n",
       "start_location": {
         "file": "base/parser/bad/cmodule-field-id-colon-with.scilla",
         "line": 9,
-        "column": 19
+        "column": 21
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/base/parser/bad/gold/cmodule-field-id-with.scilla.gold
+++ b/tests/base/parser/bad/gold/cmodule-field-id-with.scilla.gold
@@ -2,7 +2,7 @@
   "errors": [
     {
       "error_message":
-        "In a mutable field declaration, following the naming a colon is expected. This colon separates the name and the type.\n",
+        "Missing type annotation (a colon followed by a legal type).\n",
       "start_location": {
         "file": "base/parser/bad/cmodule-field-id-with.scilla",
         "line": 7,

--- a/tests/base/parser/bad/gold/exp_t-fun-lparen-id-colon-tid-with.scilexp.gold
+++ b/tests/base/parser/bad/gold/exp_t-fun-lparen-id-colon-tid-with.scilexp.gold
@@ -2,7 +2,7 @@
   "errors": [
     {
       "error_message":
-        "This function argument and argument type declaration is not closed properly.\n",
+        "This type annotation is not closed properly, or has a missing or misplaced '='.\n",
       "start_location": {
         "file":
           "base/parser/bad/exps/exp_t-fun-lparen-id-colon-tid-with.scilexp",

--- a/tests/base/parser/bad/gold/exp_t-fun-lparen-id-colon-with.scilexp.gold
+++ b/tests/base/parser/bad/gold/exp_t-fun-lparen-id-colon-with.scilexp.gold
@@ -1,11 +1,11 @@
 {
   "errors": [
     {
-      "error_message": "This function argument lacks a valid type.\n",
+      "error_message": "Invalid type in type annotation.\n",
       "start_location": {
         "file": "base/parser/bad/exps/exp_t-fun-lparen-id-colon-with.scilexp",
         "line": 1,
-        "column": 13
+        "column": 14
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/base/parser/bad/gold/exp_t-fun-lparen-id-with.scilexp.gold
+++ b/tests/base/parser/bad/gold/exp_t-fun-lparen-id-with.scilexp.gold
@@ -2,7 +2,7 @@
   "errors": [
     {
       "error_message":
-        "This function's argument is lacking a colon to associate it with its type.\n",
+        "Missing type annotation (a colon followed by a legal type).\n",
       "start_location": {
         "file": "base/parser/bad/exps/exp_t-fun-lparen-id-with.scilexp",
         "line": 1,

--- a/tests/base/parser/bad/gold/exp_t-let-id-colon-tid-with.scilexp.gold
+++ b/tests/base/parser/bad/gold/exp_t-let-id-colon-tid-with.scilexp.gold
@@ -2,7 +2,7 @@
   "errors": [
     {
       "error_message":
-        "This type-annotated let expression likely has a misplaced equals, '='.\n",
+        "This type annotation is not closed properly, or has a missing or misplaced '='.\n",
       "start_location": {
         "file": "base/parser/bad/exps/exp_t-let-id-colon-tid-with.scilexp",
         "line": 1,

--- a/tests/base/parser/bad/gold/exp_t-let-id-colon-with.scilexp.gold
+++ b/tests/base/parser/bad/gold/exp_t-let-id-colon-with.scilexp.gold
@@ -1,12 +1,11 @@
 {
   "errors": [
     {
-      "error_message":
-        "This let expression is likely missing a complete type annotation after the colon.\n",
+      "error_message": "Invalid type in type annotation.\n",
       "start_location": {
         "file": "base/parser/bad/exps/exp_t-let-id-colon-with.scilexp",
         "line": 1,
-        "column": 13
+        "column": 15
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/base/parser/bad/gold/type_t-cid-lparen-with.scilla.gold
+++ b/tests/base/parser/bad/gold/type_t-cid-lparen-with.scilla.gold
@@ -1,12 +1,11 @@
 {
   "errors": [
     {
-      "error_message":
-        "This is an invalid type term, it is likely an ADT missing a valid type as an argument in brackets.\n",
+      "error_message": "Invalid type in type annotation.\n",
       "start_location": {
         "file": "base/parser/bad/type_t-cid-lparen-with.scilla",
         "line": 5,
-        "column": 30
+        "column": 31
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/base/parser/bad/gold/type_t-forall-tid-period-with.scilla.gold
+++ b/tests/base/parser/bad/gold/type_t-forall-tid-period-with.scilla.gold
@@ -1,12 +1,11 @@
 {
   "errors": [
     {
-      "error_message":
-        "This is an invalid forall type, after the period (following forall and a type id) the parser expects a valid type.\n",
+      "error_message": "Invalid type in type annotation.\n",
       "start_location": {
         "file": "base/parser/bad/type_t-forall-tid-period-with.scilla",
-        "line": 6,
-        "column": 27
+        "line": 8,
+        "column": 9
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/base/parser/bad/gold/type_t-tid-arrow-with.scilla.gold
+++ b/tests/base/parser/bad/gold/type_t-tid-arrow-with.scilla.gold
@@ -1,11 +1,11 @@
 {
   "errors": [
     {
-      "error_message": "This function type lacks a result type.\n",
+      "error_message": "Invalid type in type annotation.\n",
       "start_location": {
         "file": "base/parser/bad/type_t-tid-arrow-with.scilla",
-        "line": 7,
-        "column": 24
+        "line": 8,
+        "column": 1
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }


### PR DESCRIPTION
This PR implements the syntax for address types, e.g.:

```
field f : ByStr20 with x : Uint128 end

transition T ( x : ByStr20 with y : Bool end )
...
```

Address types are treated as any other type by the parser. Later phases will perform any additonal checks.

I had to rewrite the grammar for type annotations a little bit, because I ended up with a few shift/reduce conflicts. I also ended up with some incomprehensible parser faults, which as far as I can tell requires us to combine some of the error messages because the associated syntax errors now end up in the same parser state.