### PR TITLE
Track source location for ADT names and their constructors

### DIFF
--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -1150,7 +1150,8 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let put_elab sc ts =
       match ts with
-      | [ MapType (kt, vt); kt'; vt' ] when type_equiv kt kt' && type_equiv vt vt' ->
+      | [ MapType (kt, vt); kt'; vt' ]
+        when type_equiv kt kt' && type_equiv vt vt' ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _ -> fail0 "Failed to elaborate"
 

--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -1129,7 +1129,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let contains_elab sc ts =
       match ts with
-      | [ MapType (kt, vt); u ] when kt = u ->
+      | [ MapType (kt, vt); u ] when type_equiv kt u ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -1150,7 +1150,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let put_elab sc ts =
       match ts with
-      | [ MapType (kt, vt); kt'; vt' ] when kt = kt' && vt = vt' ->
+      | [ MapType (kt, vt); kt'; vt' ] when type_equiv kt kt' && type_equiv vt vt' ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -1173,14 +1173,15 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let get_elab sc ts =
       match ts with
-      | [ MapType (kt, vt); kt' ] when kt = kt' ->
+      | [ MapType (kt, vt); kt' ] when type_equiv kt kt' ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _ -> fail0 "Failed to elaborate"
 
     (* Notice that get passes return type *)
     let get ls rt =
       match (ls, rt) with
-      | [ Map (_, entries); key ], ADT ("Option", [ targ ]) -> (
+      | [ Map (_, entries); key ], ADT (tname, [ targ ])
+        when get_id tname = "Option" -> (
           let res = Caml.Hashtbl.find_opt entries key in
           match res with None -> pure @@ none_lit targ | Some v -> some_lit v )
       | _ -> builtin_fail "Map.get" ls
@@ -1194,7 +1195,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let remove_elab sc ts =
       match ts with
-      | [ MapType (kt, vt); u ] when kt = u ->
+      | [ MapType (kt, vt); u ] when type_equiv kt u ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _ -> fail0 "Failed to elaborate"
 

--- a/src/base/Datatypes.mli
+++ b/src/base/Datatypes.mli
@@ -41,11 +41,14 @@ module DataTypeDictionary : sig
   (* Hiding the actual data type dicionary *)
 
   (*  Get ADT by name  *)
-  val lookup_name : string -> (adt, scilla_error list) result
+  val lookup_name :
+    ?sloc:ErrorUtils.loc -> string -> (adt, scilla_error list) result
 
   (*  Get ADT by the constructor  *)
   val lookup_constructor :
-    string -> (adt * constructor, scilla_error list) result
+    ?sloc:ErrorUtils.loc ->
+    string ->
+    (adt * constructor, scilla_error list) result
 
   (* Get typing map for a constructor *)
   val constr_tmap : adt -> string -> typ list option

--- a/src/base/JSON.ml
+++ b/src/base/JSON.ml
@@ -120,7 +120,7 @@ let rec json_to_adtargs cname tlist ajs =
   (* For each component literal of our ADT, calculate it's type.
    * This is essentially using DataTypes.constr_tmap and substituting safely. *)
   let tmap =
-    JSONParser.constr_pattern_arg_types_exn (ADT (dt.tname, tlist)) cname
+    JSONParser.constr_pattern_arg_types_exn (ADT (asId dt.tname, tlist)) cname
   in
   verify_args_exn cname (List.length ajs) (List.length tmap);
   let llist = List.map2_exn tmap ajs ~f:(fun t j -> json_to_lit t j) in
@@ -211,7 +211,7 @@ and json_to_lit t v =
       let vl = read_map_json kt vt v in
       vl
   | ADT (name, tlist) ->
-      let vl = read_adt_json name v tlist in
+      let vl = read_adt_json (get_id name) v tlist in
       vl
   | _ ->
       let tv = build_prim_lit_exn t (to_string_exn v) in

--- a/src/base/JSONParser.ml
+++ b/src/base/JSONParser.ml
@@ -45,7 +45,7 @@ let constr_pattern_arg_types_exn dt cname =
   | Ok s -> s
 
 let lookup_adt_name_exn name =
-  match DataTypeDictionary.lookup_name name with
+  match DataTypeDictionary.lookup_name (get_id name) with
   | Error emsg -> raise (Invalid_json emsg)
   | Ok s -> s
 
@@ -173,7 +173,7 @@ let gen_parser (t' : typ) : Basic.t -> literal =
                       ADTValue (cn.cname, tlist, arg_lits)
                 | `List vli ->
                     (* We make an exception for Lists, allowing them to be stored flatly. *)
-                    if name <> "List" then
+                    if (get_id name) <> "List" then
                       raise
                         (mk_invalid_json
                            "ADT value is a JSON array, but type is not List")

--- a/src/base/JSONParser.ml
+++ b/src/base/JSONParser.ml
@@ -173,7 +173,7 @@ let gen_parser (t' : typ) : Basic.t -> literal =
                       ADTValue (cn.cname, tlist, arg_lits)
                 | `List vli ->
                     (* We make an exception for Lists, allowing them to be stored flatly. *)
-                    if (get_id name) <> "List" then
+                    if get_id name <> "List" then
                       raise
                         (mk_invalid_json
                            "ADT value is a JSON array, but type is not List")

--- a/src/base/JSONParser.mli
+++ b/src/base/JSONParser.mli
@@ -33,7 +33,7 @@ val member_exn : string -> Basic.t -> Basic.t
 val constr_pattern_arg_types_exn : typ -> string -> typ list
 
 (*  Wrapper for DataTypeDictionary.lookup_name  *)
-val lookup_adt_name_exn : string -> Datatypes.adt
+val lookup_adt_name_exn : 'a Syntax.ident -> Datatypes.adt
 
 (*************************************)
 (*********** ADT parsers *************)

--- a/src/base/Recursion.ml
+++ b/src/base/Recursion.ml
@@ -69,7 +69,7 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
       | Wildcard -> pure @@ RecursionSyntax.Wildcard
       | Binder x -> pure @@ RecursionSyntax.Binder x
       | Constructor (s, ps) ->
-          let%bind _ = is_adt_ctr_in_scope (get_id s) in
+          let%bind _ = is_adt_ctr_in_scope s in
           let%bind new_ps = mapM ps ~f:walk in
           pure @@ RecursionSyntax.Constructor (s, new_ps)
     in
@@ -104,7 +104,7 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
             let%bind _ =
               forallM ~f:(fun t -> recursion_typ is_adt_in_scope t) ts
             in
-            let%bind _ = is_adt_ctr_in_scope (get_id s) in
+            let%bind _ = is_adt_ctr_in_scope s in
             pure @@ RecursionSyntax.Constr (s, ts, args)
         | MatchExpr (x, pes) ->
             let%bind new_pes =
@@ -331,20 +331,29 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
     let { lname; lentries } = lib in
     let is_adt_in_scope adts_in_scope adt_name =
       (* Check if type has already been declared *)
-      match List.findi adts_in_scope ~f:(fun _ n -> n = adt_name) with
+      match List.findi adts_in_scope ~f:(fun _ n -> n = get_id adt_name) with
       | Some _ -> pure @@ ()
       | None ->
           (* Check if the name is a builtin ADT *)
-          let%bind _ = DataTypeDictionary.lookup_name adt_name in
+          let%bind _ =
+            DataTypeDictionary.lookup_name ~sloc:(get_rep adt_name)
+              (get_id adt_name)
+          in
           pure @@ ()
     in
     let is_adt_ctr_in_scope adt_ctrs_in_scope ctr_name =
       (* Check if type has already been declared *)
-      match List.findi adt_ctrs_in_scope ~f:(fun _ n -> n = ctr_name) with
+      match
+        List.findi adt_ctrs_in_scope ~f:(fun _ n -> n = get_id ctr_name)
+      with
       | Some _ -> pure @@ ()
       | None ->
           (* Check if the name is a builtin ADT *)
-          let%bind _ = DataTypeDictionary.lookup_constructor ctr_name in
+          let%bind _ =
+            DataTypeDictionary.lookup_constructor
+              ~sloc:(SR.get_loc (get_rep ctr_name))
+              (get_id ctr_name)
+          in
           pure @@ ()
     in
     wrap_with_info
@@ -499,10 +508,16 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
          match
            recursion_contract
              (fun n ->
-               let%bind _ = DataTypeDictionary.lookup_name n in
+               let%bind _ =
+                 DataTypeDictionary.lookup_name ~sloc:(get_rep n) (get_id n)
+               in
                pure @@ ())
              (fun n ->
-               let%bind _ = DataTypeDictionary.lookup_constructor n in
+               let%bind _ =
+                 DataTypeDictionary.lookup_constructor
+                   ~sloc:(SR.get_loc (get_rep n))
+                   (get_id n)
+               in
                pure @@ ())
              contr
          with

--- a/src/base/Recursion.ml
+++ b/src/base/Recursion.ml
@@ -69,7 +69,7 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
       | Wildcard -> pure @@ RecursionSyntax.Wildcard
       | Binder x -> pure @@ RecursionSyntax.Binder x
       | Constructor (s, ps) ->
-          let%bind _ = is_adt_ctr_in_scope s in
+          let%bind _ = is_adt_ctr_in_scope (get_id s) in
           let%bind new_ps = mapM ps ~f:walk in
           pure @@ RecursionSyntax.Constructor (s, new_ps)
     in
@@ -104,7 +104,7 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
             let%bind _ =
               forallM ~f:(fun t -> recursion_typ is_adt_in_scope t) ts
             in
-            let%bind _ = is_adt_ctr_in_scope s in
+            let%bind _ = is_adt_ctr_in_scope (get_id s) in
             pure @@ RecursionSyntax.Constr (s, ts, args)
         | MatchExpr (x, pes) ->
             let%bind new_pes =

--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -240,7 +240,7 @@ simple_exp :
       (match ts with
        | None -> []
        | Some ls -> ls) in
-    (Constr (c, targs, args), toLoc $startpos)
+    (Constr (Ident(c, toLoc $startpos), targs, args), toLoc $startpos)
   }
 (* Match expression *)
 | MATCH; x = sid; WITH; cs=list(exp_pm_clause); END
@@ -282,12 +282,12 @@ map_access:
 pattern:
 | UNDERSCORE { Wildcard }
 | x = ID { Binder (Ident (x, toLoc $startpos(x))) }
-| c = scid; ps = list(arg_pattern) { Constructor (c, ps) }
+| c = scid; ps = list(arg_pattern) { Constructor (asIdL c (toLoc $startpos(c)), ps) }
 
 arg_pattern:
 | UNDERSCORE { Wildcard }
 | x = ID { Binder (Ident (x, toLoc $startpos(x))) }
-| c = scid;  { Constructor (c, []) }
+| c = scid;  { Constructor (asIdL c (toLoc $startpos(c)), []) }
 | LPAREN; p = pattern RPAREN; { p }
 
 exp_pm_clause:

--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -42,9 +42,9 @@
              Bystrx_typ b
            else raise (SyntaxError ("Invalid primitive type", loc))
 
-  let to_type d =
-    try PrimType (to_prim_type_exn d dummy_loc)
-    with | _ -> ADT (d, [])
+  let to_type d sloc =
+    try PrimType (to_prim_type_exn d sloc)
+    with | _ -> ADT (asIdL d sloc, [])
 
   let to_map_key_type_exn d loc =
     let exn () = SyntaxError (("Invalid map key type " ^ d), loc) in
@@ -172,26 +172,26 @@ t_map_key :
 (* TODO: This is a temporary fix of issue #261 *)
 t_map_value_args:
 | LPAREN; t = t_map_value_args; RPAREN; { t }
-| d = scid; { to_type d }
+| d = scid; { to_type d (toLoc $startpos(d))}
 | MAP; k=t_map_key; v = t_map_value; { MapType (k, v) }
 
 t_map_value :
 | LPAREN; d = scid; targs=list(t_map_value_args); RPAREN;
     { match targs with
-      | [] -> to_type d
-      | _ -> ADT (d, targs) }
+      | [] -> to_type d (toLoc $startpos(d))
+      | _ -> ADT (asIdL d (toLoc $startpos(d)), targs) }
 | LPAREN; MAP; k=t_map_key; v = t_map_value_args; RPAREN; { MapType (k, v) }
 | d = scid; targs=list(t_map_value_args)
     { match targs with
-      | [] -> to_type d
-      | _ -> ADT (d, targs) }
+      | [] -> to_type d (toLoc $startpos(d))
+      | _ -> ADT (asIdL d (toLoc $startpos(d)), targs) }
 | MAP; k=t_map_key; v = t_map_value; { MapType (k, v) }
 
 typ :
 | d = scid; targs=list(targ)
   { match targs with
-    | [] -> to_type d
-    | _ -> ADT (d, targs)
+    | [] -> to_type d (toLoc $startpos(d))
+    | _ -> ADT (asIdL d (toLoc $startpos(d)), targs)
   }
 | MAP; k=t_map_key; v = t_map_value; { MapType (k, v) }
 | t1 = typ; TARROW; t2 = typ; { FunType (t1, t2) }
@@ -202,7 +202,7 @@ typ :
 
 targ:
 | LPAREN; t = typ; RPAREN; { t }
-| d = scid; { to_type d }
+| d = scid; { to_type d (toLoc $startpos(d))}
 | t = TID; { TypeVar t }
 | MAP; k=t_map_key; v = t_map_value; { MapType (k, v) }
 

--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -603,7 +603,7 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
   type pattern =
     | Wildcard
     | Binder of ER.rep ident
-    | Constructor of SR.rep ident * (pattern list)
+    | Constructor of SR.rep ident * pattern list
   [@@deriving sexp]
 
   type expr_annot = expr * ER.rep
@@ -615,7 +615,7 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
     | Message of (string * payload) list
     | Fun of ER.rep ident * typ * expr_annot
     | App of ER.rep ident * ER.rep ident list
-    | Constr of (SR.rep ident) * typ list * ER.rep ident list
+    | Constr of SR.rep ident * typ list * ER.rep ident list
     | MatchExpr of ER.rep ident * (pattern * expr_annot) list
     | Builtin of ER.rep builtin_annot * ER.rep ident list
     (* Advanced features: to be added in Scilla 0.2 *)
@@ -867,7 +867,8 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
       | Message _ -> sprintf "Type error in message.\n"
       | Fun _ -> sprintf "Type error in function:\n"
       | App (f, _) -> sprintf "Type error in application of `%s`:\n" (get_id f)
-      | Constr (s, _, _) -> sprintf "Type error in constructor `%s`:\n" (get_id s)
+      | Constr (s, _, _) ->
+          sprintf "Type error in constructor `%s`:\n" (get_id s)
       | MatchExpr (x, _) ->
           sprintf
             "Type error in pattern matching on `%s`%s (or one of its branches):\n"

--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -541,7 +541,8 @@ let type_equiv t1 t2 =
     | MapType (t1_1, t1_2), MapType (t2_1, t2_2)
     | FunType (t1_1, t1_2), FunType (t2_1, t2_2) ->
         equiv t1_1 t2_1 && equiv t1_2 t2_2
-    | PolyFun (v1, t1''), PolyFun (v2, t2'') -> String.equal v1 v2 && equiv t1'' t2''
+    | PolyFun (v1, t1''), PolyFun (v2, t2'') ->
+        String.equal v1 v2 && equiv t1'' t2''
     | _ -> false
   in
   equiv t1' t2'

--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -603,7 +603,7 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
   type pattern =
     | Wildcard
     | Binder of ER.rep ident
-    | Constructor of string * pattern list
+    | Constructor of SR.rep ident * (pattern list)
   [@@deriving sexp]
 
   type expr_annot = expr * ER.rep
@@ -615,7 +615,7 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
     | Message of (string * payload) list
     | Fun of ER.rep ident * typ * expr_annot
     | App of ER.rep ident * ER.rep ident list
-    | Constr of string * typ list * ER.rep ident list
+    | Constr of (SR.rep ident) * typ list * ER.rep ident list
     | MatchExpr of ER.rep ident * (pattern * expr_annot) list
     | Builtin of ER.rep builtin_annot * ER.rep ident list
     (* Advanced features: to be added in Scilla 0.2 *)
@@ -867,7 +867,7 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
       | Message _ -> sprintf "Type error in message.\n"
       | Fun _ -> sprintf "Type error in function:\n"
       | App (f, _) -> sprintf "Type error in application of `%s`:\n" (get_id f)
-      | Constr (s, _, _) -> sprintf "Type error in constructor `%s`:\n" s
+      | Constr (s, _, _) -> sprintf "Type error in constructor `%s`:\n" (get_id s)
       | MatchExpr (x, _) ->
           sprintf
             "Type error in pattern matching on `%s`%s (or one of its branches):\n"

--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -530,8 +530,8 @@ let type_equiv t1 t2 =
   let t2' = canonicalize_tfun t2 in
   let rec equiv t1 t2 =
     match (t1, t2) with
-    | PrimType p1, PrimType p2 when p1 = p2 -> true
-    | TypeVar v1, TypeVar v2 when v1 = v2 -> true
+    | PrimType p1, PrimType p2 -> p1 = p2
+    | TypeVar v1, TypeVar v2 -> String.equal v1 v2
     | Unit, Unit -> true
     | ADT (tname1, tl1), ADT (tname2, tl2) ->
         equal_id tname1 tname2
@@ -541,7 +541,7 @@ let type_equiv t1 t2 =
     | MapType (t1_1, t1_2), MapType (t2_1, t2_2)
     | FunType (t1_1, t1_2), FunType (t2_1, t2_2) ->
         equiv t1_1 t2_1 && equiv t1_2 t2_2
-    | PolyFun (v1, t1''), PolyFun (v2, t2'') -> v1 = v2 && equiv t1'' t2''
+    | PolyFun (v1, t1''), PolyFun (v2, t2'') -> String.equal v1 v2 && equiv t1'' t2''
     | _ -> false
   in
   equiv t1' t2'

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -252,18 +252,20 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
         in
         let open Datatypes.DataTypeDictionary in
         let%bind _, constr =
-          mark_error_as_type_error remaining_gas @@ lookup_constructor (get_id cname)
+          mark_error_as_type_error remaining_gas
+          @@ lookup_constructor (get_id cname)
         in
         let alen = List.length actuals in
         if constr.arity <> alen then
           Error
             (mk_type_error0
-               (sprintf "Constructor %s expects %d arguments, but got %d." (get_id cname)
-                  constr.arity alen)
+               (sprintf "Constructor %s expects %d arguments, but got %d."
+                  (get_id cname) constr.arity alen)
                remaining_gas)
         else
           let%bind ftyp =
-            mark_error_as_type_error remaining_gas @@ elab_constr_type (get_id cname) ts
+            mark_error_as_type_error remaining_gas
+            @@ elab_constr_type (get_id cname) ts
           in
           (* Now type-check as a function application *)
           let%bind typed_actuals, apptyp, remaining_gas =

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -253,7 +253,9 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
         let open Datatypes.DataTypeDictionary in
         let%bind _, constr =
           mark_error_as_type_error remaining_gas
-          @@ lookup_constructor (get_id cname)
+          @@ lookup_constructor
+               ~sloc:(SR.get_loc (get_rep cname))
+               (get_id cname)
         in
         let alen = List.length actuals in
         if constr.arity <> alen then
@@ -633,7 +635,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
             in
             (* The return type of MapGet would be (Option v_type) or Bool. *)
             let v_type' =
-              if valfetch then ADT ("Option", [ v_type ]) else ADT ("Bool", [])
+              if valfetch then ADT (asId "Option", [ v_type ]) else ADT (asId "Bool", [])
             in
             (* Update environment. *)
             let pure' = TEnv.addT (TEnv.copy env.pure) v v_type' in
@@ -1246,7 +1248,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
               in
               let%bind _ =
                 mark_error_as_type_error remaining_gas
-                @@ assert_type_equiv (ADT ("Bool", [])) ityp.tp
+                @@ assert_type_equiv (ADT (asId "Bool", [])) ityp.tp
               in
               pure (checked_constraint, remaining_gas)
          in

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -635,7 +635,8 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
             in
             (* The return type of MapGet would be (Option v_type) or Bool. *)
             let v_type' =
-              if valfetch then ADT (asId "Option", [ v_type ]) else ADT (asId "Bool", [])
+              if valfetch then ADT (asId "Option", [ v_type ])
+              else ADT (asId "Bool", [])
             in
             (* Update environment. *)
             let pure' = TEnv.addT (TEnv.copy env.pure) v v_type' in

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -144,10 +144,10 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
           @@ ( TypedSyntax.Binder (add_type_to_ident x (mk_qual_tp atyp)),
                (x, atyp) :: tlist )
       | Constructor (cn, ps) ->
-          let%bind arg_types = constr_pattern_arg_types atyp cn in
+          let%bind arg_types = constr_pattern_arg_types atyp (get_id cn) in
           let plen = List.length arg_types in
           let alen = List.length ps in
-          let%bind _ = validate_param_length cn plen alen in
+          let%bind _ = validate_param_length (get_id cn) plen alen in
           let tps_pts = List.zip_exn arg_types ps in
           let%bind typed_ps, tps =
             foldrM ~init:([], tlist) tps_pts ~f:(fun (ps, ts) (t, pt) ->
@@ -252,18 +252,18 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
         in
         let open Datatypes.DataTypeDictionary in
         let%bind _, constr =
-          mark_error_as_type_error remaining_gas @@ lookup_constructor cname
+          mark_error_as_type_error remaining_gas @@ lookup_constructor (get_id cname)
         in
         let alen = List.length actuals in
         if constr.arity <> alen then
           Error
             (mk_type_error0
-               (sprintf "Constructor %s expects %d arguments, but got %d." cname
+               (sprintf "Constructor %s expects %d arguments, but got %d." (get_id cname)
                   constr.arity alen)
                remaining_gas)
         else
           let%bind ftyp =
-            mark_error_as_type_error remaining_gas @@ elab_constr_type cname ts
+            mark_error_as_type_error remaining_gas @@ elab_constr_type (get_id cname) ts
           in
           (* Now type-check as a function application *)
           let%bind typed_actuals, apptyp, remaining_gas =

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -183,11 +183,12 @@ functor
               is_wf_typ' rt tb
           | ADT (n, ts) ->
               let open Datatypes.DataTypeDictionary in
-              let%bind adt = lookup_name n in
+              let%bind adt = lookup_name ~sloc:(get_rep n) (get_id n) in
               if List.length ts <> List.length adt.tparams then
-                fail0
-                @@ sprintf "ADT type %s expects %d arguments but got %d.\n" n
-                     (List.length adt.tparams) (List.length ts)
+                fail1
+                  (sprintf "ADT type %s expects %d arguments but got %d.\n"
+                     (get_id n) (List.length adt.tparams) (List.length ts))
+                  (get_rep n)
               else foldM ~f:(fun _ ts' -> is_wf_typ' ts' tb) ~init:() ts
           | PrimType _ | Unit -> pure ()
           | TypeVar a -> (
@@ -277,12 +278,6 @@ module TypeUtilities = struct
 
   let unit_typ = Unit
 
-  (* Type equivalence *)
-  let type_equiv t1 t2 =
-    let t1' = canonicalize_tfun t1 in
-    let t2' = canonicalize_tfun t2 in
-    t1' = t2'
-
   (* Return True if corresponding elements are `type_equiv`,
      False otherwise, or if unequal lengths. *)
   let type_equiv_list tlist1 tlist2 =
@@ -347,7 +342,10 @@ module TypeUtilities = struct
         | Some _ -> true (* Inductive ADT - ignore this branch *)
         | None -> (
             (* Check that ADT is serializable *)
-            match DataTypeDictionary.lookup_name tname with
+            match
+              DataTypeDictionary.lookup_name ~sloc:(get_rep tname)
+                (get_id tname)
+            with
             | Error _ -> false (* Handle errors outside *)
             | Ok adt ->
                 let adt_serializable =
@@ -570,7 +568,7 @@ module TypeUtilities = struct
     { adt with tparams = tparams'; tmap = tmap' }
 
   (*  Get elaborated constructor type *)
-  let elab_constr_type ?(_sloc = dummy_loc) cn targs =
+  let elab_constr_type cn targs =
     let open Datatypes.DataTypeDictionary in
     let%bind adt', _ = lookup_constructor cn in
     let seq a b = if a = b then 0 else 1 in
@@ -583,7 +581,7 @@ module TypeUtilities = struct
     let plen = List.length adt.tparams in
     let alen = List.length targs in
     let%bind _ = validate_param_length cn plen alen in
-    let res_typ = ADT (adt.tname, targs) in
+    let res_typ = ADT (asId adt.tname, targs) in
     match List.find adt.tmap ~f:(fun (n, _) -> n = cn) with
     | None -> pure res_typ
     | Some (_, ctparams) ->
@@ -598,7 +596,7 @@ module TypeUtilities = struct
   let extract_targs cn (adt : Datatypes.adt) atyp =
     match atyp with
     | ADT (name, targs) ->
-        if adt.tname = name then
+        if adt.tname = get_id name then
           let plen = List.length adt.tparams in
           let alen = List.length targs in
           let%bind _ = validate_param_length cn plen alen in
@@ -608,7 +606,7 @@ module TypeUtilities = struct
           @@ sprintf
                "Types don't match: pattern uses a constructor of type %s, but \
                 value of type %s is given."
-               adt.tname name
+               adt.tname (get_id name)
     | _ -> fail0 @@ sprintf "Not an algebraic data type: %s" (pp_typ atyp)
 
   let constr_pattern_arg_types atyp cn =
@@ -658,7 +656,7 @@ module TypeUtilities = struct
     | Map ((kt, vt), _) -> pure (MapType (kt, vt))
     | ADTValue (cname, ts, _) ->
         let%bind adt, _ = DataTypeDictionary.lookup_constructor cname in
-        pure @@ ADT (adt.tname, ts)
+        pure @@ ADT (asId adt.tname, ts)
     | Clo _ -> fail0 @@ "Cannot type runtime closure."
     | TAbs _ -> fail0 @@ "Cannot type runtime type function."
 
@@ -727,7 +725,7 @@ module TypeUtilities = struct
                tname (List.length args) cname
           (* Verify that the types of args match that declared. *)
         else
-          let res = ADT (tname, ts) in
+          let res = ADT (asId tname, ts) in
           let%bind tmap = constr_pattern_arg_types res cname in
           let%bind arg_typs = mapM ~f:(fun l -> is_wellformed_lit l) args in
           let args_valid =

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -570,7 +570,7 @@ module TypeUtilities = struct
     { adt with tparams = tparams'; tmap = tmap' }
 
   (*  Get elaborated constructor type *)
-  let elab_constr_type cn targs =
+  let elab_constr_type ?(_sloc = dummy_loc) cn targs =
     let open Datatypes.DataTypeDictionary in
     let%bind adt', _ = lookup_constructor cn in
     let seq a b = if a = b then 0 else 1 in

--- a/src/base/TypeUtil.mli
+++ b/src/base/TypeUtil.mli
@@ -207,7 +207,8 @@ module TypeUtilities : sig
   val apply_type_subst : (string * typ) list -> typ -> typ
 
   (*  Get elaborated type for a constructor and list of type arguments *)
-  val elab_constr_type : ?_sloc:loc -> string -> typ list -> (typ, scilla_error list) result
+  val elab_constr_type :
+    ?_sloc:loc -> string -> typ list -> (typ, scilla_error list) result
 
   (* For a given instantiated ADT and a construtor name, get type *
      assignments. This is the main working horse of type-checking

--- a/src/base/TypeUtil.mli
+++ b/src/base/TypeUtil.mli
@@ -207,7 +207,7 @@ module TypeUtilities : sig
   val apply_type_subst : (string * typ) list -> typ -> typ
 
   (*  Get elaborated type for a constructor and list of type arguments *)
-  val elab_constr_type : string -> typ list -> (typ, scilla_error list) result
+  val elab_constr_type : ?_sloc:loc -> string -> typ list -> (typ, scilla_error list) result
 
   (* For a given instantiated ADT and a construtor name, get type *
      assignments. This is the main working horse of type-checking

--- a/src/base/TypeUtil.mli
+++ b/src/base/TypeUtil.mli
@@ -139,8 +139,6 @@ module TypeUtilities : sig
   (*             Utility function for matching types              *)
   (****************************************************************)
 
-  val type_equiv : typ -> typ -> bool
-
   val type_equiv_list : typ list -> typ list -> bool
 
   type typeCheckerErrorType = TypeError | GasError
@@ -207,8 +205,7 @@ module TypeUtilities : sig
   val apply_type_subst : (string * typ) list -> typ -> typ
 
   (*  Get elaborated type for a constructor and list of type arguments *)
-  val elab_constr_type :
-    ?_sloc:loc -> string -> typ list -> (typ, scilla_error list) result
+  val elab_constr_type : string -> typ list -> (typ, scilla_error list) result
 
   (* For a given instantiated ADT and a construtor name, get type *
      assignments. This is the main working horse of type-checking

--- a/src/checkers/Cashflow.ml
+++ b/src/checkers/Cashflow.ml
@@ -337,7 +337,7 @@ struct
                      match arg_typs with [] -> true | _ -> false)
               && List.exists adt.tmap ~f:(fun (_, arg_typs) ->
                      match arg_typs with
-                     | [ ADT (arg_typ_name, _) ] -> arg_typ_name = adt.tname
+                     | [ ADT (arg_typ_name, _) ] -> (get_id arg_typ_name) = adt.tname
                      | _ -> false)
             then NoInfo
             else Adt (adt.tname, [])
@@ -444,7 +444,7 @@ struct
                   NoInfo
               | MapType (_, vt) | FunType (_, vt) -> Map (tag_tmap vt)
               | ADT (adt_name, arg_typs) ->
-                  Adt (adt_name, List.map arg_typs ~f:tag_tmap)
+                  Adt (get_id adt_name, List.map arg_typs ~f:tag_tmap)
               | TypeVar tvar -> (
                   match List.Assoc.find tvar_tag_map ~equal:( = ) tvar with
                   | Some tag -> tag

--- a/src/checkers/Cashflow.ml
+++ b/src/checkers/Cashflow.ml
@@ -1053,11 +1053,11 @@ struct
                   acc_changes || p_changes ))
           in
           let new_ctr_tag_map, ctr_tag_map_changes =
-            update_ctr_tag_map ps_ctr_tag_map s new_ps_tags
+            update_ctr_tag_map ps_ctr_tag_map (get_id s) new_ps_tags
             |> Option.value_map ~default:(ps_ctr_tag_map, false) ~f:(fun map ->
                    (map, true))
           in
-          let ctr_tag = ctr_to_adt_tag s new_ps_tags in
+          let ctr_tag = ctr_to_adt_tag (get_id s) new_ps_tags in
           ( Constructor (s, new_ps),
             ctr_tag,
             new_local_env,
@@ -1079,7 +1079,7 @@ struct
           (Binder new_x, new_x_tag <> get_id_tag x)
       | Constructor (s, ps) ->
           let expected_subtags =
-            match ctr_pattern_to_subtags s expected_tag with
+            match ctr_pattern_to_subtags (get_id s) expected_tag with
             | Some ts -> ts
             | None -> List.map ps ~f:(fun _ -> NoInfo)
           in
@@ -1109,7 +1109,7 @@ struct
       | Binder x -> lub_tags (get_id_tag x) acc_tag
       | Constructor (s, ps) ->
           let expected_subtags =
-            match ctr_pattern_to_subtags s acc_tag with
+            match ctr_pattern_to_subtags (get_id s) acc_tag with
             | Some ts -> ts
             | None -> List.map ps ~f:(fun _ -> NoInfo)
           in
@@ -1118,7 +1118,7 @@ struct
             | Ok tps -> tps
             | Unequal_lengths -> []
           in
-          let new_tag = ctr_to_adt_tag s subpattern_tags in
+          let new_tag = ctr_to_adt_tag (get_id s) subpattern_tags in
           lub_tags new_tag acc_tag
     in
     List.fold_left ps ~init:NoInfo ~f:walk
@@ -1309,12 +1309,12 @@ struct
             | Unequal_lengths -> false
           in
           let new_ctr_tag_map, ctr_tag_map_changes =
-            update_ctr_tag_map ctr_tag_map cname
+            update_ctr_tag_map ctr_tag_map (get_id cname)
               (List.map new_args ~f:get_id_tag)
             |> Option.value_map ~default:(ctr_tag_map, false) ~f:(fun map ->
                    (map, true))
           in
-          let tag = ctr_to_adt_tag cname (List.map new_args ~f:get_id_tag) in
+          let tag = ctr_to_adt_tag (get_id cname) (List.map new_args ~f:get_id_tag) in
           ( Constr (cname, ts, new_args),
             tag,
             param_env,

--- a/src/checkers/Cashflow.ml
+++ b/src/checkers/Cashflow.ml
@@ -1314,7 +1314,9 @@ struct
             |> Option.value_map ~default:(ctr_tag_map, false) ~f:(fun map ->
                    (map, true))
           in
-          let tag = ctr_to_adt_tag (get_id cname) (List.map new_args ~f:get_id_tag) in
+          let tag =
+            ctr_to_adt_tag (get_id cname) (List.map new_args ~f:get_id_tag)
+          in
           ( Constr (cname, ts, new_args),
             tag,
             param_env,

--- a/src/checkers/Cashflow.ml
+++ b/src/checkers/Cashflow.ml
@@ -337,7 +337,8 @@ struct
                      match arg_typs with [] -> true | _ -> false)
               && List.exists adt.tmap ~f:(fun (_, arg_typs) ->
                      match arg_typs with
-                     | [ ADT (arg_typ_name, _) ] -> (get_id arg_typ_name) = adt.tname
+                     | [ ADT (arg_typ_name, _) ] ->
+                         get_id arg_typ_name = adt.tname
                      | _ -> false)
             then NoInfo
             else Adt (adt.tname, [])

--- a/src/checkers/GasUseAnalysis.ml
+++ b/src/checkers/GasUseAnalysis.ml
@@ -1084,7 +1084,7 @@ struct
   (* Hardcode signature for folds. *)
   let analyze_folds genv =
     (*  list_foldr: forall 'A . forall 'B . g:('A -> 'B -> 'B) -> b:'B -> a:(List 'A) -> 'B *)
-    let a = ER.mk_id (mk_ident "a") (ADT ("List", [ TypeVar "'A" ])) in
+    let a = ER.mk_id (mk_ident "a") (ADT (asId "List", [ TypeVar "'A" ])) in
     let g =
       ER.mk_id (mk_ident "g")
         (FunType (TypeVar "'A", FunType (TypeVar "'B", TypeVar "'B")))

--- a/src/checkers/GasUseAnalysis.ml
+++ b/src/checkers/GasUseAnalysis.ml
@@ -736,7 +736,7 @@ struct
     | Wildcard -> pure genv
     | Binder i -> pure @@ GUAEnv.addS genv (get_id i) ([], msref, empty_pn)
     | Constructor (cname, plist) -> (
-        match (get_id cname) with
+        match get_id cname with
         | "True" | "False" | "Nil" | "None" -> pure @@ genv
         | "Some" ->
             (* TypeChecker will ensure that plist has unit length. *)
@@ -760,7 +760,7 @@ struct
         | _ ->
             fail0
               (Printf.sprintf "Unsupported constructor %s in gas analysis."
-                 (get_id cname) ))
+                 (get_id cname)) )
 
   (* built-in op costs are propotional to size of data they operate on. *)
   (* TODO: Have all numbers in one place. Integrate with Gas.ml *)
@@ -963,7 +963,7 @@ struct
         pure (args, ressize, add_pn p cc)
     | Constr (cname, _, actuals) ->
         let%bind ressize =
-          match (get_id cname) with
+          match get_id cname with
           | "True" | "False" -> pure @@ SPol (const_pn 1)
           | "Nil" -> pure @@ Container (SPol (const_pn 0), SPol (const_pn 1))
           | "None" -> pure @@ SPol (const_pn 1)

--- a/src/checkers/GasUseAnalysis.ml
+++ b/src/checkers/GasUseAnalysis.ml
@@ -736,7 +736,7 @@ struct
     | Wildcard -> pure genv
     | Binder i -> pure @@ GUAEnv.addS genv (get_id i) ([], msref, empty_pn)
     | Constructor (cname, plist) -> (
-        match cname with
+        match (get_id cname) with
         | "True" | "False" | "Nil" | "None" -> pure @@ genv
         | "Some" ->
             (* TypeChecker will ensure that plist has unit length. *)
@@ -760,7 +760,7 @@ struct
         | _ ->
             fail0
               (Printf.sprintf "Unsupported constructor %s in gas analysis."
-                 cname) )
+                 (get_id cname) ))
 
   (* built-in op costs are propotional to size of data they operate on. *)
   (* TODO: Have all numbers in one place. Integrate with Gas.ml *)
@@ -963,7 +963,7 @@ struct
         pure (args, ressize, add_pn p cc)
     | Constr (cname, _, actuals) ->
         let%bind ressize =
-          match cname with
+          match (get_id cname) with
           | "True" | "False" -> pure @@ SPol (const_pn 1)
           | "Nil" -> pure @@ Container (SPol (const_pn 0), SPol (const_pn 1))
           | "None" -> pure @@ SPol (const_pn 1)
@@ -1020,7 +1020,7 @@ struct
           | _ ->
               fail1
                 (Printf.sprintf "Unsupported constructor %s in gas analysis."
-                   cname)
+                   (get_id cname))
                 (ER.get_loc rep)
         in
         pure ([], ressize, cc)

--- a/src/checkers/PatternChecker.ml
+++ b/src/checkers/PatternChecker.ml
@@ -95,7 +95,8 @@ struct
           in
           let success () =
             let%bind t_args = get_t_args () in
-            traverse_pattern (((get_id c_name), []) :: ctx)
+            traverse_pattern
+              ((get_id c_name, []) :: ctx)
               ((sps_cons, t_args, get_dsc_args dsc) :: sps_rest)
               i rest_clauses
           in
@@ -104,7 +105,9 @@ struct
               (build_dsc ctx new_dsc sps_rest)
               (i + 1) rest_clauses
           in
-          let%bind adt, _ = DataTypeDictionary.lookup_constructor (get_id c_name) in
+          let%bind adt, _ =
+            DataTypeDictionary.lookup_constructor (get_id c_name)
+          in
           let span = List.length adt.tconstr in
           match static_match (get_id c_name) span dsc with
           | Yes -> success ()

--- a/src/checkers/PatternChecker.ml
+++ b/src/checkers/PatternChecker.ml
@@ -87,7 +87,7 @@ struct
           traverse_pattern (augment_ctx ctx dsc) sps_rest i rest_clauses
       | Constructor (c_name, sps_cons) -> (
           let arity () = List.length sps_cons in
-          let get_t_args () = constr_pattern_arg_types t c_name in
+          let get_t_args () = constr_pattern_arg_types t (get_id c_name) in
           let get_dsc_args dsc =
             match dsc with
             | Pos (_, args) -> args
@@ -95,7 +95,7 @@ struct
           in
           let success () =
             let%bind t_args = get_t_args () in
-            traverse_pattern ((c_name, []) :: ctx)
+            traverse_pattern (((get_id c_name), []) :: ctx)
               ((sps_cons, t_args, get_dsc_args dsc) :: sps_rest)
               i rest_clauses
           in
@@ -104,14 +104,14 @@ struct
               (build_dsc ctx new_dsc sps_rest)
               (i + 1) rest_clauses
           in
-          let%bind adt, _ = DataTypeDictionary.lookup_constructor c_name in
+          let%bind adt, _ = DataTypeDictionary.lookup_constructor (get_id c_name) in
           let span = List.length adt.tconstr in
-          match static_match c_name span dsc with
+          match static_match (get_id c_name) span dsc with
           | Yes -> success ()
           | No -> failure dsc
           | Maybe ->
               let%bind s_tree = success () in
-              let%bind f_tree = failure (add_neg dsc c_name) in
+              let%bind f_tree = failure (add_neg dsc (get_id c_name)) in
               pure @@ IfEq (t, c_name, s_tree, f_tree) )
     in
     let%bind decision_tree = traverse_clauses (Neg []) 0 clauses in

--- a/src/checkers/PatternChecker.ml
+++ b/src/checkers/PatternChecker.ml
@@ -106,7 +106,9 @@ struct
               (i + 1) rest_clauses
           in
           let%bind adt, _ =
-            DataTypeDictionary.lookup_constructor (get_id c_name)
+            DataTypeDictionary.lookup_constructor
+              ~sloc:(SR.get_loc (get_rep c_name))
+              (get_id c_name)
           in
           let span = List.length adt.tconstr in
           match static_match (get_id c_name) span dsc with

--- a/src/checkers/SanityChecker.ml
+++ b/src/checkers/SanityChecker.ml
@@ -182,7 +182,7 @@ struct
       match t with
       | MapType _
       (* The result of a <- a[][], i.e., "a" is an Option type. *)
-      | ADT ("Option", [ MapType _ ]) ->
+      | ADT (Ident ("Option", _), [ MapType _ ]) ->
           warn1 "Consider using in-place Map access"
             warning_level_map_load_store lc
       | _ -> ()

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -523,7 +523,8 @@ let init_contract clibs elibs cconstraint' cparams' cfields args' init_bal =
           tryM
             ~f:(fun (ps, pt) ->
               let%bind at = fromR @@ literal_type (snd a) in
-              if get_id ps = fst a && type_equiv pt at then pure true else fail0 "")
+              if get_id ps = fst a && type_equiv pt at then pure true
+              else fail0 "")
             cparams ~msg:emsg
         in
         pure mp)

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -130,7 +130,10 @@ let rec exp_eval erep env =
       pure (fully_applied, env)
   | Constr (cname, ts, actuals) ->
       let open Datatypes.DataTypeDictionary in
-      let%bind _, constr = fromR @@ lookup_constructor (get_id cname) in
+      let%bind _, constr =
+        fromR
+        @@ lookup_constructor ~sloc:(SR.get_loc (get_rep cname)) (get_id cname)
+      in
       let alen = List.length actuals in
       if constr.arity <> alen then
         fail1
@@ -520,7 +523,7 @@ let init_contract clibs elibs cconstraint' cparams' cfields args' init_bal =
           tryM
             ~f:(fun (ps, pt) ->
               let%bind at = fromR @@ literal_type (snd a) in
-              if get_id ps = fst a && pt = at then pure true else fail0 "")
+              if get_id ps = fst a && type_equiv pt at then pure true else fail0 "")
             cparams ~msg:emsg
         in
         pure mp)

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -134,8 +134,8 @@ let rec exp_eval erep env =
       let alen = List.length actuals in
       if constr.arity <> alen then
         fail1
-        ((sprintf "Constructor %s expects %d arguments, but got %d." (get_id cname)
-             constr.arity alen))
+          (sprintf "Constructor %s expects %d arguments, but got %d."
+             (get_id cname) constr.arity alen)
           (SR.get_loc (get_rep cname))
       else
         (* Resolve the actuals *)

--- a/src/eval/PatternMatching.ml
+++ b/src/eval/PatternMatching.ml
@@ -29,7 +29,7 @@ let rec match_with_pattern v p =
   | Wildcard -> pure []
   | Binder x -> pure @@ [ (x, v) ]
   | Constructor (cn, ps) -> (
-      let%bind _, ctr = DataTypeDictionary.lookup_constructor cn in
+      let%bind _, ctr = DataTypeDictionary.lookup_constructor (get_id cn) in
       (* Check that the pattern is well-formed *)
       if ctr.arity <> List.length ps then
         fail0

--- a/src/eval/PatternMatching.ml
+++ b/src/eval/PatternMatching.ml
@@ -29,7 +29,11 @@ let rec match_with_pattern v p =
   | Wildcard -> pure []
   | Binder x -> pure @@ [ (x, v) ]
   | Constructor (cn, ps) -> (
-      let%bind _, ctr = DataTypeDictionary.lookup_constructor (get_id cn) in
+      let%bind _, ctr =
+        DataTypeDictionary.lookup_constructor
+          ~sloc:(SR.get_loc (get_rep cn))
+          (get_id cn)
+      in
       (* Check that the pattern is well-formed *)
       if ctr.arity <> List.length ps then
         fail0

--- a/src/runners/RunnerUtil.ml
+++ b/src/runners/RunnerUtil.ml
@@ -143,7 +143,7 @@ let eliminate_namespaces lib_tree ns_tree =
                 let ils' = List.map ils ~f:(check_and_prefix_id env) in
                 (App (i', ils'), eloc)
             | Constr (cname, tl, idl) ->
-                let cname' = check_and_prefix_string env cname in
+                let cname' = check_and_prefix_id env cname in
                 let tl' = List.map tl ~f:(fun t -> rename_in_type t env) in
                 let idl' = List.map idl ~f:(check_and_prefix_id env) in
                 (Constr (cname', tl', idl'), eloc)
@@ -154,7 +154,7 @@ let eliminate_namespaces lib_tree ns_tree =
                   | Wildcard -> (pat, [])
                   | Binder i -> (pat, [ get_id i ])
                   | Constructor (c, plist) ->
-                      let c' = check_and_prefix_string env c in
+                      let c' = check_and_prefix_id env c in
                       let plist', blist =
                         List.unzip @@ List.map plist ~f:(rename_in_pattern env)
                       in

--- a/src/runners/RunnerUtil.ml
+++ b/src/runners/RunnerUtil.ml
@@ -93,11 +93,6 @@ let eliminate_namespaces lib_tree ns_tree =
                 asIdL nname (get_rep id)
             | _ -> id
           in
-          let check_and_prefix_string env cname =
-            match List.Assoc.find env ~equal:( = ) cname with
-            | Some ns when ns <> "" -> ns ^ "." ^ cname
-            | _ -> cname
-          in
           let rename_in_type t env =
             let rec recurser t =
               match t with
@@ -106,7 +101,7 @@ let eliminate_namespaces lib_tree ns_tree =
               | FunType (t1, t2) -> FunType (recurser t1, recurser t2)
               | PolyFun (tvar, t) -> PolyFun (tvar, recurser t)
               | ADT (tname, tlist) ->
-                  let tname' = check_and_prefix_string env tname in
+                  let tname' = check_and_prefix_id env tname in
                   let tlist' = List.map tlist ~f:(fun t -> recurser t) in
                   ADT (tname', tlist')
             in

--- a/tests/checker/bad/TestCheckerFail.ml
+++ b/tests/checker/bad/TestCheckerFail.ml
@@ -67,6 +67,7 @@ module Tests = TestUtil.DiffBasedTests (struct
       "bad_adt_3.scilla";
       "bad_adt_4.scilla";
       "bad_adt_7.scilla";
+      "bad_adt_8.scilla";
       "unserializable_param.scilla";
       "unstorable_adt.scilla";
       "bad_version.scilla";

--- a/tests/checker/bad/bad_adt_8.scilla
+++ b/tests/checker/bad/bad_adt_8.scilla
@@ -1,0 +1,9 @@
+scilla_version 0
+
+library Test
+
+let bn = BNum 100
+let i32 = MyInt32
+
+contract Test ()
+

--- a/tests/checker/bad/gold/bad_adt_4.scilla.gold
+++ b/tests/checker/bad/gold/bad_adt_4.scilla.gold
@@ -30,7 +30,11 @@
     },
     {
       "error_message": "ADT TestType2 not found",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "start_location": {
+        "file": "checker/bad/bad_adt_4.scilla",
+        "line": 9,
+        "column": 12
+      },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ],

--- a/tests/checker/bad/gold/bad_adt_7.scilla.gold
+++ b/tests/checker/bad/gold/bad_adt_7.scilla.gold
@@ -12,7 +12,11 @@
     },
     {
       "error_message": "ADT BNum not found",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "start_location": {
+        "file": "checker/bad/bad_adt_7.scilla",
+        "line": 10,
+        "column": 23
+      },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ],

--- a/tests/checker/bad/gold/bad_adt_8.scilla.gold
+++ b/tests/checker/bad/gold/bad_adt_8.scilla.gold
@@ -2,38 +2,38 @@
   "gas_remaining": "8000",
   "errors": [
     {
-      "error_message": "Type error(s) in contract Crowdfunding:\n",
+      "error_message": "Type error(s) in contract Test:\n",
       "start_location": {
-        "file": "checker/bad/unbound.scilla",
-        "line": 48,
+        "file": "checker/bad/bad_adt_8.scilla",
+        "line": 8,
         "column": 10
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message": "Type error in library Crowdfunding:\n",
+      "error_message": "Type error in library Test:\n",
       "start_location": {
-        "file": "checker/bad/unbound.scilla",
-        "line": 9,
+        "file": "checker/bad/bad_adt_8.scilla",
+        "line": 3,
         "column": 1
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message": "Type error in library variable check_update:\n",
+      "error_message": "Type error in library variable i32:\n",
       "start_location": {
-        "file": "checker/bad/unbound.scilla",
-        "line": 16,
+        "file": "checker/bad/bad_adt_8.scilla",
+        "line": 6,
         "column": 5
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message": "ADT Uint12 not found",
+      "error_message": "No data type with constructor MyInt32 found",
       "start_location": {
-        "file": "checker/bad/unbound.scilla",
-        "line": 19,
-        "column": 17
+        "file": "checker/bad/bad_adt_8.scilla",
+        "line": 6,
+        "column": 11
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/typecheck/bad/gold/adt-error1.scilexp.gold
+++ b/tests/typecheck/bad/gold/adt-error1.scilexp.gold
@@ -6,7 +6,7 @@
       "start_location": {
         "file": "typecheck/bad/adt-error1.scilexp",
         "line": 5,
-        "column": 10
+        "column": 17
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/typecheck/bad/gold/fun3.scilexp.gold
+++ b/tests/typecheck/bad/gold/fun3.scilexp.gold
@@ -2,7 +2,11 @@
   "errors": [
     {
       "error_message": "ADT Int54 not found",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "start_location": {
+        "file": "typecheck/bad/fun3.scilexp",
+        "line": 2,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ],

--- a/tests/typecheck/bad/gold/nth-error.scilexp.gold
+++ b/tests/typecheck/bad/gold/nth-error.scilexp.gold
@@ -6,7 +6,7 @@
       "start_location": {
         "file": "typecheck/bad/nth-error.scilexp",
         "line": 14,
-        "column": 11
+        "column": 20
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/typecheck/good/Testtypes.ml
+++ b/tests/typecheck/good/Testtypes.ml
@@ -23,7 +23,6 @@ module TestTypeUtils = TypeUtil.TypeUtilities
 
 let make_type_equiv_test st1 st2 eq =
   let open FrontEndParser in
-  let open TestTypeUtils in
   let t1, t2 =
     match (parse_type st1, parse_type st2) with
     | Ok t1, Ok t2 -> (t1, t2)


### PR DESCRIPTION
This PR attaches location info to Constructor names and ADT type names.

The one downside I see to this PR is that it further enforces having to use `type_equiv` (note the changes in many places). This is because, even for non-polymorphic types we now need to use `type_equiv`. But this is probably **good** because using `=` to compare even primitive types wasn't a good practice anyway.

I don't know of a good way to prevent use of `=` for comparing types, accidentally. In addition to the test case that was added in #458, I've added one more test. A couple of other existing tests show improved location information too.

Closes #456 