### PR TITLE
Refactor the project to not rely on hard-coded paths

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -181,11 +181,12 @@ make clean; make
 
 10. Test your installation by running
 ```shell
-./bin/eval-runner -gaslimit 10000 -libdir src/stdlib tests/eval/good/let.scilexp
+eval-runner -gaslimit 10000 -libdir src/stdlib tests/eval/good/let.scilexp
 ```
+from the project root.
 
 If the output is as below, then you are good to go 👍. No further action will be necessary.
-The binaries (`eval-runner`, `scilla-checker`, `scilla-runner` & `type-checker`) are all located in the `bin/` directory
+The binaries (`eval-runner`, `scilla-checker`, `scilla-runner` & `type-checker`) are all installed in your opam switch.
 
 ```
 { [a -> (Int32 42)],

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ slim:
 dev:
 	./scripts/libff.sh
 	dune build --profile dev @install
+	@test -L bin || ln -s _build/install/default/bin .
 
 # Launch utop such that it finds the libraroes.
 utop: all
@@ -31,43 +32,46 @@ utop: all
 fmt:
 	dune build @fmt --auto-promote
 
+# Installer, uninstaller and test the installation
+install : all
+	dune install
+
+# This is different from the target "test" which runs on dev builds.
+test_install : all
+	ulimit -n 1024; dune exec -- tests/polynomials/testsuite_polynomials.exe
+	ulimit -n 1024; dune exec -- tests/base/testsuite_base.exe -print-diff true
+	ulimit -n 1024; dune exec -- tests/testsuite.exe -print-diff true
+
+uninstall : all
+	dune uninstall
+
 # === TESTS (begin) ===========================================================
 # Build and run tests
 
 testbase: dev
   # This effectively adds all the runners into PATH variable
-	dune install
 	ulimit -n 1024; dune exec -- tests/base/testsuite_base.exe -print-diff true
-	dune uninstall
 
 goldbase: dev
-	dune install
 	ulimit -n 1024; dune exec tests/base/testsuite_base.exe -- -update-gold true
-	dune uninstall
 
 # Run all tests for all packages in the repo: scilla-base, polynomials, scilla
 test: dev
-	dune install
 	ulimit -n 1024; dune exec -- tests/polynomials/testsuite_polynomials.exe
 	ulimit -n 1024; dune exec -- tests/base/testsuite_base.exe -print-diff true
 	ulimit -n 1024; dune exec -- tests/testsuite.exe -print-diff true
-	dune uninstall
 
 gold: dev
-	dune install
 	ulimit -n 1024; dune exec -- tests/base/testsuite_base.exe -update-gold true
 	ulimit -n 1024; dune exec -- tests/testsuite.exe -update-gold true
-	dune uninstall
 
 # This must be run only if there is an external IPC server available
 # that can handle access requests. It is important to use the sequential runner here as we
 # don't want multiple threads of the testsuite connecting to the same server concurrently.
 test_extipcserver: dev
-	dune install
 	dune exec -- tests/testsuite.exe -print-diff true -runner sequential \
 	-ext-ipc-server $(IPC_SOCK_PATH) \
 	-only-test "all_tests:0:contract_tests:0:these_tests_must_SUCCEED"
-	dune uninstall
 
 # === TESTS (end) =============================================================
 

--- a/Makefile
+++ b/Makefile
@@ -13,20 +13,16 @@ default: all
 all:
 	./scripts/libff.sh
 	dune build --profile release @install
-	dune install
 
 # Build only scilla-checker and scilla-runner
 slim:
 	./scripts/libff.sh
 	dune build --profile release src/runners/scilla_runner.exe
 	dune build --profile release src/runners/scilla_checker.exe
-	dune install
 
 dev:
 	./scripts/libff.sh
 	dune build --profile dev @install
-  # This effectively adds all the runners into PATH variable
-	dune install
 
 # Launch utop such that it finds the libraroes.
 utop: all
@@ -39,28 +35,39 @@ fmt:
 # Build and run tests
 
 testbase: dev
+  # This effectively adds all the runners into PATH variable
+	dune install
 	ulimit -n 1024; dune exec -- tests/base/testsuite_base.exe -print-diff true
+	dune uninstall
 
 goldbase: dev
+	dune install
 	ulimit -n 1024; dune exec tests/base/testsuite_base.exe -- -update-gold true
+	dune uninstall
 
 # Run all tests for all packages in the repo: scilla-base, polynomials, scilla
 test: dev
+	dune install
 	ulimit -n 1024; dune exec -- tests/polynomials/testsuite_polynomials.exe
 	ulimit -n 1024; dune exec -- tests/base/testsuite_base.exe -print-diff true
 	ulimit -n 1024; dune exec -- tests/testsuite.exe -print-diff true
+	dune uninstall
 
 gold: dev
+	dune install
 	ulimit -n 1024; dune exec -- tests/base/testsuite_base.exe -update-gold true
 	ulimit -n 1024; dune exec -- tests/testsuite.exe -update-gold true
+	dune uninstall
 
 # This must be run only if there is an external IPC server available
 # that can handle access requests. It is important to use the sequential runner here as we
 # don't want multiple threads of the testsuite connecting to the same server concurrently.
 test_extipcserver: dev
+	dune install
 	dune exec -- tests/testsuite.exe -print-diff true -runner sequential \
 	-ext-ipc-server $(IPC_SOCK_PATH) \
 	-only-test "all_tests:0:contract_tests:0:these_tests_must_SUCCEED"
+	dune uninstall
 
 # === TESTS (end) =============================================================
 

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,14 @@
 OCAML_VERSION_RECOMMENDED=4.07.1
 IPC_SOCK_PATH="/tmp/zilliqa.sock"
 
-.PHONY: default all utop dev clean docker zilliqa-docker
+.PHONY: default release utop dev clean docker zilliqa-docker
 
-default: all
+default: release
 
 # Build one library and one standalone executable that implements
 # multiple subcommands and uses the library.
 # The library can be loaded in utop for interactive testing.
-all:
+release:
 	./scripts/libff.sh
 	dune build --profile release @install
 
@@ -26,23 +26,23 @@ dev:
 	@test -L bin || ln -s _build/install/default/bin .
 
 # Launch utop such that it finds the libraroes.
-utop: all
+utop: release
 	OCAMLPATH=_build/install/default/lib:$(OCAMLPATH) utop
 
 fmt:
 	dune build @fmt --auto-promote
 
 # Installer, uninstaller and test the installation
-install : all
+install : release
 	dune install
 
 # This is different from the target "test" which runs on dev builds.
-test_install : all
+test_install : install
 	ulimit -n 1024; dune exec -- tests/polynomials/testsuite_polynomials.exe
 	ulimit -n 1024; dune exec -- tests/base/testsuite_base.exe -print-diff true
 	ulimit -n 1024; dune exec -- tests/testsuite.exe -print-diff true
 
-uninstall : all
+uninstall : release
 	dune uninstall
 
 # === TESTS (begin) ===========================================================

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Once the project is built you can try the following things:
 From the project root, execute
 
 ```
-./bin/eval-runner -gaslimit 10000 -libdir src/stdlib tests/eval/good/let.scilexp
+eval-runner -gaslimit 10000 -libdir src/stdlib tests/eval/good/let.scilexp
 ```
 
 Instead of `let.scilla` you might want to try any different file in
@@ -61,7 +61,7 @@ list of paths separated with `:` (or `;` on Windows).
 From the project root, execute
 
 ```
-./bin/scilla-checker -gaslimit 10000 -libdir src/stdlib tests/contracts/auction.scilla
+scilla-checker -gaslimit 10000 -libdir src/stdlib tests/contracts/auction.scilla
 ```
 
 Instead of `auction.scilla` you might want to try any different file in
@@ -85,17 +85,17 @@ The checker can be run with the following optional flags:
 From the project root, execute
 
 ```
-./bin/scilla-runner -init tests/runner/crowdfunding/init.json -istate tests/runner/crowdfunding/state_4.json -iblockchain tests/runner/crowdfunding/blockchain_4.json -imessage tests/runner/crowdfunding/message_4.json -o tests/runner/crowdfunding/output_4.json -i tests/contracts/crowdfunding.scilla -libdir src/stdlib -gaslimit 8000
+scilla-runner -init tests/runner/crowdfunding/init.json -istate tests/runner/crowdfunding/state_4.json -iblockchain tests/runner/crowdfunding/blockchain_4.json -imessage tests/runner/crowdfunding/message_4.json -o tests/runner/crowdfunding/output_4.json -i tests/contracts/crowdfunding.scilla -libdir src/stdlib -gaslimit 8000
 ```
   or
 ```
-./bin/scilla-runner -init tests/runner/zil-game/init.json -istate tests/runner/zil-game/state_5.json -iblockchain tests/runner/zil-game/blockchain_5.json -imessage tests/runner/zil-game/message_5.json -o tests/runner/zil-game/output_5.json -i tests/contracts/zil-game.scilla -libdir src/stdlib -gaslimit 8000
+scilla-runner -init tests/runner/zil-game/init.json -istate tests/runner/zil-game/state_5.json -iblockchain tests/runner/zil-game/blockchain_5.json -imessage tests/runner/zil-game/message_5.json -o tests/runner/zil-game/output_5.json -i tests/contracts/zil-game.scilla -libdir src/stdlib -gaslimit 8000
 ```
 
 If you'd like to see the output produced by the aforementioned commands,
 check the file specified by `-o path/to/file.json` argument.
 
-Alternatively, use the easyrun script as below:
+Alternatively, use the `easyrun.sh` script as below:
 
 ```
 ./easyrun.sh crowdfunding 1
@@ -149,7 +149,7 @@ dune exec tests/testsuite.exe -- -list-test
 
 To run an individual test(s), for example
 `all_tests:1:exptests:14:let.scilla`
-(one of the tests from the list obtained via `./bin/testsuite -list-test`):
+(one of the tests from the list obtained via `dune exec -- tests/testsuite -list-test`):
 
 ```shell
 dune exec tests/testsuite.exe -- -only-test all_tests:1:exptests:14:let.scilla -print-cli true 

--- a/easyrun.sh
+++ b/easyrun.sh
@@ -38,7 +38,7 @@ then
     print_usage_and_exit
 fi
 
-./bin/scilla-runner -init ${cdir}/init.json -istate ${cdir}/state_${i}.json -imessage ${cdir}/message_${i}.json -o ${cdir}/output_${i}.json -iblockchain ${cdir}/blockchain_${i}.json -i ${sdir}/${contract}.scilla -libdir src/stdlib -gaslimit 8000 -libdir tests/contracts/shogi_lib
+scilla-runner -init ${cdir}/init.json -istate ${cdir}/state_${i}.json -imessage ${cdir}/message_${i}.json -o ${cdir}/output_${i}.json -iblockchain ${cdir}/blockchain_${i}.json -i ${sdir}/${contract}.scilla -libdir src/stdlib -gaslimit 8000 -libdir tests/contracts/shogi_lib
 
 status=$?
 

--- a/misc/emacs-mode/scilla-mode.el
+++ b/misc/emacs-mode/scilla-mode.el
@@ -1,15 +1,22 @@
 ;; This is an Emacs major mode for the Scilla language.
 ;; Include the below lines (with path set properly) in ~/.emacs
 ;;    ;; For enabling flycheck mode for Scilla.
-;;    (setq scilla-root "/absolute/path/to/scilla")
+;;    (setq scilla-mode-path "/absolute/path/to/scilla-mode.el")
+;;    (setq scilla-bin-path "/absolute/path/to/scilla-checkers-and-runners/bin")
+;;    (setq scilla-stdlib-path "/absolute/path/to/scilla/stdlib")
+;;
+;;    Note that `dune install` command, which executes when you do `make`,
+;;    issues the paths where it installs things. You may use that information
+;;    to setup some of the paths mentioned above.
+;;
 ;;    ;; Load the Scilla major mode.
-;;    (load-file (concat scilla-root "/misc/emacs-mode/scilla-mode.el"))
+;;    (load-file scilla-mode-path)
 ;;
 ;; or via use-package, e.g.:
 ;;
 ;; (use-package scilla
 ;;   :require flycheck
-;;   :load-path (lambda () (concat scilla-root "/misc/emacs-mode")))
+;;   :load-path (lambda () scilla-mode-path))
 
 (defvar scilla-mode-map
   (let ((map (make-sparse-keymap)))
@@ -349,18 +356,20 @@
     )
   )
 
-;; Set scilla-root in your ~/.emacs file as "setq scilla-root /path/to/scilla".
-;;  Note: make sure to set scilla-root *before* loading this file (scilla-mode.el)
-;; If scilla-root has been set and flycheck is available, enable flycheck.
-(if (boundp 'scilla-root)
+;; Set scilla paths (see file header) in your ~/.emacs file.
+;; Note: make sure to set the paths *before* loading this file (scilla-mode.el)
+;; If the paths have been set and flycheck is available, enable flycheck.
+(if (and (boundp 'scilla-mode-path)
+         (boundp 'scilla-bin-path)
+         (boundp 'scilla-stdlib-path))
     (progn
-      ;; derive stdlib and scilla-checker paths from scilla-root.
-      (setq lib-dir (concat scilla-root "/src/stdlib"))
-      (setq scilla-checker-bin (concat scilla-root "/bin/scilla-checker"))
+      (setq lib-dir scilla-stdlib-path)
+      (setq scilla-checker-bin (concat scilla-bin-path "/scilla-checker"))
       ;; See comment later on why we have two flycheck modes.
-      (setq type-checker-bin (concat scilla-root "/bin/type-checker"))
-      (if (and  (file-directory-p scilla-root) (file-directory-p lib-dir)
-                (file-exists-p scilla-checker-bin) (file-exists-p type-checker-bin))
+      (setq type-checker-bin (concat scilla-bin-path "/type-checker"))
+      (if (and (file-directory-p lib-dir)
+               (file-exists-p scilla-checker-bin)
+               (file-exists-p type-checker-bin))
         (progn
           (if (require 'flycheck nil t)
               (progn
@@ -422,10 +431,10 @@
             (message "json package not available")
             )
           )
-        (message "Scilla-Flycheck: scilla-root set incorrectly or one of src/stdlib bin/(scilla/type)-checker missing.")
+        (message "Scilla-Flycheck: scilla paths set incorrectly or one of stdlib or bin/(scilla/type)-checker missing.")
         )
       )
-  (message "Scilla-FlyCheck: scilla-root not set.")
+  (message "Scilla-FlyCheck: scilla paths not set.")
   )
 
  ;;; scilla-mode.el ends here

--- a/scripts/run_ipc_map_corner_tests.sh
+++ b/scripts/run_ipc_map_corner_tests.sh
@@ -4,7 +4,7 @@
 
 num_transitions=18
 ipcaddress=/tmp/zilliqa.sock
-scilla_runner=../bin/scilla-runner
+scilla_runner=scilla-runner
 test_source=../tests/contracts/map_corners_test.scilla
 libdir=../src/stdlib
 init_json_file=/tmp/ipc_map_corner_tests.init.json

--- a/src/runners/RunnerUtil.ml
+++ b/src/runners/RunnerUtil.ml
@@ -313,22 +313,15 @@ let import_all_libs ldirs =
     if not (Caml.Sys.file_exists dir) then []
     else
       let files = Array.to_list (Sys.readdir dir) in
-      List.fold_right files
-        ~f:(fun file names ->
-          if FilePath.check_extension file StdlibTracker.file_extn_library then
-            let name = FilePath.chop_extension (FilePath.basename file) in
-            (asId name, None (* no import-as *)) :: names
-          else names)
-        ~init:[]
+      List.filter_map files ~f:(fun file ->
+          let open FilePath in
+          if check_extension file StdlibTracker.file_extn_library then
+            let lib_name = chop_extension (basename file) in
+            Some (asId lib_name, None (* no import-as *))
+          else None)
   in
   (* Make a list of all libraries and parse them through import_lib above. *)
-  let names =
-    List.fold_right ldirs
-      ~f:(fun dir names ->
-        let names' = get_lib_list dir in
-        List.append names names')
-      ~init:[]
-  in
+  let names = List.concat_map ldirs ~f:get_lib_list in
   import_libs names None
 
 type runner_cli = {

--- a/src/stdlib/dune
+++ b/src/stdlib/dune
@@ -1,0 +1,9 @@
+(install
+ (section lib)
+ (package scilla)
+ (files
+  (BoolUtils.scillib as stdlib/BoolUtils.scillib)
+  (IntUtils.scillib as stdlib/IntUtils.scillib)
+  (ListUtils.scillib as stdlib/ListUtils.scillib)
+  (NatUtils.scillib as stdlib/NatUtils.scillib)
+  (PairUtils.scillib as stdlib/PairUtils.scillib)))

--- a/tests/runner/Testcontracts.ml
+++ b/tests/runner/Testcontracts.ml
@@ -105,12 +105,12 @@ let rec build_contract_tests_with_init_file env name exit_code i n
         if disable_validate_json then "-disable-validate-json" :: args'
         else args'
       in
-      let scillabin = env.bin_dir test_ctxt ^/ "scilla-runner" in
-      print_cli_usage (env.print_cli test_ctxt) scillabin args;
+      let runner = "scilla-runner" in
+      print_cli_usage (env.print_cli test_ctxt) runner args;
       let test_name = name ^ "_" ^ istr in
       let goldoutput_file = dir ^/ "output_" ^ istr ^. "json" in
-      let msg = cli_usage_on_err scillabin args in
-      assert_command ~exit_code ~use_stderr:true ~ctxt:test_ctxt scillabin args
+      let msg = cli_usage_on_err runner args in
+      assert_command ~exit_code ~use_stderr:true ~ctxt:test_ctxt runner args
         ~foutput:(fun s ->
           (* if the test is supposed to succeed we read the output from a file,
                  otherwise we read from the output stream *)
@@ -188,7 +188,7 @@ let build_contract_init_test env exit_code name init_name is_library =
       dir ^/ "blockchain_1" ^. "json";
     ]
   in
-  let scillabin = env.bin_dir test_ctxt ^/ "scilla-runner" in
+  let scillabin = "scilla-runner" in
   print_cli_usage (env.print_cli test_ctxt) scillabin args;
   let test_name = name ^ "_" ^ init_name in
   let goldoutput_file = dir ^/ init_name ^ "_output" ^. "json" in
@@ -206,7 +206,7 @@ let build_contract_init_test env exit_code name init_name is_library =
       else output_verifier goldoutput_file msg (env.print_diff test_ctxt) out)
 
 let build_misc_tests env =
-  let scillabin bin_dir test_ctxt = bin_dir test_ctxt ^/ "scilla-runner" in
+  let scillabin = "scilla-runner" in
   let output_file test_ctxt name = bracket_tmpdir test_ctxt ^/ name in
   let tests_dir_file testsdir test_ctxt name =
     testsdir test_ctxt ^/ "runner" ^/ "crowdfunding" ^/ name
@@ -233,7 +233,6 @@ let build_misc_tests env =
         tests_dir_file env.tests_dir test_ctxt ("blockchain_" ^ snum ^. "json");
       ]
     in
-    let scillabin = scillabin env.bin_dir test_ctxt in
     print_cli_usage (env.print_cli test_ctxt) scillabin args;
     assert_command ~exit_code:fail_code ~ctxt:test_ctxt scillabin args
   in

--- a/tests/runner/pingpong.sh
+++ b/tests/runner/pingpong.sh
@@ -3,43 +3,43 @@
 cd ../../
 
 echo "SetPongAddr"
-bin/scilla-runner -init tests/runner/ping/init.json -i tests/runner/ping/contract.scilla -o /tmp/ping_output.json -imessage tests/runner/ping/message_0.json -istate tests/runner/ping/state_0.json -iblockchain tests/runner/ping/blockchain_0.json
+scilla-runner -init tests/runner/ping/init.json -i tests/runner/ping/contract.scilla -o /tmp/ping_output.json -imessage tests/runner/ping/message_0.json -istate tests/runner/ping/state_0.json -iblockchain tests/runner/ping/blockchain_0.json
 echo "Output of Ping after setting pong address"
 cat /tmp/ping_output.json
 echo ""
 
 echo "SetPingAddr"
-bin/scilla-runner -init tests/runner/pong/init.json -i tests/runner/pong/contract.scilla -o /tmp/pong_output.json -imessage tests/runner/pong/message_0.json -istate tests/runner/pong/state_0.json -iblockchain tests/runner/pong/blockchain_0.json
+scilla-runner -init tests/runner/pong/init.json -i tests/runner/pong/contract.scilla -o /tmp/pong_output.json -imessage tests/runner/pong/message_0.json -istate tests/runner/pong/state_0.json -iblockchain tests/runner/pong/blockchain_0.json
 echo "Output of Pong after setting ping address"
 cat /tmp/pong_output.json
 echo ""
 
 echo "Ping ..."
-bin/scilla-runner -init tests/runner/ping/init.json -i tests/runner/ping/contract.scilla -o /tmp/ping_output.json -imessage tests/runner/ping/message_1.json -istate tests/runner/ping/state_1.json -iblockchain tests/runner/ping/blockchain_1.json
+scilla-runner -init tests/runner/ping/init.json -i tests/runner/ping/contract.scilla -o /tmp/ping_output.json -imessage tests/runner/ping/message_1.json -istate tests/runner/ping/state_1.json -iblockchain tests/runner/ping/blockchain_1.json
 echo "Output of Ping after pinging"
 cat /tmp/ping_output.json
 echo ""
 
 echo "Pong ..."
-bin/scilla-runner -init tests/runner/pong/init.json -i tests/runner/pong/contract.scilla -o /tmp/pong_output.json -imessage tests/runner/pong/message_1.json -istate tests/runner/pong/state_1.json -iblockchain tests/runner/pong/blockchain_1.json 
+scilla-runner -init tests/runner/pong/init.json -i tests/runner/pong/contract.scilla -o /tmp/pong_output.json -imessage tests/runner/pong/message_1.json -istate tests/runner/pong/state_1.json -iblockchain tests/runner/pong/blockchain_1.json 
 echo "Output of Pong after ponging"
 cat /tmp/pong_output.json
 echo ""
 
 echo "Ping ..."
-bin/scilla-runner -init tests/runner/ping/init.json -i tests/runner/ping/contract.scilla -o /tmp/ping_output.json -imessage tests/runner/ping/message_2.json -istate tests/runner/ping/state_2.json -iblockchain tests/runner/ping/blockchain_2.json
+scilla-runner -init tests/runner/ping/init.json -i tests/runner/ping/contract.scilla -o /tmp/ping_output.json -imessage tests/runner/ping/message_2.json -istate tests/runner/ping/state_2.json -iblockchain tests/runner/ping/blockchain_2.json
 echo "Output of Ping after pinging"
 cat /tmp/ping_output.json
 echo ""
 
 echo "Pong ..."
-bin/scilla-runner -init tests/runner/pong/init.json -i tests/runner/pong/contract.scilla -o /tmp/pong_output.json -imessage tests/runner/pong/message_2.json -istate tests/runner/pong/state_2.json -iblockchain tests/runner/pong/blockchain_2.json 
+scilla-runner -init tests/runner/pong/init.json -i tests/runner/pong/contract.scilla -o /tmp/pong_output.json -imessage tests/runner/pong/message_2.json -istate tests/runner/pong/state_2.json -iblockchain tests/runner/pong/blockchain_2.json 
 echo "Output of Pong after ponging"
 cat /tmp/pong_output.json
 echo ""
 
 echo "Ping ..."
-bin/scilla-runner -init tests/runner/ping/init.json -i tests/runner/ping/contract.scilla -o /tmp/ping_output.json -imessage tests/runner/ping/message_3.json -istate tests/runner/ping/state_3.json -iblockchain tests/runner/ping/blockchain_3.json 
+scilla-runner -init tests/runner/ping/init.json -i tests/runner/ping/contract.scilla -o /tmp/ping_output.json -imessage tests/runner/ping/message_3.json -istate tests/runner/ping/state_3.json -iblockchain tests/runner/ping/blockchain_3.json 
 echo "Output of Ping after pinging"
 cat /tmp/ping_output.json
 echo ""


### PR DESCRIPTION
This is needed to for the ongoing package splitting project.