### PR TITLE
Forbid polymorphic compare

### DIFF
--- a/scilla.opam
+++ b/scilla.opam
@@ -23,6 +23,7 @@ depends: [
   "ocaml-protoc" {>= "1.2.0" & < "2.1~"}
   "ppx_deriving" {>= "4.2.1" & < "4.5~"}
   "ppx_sexp_conv" {>= "v0.12.0" & < "v0.13~"}
+  "ppx_compare" {>= "v0.12.0" & < "v0.13~"}
   "ppx_deriving_rpc" {>= "6.0.0" & < "7.0~"}
   "secp256k1" {>= "0.4.0" & < "0.5~"}
   "stdint" {>= "0.5.1" & < "0.7~"}

--- a/src/base/AssocDictionary.ml
+++ b/src/base/AssocDictionary.ml
@@ -20,6 +20,9 @@
 (*   Dictionaries, i.e., maps from strings to values      *)
 (**********************************************************)
 
+open Core_kernel
+open! Int.Replace_polymorphic_compare
+
 (* Simple association list implementation of a dictionary. *)
 type key = string
 
@@ -27,46 +30,37 @@ type 'a dict = (key * 'a) list
 
 let make_dict () = []
 
+(* removes just the first key-value binding, if it exists *)
 let rec remove k d =
   match d with
   | [] -> []
-  | (kd, vd) :: rest -> if k = kd then rest else (kd, vd) :: remove k rest
+  | (kd, vd) :: rest -> if String.(k = kd) then rest else (kd, vd) :: remove k rest
 
-let rec remove_all k d =
-  match d with
-  | [] -> []
-  | (kd, vd) :: rest ->
-      if k = kd then remove_all k rest else (kd, vd) :: remove_all k rest
+let remove_all k d = List.Assoc.remove d k ~equal:String.( = )
 
 let insert k v d = (k, v) :: d
 
 let insert_all other_d this_d = other_d @ this_d
 
 let lookup k d =
-  match List.find_opt (fun (kd, _) -> k = kd) d with
-  | None -> None
-  | Some (_, v) -> Some v
+  List.Assoc.find d k ~equal:String.( = )
 
+(* updates just the first key-value binding, if it exists *)
 let rec update k v d =
   match d with
   | [] -> []
   | (kd, vd) :: rest ->
-      if k = kd then (k, v) :: rest else (kd, vd) :: update k v rest
+      if String.(k = kd) then (k, v) :: rest else (kd, vd) :: update k v rest
 
-let rec update_all k v d =
-  match d with
-  | [] -> []
-  | (kd, vd) :: rest ->
-      if k = kd then (k, v) :: update_all k v rest
-      else (kd, vd) :: update_all k v rest
+let update_all k v d =
+  List.Assoc.add d k v ~equal:String.( = )
 
 let insert_unique k v d =
-  let d' = remove_all k d in
-  insert k v d'
+  List.Assoc.add d k v ~equal:String.( = )
 
-let filter ~f d = List.filter (fun (k, _) -> f k) d
+let filter ~f d = List.filter d ~f:(fun (k, _) -> f k)
 
-let is_empty d = match d with [] -> true | _ -> false
+let is_empty d = List.is_empty d
 
 let to_list d = d
 

--- a/src/base/AssocDictionary.ml
+++ b/src/base/AssocDictionary.ml
@@ -34,7 +34,8 @@ let make_dict () = []
 let rec remove k d =
   match d with
   | [] -> []
-  | (kd, vd) :: rest -> if String.(k = kd) then rest else (kd, vd) :: remove k rest
+  | (kd, vd) :: rest ->
+      if String.(k = kd) then rest else (kd, vd) :: remove k rest
 
 let remove_all k d = List.Assoc.remove d k ~equal:String.( = )
 
@@ -42,8 +43,7 @@ let insert k v d = (k, v) :: d
 
 let insert_all other_d this_d = other_d @ this_d
 
-let lookup k d =
-  List.Assoc.find d k ~equal:String.( = )
+let lookup k d = List.Assoc.find d k ~equal:String.( = )
 
 (* updates just the first key-value binding, if it exists *)
 let rec update k v d =
@@ -52,11 +52,9 @@ let rec update k v d =
   | (kd, vd) :: rest ->
       if String.(k = kd) then (k, v) :: rest else (kd, vd) :: update k v rest
 
-let update_all k v d =
-  List.Assoc.add d k v ~equal:String.( = )
+let update_all k v d = List.Assoc.add d k v ~equal:String.( = )
 
-let insert_unique k v d =
-  List.Assoc.add d k v ~equal:String.( = )
+let insert_unique k v d = List.Assoc.add d k v ~equal:String.( = )
 
 let filter ~f d = List.filter d ~f:(fun (k, _) -> f k)
 

--- a/src/base/Bech32.ml
+++ b/src/base/Bech32.ml
@@ -17,7 +17,7 @@
 *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open Bitstring
 open Utils
 
@@ -73,11 +73,14 @@ let decode_bech32_addr ~prefix ~addr:str =
   if String.length str <> bech32_addr_len ~prefix then None
   else if
     (* 2. Must begin with prefix. *)
-    String.sub str ~pos:0 ~len:(String.length prefix) <> prefix
+    let len = String.length prefix in
+    let prfx = prefix in
+    String.(sub str ~pos:0 ~len <> prfx)
   then None
   else if
     (* 3. Must have separator "1" after prefix. *)
-    String.sub str ~pos:(String.length prefix) ~len:1 <> "1"
+    let len = String.length prefix in
+    String.(sub str ~pos:len ~len:1 <> "1")
   then None
   else
     (* 4. Scan the prefix for errors. *)

--- a/src/base/Bech32.ml
+++ b/src/base/Bech32.ml
@@ -22,7 +22,7 @@ open Bitstring
 open Utils
 
 (* https://github.com/Zilliqa/Zilliqa/wiki/Address-Standard#specification *)
-let bech32_addr_len ~prefix = String.length prefix + 1 + 32 + 6
+let bech32_addr_len ~prfx = String.length prfx + 1 + 32 + 6
 
 let bech32_payload_len = 32
 
@@ -68,24 +68,23 @@ let bytes_of_bitstring bs = Bytes.of_string @@ string_of_bitstring bs
 
 (* Decodes a bech32 address string to a string of 20 bytes.
  * Signature: prefix -> bech32_addr -> bystr20 address option. *)
-let decode_bech32_addr ~prefix ~addr:str =
+let decode_bech32_addr ~prfx ~addr:str =
   (* 1. Must be of the right length. *)
-  if String.length str <> bech32_addr_len ~prefix then None
+  if String.length str <> bech32_addr_len ~prfx then None
   else if
     (* 2. Must begin with prefix. *)
-    let len = String.length prefix in
-    let prfx = prefix in
+    let len = String.length prfx in
     String.(sub str ~pos:0 ~len <> prfx)
   then None
   else if
     (* 3. Must have separator "1" after prefix. *)
-    let len = String.length prefix in
+    let len = String.length prfx in
     String.(sub str ~pos:len ~len:1 <> "1")
   then None
   else
     (* 4. Scan the prefix for errors. *)
     let chk, err, (have_lower, have_upper) =
-      List.fold (String.to_list prefix)
+      List.fold (String.to_list prfx)
         ~init:(1, false, (false, false))
         ~f:(fun (chk, err, (have_lower, have_upper)) ch ->
           if err || ascii_of_char ch < 33 || ascii_of_char ch > 126 then
@@ -113,14 +112,14 @@ let decode_bech32_addr ~prefix ~addr:str =
       (* 5. Checksum the prefix *)
       let chk = bech32_polymod_step chk in
       let chk =
-        List.fold (String.to_list prefix) ~init:chk ~f:(fun acc_chk c ->
+        List.fold (String.to_list prfx) ~init:chk ~f:(fun acc_chk c ->
             bech32_polymod_step acc_chk lxor (ascii_of_char c land 0x1f))
       in
 
       (* 6. Scan the addr and checksum for errors. *)
       let addr_chk_str =
         String.sub str
-          ~pos:(String.length prefix + 1)
+          ~pos:(String.length prfx + 1)
           ~len:(bech32_payload_len + bech32_chk_len)
       in
       (* Create a buffer of bits for the result (20-byte raw address). *)
@@ -167,18 +166,18 @@ let decode_bech32_addr ~prefix ~addr:str =
 
 (* Check if a bech32 address string is valid, based on the specification in
  * https://github.com/Zilliqa/Zilliqa/wiki/Address-Standard#specification *)
-let is_valid_bech32 ~prefix ~addr =
-  Option.is_some (decode_bech32_addr ~prefix ~addr)
+let is_valid_bech32 ~prfx ~addr =
+  Option.is_some (decode_bech32_addr ~prfx ~addr)
 
 (* Encodes a 20-byte string into the bech32 address format.
  * Signature: prefix -> bystr20 address -> bech32_addr. *)
-let encode_bech32_addr ~prefix ~addr:bys =
+let encode_bech32_addr ~prfx ~addr:bys =
   (* 1. Must be of the right length. *)
   if String.length bys <> 20 then None
   else
     (* 2. Scan the prefix for errors. *)
     let chk, err =
-      List.fold (String.to_list prefix) ~init:(1, false)
+      List.fold (String.to_list prfx) ~init:(1, false)
         ~f:(fun (chk, err) ch ->
           if
             err
@@ -197,7 +196,7 @@ let encode_bech32_addr ~prefix ~addr:bys =
       (* 3. Checksum the prefix. *)
       let chk = bech32_polymod_step chk in
       let chk =
-        List.fold (String.to_list prefix) ~init:chk ~f:(fun acc_chk c ->
+        List.fold (String.to_list prfx) ~init:chk ~f:(fun acc_chk c ->
             bech32_polymod_step acc_chk lxor (ascii_of_char c land 0x1f))
       in
 
@@ -240,4 +239,4 @@ let encode_bech32_addr ~prefix ~addr:bys =
         in
 
         (* 8. Finally build up the bech32 encoded address. *)
-        Some (prefix ^ "1" ^ bech32_str ^ chkstr)
+        Some (prfx ^ "1" ^ bech32_str ^ chkstr)

--- a/src/base/Bech32.ml
+++ b/src/base/Bech32.ml
@@ -177,8 +177,7 @@ let encode_bech32_addr ~prfx ~addr:bys =
   else
     (* 2. Scan the prefix for errors. *)
     let chk, err =
-      List.fold (String.to_list prfx) ~init:(1, false)
-        ~f:(fun (chk, err) ch ->
+      List.fold (String.to_list prfx) ~init:(1, false) ~f:(fun (chk, err) ch ->
           if
             err
             || ascii_of_char ch < 33

--- a/src/base/Bech32.ml
+++ b/src/base/Bech32.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open Bitstring
 open Utils
 

--- a/src/base/Bech32.mli
+++ b/src/base/Bech32.mli
@@ -17,13 +17,13 @@
 *)
 
 (* The string length of a valid bech32 address.  *)
-val bech32_addr_len : prefix:string -> int
+val bech32_addr_len : prfx:string -> int
 
 (* Decodes a bech32 address string to a string of 20 bytes. *)
-val decode_bech32_addr : prefix:string -> addr:string -> string option
+val decode_bech32_addr : prfx:string -> addr:string -> string option
 
 (* Is a given string a valid bech32 address. *)
-val is_valid_bech32 : prefix:string -> addr:string -> bool
+val is_valid_bech32 : prfx:string -> addr:string -> bool
 
 (* Encodes a 20-byte string addr into the bech32 address format. *)
-val encode_bech32_addr : prefix:string -> addr:string -> string option
+val encode_bech32_addr : prfx:string -> addr:string -> string option

--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -155,10 +155,11 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let to_string_elab _ ts =
       match ts with
-      | [ t ]
-        when is_int_type t || is_uint_type t || is_bystrx_type t
-             || t = bystr_typ ->
-          elab_tfun_with_args_no_gas to_string_type ts
+      | [ PrimType pt ] ->
+          (match pt with
+           | Int_typ _ | Uint_typ _ | Bystrx_typ _ | Bystr_typ ->
+               elab_tfun_with_args_no_gas to_string_type ts
+           | _ -> fail0 "Failed to elaborate")
       | _ -> fail0 "Failed to elaborate"
 
     let to_string ls _ =
@@ -211,17 +212,13 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let binop_elab t ts =
       match ts with
-      | [ i1; i2 ] when i1 = i2 && is_int_type i1 ->
+      | [ i1; i2 ] when [%equal: typ] i1 i2 && is_int_type i1 ->
           elab_tfun_with_args_no_gas t [ i1 ]
       | _ -> fail0 "Failed to elaborate"
 
     let eq ls _ =
       match ls with
-      | [ (IntLit (Int32L _) as x); (IntLit (Int32L _) as y) ]
-      | [ (IntLit (Int64L _) as x); (IntLit (Int64L _) as y) ]
-      | [ (IntLit (Int128L _) as x); (IntLit (Int128L _) as y) ]
-      | [ (IntLit (Int256L _) as x); (IntLit (Int256L _) as y) ] ->
-          pure @@ to_Bool (x = y)
+      | [ IntLit x; IntLit y ] -> pure @@ to_Bool ([%equal: int_lit] x y)
       | _ -> builtin_fail "Int.eq: unsupported types" ls
 
     let add ls _ =
@@ -419,17 +416,13 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let binop_elab sc ts =
       match ts with
-      | [ i1; i2 ] when i1 = i2 && is_uint_type i1 ->
+      | [ i1; i2 ] when [%equal: typ] i1 i2 && is_uint_type i1 ->
           elab_tfun_with_args_no_gas sc [ i1 ]
       | _ -> fail0 "Failed to elaborate"
 
     let eq ls _ =
       match ls with
-      | [ (UintLit (Uint32L _) as x); (UintLit (Uint32L _) as y) ]
-      | [ (UintLit (Uint64L _) as x); (UintLit (Uint64L _) as y) ]
-      | [ (UintLit (Uint128L _) as x); (UintLit (Uint128L _) as y) ]
-      | [ (UintLit (Uint256L _) as x); (UintLit (Uint256L _) as y) ] ->
-          pure @@ to_Bool (x = y)
+      | [ UintLit x; UintLit y ] -> pure @@ to_Bool ([%equal: uint_lit] x y)
       | _ -> builtin_fail "Uint.eq: unsupported types" ls
 
     let add ls _ =

--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -200,7 +200,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let eq_elab t ts =
       match ts with
-      | [ i1; i2 ] when i1 = i2 && is_int_type i1 ->
+      | [ i1; i2 ] when [%equal: typ] i1 i2 && is_int_type i1 ->
           elab_tfun_with_args_no_gas t [ i1 ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -321,7 +321,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let pow_elab t ts =
       match ts with
-      | [ i1; i2 ] when is_int_type i1 && i2 = uint32_typ ->
+      | [ i1; i2 ] when is_int_type i1 && [%equal: typ] i2 uint32_typ ->
           elab_tfun_with_args_no_gas t [ i1 ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -408,7 +408,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let eq_elab sc ts =
       match ts with
-      | [ i1; i2 ] when i1 = i2 && is_uint_type i1 ->
+      | [ i1; i2 ] when [%equal: typ] i1 i2 && is_uint_type i1 ->
           elab_tfun_with_args_no_gas sc [ i1 ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -530,7 +530,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let pow_elab t ts =
       match ts with
-      | [ i1; i2 ] when is_uint_type i1 && i2 = uint32_typ ->
+      | [ i1; i2 ] when is_uint_type i1 && [%equal: typ] i2 uint32_typ ->
           elab_tfun_with_args_no_gas t [ i1 ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -617,7 +617,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       match ls with
       | [ UintLit (Uint32L n) ] ->
           let rec nat_builder (i : Uint32.t) (acc : Syntax.literal) =
-            if i = Uint32.zero then acc
+            if [%equal: uint32] i Uint32.zero then acc
             else nat_builder (Uint32.pred i) (ADTValue ("Succ", [], [ acc ]))
           in
           let zero = ADTValue ("Zero", [], []) in
@@ -781,7 +781,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       match ts with
       | [ bstyp1; bstyp2 ]
         when (* We want both types to be ByStr with equal width. *)
-             is_bystrx_type bstyp1 && bstyp1 = bstyp2 ->
+             is_bystrx_type bstyp1 && [%equal: typ] bstyp1 bstyp2 ->
           elab_tfun_with_args_no_gas sc [ bstyp1 ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -1130,7 +1130,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let contains_elab sc ts =
       match ts with
-      | [ MapType (kt, vt); u ] when type_equiv kt u ->
+      | [ MapType (kt, vt); u ] when [%equal: typ] kt u ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -1152,7 +1152,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let put_elab sc ts =
       match ts with
       | [ MapType (kt, vt); kt'; vt' ]
-        when type_equiv kt kt' && type_equiv vt vt' ->
+        when [%equal: typ] kt kt' && [%equal: typ] vt vt' ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -1175,7 +1175,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let get_elab sc ts =
       match ts with
-      | [ MapType (kt, vt); kt' ] when type_equiv kt kt' ->
+      | [ MapType (kt, vt); kt' ] when [%equal: typ] kt kt' ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -1197,7 +1197,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let remove_elab sc ts =
       match ts with
-      | [ MapType (kt, vt); u ] when type_equiv kt u ->
+      | [ MapType (kt, vt); u ] when [%equal: typ] kt u ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _ -> fail0 "Failed to elaborate"
 

--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -16,9 +16,9 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Syntax
 open Core_kernel
 open! Int.Replace_polymorphic_compare
+open Syntax
 open ErrorUtils
 open MonadUtil
 open Result.Let_syntax

--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -155,11 +155,11 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let to_string_elab _ ts =
       match ts with
-      | [ PrimType pt ] ->
-          (match pt with
-           | Int_typ _ | Uint_typ _ | Bystrx_typ _ | Bystr_typ ->
-               elab_tfun_with_args_no_gas to_string_type ts
-           | _ -> fail0 "Failed to elaborate")
+      | [ PrimType pt ] -> (
+          match pt with
+          | Int_typ _ | Uint_typ _ | Bystrx_typ _ | Bystr_typ ->
+              elab_tfun_with_args_no_gas to_string_type ts
+          | _ -> fail0 "Failed to elaborate" )
       | _ -> fail0 "Failed to elaborate"
 
     let to_string ls _ =
@@ -874,7 +874,8 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
             fail0 "Only zil and tzil bech32 addresses are supported"
           else
             match
-              Bech32.encode_bech32_addr ~prefix:prfx ~addr:(Bystrx.to_raw_bytes addr)
+              Bech32.encode_bech32_addr ~prefix:prfx
+                ~addr:(Bystrx.to_raw_bytes addr)
             with
             | Some bech32 -> some_lit @@ StringLit bech32
             | None -> fail0 "bech32 encoding failed" )

--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -853,7 +853,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
           if Core_kernel.String.(prfx <> "zil" && prfx <> "tzil") then
             fail0 "Only zil and tzil bech32 addresses are supported"
           else
-            match Bech32.decode_bech32_addr ~prefix:prfx ~addr with
+            match Bech32.decode_bech32_addr ~prfx ~addr with
             | Some bys20 -> (
                 match Bystrx.of_raw_bytes 20 bys20 with
                 | Some b -> some_lit @@ ByStrX b
@@ -874,7 +874,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
             fail0 "Only zil and tzil bech32 addresses are supported"
           else
             match
-              Bech32.encode_bech32_addr ~prefix:prfx
+              Bech32.encode_bech32_addr ~prfx
                 ~addr:(Bystrx.to_raw_bytes addr)
             with
             | Some bech32 -> some_lit @@ StringLit bech32

--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -18,6 +18,7 @@
 
 open Syntax
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open ErrorUtils
 open MonadUtil
 open Result.Let_syntax

--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -874,8 +874,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
             fail0 "Only zil and tzil bech32 addresses are supported"
           else
             match
-              Bech32.encode_bech32_addr ~prfx
-                ~addr:(Bystrx.to_raw_bytes addr)
+              Bech32.encode_bech32_addr ~prfx ~addr:(Bystrx.to_raw_bytes addr)
             with
             | Some bech32 -> some_lit @@ StringLit bech32
             | None -> fail0 "bech32 encoding failed" )

--- a/src/base/ContractUtil.ml
+++ b/src/base/ContractUtil.ml
@@ -17,7 +17,7 @@
 *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open Syntax
 open MonadUtil
 open Stdint
@@ -42,7 +42,7 @@ module MessagePayload = struct
   let exception_label = "_exception"
 
   let get_value_for_entry lab f es =
-    match List.find es ~f:(fun (l, _) -> l = lab) with
+    match List.find es ~f:(fun (l, _) -> String.(l = lab)) with
     | None ->
         fail0
         @@ sprintf "No field \"%s\" in message [%s]." lab (pp_literal_map es)
@@ -68,7 +68,7 @@ module MessagePayload = struct
     get_value_for_entry amount_label (function
       | UintLit (Uint128L i) -> (
           try
-            if compare i Uint128.zero >= 0 then Some (pure i)
+            if Uint128.(compare i zero) >= 0 then Some (pure i)
             else
               Some
                 ( fail0
@@ -81,7 +81,8 @@ module MessagePayload = struct
                    (Uint128.to_string i) ) )
       | _ -> None)
 
-  let get_other_entries es = List.filter es ~f:(fun (l, _) -> l <> tag_label)
+  let get_other_entries es =
+    List.filter es ~f:(fun (l, _) -> String.(l <> tag_label))
 end
 
 let balance_label = "_balance"
@@ -121,7 +122,7 @@ module ScillaContractUtil (SR : Rep) (ER : Rep) = struct
   let remove_noneval_args args =
     let nonevalargs = [ extlibs_label ] in
     List.filter args ~f:(fun a ->
-        not (List.mem nonevalargs (fst a) ~equal:( = )))
+        not (List.mem nonevalargs (fst a) ~equal:String.( = )))
 
   let append_implict_comp_params cparams =
     let open PrimTypes in

--- a/src/base/ContractUtil.ml
+++ b/src/base/ContractUtil.ml
@@ -42,17 +42,12 @@ module MessagePayload = struct
   let exception_label = "_exception"
 
   let get_value_for_entry lab f es =
-    match List.find es ~f:(fun (l, _) -> String.(l = lab)) with
+    match List.Assoc.find es lab ~equal:String.( = ) with
     | None ->
         fail0
         @@ sprintf "No field \"%s\" in message [%s]." lab (pp_literal_map es)
-    | Some (_, p) -> (
-        match f p with
-        | Some x -> x
-        | None ->
-            fail0
-            @@ sprintf "Wrong value of the entry \"%s\": %s." lab (pp_literal p)
-        )
+    | Some p ->
+        (f p) |> Option.value ~default:(fail0 @@ sprintf "Wrong value of the entry \"%s\": %s." lab (pp_literal p))
 
   let get_tag =
     get_value_for_entry tag_label (function

--- a/src/base/ContractUtil.ml
+++ b/src/base/ContractUtil.ml
@@ -47,7 +47,12 @@ module MessagePayload = struct
         fail0
         @@ sprintf "No field \"%s\" in message [%s]." lab (pp_literal_map es)
     | Some p ->
-        (f p) |> Option.value ~default:(fail0 @@ sprintf "Wrong value of the entry \"%s\": %s." lab (pp_literal p))
+        f p
+        |> Option.value
+             ~default:
+               ( fail0
+               @@ sprintf "Wrong value of the entry \"%s\": %s." lab
+                    (pp_literal p) )
 
   let get_tag =
     get_value_for_entry tag_label (function

--- a/src/base/ContractUtil.ml
+++ b/src/base/ContractUtil.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open Syntax
 open MonadUtil
 open Stdint

--- a/src/base/Datatypes.ml
+++ b/src/base/Datatypes.ml
@@ -161,7 +161,7 @@ module DataTypeDictionary = struct
 
   (* Get typing map for a constructor *)
   let constr_tmap adt cn =
-    List.find adt.tmap ~f:(fun (n, _) -> String.(n = cn)) |> Option.map ~f:snd
+    List.Assoc.find adt.tmap cn ~equal:String.( = )
 
   let bool_typ = ADT (asId t_bool.tname, [])
 

--- a/src/base/Datatypes.ml
+++ b/src/base/Datatypes.ml
@@ -16,9 +16,9 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Syntax
 open Core_kernel
 open! Int.Replace_polymorphic_compare
+open Syntax
 open MonadUtil
 open Result.Let_syntax
 

--- a/src/base/Datatypes.ml
+++ b/src/base/Datatypes.ml
@@ -31,7 +31,8 @@ type constructor = {
   cname : string;
   (* constructor name *)
   arity : int; (* How many arguments it takes *)
-} [@@deriving equal]
+}
+[@@deriving equal]
 
 (* An Algebraic Data Type *)
 type adt = {
@@ -46,7 +47,8 @@ type adt = {
      The arity of the constructor is the same as the length
      of the list, so the types are mapped correspondingly. *)
   tmap : (string * typ list) list;
-} [@@deriving equal]
+}
+[@@deriving equal]
 
 module DataTypeDictionary = struct
   (* Booleans *)
@@ -160,8 +162,7 @@ module DataTypeDictionary = struct
     | Some dt -> pure dt
 
   (* Get typing map for a constructor *)
-  let constr_tmap adt cn =
-    List.Assoc.find adt.tmap cn ~equal:String.( = )
+  let constr_tmap adt cn = List.Assoc.find adt.tmap cn ~equal:String.( = )
 
   let bool_typ = ADT (asId t_bool.tname, [])
 
@@ -233,7 +234,8 @@ module SnarkTypes = struct
   let scilla_g1point_to_ocaml g1p =
     match g1p with
     | ADTValue ("Pair", [ pxt; pyt ], [ ByStrX px; ByStrX py ])
-      when [%equal: typ] pxt scalar_type && [%equal: typ] pyt scalar_type
+      when [%equal: typ] pxt scalar_type
+           && [%equal: typ] pyt scalar_type
            && Bystrx.width px = scalar_len
            && Bystrx.width py = scalar_len ->
         pure { g1x = Bystrx.to_raw_bytes px; g1y = Bystrx.to_raw_bytes py }
@@ -242,7 +244,8 @@ module SnarkTypes = struct
   let scilla_g2point_to_ocaml g2p =
     match g2p with
     | ADTValue ("Pair", [ pxt; pyt ], [ ByStrX px; ByStrX py ])
-      when [%equal: typ] pxt g2comp_type && [%equal: typ] pyt g2comp_type
+      when [%equal: typ] pxt g2comp_type
+           && [%equal: typ] pyt g2comp_type
            && Bystrx.width px = g2comp_len
            && Bystrx.width py = g2comp_len ->
         pure { g2x = Bystrx.to_raw_bytes px; g2y = Bystrx.to_raw_bytes py }
@@ -265,7 +268,8 @@ module SnarkTypes = struct
       mapM g1g2ol ~f:(fun g1g2p_lit ->
           match g1g2p_lit with
           | ADTValue ("Pair", [ g1pt; g2pt ], [ g1p; g2p ])
-            when [%equal: typ] g1pt g1point_type && [%equal: typ] g2pt g2point_type ->
+            when [%equal: typ] g1pt g1point_type
+                 && [%equal: typ] g2pt g2point_type ->
               let%bind g1p' = scilla_g1point_to_ocaml g1p in
               let%bind g2p' = scilla_g2point_to_ocaml g2p in
               pure (g1p', g2p')

--- a/src/base/Datatypes.ml
+++ b/src/base/Datatypes.ml
@@ -18,7 +18,7 @@
 
 open Syntax
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open MonadUtil
 open Result.Let_syntax
 
@@ -161,7 +161,7 @@ module DataTypeDictionary = struct
 
   (* Get typing map for a constructor *)
   let constr_tmap adt cn =
-    List.find adt.tmap ~f:(fun (n, _) -> n = cn) |> Option.map ~f:snd
+    List.find adt.tmap ~f:(fun (n, _) -> String.(n = cn)) |> Option.map ~f:snd
 
   let bool_typ = ADT (asId t_bool.tname, [])
 

--- a/src/base/Datatypes.ml
+++ b/src/base/Datatypes.ml
@@ -18,6 +18,7 @@
 
 open Syntax
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open MonadUtil
 open Result.Let_syntax
 

--- a/src/base/Datatypes.ml
+++ b/src/base/Datatypes.ml
@@ -31,7 +31,7 @@ type constructor = {
   cname : string;
   (* constructor name *)
   arity : int; (* How many arguments it takes *)
-}
+} [@@deriving equal]
 
 (* An Algebraic Data Type *)
 type adt = {
@@ -46,7 +46,7 @@ type adt = {
      The arity of the constructor is the same as the length
      of the list, so the types are mapped correspondingly. *)
   tmap : (string * typ list) list;
-}
+} [@@deriving equal]
 
 module DataTypeDictionary = struct
   (* Booleans *)
@@ -233,7 +233,7 @@ module SnarkTypes = struct
   let scilla_g1point_to_ocaml g1p =
     match g1p with
     | ADTValue ("Pair", [ pxt; pyt ], [ ByStrX px; ByStrX py ])
-      when type_equiv pxt scalar_type && type_equiv pyt scalar_type
+      when [%equal: typ] pxt scalar_type && [%equal: typ] pyt scalar_type
            && Bystrx.width px = scalar_len
            && Bystrx.width py = scalar_len ->
         pure { g1x = Bystrx.to_raw_bytes px; g1y = Bystrx.to_raw_bytes py }
@@ -242,7 +242,7 @@ module SnarkTypes = struct
   let scilla_g2point_to_ocaml g2p =
     match g2p with
     | ADTValue ("Pair", [ pxt; pyt ], [ ByStrX px; ByStrX py ])
-      when type_equiv pxt g2comp_type && type_equiv pyt g2comp_type
+      when [%equal: typ] pxt g2comp_type && [%equal: typ] pyt g2comp_type
            && Bystrx.width px = g2comp_len
            && Bystrx.width py = g2comp_len ->
         pure { g2x = Bystrx.to_raw_bytes px; g2y = Bystrx.to_raw_bytes py }
@@ -265,7 +265,7 @@ module SnarkTypes = struct
       mapM g1g2ol ~f:(fun g1g2p_lit ->
           match g1g2p_lit with
           | ADTValue ("Pair", [ g1pt; g2pt ], [ g1p; g2p ])
-            when type_equiv g1pt g1point_type && type_equiv g2pt g2point_type ->
+            when [%equal: typ] g1pt g1point_type && [%equal: typ] g2pt g2point_type ->
               let%bind g1p' = scilla_g1point_to_ocaml g1p in
               let%bind g2p' = scilla_g2point_to_ocaml g2p in
               pure (g1p', g2p')

--- a/src/base/Datatypes.mli
+++ b/src/base/Datatypes.mli
@@ -28,14 +28,14 @@ type constructor = {
   cname : string;
   (* constructor name *)
   arity : int; (* How many arguments it takes *)
-}
+} [@@deriving equal]
 
 type adt = {
   tname : string;
   tparams : string list;
   tconstr : constructor list;
   tmap : (string * typ list) list;
-}
+} [@@deriving equal]
 
 module DataTypeDictionary : sig
   (* Hiding the actual data type dicionary *)

--- a/src/base/Datatypes.mli
+++ b/src/base/Datatypes.mli
@@ -28,14 +28,16 @@ type constructor = {
   cname : string;
   (* constructor name *)
   arity : int; (* How many arguments it takes *)
-} [@@deriving equal]
+}
+[@@deriving equal]
 
 type adt = {
   tname : string;
   tparams : string list;
   tconstr : constructor list;
   tmap : (string * typ list) list;
-} [@@deriving equal]
+}
+[@@deriving equal]
 
 module DataTypeDictionary : sig
   (* Hiding the actual data type dicionary *)

--- a/src/base/DebugMessage.ml
+++ b/src/base/DebugMessage.ml
@@ -16,9 +16,9 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open GlobalConfig
 open Core_kernel
 open! Int.Replace_polymorphic_compare
+open GlobalConfig
 
 (* Prints to log file *)
 let plog msg =

--- a/src/base/DebugMessage.ml
+++ b/src/base/DebugMessage.ml
@@ -18,6 +18,7 @@
 
 open GlobalConfig
 open Core_kernel
+open Int.Replace_polymorphic_compare
 
 (* Prints to log file *)
 let plog msg =

--- a/src/base/DebugMessage.ml
+++ b/src/base/DebugMessage.ml
@@ -18,14 +18,16 @@
 
 open GlobalConfig
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 
 (* Prints to log file *)
 let plog msg =
-  if get_debug_level () <> Debug_None then
-    let fname = get_log_file () in
-    Out_channel.with_file fname ~append:true ~f:(fun h ->
-        Out_channel.output_string h msg)
+  match get_debug_level () with
+  | Debug_Normal | Debug_Verbose ->
+      let fname = get_log_file () in
+      Out_channel.with_file fname ~append:true ~f:(fun h ->
+          Out_channel.output_string h msg)
+  | Debug_None -> ()
 
 (* Prints to stdout and log file *)
 let pout msg =
@@ -40,7 +42,7 @@ let perr msg =
 (* Prints to trace file, if set, else to stdout. *)
 let ptrace msg =
   let fname = GlobalConfig.get_trace_file () in
-  if fname <> "" then
+  if String.(fname <> "") then
     Out_channel.with_file fname ~append:true ~f:(fun h ->
         Out_channel.output_string h msg)
   else Out_channel.output_string Out_channel.stdout msg

--- a/src/base/ErrorUtils.ml
+++ b/src/base/ErrorUtils.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 
 (* Location info, slightly more usable than Lexing.position *)
 type loc = {

--- a/src/base/ErrorUtils.ml
+++ b/src/base/ErrorUtils.ml
@@ -27,7 +27,7 @@ type loc = {
   (* line number *)
   cnum : int; (* column number *)
 }
-[@@deriving sexp]
+[@@deriving sexp, equal]
 
 let toLoc (p : Lexing.position) : loc =
   {

--- a/src/base/ErrorUtils.ml
+++ b/src/base/ErrorUtils.ml
@@ -17,7 +17,7 @@
 *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 
 (* Location info, slightly more usable than Lexing.position *)
 type loc = {

--- a/src/base/ErrorUtils.mli
+++ b/src/base/ErrorUtils.mli
@@ -24,7 +24,7 @@ type loc = {
   (* line number *)
   cnum : int; (* column number *)
 }
-[@@deriving sexp]
+[@@deriving sexp, equal]
 
 val toLoc : Lexing.position -> loc
 

--- a/src/base/FrontEndParser.ml
+++ b/src/base/FrontEndParser.ml
@@ -17,7 +17,7 @@
 *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open Lexing
 open ErrorUtils
 open MonadUtil

--- a/src/base/FrontEndParser.ml
+++ b/src/base/FrontEndParser.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open Lexing
 open ErrorUtils
 open MonadUtil

--- a/src/base/Gas.ml
+++ b/src/base/Gas.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open ErrorUtils
 open Result.Let_syntax
 open MonadUtil

--- a/src/base/Gas.ml
+++ b/src/base/Gas.ml
@@ -17,7 +17,7 @@
 *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open ErrorUtils
 open Result.Let_syntax
 open MonadUtil
@@ -70,7 +70,7 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
     (* A constructor in HNF *)
     | ADTValue (cn, _, ll) as als ->
         (* Make a special case for Lists, to avoid overflowing recursion. *)
-        if cn = "Cons" then
+        if String.(cn = "Cons") then
           let rec walk elm acc_cost =
             match elm with
             | ADTValue ("Cons", _, [ l; ll ]) ->

--- a/src/base/Gas.ml
+++ b/src/base/Gas.ml
@@ -361,12 +361,12 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
     let matcher (name, types, fcoster, base) =
       (* The names and type list lengths must match and *)
       if
-        name = op
+        [%equal: Syntax.builtin] name op
         && List.length types = List.length arg_types
         && List.for_all2_exn
              ~f:(fun t1 t2 ->
                (* the types should match *)
-               type_equiv t1 t2
+               [%equal: typ] t1 t2
                ||
                (* or the built-in record is generic *)
                match t2 with TypeVar _ -> true | _ -> false)

--- a/src/base/Gas.ml
+++ b/src/base/Gas.ml
@@ -377,9 +377,8 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
     let msg =
       sprintf "Unable to determine gas cost for \"%s\"" (pp_builtin op)
     in
-    let open Caml in
     let dict =
-      match Hashtbl.find_opt builtin_hashtbl op with
+      match Caml.Hashtbl.find_opt builtin_hashtbl op with
       | Some rows -> rows
       | None -> []
     in

--- a/src/base/GlobalConfig.ml
+++ b/src/base/GlobalConfig.ml
@@ -17,7 +17,7 @@
 *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open ScillaUtil.FilePathInfix
 
 (* Available debug levels for functions in DbgMsg *)
@@ -57,7 +57,8 @@ let get_debug_level () = !debug_level
 let set_debug_level l = debug_level := l
 
 let get_log_file () =
-  if !log_file = "" then log_file := create_log_filename ("_build" ^/ "logs");
+  if String.is_empty !log_file then
+    log_file := create_log_filename ("_build" ^/ "logs");
   !log_file
 
 let set_log_file s = log_file := s

--- a/src/base/GlobalConfig.ml
+++ b/src/base/GlobalConfig.ml
@@ -130,7 +130,6 @@ module StdlibTracker = struct
   (* Try find library "name" in known locations *)
   let find_lib_dir name =
     let dirs = get_stdlib_dirs () in
-    BatList.find_opt
-      (fun d -> Caml.Sys.file_exists (d ^/ name ^. file_extn_library))
-      dirs
+    List.find dirs
+      ~f:(fun d -> Caml.Sys.file_exists (d ^/ name ^. file_extn_library))
 end

--- a/src/base/GlobalConfig.ml
+++ b/src/base/GlobalConfig.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open ScillaUtil.FilePathInfix
 
 (* Available debug levels for functions in DbgMsg *)

--- a/src/base/GlobalConfig.ml
+++ b/src/base/GlobalConfig.ml
@@ -130,6 +130,6 @@ module StdlibTracker = struct
   (* Try find library "name" in known locations *)
   let find_lib_dir name =
     let dirs = get_stdlib_dirs () in
-    List.find dirs
-      ~f:(fun d -> Caml.Sys.file_exists (d ^/ name ^. file_extn_library))
+    List.find dirs ~f:(fun d ->
+        Caml.Sys.file_exists (d ^/ name ^. file_extn_library))
 end

--- a/src/base/Integer256.ml
+++ b/src/base/Integer256.ml
@@ -44,6 +44,12 @@ module Uint256 = struct
 
   let min_int = zero
 
+  let compare a b =
+    if Uint128.compare a.high b.high < 0 then -1
+    else if Uint128.compare a.high b.high > 0 then 1
+    else (* compare lower halfs *)
+      Uint128.compare a.low b.low
+
   let add a b =
     let low = Uint128.add a.low b.low in
     let carry =
@@ -204,7 +210,7 @@ module Uint256 = struct
     if compare b zero = 0 then raise Division_by_zero
     else if
       (* If we can do 128b arithmetic, do it, hoping that it may be faster. *)
-      compare a.high Uint128.zero = 0 && compare b.high Uint128.zero = 0
+      Uint128.(compare a.high zero) = 0 && Uint128.(compare b.high zero) = 0
     then
       ( { high = Uint128.zero; low = Uint128.div a.low b.low },
         { high = Uint128.zero; low = Uint128.rem a.low b.low } )
@@ -241,16 +247,9 @@ module Uint256 = struct
 
   let neg _ = raise (Failure "Cannot negate Uint256")
 
-  let compare a b =
-    if Uint128.compare a.high b.high < 0 then -1
-    else if Uint128.compare a.high b.high > 0 then 1
-    else (* compare lower halfs *)
-      Uint128.compare a.low b.low
-
   let of_string s =
     let cl = Extlib.ExtString.String.to_list s in
-    List.fold_left
-      (fun i c ->
+    List.fold_left cl ~init:zero ~f:(fun i c ->
         let ten = { high = Uint128.zero; low = Uint128.of_string "10" } in
         let m = mul i ten in
         match c with
@@ -265,7 +264,6 @@ module Uint256 = struct
         | '8' -> add m { high = Uint128.zero; low = Uint128.of_string "8" }
         | '9' -> add m { high = Uint128.zero; low = Uint128.of_string "9" }
         | _ -> raise (Failure ("Invalid Uint256 string: " ^ s)))
-      zero cl
 
   let to_string ui =
     if compare ui zero = 0 then "0"
@@ -278,7 +276,7 @@ module Uint256 = struct
           let q, r = divrem i ten in
           let s' = app q s in
           let d = Uint128.to_int r.low in
-          s' ^ List.nth c d
+          s' ^ List.nth_exn c d
       in
       app ui ""
 
@@ -395,15 +393,15 @@ module Int256 = struct
 
   let of_string s =
     let s', n =
-      if s.[0] = '-' (* s' = s without the leading '-' *) then
-        (String.sub s 1 (String.length s - 1), true)
+      if Char.(s.[0] = '-') (* s' = s without the leading '-' *) then
+        (String.drop_prefix s 1, true)
       else (s, false)
     in
     let i =
       try Uint256.of_string s'
       with _ -> raise (Failure ("Invalid Int256 string: " ^ s))
     in
-    if isneg i && i <> min_int then
+    if isneg i && compare i min_int <> 0 then
       (* if i is negative, then the number is too big.
        * It can't be represented in 255 bits.
        * Unless it's min_int. 2s complement has one extra 

--- a/src/base/Integer256.ml
+++ b/src/base/Integer256.ml
@@ -16,6 +16,8 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
+open Core_kernel
+open! Int.Replace_polymorphic_compare
 open Stdint
 
 type uint256 = { high : uint128; low : uint128 }

--- a/src/base/JSON.ml
+++ b/src/base/JSON.ml
@@ -353,10 +353,8 @@ module Message = struct
   (* Same as message_to_jstring, but instead gives out raw json, not it's string *)
   let message_to_json message =
     (* extract out "_tag", "_amount", "_accepted" and "_recipient" parts of the message *)
-    let _, taglit = List.find_exn message ~f:(fun (x, _) -> String.(x = tag_label)) in
-    let _, amountlit =
-      List.find_exn message ~f:(fun (x, _) -> String.(x = amount_label))
-    in
+    let taglit = List.Assoc.find_exn message tag_label ~equal:String.( = ) in
+    let amountlit = List.Assoc.find_exn message amount_label ~equal:String.( = ) in
     (* message_to_json may be used to print both output and input message. Choose label accordingly. *)
     let toORfrom, tofromlit =
       List.find_exn message ~f:(fun (x, _) ->
@@ -506,8 +504,8 @@ module Event = struct
   (* Same as Event_to_jstring, but instead gives out raw json, not it's string *)
   let event_to_json e =
     (* extract out "_eventname" from the message *)
-    let _, eventnamelit =
-      List.find_exn e ~f:(fun (x, _) -> String.(x = eventname_label))
+    let eventnamelit =
+      List.Assoc.find_exn e eventname_label ~equal:String.( = )
     in
     let eventnames = get_string_literal eventnamelit in
     (* Get a list without the extracted components *)

--- a/src/base/JSON.ml
+++ b/src/base/JSON.ml
@@ -154,7 +154,7 @@ and read_adt_json name j tlist_verify =
           | Error emsg -> raise (Invalid_json emsg)
           | Ok (r, _) -> r
         in
-        if dt <> dt' then
+        if not @@ [%equal: Datatypes.adt] dt dt' then
           raise
             (mk_invalid_json
                ("ADT type " ^ dt.tname ^ " does not match constructor " ^ constr));
@@ -306,8 +306,8 @@ module ContractState = struct
             List.map lit' ~f:(fun sp ->
                 match sp with
                 | ADTValue ("Pair", [ t1; t2 ], [ StringLit name; ByStrX bs ])
-                  when t1 = PrimTypes.string_typ
-                       && t2 = PrimTypes.bystrx_typ address_length
+                  when [%equal: typ] t1 PrimTypes.string_typ
+                       && [%equal: typ] t2 (PrimTypes.bystrx_typ address_length)
                        && Bystrx.width bs = address_length ->
                     (name, Bystrx.hex_encoding bs)
                 | _ ->

--- a/src/base/JSON.ml
+++ b/src/base/JSON.ml
@@ -19,6 +19,7 @@
 open Syntax
 open ErrorUtils
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open Yojson
 open ContractUtil.MessagePayload
 open Datatypes

--- a/src/base/JSON.ml
+++ b/src/base/JSON.ml
@@ -16,10 +16,10 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Syntax
-open ErrorUtils
 open Core_kernel
 open! Int.Replace_polymorphic_compare
+open Syntax
+open ErrorUtils
 open Yojson
 open ContractUtil.MessagePayload
 open Datatypes

--- a/src/base/JSON.ml
+++ b/src/base/JSON.ml
@@ -19,7 +19,7 @@
 open Syntax
 open ErrorUtils
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open Yojson
 open ContractUtil.MessagePayload
 open Datatypes
@@ -137,7 +137,7 @@ and read_adt_json name j tlist_verify =
     match j with
     | `List vli ->
         (* We make an exception for Lists, allowing them to be stored flatly. *)
-        if dt.tname <> "List" then
+        if String.(dt.tname <> "List") then
           raise
             (Invalid_json
                (mk_error0 "ADT value is a JSON array, but type is not List"))
@@ -290,7 +290,7 @@ module ContractState = struct
   let get_init_extlibs filename =
     let allf = get_json_data filename in
     let extlibs =
-      List.filter allf ~f:(fun (name, _) -> name = ContractUtil.extlibs_label)
+      List.filter allf ~f:(fun (name, _) -> String.(name = ContractUtil.extlibs_label))
     in
     match extlibs with
     | [] -> []
@@ -353,17 +353,17 @@ module Message = struct
   (* Same as message_to_jstring, but instead gives out raw json, not it's string *)
   let message_to_json message =
     (* extract out "_tag", "_amount", "_accepted" and "_recipient" parts of the message *)
-    let _, taglit = List.find_exn message ~f:(fun (x, _) -> x = tag_label) in
+    let _, taglit = List.find_exn message ~f:(fun (x, _) -> String.(x = tag_label)) in
     let _, amountlit =
-      List.find_exn message ~f:(fun (x, _) -> x = amount_label)
+      List.find_exn message ~f:(fun (x, _) -> String.(x = amount_label))
     in
     (* message_to_json may be used to print both output and input message. Choose label accordingly. *)
     let toORfrom, tofromlit =
       List.find_exn message ~f:(fun (x, _) ->
-          x = recipient_label || x = sender_label)
+          String.(x = recipient_label || x = sender_label))
     in
     let tofrom_label =
-      if toORfrom = recipient_label then recipient_label else sender_label
+      if String.(toORfrom = recipient_label) then recipient_label else sender_label
     in
     let tags = get_string_literal taglit in
     let amounts = get_uint_literal amountlit in
@@ -371,7 +371,7 @@ module Message = struct
     (* Get a list without any of these components *)
     let filtered_list =
       List.filter message ~f:(fun (x, _) ->
-          not (x = tag_label || x = amount_label || x = recipient_label))
+          String.(not (x = tag_label || x = amount_label || x = recipient_label)))
     in
     `Assoc
       [
@@ -507,12 +507,12 @@ module Event = struct
   let event_to_json e =
     (* extract out "_eventname" from the message *)
     let _, eventnamelit =
-      List.find_exn e ~f:(fun (x, _) -> x = eventname_label)
+      List.find_exn e ~f:(fun (x, _) -> String.(x = eventname_label))
     in
     let eventnames = get_string_literal eventnamelit in
     (* Get a list without the extracted components *)
     let filtered_list =
-      List.filter e ~f:(fun (x, _) -> not (x = eventname_label))
+      List.filter e ~f:(fun (x, _) -> String.(not (x = eventname_label)))
     in
     `Assoc
       [

--- a/src/base/JSON.ml
+++ b/src/base/JSON.ml
@@ -290,7 +290,8 @@ module ContractState = struct
   let get_init_extlibs filename =
     let allf = get_json_data filename in
     let extlibs =
-      List.filter allf ~f:(fun (name, _) -> String.(name = ContractUtil.extlibs_label))
+      List.filter allf ~f:(fun (name, _) ->
+          String.(name = ContractUtil.extlibs_label))
     in
     match extlibs with
     | [] -> []
@@ -354,14 +355,17 @@ module Message = struct
   let message_to_json message =
     (* extract out "_tag", "_amount", "_accepted" and "_recipient" parts of the message *)
     let taglit = List.Assoc.find_exn message tag_label ~equal:String.( = ) in
-    let amountlit = List.Assoc.find_exn message amount_label ~equal:String.( = ) in
+    let amountlit =
+      List.Assoc.find_exn message amount_label ~equal:String.( = )
+    in
     (* message_to_json may be used to print both output and input message. Choose label accordingly. *)
     let toORfrom, tofromlit =
       List.find_exn message ~f:(fun (x, _) ->
           String.(x = recipient_label || x = sender_label))
     in
     let tofrom_label =
-      if String.(toORfrom = recipient_label) then recipient_label else sender_label
+      if String.(toORfrom = recipient_label) then recipient_label
+      else sender_label
     in
     let tags = get_string_literal taglit in
     let amounts = get_uint_literal amountlit in
@@ -369,7 +373,8 @@ module Message = struct
     (* Get a list without any of these components *)
     let filtered_list =
       List.filter message ~f:(fun (x, _) ->
-          String.(not (x = tag_label || x = amount_label || x = recipient_label)))
+          String.(
+            not (x = tag_label || x = amount_label || x = recipient_label)))
     in
     `Assoc
       [

--- a/src/base/JSONParser.ml
+++ b/src/base/JSONParser.ml
@@ -22,8 +22,7 @@ open Yojson
 open Syntax
 open ErrorUtils
 open Core_kernel
-open Int.Replace_polymorphic_compare
-open PrimTypes
+open! Int.Replace_polymorphic_compare
 open TypeUtil
 open Datatypes
 module JSONTypeUtilities = TypeUtilities
@@ -174,7 +173,7 @@ let gen_parser (t' : typ) : Basic.t -> literal =
                       ADTValue (cn.cname, tlist, arg_lits)
                 | `List vli ->
                     (* We make an exception for Lists, allowing them to be stored flatly. *)
-                    if get_id name <> "List" then
+                    if String.(get_id name <> "List") then
                       raise
                         (mk_invalid_json
                            "ADT value is a JSON array, but type is not List")

--- a/src/base/JSONParser.ml
+++ b/src/base/JSONParser.ml
@@ -18,11 +18,11 @@
 
 (* A fast JSON parser for states that performs no validations. *)
 
+open Core_kernel
+open! Int.Replace_polymorphic_compare
 open Yojson
 open Syntax
 open ErrorUtils
-open Core_kernel
-open! Int.Replace_polymorphic_compare
 open TypeUtil
 open Datatypes
 module JSONTypeUtilities = TypeUtilities

--- a/src/base/JSONParser.ml
+++ b/src/base/JSONParser.ml
@@ -92,14 +92,29 @@ let gen_parser (t' : typ) : Basic.t -> literal =
         | Bnum_typ -> fun j -> BNum (Util.to_string j)
         | Bystr_typ -> fun j -> ByStr (Bystr.parse_hex (Util.to_string j))
         | Bystrx_typ _ -> fun j -> ByStrX (Bystrx.parse_hex (Util.to_string j))
-        | Int_typ Bits32 -> fun j -> IntLit (Int32L (Int32.of_string (Util.to_string j)))
-        | Int_typ Bits64 -> fun j -> IntLit (Int64L (Int64.of_string (Util.to_string j)))
-        | Int_typ Bits128 -> fun j -> IntLit (Int128L (Stdint.Int128.of_string (Util.to_string j)))
-        | Int_typ Bits256 -> fun j -> IntLit (Int256L (Integer256.Int256.of_string (Util.to_string j)))
-        | Uint_typ Bits32 -> fun j -> UintLit (Uint32L (Stdint.Uint32.of_string (Util.to_string j)))
-        | Uint_typ Bits64 -> fun j -> UintLit (Uint64L (Stdint.Uint64.of_string (Util.to_string j)))
-        | Uint_typ Bits128 -> fun j -> UintLit (Uint128L (Stdint.Uint128.of_string (Util.to_string j)))
-        | Uint_typ Bits256 -> fun j -> UintLit (Uint256L (Integer256.Uint256.of_string (Util.to_string j)))
+        | Int_typ Bits32 ->
+            fun j -> IntLit (Int32L (Int32.of_string (Util.to_string j)))
+        | Int_typ Bits64 ->
+            fun j -> IntLit (Int64L (Int64.of_string (Util.to_string j)))
+        | Int_typ Bits128 ->
+            fun j ->
+              IntLit (Int128L (Stdint.Int128.of_string (Util.to_string j)))
+        | Int_typ Bits256 ->
+            fun j ->
+              IntLit (Int256L (Integer256.Int256.of_string (Util.to_string j)))
+        | Uint_typ Bits32 ->
+            fun j ->
+              UintLit (Uint32L (Stdint.Uint32.of_string (Util.to_string j)))
+        | Uint_typ Bits64 ->
+            fun j ->
+              UintLit (Uint64L (Stdint.Uint64.of_string (Util.to_string j)))
+        | Uint_typ Bits128 ->
+            fun j ->
+              UintLit (Uint128L (Stdint.Uint128.of_string (Util.to_string j)))
+        | Uint_typ Bits256 ->
+            fun j ->
+              UintLit
+                (Uint256L (Integer256.Uint256.of_string (Util.to_string j)))
         | _ -> raise (mk_invalid_json "Invalid primitive type") )
     | MapType (kt, vt) -> (
         let kp = recurser kt in

--- a/src/base/JSONParser.ml
+++ b/src/base/JSONParser.ml
@@ -22,6 +22,7 @@ open Yojson
 open Syntax
 open ErrorUtils
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open PrimTypes
 open TypeUtil
 open Datatypes

--- a/src/base/JSONParser.ml
+++ b/src/base/JSONParser.ml
@@ -86,37 +86,20 @@ let gen_parser (t' : typ) : Basic.t -> literal =
   let open Basic in
   let rec recurser t =
     match t with
-    | PrimType _ -> (
-        match t with
-        | x when x = string_typ -> fun j -> StringLit (Util.to_string j)
-        | x when x = bnum_typ -> fun j -> BNum (Util.to_string j)
-        | x when x = bystr_typ ->
-            fun j -> ByStr (Bystr.parse_hex (Util.to_string j))
-        | x when is_bystrx_type x ->
-            fun j -> ByStrX (Bystrx.parse_hex (Util.to_string j))
-        | x when x = int32_typ ->
-            fun j -> IntLit (Int32L (Int32.of_string (Util.to_string j)))
-        | x when x = int64_typ ->
-            fun j -> IntLit (Int64L (Int64.of_string (Util.to_string j)))
-        | x when x = int128_typ ->
-            fun j ->
-              IntLit (Int128L (Stdint.Int128.of_string (Util.to_string j)))
-        | x when x = int256_typ ->
-            fun j ->
-              IntLit (Int256L (Integer256.Int256.of_string (Util.to_string j)))
-        | x when x = uint32_typ ->
-            fun j ->
-              UintLit (Uint32L (Stdint.Uint32.of_string (Util.to_string j)))
-        | x when x = uint64_typ ->
-            fun j ->
-              UintLit (Uint64L (Stdint.Uint64.of_string (Util.to_string j)))
-        | x when x = uint128_typ ->
-            fun j ->
-              UintLit (Uint128L (Stdint.Uint128.of_string (Util.to_string j)))
-        | x when x = uint256_typ ->
-            fun j ->
-              UintLit
-                (Uint256L (Integer256.Uint256.of_string (Util.to_string j)))
+    | PrimType pt -> (
+        match pt with
+        | String_typ -> fun j -> StringLit (Util.to_string j)
+        | Bnum_typ -> fun j -> BNum (Util.to_string j)
+        | Bystr_typ -> fun j -> ByStr (Bystr.parse_hex (Util.to_string j))
+        | Bystrx_typ _ -> fun j -> ByStrX (Bystrx.parse_hex (Util.to_string j))
+        | Int_typ Bits32 -> fun j -> IntLit (Int32L (Int32.of_string (Util.to_string j)))
+        | Int_typ Bits64 -> fun j -> IntLit (Int64L (Int64.of_string (Util.to_string j)))
+        | Int_typ Bits128 -> fun j -> IntLit (Int128L (Stdint.Int128.of_string (Util.to_string j)))
+        | Int_typ Bits256 -> fun j -> IntLit (Int256L (Integer256.Int256.of_string (Util.to_string j)))
+        | Uint_typ Bits32 -> fun j -> UintLit (Uint32L (Stdint.Uint32.of_string (Util.to_string j)))
+        | Uint_typ Bits64 -> fun j -> UintLit (Uint64L (Stdint.Uint64.of_string (Util.to_string j)))
+        | Uint_typ Bits128 -> fun j -> UintLit (Uint128L (Stdint.Uint128.of_string (Util.to_string j)))
+        | Uint_typ Bits256 -> fun j -> UintLit (Uint256L (Integer256.Uint256.of_string (Util.to_string j)))
         | _ -> raise (mk_invalid_json "Invalid primitive type") )
     | MapType (kt, vt) -> (
         let kp = recurser kt in

--- a/src/base/MonadUtil.ml
+++ b/src/base/MonadUtil.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open Result.Let_syntax
 open ErrorUtils
 open Stdint

--- a/src/base/MonadUtil.ml
+++ b/src/base/MonadUtil.ml
@@ -17,7 +17,7 @@
 *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open Result.Let_syntax
 open ErrorUtils
 open Stdint

--- a/src/base/PatternUtil.ml
+++ b/src/base/PatternUtil.ml
@@ -17,7 +17,7 @@
 *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open ErrorUtils
 
 (****************************************************************)

--- a/src/base/PatternUtil.ml
+++ b/src/base/PatternUtil.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open ErrorUtils
 
 (****************************************************************)

--- a/src/base/PrettyPrinters.ml
+++ b/src/base/PrettyPrinters.ml
@@ -17,7 +17,7 @@
 *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open Syntax
 open Yojson
 open PrimTypes
@@ -72,7 +72,7 @@ and literal_to_json lit =
   | ADTValue (n, t, v) as ls ->
       let open Datatypes in
       let a, _ = lookup_constructor_exn n in
-      if a.tname = "List" then
+      if String.(a.tname = "List") then
         (* We make an exception for Lists and print them as a JSON array. *)
         match Datatypes.scilla_list_to_ocaml_rev ls with
         | Ok ls' ->

--- a/src/base/PrettyPrinters.ml
+++ b/src/base/PrettyPrinters.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open Syntax
 open Yojson
 open PrimTypes

--- a/src/base/PrimTypes.ml
+++ b/src/base/PrimTypes.ml
@@ -17,7 +17,7 @@
 *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open Syntax
 open Stdint
 open Integer256
@@ -52,16 +52,12 @@ let bystr_typ = PrimType Bystr_typ
 
 let bystrx_typ b = PrimType (Bystrx_typ b)
 
-let int_width t =
-  if t = int32_typ then Some 32
-  else if t = int64_typ then Some 64
-  else if t = int128_typ then Some 128
-  else if t = int256_typ then Some 256
-  else if t = uint32_typ then Some 32
-  else if t = uint64_typ then Some 64
-  else if t = uint128_typ then Some 128
-  else if t = uint256_typ then Some 256
-  else None
+let int_width = function
+  | PrimType (Int_typ Bits32) | PrimType (Uint_typ Bits32) -> Some 32
+  | PrimType (Int_typ Bits64) | PrimType (Uint_typ Bits64) -> Some 64
+  | PrimType (Int_typ Bits128) | PrimType (Uint_typ Bits128) -> Some 128
+  | PrimType (Int_typ Bits256) | PrimType (Uint_typ Bits256) -> Some 256
+  | _ -> None
 
 (* Given a ByStrX string, return integer X *)
 let bystrx_width = function PrimType (Bystrx_typ w) -> Some w | _ -> None
@@ -80,6 +76,7 @@ let is_bystrx_type = function PrimType (Bystrx_typ _) -> true | _ -> false
 
 (* Is string representation of integer valid for integer typ. *)
 let validate_int_string pt x =
+  let open String in
   try
     match pt with
     | Int_typ Bits32 -> Int32.to_string (Int32.of_string x) = x
@@ -149,7 +146,7 @@ let validate_string_literal s =
       else
         let c_int = Char.to_int c in
         if c_int >= 32 && c_int <= 126 then true
-        else if List.mem specials c ~equal:( = ) then true
+        else if List.mem specials c ~equal:Char.( = ) then true
         else false)
 
 let build_prim_literal pt v =

--- a/src/base/PrimTypes.ml
+++ b/src/base/PrimTypes.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open Syntax
 open Stdint
 open Integer256

--- a/src/base/Recursion.ml
+++ b/src/base/Recursion.ml
@@ -217,7 +217,7 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
     in
     let%bind recursion_ccomps_rev, _ =
       foldM ccomps ~init:([], []) ~f:(fun (acc_comps, acc_procs) comp ->
-          let is_proc_in_scope p = List.exists acc_procs ~f:(fun x -> p = x) in
+          let is_proc_in_scope p = List.mem acc_procs p ~equal:String.( = ) in
           let%bind checked_component =
             recursion_component is_adt_in_scope is_adt_ctr_in_scope
               is_proc_in_scope comp

--- a/src/base/Recursion.ml
+++ b/src/base/Recursion.ml
@@ -16,9 +16,9 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Syntax
 open Core_kernel
 open! Int.Replace_polymorphic_compare
+open Syntax
 open ErrorUtils
 open MonadUtil
 open Result.Let_syntax

--- a/src/base/Recursion.ml
+++ b/src/base/Recursion.ml
@@ -18,6 +18,7 @@
 
 open Syntax
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open ErrorUtils
 open MonadUtil
 open Result.Let_syntax

--- a/src/base/Recursion.ml
+++ b/src/base/Recursion.ml
@@ -18,7 +18,7 @@
 
 open Syntax
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open ErrorUtils
 open MonadUtil
 open Result.Let_syntax
@@ -479,7 +479,7 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
                (SR.get_loc (get_rep md.libs.lname))
        in
 
-       if emsgs = [] then
+       if List.is_empty emsgs then
          pure
          @@ ( {
                 RecursionSyntax.smver = md.smver;
@@ -537,7 +537,7 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
                  emsgs @ el )
        in
 
-       if emsgs = [] then
+       if List.is_empty emsgs then
          pure
          @@ ( {
                 RecursionSyntax.smver;

--- a/src/base/Recursion.ml
+++ b/src/base/Recursion.ml
@@ -332,30 +332,27 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
     let { lname; lentries } = lib in
     let is_adt_in_scope adts_in_scope adt_name =
       (* Check if type has already been declared *)
-      match List.findi adts_in_scope ~f:(fun _ n -> n = get_id adt_name) with
-      | Some _ -> pure @@ ()
-      | None ->
-          (* Check if the name is a builtin ADT *)
-          let%bind _ =
-            DataTypeDictionary.lookup_name ~sloc:(get_rep adt_name)
-              (get_id adt_name)
-          in
-          pure @@ ()
+      if List.mem adts_in_scope (get_id adt_name) ~equal:String.( = ) then
+        pure ()
+      else
+        (* Check if the name is a builtin ADT *)
+        let%bind _ =
+          DataTypeDictionary.lookup_name ~sloc:(get_rep adt_name) (get_id adt_name)
+        in
+        pure ()
     in
     let is_adt_ctr_in_scope adt_ctrs_in_scope ctr_name =
       (* Check if type has already been declared *)
-      match
-        List.findi adt_ctrs_in_scope ~f:(fun _ n -> n = get_id ctr_name)
-      with
-      | Some _ -> pure @@ ()
-      | None ->
-          (* Check if the name is a builtin ADT *)
-          let%bind _ =
-            DataTypeDictionary.lookup_constructor
-              ~sloc:(SR.get_loc (get_rep ctr_name))
-              (get_id ctr_name)
-          in
-          pure @@ ()
+      if List.mem adt_ctrs_in_scope (get_id ctr_name) ~equal:String.( = ) then
+        pure ()
+      else
+        (* Check if the name is a builtin ADT *)
+        let%bind _ =
+          DataTypeDictionary.lookup_constructor
+            ~sloc:(SR.get_loc (get_rep ctr_name))
+            (get_id ctr_name)
+        in
+        pure ()
     in
     wrap_with_info
       ( sprintf "Type error in library %s:\n" (get_id lname),

--- a/src/base/Recursion.ml
+++ b/src/base/Recursion.ml
@@ -337,7 +337,8 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
       else
         (* Check if the name is a builtin ADT *)
         let%bind _ =
-          DataTypeDictionary.lookup_name ~sloc:(get_rep adt_name) (get_id adt_name)
+          DataTypeDictionary.lookup_name ~sloc:(get_rep adt_name)
+            (get_id adt_name)
         in
         pure ()
     in

--- a/src/base/RecursionPrinciples.ml
+++ b/src/base/RecursionPrinciples.ml
@@ -18,7 +18,7 @@
 
 open Syntax
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open FrontEndParser
 
 (***********************************************************)

--- a/src/base/RecursionPrinciples.ml
+++ b/src/base/RecursionPrinciples.ml
@@ -18,6 +18,7 @@
 
 open Syntax
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open FrontEndParser
 
 (***********************************************************)

--- a/src/base/SafeArith.ml
+++ b/src/base/SafeArith.ml
@@ -1,4 +1,6 @@
 open Base
+(* No need to open! Int.Replace_polymorphic_compare
+   because open Base already disables polymorphic comparisons except for ints *)
 open Stdint
 
 exception IntOverflow

--- a/src/base/SafeArith.ml
+++ b/src/base/SafeArith.ml
@@ -1,4 +1,5 @@
 open Base
+
 (* No need to open! Int.Replace_polymorphic_compare
    because open Base already disables polymorphic comparisons except for ints *)
 open Stdint

--- a/src/base/ScillaUtil.ml
+++ b/src/base/ScillaUtil.ml
@@ -16,6 +16,9 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
+open Core_kernel
+open! Int.Replace_polymorphic_compare
+
 module FilePathInfix = struct
   let ( ^/ ) = FilePath.concat
 

--- a/src/base/Secp256k1Wrapper.ml
+++ b/src/base/Secp256k1Wrapper.ml
@@ -16,9 +16,10 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
+open Core_kernel
+open Result
+open Result.Let_syntax
 open Secp256k1
-open Core_kernel.Result
-open Core_kernel.Result.Let_syntax
 open MonadUtil
 
 let ctx = Context.create [ Sign; Verify ]

--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -150,13 +150,15 @@ let hash_length = 32
 open Integer256
 
 let equal_int128 x y = Int128.compare x y = 0
+
 let equal_int256 x y = Int256.compare x y = 0
 
 type int_lit =
   | Int32L of int32
   | Int64L of int64
   | Int128L of int128
-  | Int256L of int256 [@@deriving equal]
+  | Int256L of int256
+[@@deriving equal]
 
 let sexp_of_int_lit = function
   | Int32L i' -> Sexp.Atom ("Int32 " ^ Int32.to_string i')
@@ -167,15 +169,19 @@ let sexp_of_int_lit = function
 let int_lit_of_sexp _ = failwith "int_lit_of_sexp is not implemented"
 
 let equal_uint32 x y = Uint32.compare x y = 0
+
 let equal_uint64 x y = Uint64.compare x y = 0
+
 let equal_uint128 x y = Uint128.compare x y = 0
+
 let equal_uint256 x y = Uint256.compare x y = 0
 
 type uint_lit =
   | Uint32L of uint32
   | Uint64L of uint64
   | Uint128L of uint128
-  | Uint256L of uint256 [@@deriving equal]
+  | Uint256L of uint256
+[@@deriving equal]
 
 let sexp_of_uint_lit = function
   | Uint32L i' -> Sexp.Atom ("Uint32 " ^ Uint32.to_string i')

--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open Sexplib.Std
 open MonadUtil
 open ErrorUtils

--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -55,7 +55,8 @@ let is_mem_id i l = List.exists l ~f:(equal_id i)
 (*                         Types                       *)
 (*******************************************************)
 
-type int_bit_width = Bits32 | Bits64 | Bits128 | Bits256 [@@deriving sexp]
+type int_bit_width = Bits32 | Bits64 | Bits128 | Bits256
+[@@deriving sexp, equal]
 
 type prim_typ =
   | Int_typ of int_bit_width
@@ -67,6 +68,7 @@ type prim_typ =
   | Exception_typ
   | Bystr_typ
   | Bystrx_typ of int
+[@@deriving equal]
 
 let sexp_of_prim_typ = function
   | Int_typ Bits32 -> Sexp.Atom "Int32"
@@ -145,25 +147,35 @@ let address_length = 20
 
 let hash_length = 32
 
+open Integer256
+
+let equal_int128 x y = Int128.compare x y = 0
+let equal_int256 x y = Int256.compare x y = 0
+
 type int_lit =
   | Int32L of int32
   | Int64L of int64
   | Int128L of int128
-  | Int256L of Integer256.int256
+  | Int256L of int256 [@@deriving equal]
 
 let sexp_of_int_lit = function
   | Int32L i' -> Sexp.Atom ("Int32 " ^ Int32.to_string i')
   | Int64L i' -> Sexp.Atom ("Int64 " ^ Int64.to_string i')
   | Int128L i' -> Sexp.Atom ("Int128 " ^ Int128.to_string i')
-  | Int256L i' -> Sexp.Atom ("Int256 " ^ Integer256.Int256.to_string i')
+  | Int256L i' -> Sexp.Atom ("Int256 " ^ Int256.to_string i')
 
 let int_lit_of_sexp _ = failwith "int_lit_of_sexp is not implemented"
+
+let equal_uint32 x y = Uint32.compare x y = 0
+let equal_uint64 x y = Uint64.compare x y = 0
+let equal_uint128 x y = Uint128.compare x y = 0
+let equal_uint256 x y = Uint256.compare x y = 0
 
 type uint_lit =
   | Uint32L of uint32
   | Uint64L of uint64
   | Uint128L of uint128
-  | Uint256L of Integer256.uint256
+  | Uint256L of uint256 [@@deriving equal]
 
 let sexp_of_uint_lit = function
   | Uint32L i' -> Sexp.Atom ("Uint32 " ^ Uint32.to_string i')
@@ -348,7 +360,7 @@ type builtin =
   | Builtin_to_uint128
   | Builtin_to_nat
   | Builtin_schnorr_get_address
-[@@deriving sexp]
+[@@deriving sexp, equal]
 
 type 'rep builtin_annot = builtin * 'rep [@@deriving sexp]
 
@@ -527,12 +539,12 @@ let canonicalize_tfun t =
   rename_bound_vars mk_new_name (const @@ Int.succ) t 1
 
 (* Type equivalence *)
-let type_equiv t1 t2 =
+let equal_typ t1 t2 =
   let t1' = canonicalize_tfun t1 in
   let t2' = canonicalize_tfun t2 in
   let rec equiv t1 t2 =
     match (t1, t2) with
-    | PrimType p1, PrimType p2 -> p1 = p2
+    | PrimType p1, PrimType p2 -> [%equal: prim_typ] p1 p2
     | TypeVar v1, TypeVar v2 -> String.equal v1 v2
     | Unit, Unit -> true
     | ADT (tname1, tl1), ADT (tname2, tl2) ->
@@ -959,7 +971,8 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
     (* Handle a special case where we're dealing with the most precise error. *)
     | Error [ e' ] ->
         let m, l = get_failure_msg e phase opt in
-        if e'.startl = dummy_loc then Error (mk_error1 (m ^ e'.emsg) l)
+        if [%equal: loc] e'.startl dummy_loc then
+          Error (mk_error1 (m ^ e'.emsg) l)
         else Error (mk_error2 (m ^ e'.emsg) e'.startl e'.endl)
     | _ -> wrap_with_info (get_failure_msg e phase opt) res
 
@@ -969,7 +982,8 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
     (* Handle a special case where we're dealing with the most precise error. *)
     | Error [ e' ] ->
         let m, l = get_failure_msg_stmt s phase opt in
-        if e'.startl = dummy_loc then Error (mk_error1 (m ^ e'.emsg) l)
+        if [%equal: loc] e'.startl dummy_loc then
+          Error (mk_error1 (m ^ e'.emsg) l)
         else Error (mk_error2 (m ^ e'.emsg) e'.startl e'.endl)
     | _ -> wrap_with_info (get_failure_msg_stmt s phase opt) res
 end

--- a/src/base/TypeCache.ml
+++ b/src/base/TypeCache.ml
@@ -162,10 +162,8 @@ struct
           | LibVar (lname, _, _) -> `Fst (get_id lname)
           | LibTyp (tname, _) -> `Snd (get_id tname))
     in
-    (* OCaml's List.mem is not according to online docs. Why? *)
-    let list_mem l a = List.exists l ~f:(fun b -> b = a) in
     let lib_entries =
-      List.filter ~f:(fun e -> list_mem entry_names (fst e)) (TEnv.to_list tenv)
+      List.filter ~f:(fun e -> List.mem entry_names (fst e) ~equal:String.( = )) (TEnv.to_list tenv)
     in
 
     (* TODO: Handle typ_names *)

--- a/src/base/TypeCache.ml
+++ b/src/base/TypeCache.ml
@@ -163,7 +163,9 @@ struct
           | LibTyp (tname, _) -> `Snd (get_id tname))
     in
     let lib_entries =
-      List.filter ~f:(fun e -> List.mem entry_names (fst e) ~equal:String.( = )) (TEnv.to_list tenv)
+      List.filter
+        ~f:(fun e -> List.mem entry_names (fst e) ~equal:String.( = ))
+        (TEnv.to_list tenv)
     in
 
     (* TODO: Handle typ_names *)

--- a/src/base/TypeCache.ml
+++ b/src/base/TypeCache.ml
@@ -17,7 +17,7 @@
 *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open Syntax
 open ErrorUtils
 open TypeUtil
@@ -143,7 +143,7 @@ struct
           match entries_opt with
           | Some (n, h, entries) ->
               (* Verify name and hash. *)
-              if n = lib_name && h = hash_lib lib then
+              if String.(n = lib_name && h = hash_lib lib) then
                 Some (TEnv.addTs (TEnv.copy tenv) entries)
               else (* name/hash does not match. TODO: print to logger. *)
                 None

--- a/src/base/TypeCache.ml
+++ b/src/base/TypeCache.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open Syntax
 open ErrorUtils
 open TypeUtil

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -121,8 +121,8 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
     [ (TypeUtil.blocknum_name, bnum_typ) ]
 
   let lookup_bc_type x =
-    match List.findi bc_types ~f:(fun _ (f, _) -> f = x) with
-    | Some (_, (_, t)) -> pure @@ t
+    match List.Assoc.find bc_types x ~equal:String.( = ) with
+    | Some t -> pure t
     | None -> fail0 @@ sprintf "Unknown blockchain field %s." x
 
   (**************************************************************)

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -16,9 +16,9 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Syntax
 open Core_kernel
 open! Int.Replace_polymorphic_compare
+open Syntax
 open ErrorUtils
 open MonadUtil
 open Result.Let_syntax

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -366,7 +366,10 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
         in
         let payload_type fld pld remaining_gas =
           let check_field_type seen_type =
-            match List.Assoc.find CU.msg_mandatory_field_types fld ~equal:String.( = ) with
+            match
+              List.Assoc.find CU.msg_mandatory_field_types fld
+                ~equal:String.( = )
+            with
             | Some fld_t when not ([%equal: typ] fld_t seen_type) ->
                 fail1
                   (sprintf
@@ -540,8 +543,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
                  (TypedSyntax.Load (typed_x, typed_f), rep)
                  checked_stmts remaining_gas
         | Store (f, r) ->
-            if List.mem ~equal:String.( = ) no_store_fields (get_id f)
-            then
+            if List.mem ~equal:String.( = ) no_store_fields (get_id f) then
               wrap_type_serr stmt
                 (Error
                    (mk_type_error0
@@ -871,7 +873,8 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
       | CompTrans -> procedures
       | CompProc ->
           let proc_sig = List.map comp_params ~f:snd in
-          List.Assoc.add procedures ~equal:String.( = ) (get_id comp_name) proc_sig
+          List.Assoc.add procedures ~equal:String.( = ) (get_id comp_name)
+            proc_sig
     in
     pure
     @@ ( ( {

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -18,6 +18,7 @@
 
 open Syntax
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open ErrorUtils
 open MonadUtil
 open Result.Let_syntax

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -366,8 +366,8 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
         in
         let payload_type fld pld remaining_gas =
           let check_field_type seen_type =
-            match Caml.List.assoc_opt fld CU.msg_mandatory_field_types with
-            | Some fld_t when fld_t <> seen_type ->
+            match List.Assoc.find CU.msg_mandatory_field_types fld ~equal:String.( = ) with
+            | Some fld_t when not ([%equal: typ] fld_t seen_type) ->
                 fail1
                   (sprintf
                      "Type mismatch for Message field %s. Expected %s but got \

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -566,8 +566,7 @@ module TypeUtilities = struct
     let%bind adt', _ = lookup_constructor cn in
     let seq a b = if String.(a = b) then 0 else 1 in
     let taken =
-      List.map targs ~f:free_tvars
-      |> List.concat
+      List.concat_map targs ~f:free_tvars
       |> List.dedup_and_sort ~compare:seq
     in
     let adt = refresh_adt adt' taken in

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open ErrorUtils
 open Sexplib.Std
 open Syntax

--- a/src/base/Utils.ml
+++ b/src/base/Utils.ml
@@ -17,7 +17,7 @@
 *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 
 (* Add item a to list if it isn't already present. Use ~equal to check presence. *)
 let list_add_unique ~equal ls a = if List.mem ls a ~equal then ls else a :: ls

--- a/src/base/Utils.ml
+++ b/src/base/Utils.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 
 (* Add item a to list if it isn't already present. Use ~equal to check presence. *)
 let list_add_unique ~equal ls a = if List.mem ls a ~equal then ls else a :: ls

--- a/src/base/cpp/dune
+++ b/src/base/cpp/dune
@@ -2,6 +2,8 @@
  (name scilla_cpp_deps)
  (wrapped false)
  (libraries ctypes ctypes.foreign cryptokit)
+ (preprocess
+  (pps ppx_compare))
  (foreign_stubs
   (language c)
   (names generate_dsa_nonce)

--- a/src/base/dune
+++ b/src/base/dune
@@ -18,8 +18,8 @@
 (library
  (name scilla_base)
  (wrapped false)
- (libraries core num hex stdint batteries cryptokit secp256k1 bitstring yojson fileutils scilla_cpp_deps
-   menhirLib)
+ (libraries core num hex stdint batteries cryptokit secp256k1 bitstring
+   yojson fileutils scilla_cpp_deps menhirLib)
  (preprocess
   (pps ppx_sexp_conv ppx_let ppx_deriving.show ppx_compare bisect_ppx
     -conditional))

--- a/src/base/dune
+++ b/src/base/dune
@@ -18,8 +18,7 @@
 (library
  (name scilla_base)
  (wrapped false)
- (libraries core ppx_sexp_conv num hex stdint batteries ppx_deriving.show
-   ppx_compare cryptokit secp256k1 bitstring yojson fileutils scilla_cpp_deps
+ (libraries core num hex stdint batteries cryptokit secp256k1 bitstring yojson fileutils scilla_cpp_deps
    menhirLib)
  (preprocess
   (pps ppx_sexp_conv ppx_let ppx_deriving.show ppx_compare bisect_ppx

--- a/src/base/dune
+++ b/src/base/dune
@@ -19,7 +19,9 @@
  (name scilla_base)
  (wrapped false)
  (libraries core ppx_sexp_conv num hex stdint batteries ppx_deriving.show
-   cryptokit secp256k1 bitstring yojson fileutils scilla_cpp_deps menhirLib)
+   ppx_compare cryptokit secp256k1 bitstring yojson fileutils scilla_cpp_deps
+   menhirLib)
  (preprocess
-  (pps ppx_sexp_conv ppx_let ppx_deriving.show bisect_ppx -conditional))
+  (pps ppx_sexp_conv ppx_let ppx_deriving.show ppx_compare bisect_ppx
+    -conditional))
  (synopsis "Scilla workbench implementation."))

--- a/src/checkers/Accept.ml
+++ b/src/checkers/Accept.ml
@@ -68,7 +68,8 @@ struct
          maybe some but not all of the branches will include accepts.
          So we need an entry on the seen list for each path, because
          we don't know what will happen on each in advance. *)
-      List.fold_left stmts ~init:seen ~f:(fun (seen2 : loc list list) (stmt : stmt_annot) ->
+      List.fold_left stmts ~init:seen
+        ~f:(fun (seen2 : loc list list) (stmt : stmt_annot) ->
           let loc = stmt_loc stmt in
           match fst stmt with
           | AcceptPayment ->
@@ -81,7 +82,8 @@ struct
                   which already reached this point, so walk each
                   branch and build all the results into a new list.
               *)
-              List.concat_map branches ~f:(fun (_pattern, branchstmts) -> walk seen2 branchstmts)
+              List.concat_map branches ~f:(fun (_pattern, branchstmts) ->
+                  walk seen2 branchstmts)
           | _ -> seen2)
     in
     walk [ [] ] stmts
@@ -102,7 +104,7 @@ struct
               "transition %s had a potential code path with duplicate accept \
                statements:\n"
               (get_id transition.comp_name)
-            ^ String.concat ~sep:""
+          ^ String.concat ~sep:""
               (List.map group ~f:(fun loc ->
                    sprintf "  Accept at %s\n" (get_loc_str loc))) )
           warning_level_duplicate_accepts (List.hd_exn group)
@@ -121,8 +123,7 @@ struct
 
     if List.for_all all_accept_groups ~f:List.is_empty then
       warn0
-        (sprintf
-           "No transition in contract %s contains an accept statement\n"
+        (sprintf "No transition in contract %s contains an accept statement\n"
            (get_id contr.cname))
         warning_level_missing_accept
 

--- a/src/checkers/Accept.ml
+++ b/src/checkers/Accept.ml
@@ -25,6 +25,8 @@
    statements.  There might be valid reasons for writing such contracts,
    so again we only generate warnings not errors. *)
 
+open Core_kernel
+open! Int.Replace_polymorphic_compare
 open TypeUtil
 open ErrorUtils
 open Syntax

--- a/src/checkers/Accept.ml
+++ b/src/checkers/Accept.ml
@@ -68,35 +68,28 @@ struct
          maybe some but not all of the branches will include accepts.
          So we need an entry on the seen list for each path, because
          we don't know what will happen on each in advance. *)
-      List.fold_left
-        (fun (seen2 : loc list list) (stmt : stmt_annot) ->
+      List.fold_left stmts ~init:seen ~f:(fun (seen2 : loc list list) (stmt : stmt_annot) ->
           let loc = stmt_loc stmt in
           match fst stmt with
           | AcceptPayment ->
               (* Add this accept statement to the list of accepts
                * already seen on each code path reaching this point. *)
-              List.map (fun accepts -> loc :: accepts) seen2
+              List.map seen2 ~f:(fun accepts -> loc :: accepts)
           | MatchStmt (_ident, branches) ->
               (* For each branch in the match statement we have a
                   new code path to "multiply" with the code paths
                   which already reached this point, so walk each
                   branch and build all the results into a new list.
               *)
-              List.fold_left
-                (fun seen3 (_pattern, branchstmts) ->
-                  match walk seen2 branchstmts with
-                  | [] -> seen3
-                  | seen4 -> seen3 @ seen4)
-                [] branches
+              List.concat_map branches ~f:(fun (_pattern, branchstmts) -> walk seen2 branchstmts)
           | _ -> seen2)
-        seen stmts
     in
     walk [ [] ] stmts
 
   let check_accepts (contr : contract) =
     let check_transition_accepts (transition : component) =
       let transition_accept_groups =
-        List.map List.rev (find_accept_groups transition.comp_body)
+        List.map (find_accept_groups transition.comp_body) ~f:List.rev
       in
 
       let accept_loc_end (l : loc) =
@@ -105,41 +98,33 @@ struct
 
       let dup_accept_warning (group : loc list) : unit =
         warn2
-          ( Core_kernel.sprintf
+          ( sprintf
               "transition %s had a potential code path with duplicate accept \
                statements:\n"
               (get_id transition.comp_name)
-          ^ String.concat ""
-              (List.map
-                 (fun loc ->
-                   Core_kernel.sprintf "  Accept at %s\n" (get_loc_str loc))
-                 group) )
-          warning_level_duplicate_accepts (List.hd group)
-          (accept_loc_end @@ BatList.last group)
+            ^ String.concat ~sep:""
+              (List.map group ~f:(fun loc ->
+                   sprintf "  Accept at %s\n" (get_loc_str loc))) )
+          warning_level_duplicate_accepts (List.hd_exn group)
+          (accept_loc_end @@ List.last_exn group)
       in
 
-      List.iter
-        (fun group ->
-          match group with _ :: _ :: _ -> dup_accept_warning group | _ -> ())
-        transition_accept_groups;
+      List.iter transition_accept_groups ~f:(fun group ->
+          match group with _ :: _ :: _ -> dup_accept_warning group | _ -> ());
 
       transition_accept_groups
     in
 
     let all_accept_groups =
-      List.fold_left
-        (fun acc t -> acc @ check_transition_accepts t)
-        [] contr.ccomps
+      List.concat_map contr.ccomps ~f:check_transition_accepts
     in
 
-    match List.for_all BatList.is_empty all_accept_groups with
-    | true ->
-        warn0
-          (Core_kernel.sprintf
-             "No transition in contract %s contains an accept statement\n"
-             (get_id contr.cname))
-          warning_level_missing_accept
-    | false -> ()
+    if List.for_all all_accept_groups ~f:List.is_empty then
+      warn0
+        (sprintf
+           "No transition in contract %s contains an accept statement\n"
+           (get_id contr.cname))
+        warning_level_missing_accept
 
   (* ************************************** *)
   (* ******** Interface to Accept ********* *)

--- a/src/checkers/Cashflow.ml
+++ b/src/checkers/Cashflow.ml
@@ -16,6 +16,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open Sexplib.Std
 open Syntax
 open Datatypes

--- a/src/checkers/Cashflow.ml
+++ b/src/checkers/Cashflow.ml
@@ -204,7 +204,7 @@ struct
   let cf_init_tag_contract contract token_fields =
     let { cname; cparams; cconstraint; cfields; ccomps } = contract in
     let token_fields_contains x =
-      List.exists ~f:(fun token_field -> get_id x = token_field) token_fields
+      List.mem token_fields (get_id x) ~equal:String.( = )
     in
     {
       CFSyntax.cname;

--- a/src/checkers/Cashflow.ml
+++ b/src/checkers/Cashflow.ml
@@ -334,8 +334,7 @@ struct
                  takes no argument : NoInfo *)
             else if
               List.length adt.tconstr = 2
-              && List.exists adt.tmap ~f:(fun (_, arg_typs) ->
-                     match arg_typs with [] -> true | _ -> false)
+              && List.exists adt.tmap ~f:(fun (_, arg_typs) -> List.is_empty arg_typs)
               && List.exists adt.tmap ~f:(fun (_, arg_typs) ->
                      match arg_typs with
                      | [ ADT (arg_typ_name, _) ] ->

--- a/src/checkers/Cashflow.ml
+++ b/src/checkers/Cashflow.ml
@@ -334,7 +334,8 @@ struct
                  takes no argument : NoInfo *)
             else if
               List.length adt.tconstr = 2
-              && List.exists adt.tmap ~f:(fun (_, arg_typs) -> List.is_empty arg_typs)
+              && List.exists adt.tmap ~f:(fun (_, arg_typs) ->
+                     List.is_empty arg_typs)
               && List.exists adt.tmap ~f:(fun (_, arg_typs) ->
                      match arg_typs with
                      | [ ADT (arg_typ_name, _) ] ->
@@ -419,7 +420,8 @@ struct
             let tvar_tag_map =
               let zipped_tvar_tags =
                 match expected_tag with
-                | Adt (exp_typ_name, arg_tags) when String.(exp_typ_name = adt.tname) ->
+                | Adt (exp_typ_name, arg_tags)
+                  when String.(exp_typ_name = adt.tname) ->
                     List.zip adt.tparams arg_tags
                 | NoInfo (* Nothing known *) | Money (* Nat case *) | NotMoney
                 (* Nat case *) ->
@@ -447,7 +449,9 @@ struct
               | ADT (adt_name, arg_typs) ->
                   Adt (get_id adt_name, List.map arg_typs ~f:tag_tmap)
               | TypeVar tvar -> (
-                  match List.Assoc.find tvar_tag_map ~equal:String.( = ) tvar with
+                  match
+                    List.Assoc.find tvar_tag_map ~equal:String.( = ) tvar
+                  with
                   | Some tag -> tag
                   | None -> Inconsistent )
               | _ -> Inconsistent
@@ -490,8 +494,12 @@ struct
           List.map2 arg_map_tags arg_tags ~f:(fun arg_map_tag arg_tag ->
               Option.map arg_map_tag ~f:(lub_tags arg_tag))
         with
-        | Ok new_tags when not @@ [%equal: ECFR.money_tag Option.t list] new_tags arg_map_tags ->
-            Some (List.Assoc.add ctr_tag_map ~equal:String.( = ) ctr_name new_tags)
+        | Ok new_tags
+          when not
+               @@ [%equal: ECFR.money_tag Option.t list] new_tags arg_map_tags
+          ->
+            Some
+              (List.Assoc.add ctr_tag_map ~equal:String.( = ) ctr_name new_tags)
         | _ -> None )
 
   (*******************************************************)
@@ -1033,7 +1041,7 @@ struct
             new_x_tag,
             new_local_env,
             ctr_tag_map,
-            not @@ [%equal: ECFR.money_tag] (get_id_tag x) (get_id_tag new_x))
+            not @@ [%equal: ECFR.money_tag] (get_id_tag x) (get_id_tag new_x) )
       | Constructor (s, ps) ->
           let new_ps, new_ps_tags, new_local_env, ps_ctr_tag_map, ps_changes =
             List.fold_right ps ~init:([], [], local_env, ctr_tag_map, false)
@@ -1196,8 +1204,8 @@ struct
             res_param_env,
             new_local_env,
             res_ctr_tag_map,
-            body_changes ||
-            not @@ [%equal: ECFR.money_tag] (get_id_tag arg) res_arg_tag )
+            body_changes
+            || (not @@ [%equal: ECFR.money_tag] (get_id_tag arg) res_arg_tag) )
       | App (f, args) ->
           let new_args =
             List.map
@@ -1209,7 +1217,9 @@ struct
             match
               List.exists2
                 ~f:(fun arg new_arg ->
-                      not @@ [%equal: ECFR.money_tag] (get_id_tag arg) (get_id_tag new_arg))
+                  not
+                  @@ [%equal: ECFR.money_tag] (get_id_tag arg)
+                       (get_id_tag new_arg))
                 args new_args
             with
             | Ok res -> res
@@ -1228,8 +1238,8 @@ struct
             param_env,
             new_local_env,
             ctr_tag_map,
-            args_changes ||
-            not @@ [%equal: ECFR.money_tag] f_tag (get_id_tag f) )
+            args_changes
+            || (not @@ [%equal: ECFR.money_tag] f_tag (get_id_tag f)) )
       | Builtin (f, args) ->
           let args_tags =
             List.map
@@ -1255,8 +1265,9 @@ struct
                 ( update_id_tag arg arg_tag :: acc_args,
                   new_param_env,
                   new_local_env,
-                  acc_changes ||
-                  not @@ [%equal: ECFR.money_tag] (get_id_tag arg) arg_tag ))
+                  acc_changes
+                  || (not @@ [%equal: ECFR.money_tag] (get_id_tag arg) arg_tag)
+                ))
           in
           let f_tag = lub_tags (Map res_tag) (Map expected_tag) in
 
@@ -1268,8 +1279,7 @@ struct
             final_param_env,
             final_local_env,
             ctr_tag_map,
-            changes ||
-            not @@ [%equal: ECFR.money_tag] f_tag tag )
+            changes || (not @@ [%equal: ECFR.money_tag] f_tag tag) )
       | Let (i, topt, lhs, rhs) ->
           let ( ((_, (new_lhs_tag, _)) as new_lhs),
                 lhs_param_env,
@@ -1297,8 +1307,8 @@ struct
             rhs_param_env,
             res_local_env,
             rhs_ctr_tag_map,
-            lhs_changes || rhs_changes ||
-            not @@ [%equal: ECFR.money_tag] new_i_tag (get_id_tag i) )
+            lhs_changes || rhs_changes
+            || (not @@ [%equal: ECFR.money_tag] new_i_tag (get_id_tag i)) )
       | Constr (cname, ts, args) ->
           let new_args =
             List.map
@@ -1308,8 +1318,11 @@ struct
           in
           let args_changes =
             match
-              List.exists2 ~f:(fun arg new_arg ->
-                  not @@ [%equal: ECFR.money_tag] (get_id_tag arg) (get_id_tag new_arg))
+              List.exists2
+                ~f:(fun arg new_arg ->
+                  not
+                  @@ [%equal: ECFR.money_tag] (get_id_tag arg)
+                       (get_id_tag new_arg))
                 args new_args
             with
             | Ok res -> res
@@ -1392,8 +1405,8 @@ struct
             res_param_env,
             res_local_env,
             new_ctr_tag_map,
-            clause_changes ||
-            not @@ [%equal: ECFR.money_tag] (get_id_tag x) (new_x_tag) )
+            clause_changes
+            || (not @@ [%equal: ECFR.money_tag] (get_id_tag x) new_x_tag) )
       | Fixpoint (_f, _t, _body) ->
           (* Library functions not handled. *)
           (e, Inconsistent, param_env, local_env, ctr_tag_map, false)
@@ -1436,10 +1449,11 @@ struct
                       match s with
                       | x when String.(x = MessagePayload.amount_label) -> Money
                       | x
-                        when String.(x = MessagePayload.tag_label
-                             || x = MessagePayload.recipient_label
-                             || x = MessagePayload.eventname_label
-                             || x = MessagePayload.exception_label) ->
+                        when String.(
+                               x = MessagePayload.tag_label
+                               || x = MessagePayload.recipient_label
+                               || x = MessagePayload.eventname_label
+                               || x = MessagePayload.exception_label) ->
                           NotMoney
                       | _ -> NoInfo
                     in
@@ -1454,8 +1468,9 @@ struct
                     ( (s, MVar new_x) :: acc_bs,
                       new_param_env,
                       new_local_env,
-                      acc_changes ||
-                      not @@ [%equal: ECFR.money_tag] (get_id_tag x) new_x_tag ))
+                      acc_changes
+                      || not
+                         @@ [%equal: ECFR.money_tag] (get_id_tag x) new_x_tag ))
           in
           ( Message new_bs,
             NotMoney,
@@ -1469,8 +1484,7 @@ struct
       new_param_env,
       new_local_env,
       new_ctr_tag_map,
-      new_changes ||
-      not @@ [%equal: ECFR.money_tag] tag e_tag )
+      new_changes || (not @@ [%equal: ECFR.money_tag] tag e_tag) )
 
   (* Helper function for Load and Store - ensure field and local have same tag *)
   let cf_update_tag_for_field_assignment f x param_env field_env local_env =
@@ -1506,9 +1520,9 @@ struct
             new_field_env,
             new_local_env,
             ctr_tag_map,
-            not @@ [%equal: ECFR.money_tag] (get_id_tag new_x) (get_id_tag x) ||
-            not @@ [%equal: ECFR.money_tag] (get_id_tag new_f) (get_id_tag f)
-          )
+            (not @@ [%equal: ECFR.money_tag] (get_id_tag new_x) (get_id_tag x))
+            || not
+               @@ [%equal: ECFR.money_tag] (get_id_tag new_f) (get_id_tag f) )
       | Store (f, x) ->
           let new_f, new_x, new_param_env, new_field_env, new_local_env =
             cf_update_tag_for_field_assignment f x param_env field_env local_env
@@ -1518,9 +1532,9 @@ struct
             new_field_env,
             new_local_env,
             ctr_tag_map,
-            not @@ [%equal: ECFR.money_tag] (get_id_tag new_x) (get_id_tag x) ||
-            not @@ [%equal: ECFR.money_tag] (get_id_tag new_f) (get_id_tag f)
-          )
+            (not @@ [%equal: ECFR.money_tag] (get_id_tag new_x) (get_id_tag x))
+            || not
+               @@ [%equal: ECFR.money_tag] (get_id_tag new_f) (get_id_tag f) )
       | Bind (x, e) ->
           let x_tag = lookup_var_tag x local_env in
           let e_local_env = AssocDictionary.remove (get_id x) local_env in
@@ -1538,8 +1552,8 @@ struct
             field_env,
             new_local_env,
             new_ctr_tag_map,
-            e_changes ||
-            not @@ [%equal: ECFR.money_tag] (get_id_tag x) new_x_tag )
+            e_changes
+            || (not @@ [%equal: ECFR.money_tag] (get_id_tag x) new_x_tag) )
       | MapUpdate (m, ks, v_opt) ->
           let v_tag =
             match v_opt with
@@ -1582,9 +1596,9 @@ struct
             new_field_env,
             new_local_env,
             ctr_tag_map,
-            not @@ [%equal: ECFR.money_tag] (get_id_tag m) m_tag ||
-            not @@ [%equal: _] new_v_opt v_opt ||
-            not @@ [%equal: _] new_ks ks )
+            (not @@ [%equal: ECFR.money_tag] (get_id_tag m) m_tag)
+            || (not @@ [%equal: _] new_v_opt v_opt)
+            || (not @@ [%equal: _] new_ks ks) )
       | MapGet (x, m, ks, fetch) ->
           let x_tag = lookup_var_tag x local_env in
           let val_tag =
@@ -1628,10 +1642,9 @@ struct
             new_field_env,
             ks_local_env,
             ctr_tag_map,
-            not @@ [%equal: ECFR.money_tag] (get_id_tag x) new_x_tag ||
-            not @@ [%equal: ECFR.money_tag] (get_id_tag m) m_tag ||
-            not @@ [%equal: _] new_ks ks
-          )
+            (not @@ [%equal: ECFR.money_tag] (get_id_tag x) new_x_tag)
+            || (not @@ [%equal: ECFR.money_tag] (get_id_tag m) m_tag)
+            || (not @@ [%equal: _] new_ks ks) )
       | MatchStmt (x, clauses) ->
           let ( res_clauses,
                 new_param_env,
@@ -1695,8 +1708,8 @@ struct
             new_field_env,
             res_local_env,
             new_ctr_tag_map,
-            clause_changes ||
-            not @@ [%equal: ECFR.money_tag] (get_id_tag x) new_x_tag )
+            clause_changes
+            || (not @@ [%equal: ECFR.money_tag] (get_id_tag x) new_x_tag) )
       | ReadFromBC (x, s) ->
           let x_tag = lub_tags NotMoney (lookup_var_tag x local_env) in
           let new_x = update_id_tag x x_tag in
@@ -1740,8 +1753,11 @@ struct
           in
           let args_changes =
             match
-              List.exists2 ~f:(fun arg new_arg ->
-                  not @@ [%equal: ECFR.money_tag] (get_id_tag arg) (get_id_tag new_arg))
+              List.exists2
+                ~f:(fun arg new_arg ->
+                  not
+                  @@ [%equal: ECFR.money_tag] (get_id_tag arg)
+                       (get_id_tag new_arg))
                 args new_args
             with
             | Ok res -> res
@@ -1838,8 +1854,8 @@ struct
         ~f:(fun (p, typ) (acc_ps, acc_changes) ->
           let new_tag = lookup_var_tag p new_local_env in
           ( (update_id_tag p new_tag, typ) :: acc_ps,
-            acc_changes ||
-            not @@ [%equal: ECFR.money_tag] (get_id_tag p) new_tag ))
+            acc_changes
+            || (not @@ [%equal: ECFR.money_tag] (get_id_tag p) new_tag) ))
     in
     ( {
         comp_type;
@@ -1957,7 +1973,9 @@ struct
       List.filter_map all_adts ~f:(fun adt ->
           match
             List.filter_map adt.tconstr ~f:(fun ctr ->
-                match List.Assoc.find ctr_tag_map ~equal:String.( = ) ctr.cname with
+                match
+                  List.Assoc.find ctr_tag_map ~equal:String.( = ) ctr.cname
+                with
                 | Some arg_tag_opts -> Some (ctr.cname, arg_tag_opts)
                 | None -> None)
           with

--- a/src/checkers/EventInfo.ml
+++ b/src/checkers/EventInfo.ml
@@ -64,10 +64,11 @@ struct
           | Some tlist ->
               (* verify types match *)
               let printer tplist =
-                "[" ^
-                (List.map tplist ~f:(fun (n, t) -> Printf.sprintf "(%s : %s); " n (pp_typ t))
-                 |> String.concat ~sep:"") ^
-                "]"
+                "["
+                ^ ( List.map tplist ~f:(fun (n, t) ->
+                        Printf.sprintf "(%s : %s); " n (pp_typ t))
+                  |> String.concat ~sep:"" )
+                ^ "]"
               in
               if not @@ [%equal: (string * typ) list] m_types tlist then
                 fail1

--- a/src/checkers/EventInfo.ml
+++ b/src/checkers/EventInfo.ml
@@ -40,7 +40,7 @@ struct
           in
           (* Get the type of the event parameters. *)
           let filtered_m =
-            List.filter (fun (label, _) -> not (label = eventname_label)) m
+            List.filter m ~f:(fun (label, _) -> not String.(label = eventname_label))
           in
           let%bind m_types =
             mapM

--- a/src/checkers/EventInfo.ml
+++ b/src/checkers/EventInfo.ml
@@ -64,9 +64,10 @@ struct
           | Some tlist ->
               (* verify types match *)
               let printer tplist =
-                List.fold_left tplist ~init:"[" ~f:(fun acc (n, t) ->
-                    acc ^ Printf.sprintf "(%s : %s); " n (pp_typ t))
-                ^ "]"
+                "[" ^
+                (List.map tplist ~f:(fun (n, t) -> Printf.sprintf "(%s : %s); " n (pp_typ t))
+                 |> String.concat ~sep:"") ^
+                "]"
               in
               if not @@ [%equal: (string * typ) list] m_types tlist then
                 fail1

--- a/src/checkers/EventInfo.ml
+++ b/src/checkers/EventInfo.ml
@@ -29,8 +29,8 @@ struct
      * info from message and append to the list. *)
     let extract_from_message bloc m acc =
       (* Check if this is for an event. *)
-      match List.find_opt (fun (label, _) -> label = eventname_label) m with
-      | Some (_, epld) -> (
+      match List.Assoc.find m eventname_label ~equal:String.( = ) with
+      | Some epld ->
           let emsg = "Error determining event name\n" in
           let%bind eventname =
             match epld with
@@ -59,8 +59,8 @@ struct
           in
           (* If we already have an entry for "eventname" in "acc",
              * check that the type matches. Add entry otherwise. *)
-          match List.find_opt (fun (n, _) -> n = eventname) acc with
-          | Some (_, tlist) ->
+          (match List.Assoc.find acc eventname ~equal:String.( = ) with
+           | Some tlist ->
               (* verify types match *)
               let printer tplist =
                 List.fold_left

--- a/src/checkers/EventInfo.ml
+++ b/src/checkers/EventInfo.ml
@@ -30,18 +30,20 @@ struct
     let extract_from_message bloc m acc =
       (* Check if this is for an event. *)
       match List.Assoc.find m eventname_label ~equal:String.( = ) with
-      | Some epld ->
+      | Some epld -> (
           let emsg = "Error determining event name\n" in
           let%bind eventname =
-            (match epld with
-             | MLit l -> (match l with StringLit s -> pure s | _ -> fail1 emsg bloc)
-             (* Variables are not allowed for eventname_label to ensure that
-                all possible events can be determined statically. *)
-             | MVar _ -> fail1 emsg bloc)
+            match epld with
+            | MLit l -> (
+                match l with StringLit s -> pure s | _ -> fail1 emsg bloc )
+            (* Variables are not allowed for eventname_label to ensure that
+               all possible events can be determined statically. *)
+            | MVar _ -> fail1 emsg bloc
           in
           (* Get the type of the event parameters. *)
           let filtered_m =
-            List.filter m ~f:(fun (label, _) -> not String.(label = eventname_label))
+            List.filter m ~f:(fun (label, _) ->
+                not String.(label = eventname_label))
           in
           let%bind m_types =
             mapM
@@ -58,11 +60,11 @@ struct
           in
           (* If we already have an entry for "eventname" in "acc",
              * check that the type matches. Add entry otherwise. *)
-          (match List.Assoc.find acc eventname ~equal:String.( = ) with
-           | Some tlist ->
+          match List.Assoc.find acc eventname ~equal:String.( = ) with
+          | Some tlist ->
               (* verify types match *)
               let printer tplist =
-                List.fold_left tplist ~init: "[" ~f:(fun acc (n, t) ->
+                List.fold_left tplist ~init:"[" ~f:(fun acc (n, t) ->
                     acc ^ Printf.sprintf "(%s : %s); " n (pp_typ t))
                 ^ "]"
               in
@@ -72,10 +74,10 @@ struct
                      eventname (printer tlist) (printer m_types))
                   bloc
               else pure acc
-           | None ->
-               (* No entry. *)
-               let entry = (eventname, m_types) in
-               pure (entry :: acc) )
+          | None ->
+              (* No entry. *)
+              let entry = (eventname, m_types) in
+              pure (entry :: acc) )
       | None -> (* Not for an event. *) pure acc
     in
 

--- a/src/checkers/EventInfo.ml
+++ b/src/checkers/EventInfo.ml
@@ -67,7 +67,7 @@ struct
                   "[" tplist
                 ^ "]"
               in
-              if m_types <> tlist then
+              if not @@ [%equal: (string * typ) list] m_types tlist then
                 fail1
                   (Printf.sprintf "Parameter mismatch for event %s. %s vs %s\n"
                      eventname (printer tlist) (printer m_types))

--- a/src/checkers/EventInfo.ml
+++ b/src/checkers/EventInfo.ml
@@ -33,12 +33,11 @@ struct
       | Some epld ->
           let emsg = "Error determining event name\n" in
           let%bind eventname =
-            match epld with
-            | MLit l -> (
-                match l with StringLit s -> pure s | _ -> fail1 emsg bloc )
-            (* Variables are not allowed for eventname_label to ensure that
-             * all possible events can be determined statically. *)
-            | MVar _ -> fail1 emsg bloc
+            (match epld with
+             | MLit l -> (match l with StringLit s -> pure s | _ -> fail1 emsg bloc)
+             (* Variables are not allowed for eventname_label to ensure that
+                all possible events can be determined statically. *)
+             | MVar _ -> fail1 emsg bloc)
           in
           (* Get the type of the event parameters. *)
           let filtered_m =
@@ -63,10 +62,8 @@ struct
            | Some tlist ->
               (* verify types match *)
               let printer tplist =
-                List.fold_left
-                  (fun acc (n, t) ->
+                List.fold_left tplist ~init: "[" ~f:(fun acc (n, t) ->
                     acc ^ Printf.sprintf "(%s : %s); " n (pp_typ t))
-                  "[" tplist
                 ^ "]"
               in
               if not @@ [%equal: (string * typ) list] m_types tlist then
@@ -74,11 +71,11 @@ struct
                   (Printf.sprintf "Parameter mismatch for event %s. %s vs %s\n"
                      eventname (printer tlist) (printer m_types))
                   bloc
-              else pure @@ acc
-          | None ->
-              (* No entry. *)
-              let entry = (eventname, m_types) in
-              pure (entry :: acc) )
+              else pure acc
+           | None ->
+               (* No entry. *)
+               let entry = (eventname, m_types) in
+               pure (entry :: acc) )
       | None -> (* Not for an event. *) pure acc
     in
 

--- a/src/checkers/EventInfo.ml
+++ b/src/checkers/EventInfo.ml
@@ -1,8 +1,10 @@
+open Core_kernel
+open! Int.Replace_polymorphic_compare
+open Result.Let_syntax
 open TypeUtil
 open Syntax
 open ContractUtil.MessagePayload
 open MonadUtil
-open Core_kernel.Result.Let_syntax
 
 module ScillaEventInfo
     (SR : Rep) (ER : sig

--- a/src/checkers/GasUseAnalysis.ml
+++ b/src/checkers/GasUseAnalysis.ml
@@ -17,12 +17,12 @@
 
 (* Gas Usage Analysis for Scilla contracts. *)
 
+open Core_kernel.Result.Let_syntax
 open TypeUtil
 open Syntax
 open ErrorUtils
 open MonadUtil
 open Polynomial
-open Core_kernel.Result.Let_syntax
 
 module ScillaGUA
     (SR : Rep) (ER : sig

--- a/src/checkers/PatternChecker.ml
+++ b/src/checkers/PatternChecker.ml
@@ -16,6 +16,7 @@
 
 open Syntax
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open ErrorUtils
 open MonadUtil
 open Result.Let_syntax

--- a/src/checkers/PatternChecker.ml
+++ b/src/checkers/PatternChecker.ml
@@ -49,11 +49,12 @@ struct
     let reachable = Array.create ~len:(List.length clauses) false in
     let static_match c_name span dsc =
       match dsc with
-      | Pos (dsc_c_name, _) -> if c_name = dsc_c_name then Yes else No
-      | Neg c_names -> (
-          match List.findi c_names ~f:(fun _ c -> c = c_name) with
-          | None -> if List.length c_names = span - 1 then Yes else Maybe
-          | Some _ -> No )
+      | Pos (dsc_c_name, _) -> if String.(c_name = dsc_c_name) then Yes else No
+      | Neg c_names ->
+          if List.mem c_names c_name ~equal:String.( = ) then
+            No
+          else
+            if List.length c_names = span - 1 then Yes else Maybe
     in
     let rec traverse_clauses dsc i rest_clauses =
       match rest_clauses with

--- a/src/checkers/PatternChecker.ml
+++ b/src/checkers/PatternChecker.ml
@@ -16,7 +16,7 @@
 
 open Syntax
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open ErrorUtils
 open MonadUtil
 open Result.Let_syntax
@@ -376,7 +376,7 @@ struct
        in
        let checked_comps = List.rev c_comps in
 
-       if emsgs''' = [] (* Return pure environment *) then
+       if List.is_empty emsgs''' (* Return pure environment *) then
          pure
            ( {
                CheckedPatternSyntax.smver = mod_smver;

--- a/src/checkers/PatternChecker.ml
+++ b/src/checkers/PatternChecker.ml
@@ -51,10 +51,9 @@ struct
       match dsc with
       | Pos (dsc_c_name, _) -> if String.(c_name = dsc_c_name) then Yes else No
       | Neg c_names ->
-          if List.mem c_names c_name ~equal:String.( = ) then
-            No
-          else
-            if List.length c_names = span - 1 then Yes else Maybe
+          if List.mem c_names c_name ~equal:String.( = ) then No
+          else if List.length c_names = span - 1 then Yes
+          else Maybe
     in
     let rec traverse_clauses dsc i rest_clauses =
       match rest_clauses with

--- a/src/checkers/SanityChecker.ml
+++ b/src/checkers/SanityChecker.ml
@@ -124,9 +124,8 @@ struct
                 eloc
         else if
           (* It must be an event or an exception. *)
-          List.exists
-            (fun (s, _) -> s = eventname_label || s = exception_label)
-            msg
+          List.exists msg ~f:(fun (s, _) ->
+              String.(s = eventname_label || s = exception_label))
         then e
         else e @ mk_error1 "Invalid message construct." eloc
       in
@@ -216,17 +215,17 @@ struct
   module CheckShadowing = struct
     (* A utility function that checks if "id" is shadowing cparams, cfields or pnames. *)
     let check_warn_redef cparams cfields pnames id =
-      if List.mem (get_id id) cparams then
+      if List.mem cparams (get_id id) ~equal:String.( = ) then
         warn1
           (Printf.sprintf "Name %s shadows a contract parameter." (get_id id))
           warning_level_name_shadowing
           (ER.get_loc (get_rep id))
-      else if List.mem (get_id id) cfields then
+      else if List.mem cfields (get_id id) ~equal:String.( = ) then
         warn1
           (Printf.sprintf "Name %s shadows a field declaration." (get_id id))
           warning_level_name_shadowing
           (ER.get_loc (get_rep id))
-      else if List.mem (get_id id) pnames then
+      else if List.mem pnames (get_id id) ~equal:String.( = ) then
         warn1
           (Printf.sprintf "Name %s shadows a transition parameter." (get_id id))
           warning_level_name_shadowing

--- a/src/checkers/SanityChecker.ml
+++ b/src/checkers/SanityChecker.ml
@@ -81,20 +81,20 @@ struct
     let e =
       e
       @ check_duplicate_ident ER.get_loc
-        (List.map contr.cfields ~f:(fun (i, _, _) -> i))
+          (List.map contr.cfields ~f:(fun (i, _, _) -> i))
     in
     (* No repeating component names. *)
     let e =
       e
       @ check_duplicate_ident SR.get_loc
-        (List.map contr.ccomps ~f:(fun c -> c.comp_name))
+          (List.map contr.ccomps ~f:(fun c -> c.comp_name))
     in
     (* No repeating component parameter names. *)
     let e =
       List.fold_left contr.ccomps ~init:e ~f:(fun e t ->
           e
           @ check_duplicate_ident ER.get_loc
-            (List.map t.comp_params ~f:(fun (i, _) -> i)))
+              (List.map t.comp_params ~f:(fun (i, _) -> i)))
     in
 
     (* Message literals must either be for "send" or "event" and well formed. *)
@@ -143,8 +143,8 @@ struct
           | Some (s, _) ->
               e
               @ mk_error1
-                  (sprintf
-                     "Parameter %s in %s %s cannot be explicit.\n" (get_id s)
+                  (sprintf "Parameter %s in %s %s cannot be explicit.\n"
+                     (get_id s)
                      (component_type_to_string c.comp_type)
                      (get_id c.comp_name))
                   (SR.get_loc @@ get_rep c.comp_name)
@@ -164,8 +164,7 @@ struct
       | Some (s, _) ->
           e
           @ mk_error1
-              (sprintf "Contract parameter %s cannot be explicit.\n"
-                 (get_id s))
+              (sprintf "Contract parameter %s cannot be explicit.\n" (get_id s))
               (ER.get_loc @@ get_rep s)
       | None -> e
     in
@@ -228,8 +227,7 @@ struct
       let rec outer_scope_iter = function
         | Wildcard -> ()
         | Binder i -> check_warn_redef cparams cfields pnames i
-        | Constructor (_, plist) ->
-            List.iter plist ~f:outer_scope_iter
+        | Constructor (_, plist) -> List.iter plist ~f:outer_scope_iter
       in
       outer_scope_iter pat;
       (* Check for shadowing of names within this pattern and warn that it is
@@ -304,13 +302,16 @@ struct
           cmod.contr.cfields
       in
 
-      let cfields = List.map cmod.contr.cfields ~f:(fun (f, _, _) -> get_id f) in
+      let cfields =
+        List.map cmod.contr.cfields ~f:(fun (f, _, _) -> get_id f)
+      in
 
       (* Go through each component. *)
       iterM
         ~f:(fun c ->
           (* 1. If a parameter name shadows one of cparams or cfields, warn. *)
-          List.iter c.comp_params ~f:(fun (p, _) -> check_warn_redef cparams cfields [] p);
+          List.iter c.comp_params ~f:(fun (p, _) ->
+              check_warn_redef cparams cfields [] p);
           let pnames = List.map c.comp_params ~f:(fun (p, _) -> get_id p) in
           (* Check for shadowing in statements. *)
           let rec stmt_iter stmts =

--- a/src/checkers/TypeInfo.ml
+++ b/src/checkers/TypeInfo.ml
@@ -17,7 +17,7 @@
 *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open TypeUtil
 open Syntax
 open ErrorUtils

--- a/src/checkers/TypeInfo.ml
+++ b/src/checkers/TypeInfo.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open TypeUtil
 open Syntax
 open ErrorUtils

--- a/src/checkers/dune
+++ b/src/checkers/dune
@@ -1,8 +1,8 @@
 (library
  (name scilla_checkers)
  (wrapped false)
- (libraries core angstrom stdint polynomials ppx_sexp_conv ppx_deriving
-   batteries ppx_let yojson cryptokit scilla_base)
+ (libraries core angstrom stdint polynomials
+   batteries yojson cryptokit scilla_base)
  (preprocess
   (pps ppx_sexp_conv ppx_let bisect_ppx ppx_compare -conditional ppx_deriving.show))
  (synopsis "Custom Scilla checkers"))

--- a/src/checkers/dune
+++ b/src/checkers/dune
@@ -1,8 +1,9 @@
 (library
  (name scilla_checkers)
  (wrapped false)
- (libraries core angstrom stdint polynomials
-   batteries yojson cryptokit scilla_base)
+ (libraries core angstrom stdint polynomials batteries yojson cryptokit
+   scilla_base)
  (preprocess
-  (pps ppx_sexp_conv ppx_let bisect_ppx ppx_compare -conditional ppx_deriving.show))
+  (pps ppx_sexp_conv ppx_let bisect_ppx ppx_compare -conditional
+    ppx_deriving.show))
  (synopsis "Custom Scilla checkers"))

--- a/src/checkers/dune
+++ b/src/checkers/dune
@@ -4,5 +4,5 @@
  (libraries core angstrom stdint polynomials ppx_sexp_conv ppx_deriving
    batteries ppx_let yojson cryptokit scilla_base)
  (preprocess
-  (pps ppx_sexp_conv ppx_let bisect_ppx -conditional ppx_deriving.show))
+  (pps ppx_sexp_conv ppx_let bisect_ppx ppx_compare -conditional ppx_deriving.show))
  (synopsis "Custom Scilla checkers"))

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -50,7 +50,9 @@ let pp_result r exclude_names =
   match r with
   | Error (s, _) -> sprint_scilla_error_list s
   | Ok ((e, env), _) ->
-      let filter_prelude (k, _) = not @@ List.mem enames k ~equal:String.( = ) in
+      let filter_prelude (k, _) =
+        not @@ List.mem enames k ~equal:String.( = )
+      in
       sprintf "%s,\n%s" (Env.pp_value e) (Env.pp ~f:filter_prelude env)
 
 (* Makes sure that the literal has no closures in it *)
@@ -522,7 +524,8 @@ let init_contract clibs elibs cconstraint' cparams' cfields args' init_bal =
           tryM
             ~f:(fun (ps, pt) ->
               let%bind at = fromR @@ literal_type (snd a) in
-              if String.(get_id ps = fst a) && [%equal: typ] pt at then pure true
+              if String.(get_id ps = fst a) && [%equal: typ] pt at then
+                pure true
               else fail0 "")
             cparams ~msg:emsg
         in
@@ -571,7 +574,8 @@ let create_cur_state_fields initcstate curcstate =
             ~f:(fun (t, li) ->
               let%bind t1 = fromR @@ literal_type lc in
               let%bind t2 = fromR @@ literal_type li in
-              if String.(s = t) && [%equal: typ] t1 t2 then pure true else fail0 "")
+              if String.(s = t) && [%equal: typ] t1 t2 then pure true
+              else fail0 "")
             initcstate ~msg:emsg
         in
         pure ex)
@@ -660,7 +664,11 @@ let check_message_entries cparams_o entries =
         List.exists tparams ~f:(fun (i, _) -> String.(s = get_id i)))
   in
   (* Each entry name is unique *)
-  let uniq_entries = not @@ List.contains_dup entries ~compare:(fun (s, _) (t, _) -> String.compare s t) in
+  let uniq_entries =
+    not
+    @@ List.contains_dup entries ~compare:(fun (s, _) (t, _) ->
+           String.compare s t)
+  in
   if not (valid_entries && uniq_entries && valid_params) then
     fail0
     @@ sprintf

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -571,7 +571,7 @@ let create_cur_state_fields initcstate curcstate =
             ~f:(fun (t, li) ->
               let%bind t1 = fromR @@ literal_type lc in
               let%bind t2 = fromR @@ literal_type li in
-              if s = t && type_equiv t1 t2 then pure true else fail0 "")
+              if String.(s = t) && [%equal: typ] t1 t2 then pure true else fail0 "")
             initcstate ~msg:emsg
         in
         pure ex)

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -18,6 +18,7 @@
 
 open Syntax
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open ErrorUtils
 open EvalUtil
 open MonadUtil

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -16,9 +16,9 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Syntax
 open Core_kernel
 open! Int.Replace_polymorphic_compare
+open Syntax
 open ErrorUtils
 open EvalUtil
 open MonadUtil

--- a/src/eval/EvalUtil.ml
+++ b/src/eval/EvalUtil.ml
@@ -16,9 +16,9 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Syntax
 open Core_kernel
 open! Int.Replace_polymorphic_compare
+open Syntax
 open ErrorUtils
 open MonadUtil
 open EvalMonad

--- a/src/eval/EvalUtil.ml
+++ b/src/eval/EvalUtil.ml
@@ -286,7 +286,8 @@ module Configuration = struct
   let lookup_procedure st proc_name =
     let rec finder procs =
       match procs with
-      | p :: p_rest when String.(get_id p.comp_name = proc_name) -> pure (p, p_rest)
+      | p :: p_rest when String.(get_id p.comp_name = proc_name) ->
+          pure (p, p_rest)
       | _ :: p_rest -> finder p_rest
       | [] -> fail0 @@ sprintf "Procedure %s not found." proc_name
     in
@@ -317,8 +318,14 @@ module Configuration = struct
         (* All outgoing messages must have certain mandatory fields *)
         let tag_found = List.Assoc.mem m tag_label ~equal:String.( = ) in
         let amount_found = List.Assoc.mem m amount_label ~equal:String.( = ) in
-        let recipient_found = List.Assoc.mem m recipient_label ~equal:String.( = ) in
-        let uniq_entries = not @@ List.contains_dup m ~compare:(fun (s, _) (t, _) -> String.compare s t) in
+        let recipient_found =
+          List.Assoc.mem m recipient_label ~equal:String.( = )
+        in
+        let uniq_entries =
+          not
+          @@ List.contains_dup m ~compare:(fun (s, _) (t, _) ->
+                 String.compare s t)
+        in
         if tag_found && amount_found && recipient_found && uniq_entries then
           pure m'
         else
@@ -347,7 +354,11 @@ module Configuration = struct
         let eventname_found =
           List.Assoc.mem m eventname_label ~equal:String.( = )
         in
-        let uniq_entries = not @@ List.contains_dup m ~compare:(fun (s, _) (t, _) -> String.compare s t) in
+        let uniq_entries =
+          not
+          @@ List.contains_dup m ~compare:(fun (s, _) (t, _) ->
+                 String.compare s t)
+        in
         if eventname_found && uniq_entries then pure m'
         else
           fail0

--- a/src/eval/EvalUtil.ml
+++ b/src/eval/EvalUtil.ml
@@ -18,6 +18,7 @@
 
 open Syntax
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open ErrorUtils
 open MonadUtil
 open EvalMonad

--- a/src/eval/EvalUtil.ml
+++ b/src/eval/EvalUtil.ml
@@ -18,7 +18,7 @@
 
 open Syntax
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open ErrorUtils
 open MonadUtil
 open EvalMonad
@@ -179,7 +179,7 @@ module Configuration = struct
 
   let load st k =
     let i = get_id k in
-    if i = balance_label then
+    if String.(i = balance_label) then
       (* Balance is a special case *)
       let l = UintLit (Uint128L st.balance) in
       pure (l, G_Load l)
@@ -257,7 +257,7 @@ module Configuration = struct
     | Ok kvs ->
         let filtered_env =
           List.filter e ~f:(fun z ->
-              not (List.exists ks ~f:(fun x -> fst z = x)))
+              not (List.mem ks (fst z) ~equal:String.( = )))
         in
         pure { st with env = kvs @ filtered_env }
 
@@ -285,7 +285,7 @@ module Configuration = struct
   let lookup_procedure st proc_name =
     let rec finder procs =
       match procs with
-      | p :: p_rest when get_id p.comp_name = proc_name -> pure (p, p_rest)
+      | p :: p_rest when String.(get_id p.comp_name = proc_name) -> pure (p, p_rest)
       | _ :: p_rest -> finder p_rest
       | [] -> fail0 @@ sprintf "Procedure %s not found." proc_name
     in

--- a/src/eval/EvalUtil.ml
+++ b/src/eval/EvalUtil.ml
@@ -78,7 +78,8 @@ module Env = struct
 
   let empty = []
 
-  let bind e k v = (k, v) :: List.filter ~f:(fun z -> fst z <> k) e
+  (* Core's List.Assoc.add function removes duplicate key-value entries to keep lists small *)
+  let bind e k v = List.Assoc.add e k v ~equal:String.( = )
 
   let bind_all e kvs =
     List.fold_left ~init:e ~f:(fun z (k, v) -> bind z k v) kvs
@@ -88,8 +89,8 @@ module Env = struct
 
   let lookup e k =
     let i = get_id k in
-    match List.find ~f:(fun z -> fst z = i) e with
-    | Some x -> pure @@ snd x
+    match List.Assoc.find e i ~equal:String.( = ) with
+    | Some v -> pure v
     | None ->
         fail1
           (sprintf "Identifier \"%s\" is not bound in environment:\n" i)
@@ -103,8 +104,8 @@ module BlockchainState = struct
   type t = (string * literal) list
 
   let lookup e k =
-    match List.find ~f:(fun z -> fst z = k) e with
-    | Some x -> pure @@ snd x
+    match List.Assoc.find e k ~equal:String.( = ) with
+    | Some v -> pure v
     | None ->
         fail0
         @@ sprintf "No value for key \"%s\" at in the blockchain state:\n%s" k
@@ -203,8 +204,8 @@ module Configuration = struct
     let open BuiltIns.UsefulLiterals in
     if fetchval then
       let%bind vopt = fromR @@ StateService.fetch ~fname:m ~keys:klist in
-      match List.find st.fields ~f:(fun (z, _) -> z = get_id m) with
-      | Some (_, mt) -> (
+      match List.Assoc.find st.fields (get_id m) ~equal:String.( = ) with
+      | Some mt -> (
           let%bind vt =
             fromR @@ EvalTypeUtilities.map_access_type mt (List.length klist)
           in
@@ -295,7 +296,7 @@ module Configuration = struct
   let rec validate_messages ls =
     (* Note: We don't need a whole lot of checks as the checker does it. *)
     let validate_msg_payload pl =
-      let has_tag = List.exists pl ~f:(fun (k, _) -> k = "tag") in
+      let has_tag = List.Assoc.mem pl "tag" ~equal:String.( = ) in
       if has_tag then pure true
       else
         fail0
@@ -314,15 +315,10 @@ module Configuration = struct
     match m' with
     | Msg m ->
         (* All outgoing messages must have certain mandatory fields *)
-        let tag_found = List.exists ~f:(fun (s, _) -> s = tag_label) m in
-        let amount_found = List.exists ~f:(fun (s, _) -> s = amount_label) m in
-        let recipient_found =
-          List.exists ~f:(fun (s, _) -> s = recipient_label) m
-        in
-        let uniq_entries =
-          List.for_all m ~f:(fun e ->
-              List.count m ~f:(fun e' -> fst e = fst e') = 1)
-        in
+        let tag_found = List.Assoc.mem m tag_label ~equal:String.( = ) in
+        let amount_found = List.Assoc.mem m amount_label ~equal:String.( = ) in
+        let recipient_found = List.Assoc.mem m recipient_label ~equal:String.( = ) in
+        let uniq_entries = not @@ List.contains_dup m ~compare:(fun (s, _) (t, _) -> String.compare s t) in
         if tag_found && amount_found && recipient_found && uniq_entries then
           pure m'
         else
@@ -349,12 +345,9 @@ module Configuration = struct
     | Msg m ->
         (* All events must have certain mandatory fields *)
         let eventname_found =
-          List.exists ~f:(fun (s, _) -> s = eventname_label) m
+          List.Assoc.mem m eventname_label ~equal:String.( = )
         in
-        let uniq_entries =
-          List.for_all m ~f:(fun e ->
-              List.count m ~f:(fun e' -> fst e = fst e') = 1)
-        in
+        let uniq_entries = not @@ List.contains_dup m ~compare:(fun (s, _) (t, _) -> String.compare s t) in
         if eventname_found && uniq_entries then pure m'
         else
           fail0

--- a/src/eval/EvalUtil.ml
+++ b/src/eval/EvalUtil.ml
@@ -246,7 +246,7 @@ module Configuration = struct
 
   let bind st k v =
     let e = st.env in
-    { st with env = (k, v) :: List.filter ~f:(fun z -> fst z <> k) e }
+    { st with env = List.Assoc.add e k v ~equal:String.( = ) }
 
   let bind_all st ks vs =
     let e = st.env in

--- a/src/eval/Ipcmessage_pb.ml
+++ b/src/eval/Ipcmessage_pb.ml
@@ -1,3 +1,6 @@
+open Core_kernel
+open! Int.Replace_polymorphic_compare
+
 [@@@ocaml.warning "-27-30-39"]
 
 type proto_scilla_val_map_mutable = {

--- a/src/eval/Ipcmessage_pb.ml
+++ b/src/eval/Ipcmessage_pb.ml
@@ -97,13 +97,10 @@ let rec encode_proto_scilla_val_map (v : Ipcmessage_types.proto_scilla_val_map)
   let encode_value x encoder =
     Pbrt.Encoder.nested (encode_proto_scilla_val x) encoder
   in
-  List.iter
-    (fun (k, v) ->
+  List.iter v.Ipcmessage_types.m ~f:(fun (k, v) ->
       Pbrt.Encoder.key (1, Pbrt.Bytes) encoder;
       let map_entry = ((k, Pbrt.Bytes), (v, Pbrt.Bytes)) in
       Pbrt.Encoder.map_entry ~encode_key ~encode_value map_entry encoder)
-    v.Ipcmessage_types.m;
-  ()
 
 and encode_proto_scilla_val (v : Ipcmessage_types.proto_scilla_val) encoder =
   match v with
@@ -120,11 +117,9 @@ let rec encode_proto_scilla_query (v : Ipcmessage_types.proto_scilla_query)
   Pbrt.Encoder.string v.Ipcmessage_types.name encoder;
   Pbrt.Encoder.key (2, Pbrt.Varint) encoder;
   Pbrt.Encoder.int_as_varint v.Ipcmessage_types.mapdepth encoder;
-  List.iter
-    (fun x ->
+  List.iter v.Ipcmessage_types.indices ~f:(fun x ->
       Pbrt.Encoder.key (3, Pbrt.Bytes) encoder;
-      Pbrt.Encoder.bytes x encoder)
-    v.Ipcmessage_types.indices;
+      Pbrt.Encoder.bytes x encoder);
   Pbrt.Encoder.key (4, Pbrt.Varint) encoder;
   Pbrt.Encoder.bool v.Ipcmessage_types.ignoreval encoder;
   ()

--- a/src/eval/Ipcmessage_types.ml
+++ b/src/eval/Ipcmessage_types.ml
@@ -1,3 +1,6 @@
+open Core_kernel
+open! Int.Replace_polymorphic_compare
+
 [@@@ocaml.warning "-27-30-39"]
 
 type proto_scilla_val_map = { m : (string * proto_scilla_val) list }

--- a/src/eval/PatternMatching.ml
+++ b/src/eval/PatternMatching.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open Datatypes
 open Syntax
 open EvalUtil

--- a/src/eval/PatternMatching.ml
+++ b/src/eval/PatternMatching.ml
@@ -17,7 +17,7 @@
 *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open Datatypes
 open Syntax
 open EvalUtil
@@ -44,7 +44,7 @@ let rec match_with_pattern v p =
       else
         match v with
         | ADTValue (cn', _, ls')
-          when cn' = ctr.cname && List.length ls' = ctr.arity -> (
+          when String.(cn' = ctr.cname) && List.length ls' = ctr.arity -> (
             (* The value structure matches the pattern *)
             match List.zip ls' ps with
             | Unequal_lengths ->

--- a/src/eval/StateIPCClient.ml
+++ b/src/eval/StateIPCClient.ml
@@ -16,6 +16,7 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 open Core
+open! Int.Replace_polymorphic_compare
 open Result.Let_syntax
 open MonadUtil
 open Syntax

--- a/src/eval/StateIPCIdl.ml
+++ b/src/eval/StateIPCIdl.ml
@@ -1,3 +1,5 @@
+open Core_kernel
+open! Int.Replace_polymorphic_compare
 open Idl
 
 (* This error matches for the error returned by jsonrpccpp *)

--- a/src/eval/StateService.ml
+++ b/src/eval/StateService.ml
@@ -17,7 +17,7 @@
 *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open Result.Let_syntax
 open MonadUtil
 open TypeUtil
@@ -57,7 +57,7 @@ module MakeStateService () = struct
     | SS (sm, fields) -> pure (sm, fields)
 
   let field_type fields fname =
-    match List.find fields ~f:(fun z -> z.fname = get_id fname) with
+    match List.find fields ~f:(fun z -> String.(z.fname = get_id fname)) with
     | Some f -> pure @@ f.ftyp
     | None ->
         fail1
@@ -67,9 +67,9 @@ module MakeStateService () = struct
 
   let fetch_local ~fname ~keys fields =
     let s = fields in
-    match List.find s ~f:(fun z -> z.fname = get_id fname) with
+    match List.find s ~f:(fun z -> String.(z.fname = get_id fname)) with
     | Some { fname = _; ftyp = MapType _; fval = Some (Map ((kt, vt), mlit)) }
-      when keys <> [] ->
+      when not @@ List.is_empty keys ->
         let%bind ret_val_type =
           SSTypeUtil.map_access_type (MapType (kt, vt)) (List.length keys)
         in
@@ -125,7 +125,7 @@ module MakeStateService () = struct
     | IPC socket_addr -> (
         let%bind tp = field_type fields fname in
         let%bind res = StateIPCClient.fetch ~socket_addr ~fname ~keys ~tp in
-        if keys <> [] then pure @@ (res, G_MapGet (List.length keys, res))
+        if not @@ List.is_empty keys then pure @@ (res, G_MapGet (List.length keys, res))
         else
           match res with
           | None ->
@@ -138,9 +138,9 @@ module MakeStateService () = struct
 
   let update_local ~fname ~keys vopt fields =
     let s = fields in
-    match List.find s ~f:(fun z -> z.fname = get_id fname) with
+    match List.find s ~f:(fun z -> String.(z.fname = get_id fname)) with
     | Some { fname = _; ftyp = _; fval = Some (Map ((_, vt), mlit)) }
-      when keys <> [] ->
+      when not @@ List.is_empty keys ->
         let rec recurser mlit' klist' vt' =
           match klist' with
           (* we're at the last key, update literal. *)
@@ -199,7 +199,7 @@ module MakeStateService () = struct
         match vopt with
         | Some fval' ->
             let fields' =
-              List.filter fields ~f:(fun f -> f.fname <> get_id fname)
+              List.filter fields ~f:(fun f -> String.(f.fname <> get_id fname))
             in
             pure
               ( { fname = f; ftyp = t; fval = Some fval' } :: fields',
@@ -222,7 +222,7 @@ module MakeStateService () = struct
         let%bind _ =
           StateIPCClient.update ~socket_addr ~fname ~keys ~value ~tp
         in
-        if keys <> [] then pure @@ G_MapUpdate (List.length keys, Some value)
+        if not @@ List.is_empty keys then pure @@ G_MapUpdate (List.length keys, Some value)
         else pure @@ G_Store value
     | Local ->
         let%bind fields', g = update_local ~fname ~keys (Some value) fields in

--- a/src/eval/StateService.ml
+++ b/src/eval/StateService.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open Result.Let_syntax
 open MonadUtil
 open TypeUtil

--- a/src/eval/StateService.ml
+++ b/src/eval/StateService.ml
@@ -125,7 +125,8 @@ module MakeStateService () = struct
     | IPC socket_addr -> (
         let%bind tp = field_type fields fname in
         let%bind res = StateIPCClient.fetch ~socket_addr ~fname ~keys ~tp in
-        if not @@ List.is_empty keys then pure @@ (res, G_MapGet (List.length keys, res))
+        if not @@ List.is_empty keys then
+          pure @@ (res, G_MapGet (List.length keys, res))
         else
           match res with
           | None ->
@@ -222,7 +223,8 @@ module MakeStateService () = struct
         let%bind _ =
           StateIPCClient.update ~socket_addr ~fname ~keys ~value ~tp
         in
-        if not @@ List.is_empty keys then pure @@ G_MapUpdate (List.length keys, Some value)
+        if not @@ List.is_empty keys then
+          pure @@ G_MapUpdate (List.length keys, Some value)
         else pure @@ G_Store value
     | Local ->
         let%bind fields', g = update_local ~fname ~keys (Some value) fields in

--- a/src/eval/StateService.ml
+++ b/src/eval/StateService.ml
@@ -78,7 +78,7 @@ module MakeStateService () = struct
           match klist' with
           | [ k ] ->
               (* Just an assert. *)
-              if vt' <> ret_val_type then
+              if not @@ [%equal: typ] vt' ret_val_type then
                 fail1
                   (sprintf
                      "StateService: Failed indexing into map %s. Internal \

--- a/src/eval/dune
+++ b/src/eval/dune
@@ -1,7 +1,7 @@
 (library
  (name scilla_eval)
  (wrapped false)
- (libraries core angstrom stdint ppx_sexp_conv ppx_deriving batteries ppx_let
+ (libraries core angstrom stdint batteries
    yojson cryptokit scilla_base rpclib unix rpclib.json rresult ocaml-protoc)
  (preprocess
   (pps ppx_sexp_conv ppx_let bisect_ppx -conditional ppx_deriving_rpc

--- a/src/eval/dune
+++ b/src/eval/dune
@@ -5,5 +5,5 @@
    yojson cryptokit scilla_base rpclib unix rpclib.json rresult ocaml-protoc)
  (preprocess
   (pps ppx_sexp_conv ppx_let bisect_ppx -conditional ppx_deriving_rpc
-    ppx_deriving.show))
+    ppx_deriving.show ppx_compare))
  (synopsis "Scilla workbench implementation."))

--- a/src/eval/dune
+++ b/src/eval/dune
@@ -1,8 +1,8 @@
 (library
  (name scilla_eval)
  (wrapped false)
- (libraries core angstrom stdint batteries
-   yojson cryptokit scilla_base rpclib unix rpclib.json rresult ocaml-protoc)
+ (libraries core angstrom stdint batteries yojson cryptokit scilla_base
+   rpclib unix rpclib.json rresult ocaml-protoc)
  (preprocess
   (pps ppx_sexp_conv ppx_let bisect_ppx -conditional ppx_deriving_rpc
     ppx_deriving.show ppx_compare))

--- a/src/polynomials/Polynomial.ml
+++ b/src/polynomials/Polynomial.ml
@@ -19,6 +19,7 @@
 (* Library to create and operate on multivariate polynomials *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 
 exception Polynomial_error of string
 

--- a/src/polynomials/Polynomial.ml
+++ b/src/polynomials/Polynomial.ml
@@ -19,7 +19,6 @@
 (* Library to create and operate on multivariate polynomials *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
 
 exception Polynomial_error of string
 

--- a/src/runners/RunnerUtil.ml
+++ b/src/runners/RunnerUtil.ml
@@ -17,7 +17,7 @@
 *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open Printf
 open Syntax
 open ParsedSyntax
@@ -85,8 +85,8 @@ let eliminate_namespaces lib_tree ns_tree =
         ~f:(fun (accentries, accenv, accnames) entry ->
           (* check if id is in env and prefix it with a namespace. *)
           let check_and_prefix_id env id =
-            match List.Assoc.find env ~equal:( = ) (get_id id) with
-            | Some ns when ns <> "" ->
+            match List.Assoc.find env (get_id id) ~equal:String.( = ) with
+            | Some ns when not @@ String.is_empty ns ->
                 let nname = ns ^ "." ^ get_id id in
                 plog
                 @@ Printf.sprintf "Prefixing namespace %s to name %s = %s\n" ns
@@ -115,7 +115,7 @@ let eliminate_namespaces lib_tree ns_tree =
             | Let (i, t, elhs, erhs) ->
                 let elhs' = rename_in_expr elhs env in
                 (* "i" get's a local binding now, don't rename it in rhs. *)
-                let env' = List.Assoc.remove env ~equal:( = ) (get_id i) in
+                let env' = List.Assoc.remove env (get_id i) ~equal:String.( = ) in
                 let t' = Option.map t ~f:(fun t -> rename_in_type t env) in
                 let erhs' = rename_in_expr erhs env' in
                 (Let (i, t', elhs', erhs'), eloc)
@@ -130,7 +130,7 @@ let eliminate_namespaces lib_tree ns_tree =
                 in
                 (Message spl', eloc)
             | Fun (i, t, exp) ->
-                let env' = List.Assoc.remove env ~equal:( = ) (get_id i) in
+                let env' = List.Assoc.remove env (get_id i) ~equal:String.( = ) in
                 let t' = rename_in_type t env' in
                 let exp' = rename_in_expr exp env' in
                 (Fun (i, t', exp'), eloc)
@@ -166,7 +166,7 @@ let eliminate_namespaces lib_tree ns_tree =
                       (* remove all binds from env *)
                       let env' =
                         List.fold_left binds ~init:env ~f:(fun accenv b ->
-                            List.Assoc.remove accenv ~equal:( = ) b)
+                            List.Assoc.remove accenv b ~equal:String.( = ))
                       in
                       (pat', rename_in_expr expr env'))
                 in
@@ -179,7 +179,7 @@ let eliminate_namespaces lib_tree ns_tree =
                 let tl' = List.map tl ~f:(fun t -> rename_in_type t env) in
                 (TApp (check_and_prefix_id env i, tl'), eloc)
             | Fixpoint (i, t, e) ->
-                let env' = List.Assoc.remove env ~equal:( = ) (get_id i) in
+                let env' = List.Assoc.remove env (get_id i) ~equal:String.( = ) in
                 let exp' = rename_in_expr e env' in
                 (Fixpoint (i, t, exp'), eloc)
           in
@@ -224,7 +224,7 @@ let eliminate_namespaces lib_tree ns_tree =
     let this_namespace = nsnode.nspace in
     let fullns =
       match this_namespace with
-      | Some i -> if outerns <> "" then outerns ^ "." ^ get_id i else get_id i
+      | Some i -> if String.is_empty outerns then get_id i else outerns ^ "." ^ get_id i
       | None -> outerns
     in
     (* rename deps first *)
@@ -253,7 +253,7 @@ let import_libs names init_file =
   let rec importer names name_map stack =
     let mapped_names =
       List.map names ~f:(fun (n, namespace) ->
-          match List.Assoc.find name_map ~equal:( = ) (get_id n) with
+          match List.Assoc.find name_map (get_id n) ~equal:String.( = ) with
           | Some n' ->
               (* Use a known source location for the mapped id. *)
               (asIdL n' (get_rep n), n, namespace)
@@ -261,9 +261,9 @@ let import_libs names init_file =
     in
     List.fold_left
       ~f:(fun (libacc, nacc) (name, mapped_name, namespace) ->
-        if List.mem stack (get_id name) ~equal:( = ) then
+        if List.mem stack (get_id name) ~equal:String.( = ) then
           let errmsg =
-            if get_id mapped_name = get_id name then
+            if equal_id mapped_name name then
               sprintf "Cyclic dependence found when importing %s." (get_id name)
             else
               sprintf
@@ -308,7 +308,7 @@ let import_all_libs ldirs =
       let files = Array.to_list (Sys.readdir dir) in
       List.fold_right files
         ~f:(fun file names ->
-          if FilePath.get_extension file = StdlibTracker.file_extn_library then
+          if FilePath.check_extension file StdlibTracker.file_extn_library then
             let name = FilePath.chop_extension (FilePath.basename file) in
             (asId name, None (* no import-as *)) :: names
           else names)
@@ -414,11 +414,11 @@ let parse_cli () =
   (* Only one input file allowed, so the last anonymous argument will be *it*. *)
   let anon_handler s = r_input_file := s in
   let () = Arg.parse speclist anon_handler mandatory_usage in
-  if !r_input_file = "" then fatal_error_noformat usage;
+  if String.is_empty !r_input_file then fatal_error_noformat usage;
   let gas_limit =
     match !r_gas_limit with Some g -> g | None -> fatal_error_noformat usage
   in
-  if !r_cf_token_fields <> [] then r_cf := true;
+  if not @@ List.is_empty !r_cf_token_fields then r_cf := true;
   GlobalConfig.set_use_json_errors !r_json_errors;
   {
     input_file = !r_input_file;

--- a/src/runners/RunnerUtil.ml
+++ b/src/runners/RunnerUtil.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open Printf
 open Syntax
 open ParsedSyntax

--- a/src/runners/RunnerUtil.ml
+++ b/src/runners/RunnerUtil.ml
@@ -115,7 +115,9 @@ let eliminate_namespaces lib_tree ns_tree =
             | Let (i, t, elhs, erhs) ->
                 let elhs' = rename_in_expr elhs env in
                 (* "i" get's a local binding now, don't rename it in rhs. *)
-                let env' = List.Assoc.remove env (get_id i) ~equal:String.( = ) in
+                let env' =
+                  List.Assoc.remove env (get_id i) ~equal:String.( = )
+                in
                 let t' = Option.map t ~f:(fun t -> rename_in_type t env) in
                 let erhs' = rename_in_expr erhs env' in
                 (Let (i, t', elhs', erhs'), eloc)
@@ -130,7 +132,9 @@ let eliminate_namespaces lib_tree ns_tree =
                 in
                 (Message spl', eloc)
             | Fun (i, t, exp) ->
-                let env' = List.Assoc.remove env (get_id i) ~equal:String.( = ) in
+                let env' =
+                  List.Assoc.remove env (get_id i) ~equal:String.( = )
+                in
                 let t' = rename_in_type t env' in
                 let exp' = rename_in_expr exp env' in
                 (Fun (i, t', exp'), eloc)
@@ -179,7 +183,9 @@ let eliminate_namespaces lib_tree ns_tree =
                 let tl' = List.map tl ~f:(fun t -> rename_in_type t env) in
                 (TApp (check_and_prefix_id env i, tl'), eloc)
             | Fixpoint (i, t, e) ->
-                let env' = List.Assoc.remove env (get_id i) ~equal:String.( = ) in
+                let env' =
+                  List.Assoc.remove env (get_id i) ~equal:String.( = )
+                in
                 let exp' = rename_in_expr e env' in
                 (Fixpoint (i, t, exp'), eloc)
           in
@@ -224,7 +230,8 @@ let eliminate_namespaces lib_tree ns_tree =
     let this_namespace = nsnode.nspace in
     let fullns =
       match this_namespace with
-      | Some i -> if String.is_empty outerns then get_id i else outerns ^ "." ^ get_id i
+      | Some i ->
+          if String.is_empty outerns then get_id i else outerns ^ "." ^ get_id i
       | None -> outerns
     in
     (* rename deps first *)

--- a/src/runners/cli.ml
+++ b/src/runners/cli.ml
@@ -175,7 +175,9 @@ let parse () =
       ( "-libdir",
         Arg.String
           (fun x ->
-            let xl = if String.is_empty x then [] else Str.split (Str.regexp "[;:]") x in
+            let xl =
+              if String.is_empty x then [] else Str.split (Str.regexp "[;:]") x
+            in
             d_libs := !d_libs @ xl),
         "Path(s) to directory containing libraries separated by ':' (';' on \
          windows)" );

--- a/src/runners/cli.ml
+++ b/src/runners/cli.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 
 let f_input_init = ref ""
 

--- a/src/runners/cli.ml
+++ b/src/runners/cli.ml
@@ -17,7 +17,7 @@
 *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 
 let f_input_init = ref ""
 
@@ -118,9 +118,8 @@ let validate_main usage =
          address and balance) provided\n"
     else msg
   in
-  if msg <> "" then
+  if not @@ String.is_empty msg then
     PrettyPrinters.fatal_error_noformat (usage ^ Printf.sprintf "%s\n" msg)
-  else ()
 
 type ioFiles = {
   input_init : string;
@@ -176,7 +175,7 @@ let parse () =
       ( "-libdir",
         Arg.String
           (fun x ->
-            let xl = if x = "" then [] else Str.split (Str.regexp "[;:]") x in
+            let xl = if String.is_empty x then [] else Str.split (Str.regexp "[;:]") x in
             d_libs := !d_libs @ xl),
         "Path(s) to directory containing libraries separated by ':' (';' on \
          windows)" );

--- a/src/runners/dune
+++ b/src/runners/dune
@@ -4,7 +4,7 @@
  (package scilla)
  (modules scilla_runner eval_runner type_checker scilla_checker cli
    RunnerUtil)
- (libraries core angstrom ppx_sexp_conv ppx_deriving ppx_let yojson cryptokit
+ (libraries core angstrom yojson cryptokit
    fileutils scilla_base scilla_eval scilla_checkers scilla_cpp_deps)
  (preprocess
   (pps ppx_sexp_conv ppx_let ppx_deriving.show bisect_ppx -conditional)))

--- a/src/runners/dune
+++ b/src/runners/dune
@@ -4,7 +4,7 @@
  (package scilla)
  (modules scilla_runner eval_runner type_checker scilla_checker cli
    RunnerUtil)
- (libraries core angstrom yojson cryptokit
-   fileutils scilla_base scilla_eval scilla_checkers scilla_cpp_deps)
+ (libraries core angstrom yojson cryptokit fileutils scilla_base scilla_eval
+   scilla_checkers scilla_cpp_deps)
  (preprocess
   (pps ppx_sexp_conv ppx_let ppx_deriving.show bisect_ppx -conditional)))

--- a/src/runners/eval_runner.ml
+++ b/src/runners/eval_runner.ml
@@ -16,13 +16,13 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
+open Core_kernel
+open! Int.Replace_polymorphic_compare
 open Syntax
 open FrontEndParser
 open RunnerUtil
 open GlobalConfig
 open PrettyPrinters
-open Core_kernel
-open! Int.Replace_polymorphic_compare
 module PSRep = ParserRep
 module PERep = ParserRep
 module TC = TypeChecker.ScillaTypechecker (PSRep) (PERep)

--- a/src/runners/eval_runner.ml
+++ b/src/runners/eval_runner.ml
@@ -22,6 +22,7 @@ open RunnerUtil
 open GlobalConfig
 open PrettyPrinters
 open Core_kernel
+open Int.Replace_polymorphic_compare
 module PSRep = ParserRep
 module PERep = ParserRep
 module TC = TypeChecker.ScillaTypechecker (PSRep) (PERep)

--- a/src/runners/eval_runner.ml
+++ b/src/runners/eval_runner.ml
@@ -22,7 +22,7 @@ open RunnerUtil
 open GlobalConfig
 open PrettyPrinters
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 module PSRep = ParserRep
 module PERep = ParserRep
 module TC = TypeChecker.ScillaTypechecker (PSRep) (PERep)
@@ -35,7 +35,7 @@ let () =
   let cli = parse_cli () in
   let filename = cli.input_file in
   let gas_limit =
-    if cli.gas_limit = Stdint.Uint64.zero then default_gas_limit
+    if Stdint.Uint64.(compare cli.gas_limit zero = 0) then default_gas_limit
     else cli.gas_limit
   in
   match parse_expr_from_file filename with
@@ -49,7 +49,7 @@ let () =
       in
       StdlibTracker.add_stdlib_dirs cli.stdlib_dirs;
       let lib_dirs = StdlibTracker.get_stdlib_dirs () in
-      if lib_dirs = [] then stdlib_not_found_err ();
+      if List.is_empty lib_dirs then stdlib_not_found_err ();
       (* Import all libraries in known stdlib paths. *)
       let elibs = import_all_libs lib_dirs in
       let envres = Eval.init_libraries (Some clib) elibs in

--- a/src/runners/scilla_checker.ml
+++ b/src/runners/scilla_checker.ml
@@ -16,9 +16,9 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Syntax
 open Core_kernel
 open! Int.Replace_polymorphic_compare
+open Syntax
 open ErrorUtils
 open PrettyPrinters
 open DebugMessage

--- a/src/runners/scilla_checker.ml
+++ b/src/runners/scilla_checker.ml
@@ -341,9 +341,13 @@ let () =
        So disable the logger. *)
   set_debug_level Debug_None;
 
-  (* Check library modules. *)
-  if file_extn = StdlibTracker.file_extn_library then check_lmodule cli
-  else if file_extn <> StdlibTracker.file_extn_contract then
-    fatal_error (mk_error0 (sprintf "Unknown file extension %s\n" file_extn))
-  else (* Check contract modules. *)
+  let open FilePath in
+  let open StdlibTracker in
+  if check_extension cli.input_file file_extn_library then
+    (* Check library modules. *)
+    check_lmodule cli
+  else if check_extension cli.input_file file_extn_contract then
+    (* Check contract modules. *)
     check_cmodule cli
+  else
+    fatal_error (mk_error0 (sprintf "Unknown file extension\n"))

--- a/src/runners/scilla_checker.ml
+++ b/src/runners/scilla_checker.ml
@@ -18,6 +18,7 @@
 
 open Syntax
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open ErrorUtils
 open PrettyPrinters
 open DebugMessage

--- a/src/runners/scilla_checker.ml
+++ b/src/runners/scilla_checker.ml
@@ -18,7 +18,7 @@
 
 open Syntax
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open ErrorUtils
 open PrettyPrinters
 open DebugMessage
@@ -332,10 +332,9 @@ let () =
   let cli = parse_cli () in
   let open GlobalConfig in
   StdlibTracker.add_stdlib_dirs cli.stdlib_dirs;
-  let file_extn = FilePath.get_extension cli.input_file in
   (* Get list of stdlib dirs. *)
   let lib_dirs = StdlibTracker.get_stdlib_dirs () in
-  if lib_dirs = [] then stdlib_not_found_err ();
+  if List.is_empty lib_dirs then stdlib_not_found_err ();
 
   (* Testsuite runs this executable with cwd=tests and ends
        up complaining about missing _build directory for logger.

--- a/src/runners/scilla_checker.ml
+++ b/src/runners/scilla_checker.ml
@@ -349,5 +349,4 @@ let () =
   else if check_extension cli.input_file file_extn_contract then
     (* Check contract modules. *)
     check_cmodule cli
-  else
-    fatal_error (mk_error0 (sprintf "Unknown file extension\n"))
+  else fatal_error (mk_error0 (sprintf "Unknown file extension\n"))

--- a/src/runners/scilla_runner.ml
+++ b/src/runners/scilla_runner.ml
@@ -17,7 +17,7 @@
 *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open Syntax
 open FrontEndParser
 open ErrorUtils
@@ -180,8 +180,7 @@ let () =
   let is_deployment = String.is_empty cli.input_message in
   let is_ipc = not @@ String.is_empty cli.ipc_address in
   let is_library =
-    FilePath.get_extension cli.input
-    = GlobalConfig.StdlibTracker.file_extn_library
+    FilePath.check_extension cli.input GlobalConfig.StdlibTracker.file_extn_library
   in
   let gas_remaining =
     (* Subtract gas based on (contract+init) size / message size. *)
@@ -273,7 +272,7 @@ let () =
               (* We push all fields except _balance. *)
               let fields =
                 List.filter_map cstate'.fields ~f:(fun (s, t) ->
-                    if s = balance_label then None
+                    if String.(s = balance_label) then None
                     else Some { fname = s; ftyp = t; fval = None })
               in
               let sm = IPC cli.ipc_address in
@@ -325,7 +324,7 @@ let () =
                 let fields =
                   List.filter_map cstate.fields ~f:(fun (s, t) ->
                       let open StateService in
-                      if s = balance_label then None
+                      if String.(s = balance_label) then None
                       else Some { fname = s; ftyp = t; fval = None })
                 in
                 let () =
@@ -360,7 +359,7 @@ let () =
                   List.map field_vals ~f:(fun (s, l) ->
                       let open StateService in
                       let t =
-                        List.Assoc.find_exn cstate.fields ~equal:( = ) s
+                        List.Assoc.find_exn cstate.fields s ~equal:String.( = )
                       in
                       { fname = s; ftyp = t; fval = Some l })
                 in

--- a/src/runners/scilla_runner.ml
+++ b/src/runners/scilla_runner.ml
@@ -180,7 +180,8 @@ let () =
   let is_deployment = String.is_empty cli.input_message in
   let is_ipc = not @@ String.is_empty cli.ipc_address in
   let is_library =
-    FilePath.check_extension cli.input GlobalConfig.StdlibTracker.file_extn_library
+    FilePath.check_extension cli.input
+      GlobalConfig.StdlibTracker.file_extn_library
   in
   let gas_remaining =
     (* Subtract gas based on (contract+init) size / message size. *)

--- a/src/runners/scilla_runner.ml
+++ b/src/runners/scilla_runner.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open Syntax
 open FrontEndParser
 open ErrorUtils

--- a/src/runners/type_checker.ml
+++ b/src/runners/type_checker.ml
@@ -17,7 +17,7 @@
 *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open Printf
 open Syntax
 open TypeUtil
@@ -86,7 +86,7 @@ let () =
   | Ok e -> (
       (* Get list of stdlib dirs. *)
       let lib_dirs = StdlibTracker.get_stdlib_dirs () in
-      if lib_dirs = [] then stdlib_not_found_err ();
+      if List.is_empty lib_dirs then stdlib_not_found_err ();
       (* Import all libs. *)
       let std_lib = import_all_libs lib_dirs in
       match check_typing e std_lib gas_limit with

--- a/src/runners/type_checker.ml
+++ b/src/runners/type_checker.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open Printf
 open Syntax
 open TypeUtil

--- a/tests/Testsuite.ml
+++ b/tests/Testsuite.ml
@@ -16,6 +16,8 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
+open Core_kernel
+open! Int.Replace_polymorphic_compare
 open TestUtil
 
 let () =

--- a/tests/base/TestBech32.ml
+++ b/tests/base/TestBech32.ml
@@ -21,6 +21,7 @@ open Bech32
 open Syntax
 open Utils
 open Core_kernel
+open Int.Replace_polymorphic_compare
 
 let hex_to_raw_bytes h = Bystr.parse_hex h |> Bystr.to_raw_bytes
 

--- a/tests/base/TestBech32.ml
+++ b/tests/base/TestBech32.ml
@@ -35,7 +35,8 @@ let test1 =
       match decode_bech32_addr ~prefix:"zil" ~addr:bech32_addr with
       | Some b ->
           assert_bool "Bech32 address decode failed"
-            (String.(b = decoded_gold) && is_valid_bech32 ~prefix:"zil" ~addr:bech32_addr)
+            ( String.(b = decoded_gold)
+            && is_valid_bech32 ~prefix:"zil" ~addr:bech32_addr )
       | None -> assert_failure "Bech32 address validity check failed")
 
 let test2 =
@@ -47,7 +48,8 @@ let test2 =
       match decode_bech32_addr ~prefix:"zil" ~addr:bech32_addr with
       | Some b ->
           assert_bool "Bech32 address decode failed"
-            (String.(b = decoded_gold) && is_valid_bech32 ~prefix:"zil" ~addr:bech32_addr)
+            ( String.(b = decoded_gold)
+            && is_valid_bech32 ~prefix:"zil" ~addr:bech32_addr )
       | None -> assert_failure "Bech32 address validity check failed")
 
 let test3 =

--- a/tests/base/TestBech32.ml
+++ b/tests/base/TestBech32.ml
@@ -32,11 +32,11 @@ let test1 =
         hex_to_raw_bytes "0x7aa7ea9f4534d8d70224b9c2fb165242f321f12b"
       in
       let bech32_addr = "zil102n74869xnvdwq3yh8p0k9jjgtejruft268tg8" in
-      match decode_bech32_addr ~prefix:"zil" ~addr:bech32_addr with
+      match decode_bech32_addr ~prfx:"zil" ~addr:bech32_addr with
       | Some b ->
           assert_bool "Bech32 address decode failed"
             ( String.(b = decoded_gold)
-            && is_valid_bech32 ~prefix:"zil" ~addr:bech32_addr )
+            && is_valid_bech32 ~prfx:"zil" ~addr:bech32_addr )
       | None -> assert_failure "Bech32 address validity check failed")
 
 let test2 =
@@ -45,22 +45,22 @@ let test2 =
         hex_to_raw_bytes "0xa9d24392469ea49a3a3ab031e37a206c789e7155"
       in
       let bech32_addr = "zil148fy8yjxn6jf5w36kqc7x73qd3ufuu24a4u8t9" in
-      match decode_bech32_addr ~prefix:"zil" ~addr:bech32_addr with
+      match decode_bech32_addr ~prfx:"zil" ~addr:bech32_addr with
       | Some b ->
           assert_bool "Bech32 address decode failed"
             ( String.(b = decoded_gold)
-            && is_valid_bech32 ~prefix:"zil" ~addr:bech32_addr )
+            && is_valid_bech32 ~prfx:"zil" ~addr:bech32_addr )
       | None -> assert_failure "Bech32 address validity check failed")
 
 let test3 =
   test_case (fun _ ->
       (* This address below is same as test2's, but with the last checksum character modified. *)
       let bech32_addr = "zil148fy8yjxn6jf5w36kqc7x73qd3ufuu24a4u8t8" in
-      match decode_bech32_addr ~prefix:"zil" ~addr:bech32_addr with
+      match decode_bech32_addr ~prfx:"zil" ~addr:bech32_addr with
       | Some _ -> assert_failure "Bech32 address decode incorrectly validated"
       | None ->
           assert_bool "Bech32 address incorrectly validated"
-            (not (is_valid_bech32 ~prefix:"zil" ~addr:bech32_addr)))
+            (not (is_valid_bech32 ~prfx:"zil" ~addr:bech32_addr)))
 
 let test4 =
   test_case (fun _ ->
@@ -68,7 +68,7 @@ let test4 =
         hex_to_raw_bytes "0x7aa7ea9f4534d8d70224b9c2fb165242f321f12b"
       in
       let gold_output = "zil102n74869xnvdwq3yh8p0k9jjgtejruft268tg8" in
-      match encode_bech32_addr ~prefix:"zil" ~addr:input with
+      match encode_bech32_addr ~prfx:"zil" ~addr:input with
       | Some output ->
           assert_bool "Bech32 encode mismatch" String.(output = gold_output)
       | None -> assert_failure "Bech32 encoding failed")
@@ -79,7 +79,7 @@ let test5 =
         hex_to_raw_bytes "0xa9d24392469ea49a3a3ab031e37a206c789e7155"
       in
       let gold_output = "zil148fy8yjxn6jf5w36kqc7x73qd3ufuu24a4u8t9" in
-      match encode_bech32_addr ~prefix:"zil" ~addr:input with
+      match encode_bech32_addr ~prfx:"zil" ~addr:input with
       | Some output ->
           assert_bool "Bech32 encode mismatch" String.(output = gold_output)
       | None -> assert_failure "Bech32 encoding failed")
@@ -99,9 +99,9 @@ let random_test seed =
     Printf.sprintf
       "Failed: Random test for bech32 encoding / decoding with seed %d" seed
   in
-  match encode_bech32_addr ~prefix:"zil" ~addr:bystr20_r with
+  match encode_bech32_addr ~prfx:"zil" ~addr:bystr20_r with
   | Some encoded_str -> (
-      match decode_bech32_addr ~prefix:"zil" ~addr:encoded_str with
+      match decode_bech32_addr ~prfx:"zil" ~addr:encoded_str with
       | Some decoded_str -> assert_bool errmsg String.(bystr20_r = decoded_str)
       | None -> assert_failure errmsg )
   | None -> assert_failure errmsg

--- a/tests/base/TestBech32.ml
+++ b/tests/base/TestBech32.ml
@@ -16,12 +16,12 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
+open Core_kernel
+open! Int.Replace_polymorphic_compare
 open OUnit2
 open Bech32
 open Syntax
 open Utils
-open Core_kernel
-open! Int.Replace_polymorphic_compare
 
 let hex_to_raw_bytes h = Bystr.parse_hex h |> Bystr.to_raw_bytes
 

--- a/tests/base/TestBech32.ml
+++ b/tests/base/TestBech32.ml
@@ -21,7 +21,7 @@ open Bech32
 open Syntax
 open Utils
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 
 let hex_to_raw_bytes h = Bystr.parse_hex h |> Bystr.to_raw_bytes
 
@@ -35,7 +35,7 @@ let test1 =
       match decode_bech32_addr ~prefix:"zil" ~addr:bech32_addr with
       | Some b ->
           assert_bool "Bech32 address decode failed"
-            (b = decoded_gold && is_valid_bech32 ~prefix:"zil" ~addr:bech32_addr)
+            (String.(b = decoded_gold) && is_valid_bech32 ~prefix:"zil" ~addr:bech32_addr)
       | None -> assert_failure "Bech32 address validity check failed")
 
 let test2 =
@@ -47,7 +47,7 @@ let test2 =
       match decode_bech32_addr ~prefix:"zil" ~addr:bech32_addr with
       | Some b ->
           assert_bool "Bech32 address decode failed"
-            (b = decoded_gold && is_valid_bech32 ~prefix:"zil" ~addr:bech32_addr)
+            (String.(b = decoded_gold) && is_valid_bech32 ~prefix:"zil" ~addr:bech32_addr)
       | None -> assert_failure "Bech32 address validity check failed")
 
 let test3 =
@@ -68,7 +68,7 @@ let test4 =
       let gold_output = "zil102n74869xnvdwq3yh8p0k9jjgtejruft268tg8" in
       match encode_bech32_addr ~prefix:"zil" ~addr:input with
       | Some output ->
-          assert_bool "Bech32 encode mismatch" (output = gold_output)
+          assert_bool "Bech32 encode mismatch" String.(output = gold_output)
       | None -> assert_failure "Bech32 encoding failed")
 
 let test5 =
@@ -79,7 +79,7 @@ let test5 =
       let gold_output = "zil148fy8yjxn6jf5w36kqc7x73qd3ufuu24a4u8t9" in
       match encode_bech32_addr ~prefix:"zil" ~addr:input with
       | Some output ->
-          assert_bool "Bech32 encode mismatch" (output = gold_output)
+          assert_bool "Bech32 encode mismatch" String.(output = gold_output)
       | None -> assert_failure "Bech32 encoding failed")
 
 (* Takes in a random number and uses that to run a random test of bech32 encoding/decoding.
@@ -100,7 +100,7 @@ let random_test seed =
   match encode_bech32_addr ~prefix:"zil" ~addr:bystr20_r with
   | Some encoded_str -> (
       match decode_bech32_addr ~prefix:"zil" ~addr:encoded_str with
-      | Some decoded_str -> assert_bool errmsg (bystr20_r = decoded_str)
+      | Some decoded_str -> assert_bool errmsg String.(bystr20_r = decoded_str)
       | None -> assert_failure errmsg )
   | None -> assert_failure errmsg
 

--- a/tests/base/TestInteger256.ml
+++ b/tests/base/TestInteger256.ml
@@ -178,10 +178,12 @@ let t3_uint =
       in
       assert_bool "Uint256.to_float failed max_int"
         String.(max_float = do_conv Uint256.max_int);
-      assert_bool "Uint256.to_float failed one" String.(one_float = do_conv Uint256.one);
+      assert_bool "Uint256.to_float failed one"
+        String.(one_float = do_conv Uint256.one);
       assert_bool "Uint256.to_float failed zero"
         String.(zero_float = do_conv Uint256.zero);
-      assert_bool "Uint256.to_float failed two" String.(two_float = do_conv uint256_two);
+      assert_bool "Uint256.to_float failed two"
+        String.(two_float = do_conv uint256_two);
       assert_bool "Uint256.to_float failed max_minus_one"
         String.(max_minus_one_float = do_conv uint256_max_minus_one);
       assert_bool "Uint256.to_float failed max_minus_two"
@@ -364,29 +366,50 @@ let non_arithmetic_tests =
       let err = "Error in logical operation test(s)." in
 
       let ofs = Int256.of_string in
-      assert_bool err (Int256.compare (Int256.logand (ofs "1") (ofs "1")) (ofs "1") = 0);
-      assert_bool err (Int256.compare (Int256.logand (ofs "1") (ofs "0")) (ofs "0") = 0);
-      assert_bool err (Int256.compare (Int256.logor (ofs "0") (ofs "1")) (ofs "1") = 0);
-      assert_bool err (Int256.compare (Int256.logor (ofs "0") (ofs "0")) (ofs "0") = 0);
-      assert_bool err (Int256.compare (Int256.logxor (ofs "0") (ofs "1")) (ofs "1") = 0);
-      assert_bool err (Int256.compare (Int256.logxor (ofs "0") (ofs "0")) (ofs "0") = 0);
-      assert_bool err (Int256.compare (Int256.logxor (ofs "1") (ofs "1")) (ofs "0") = 0);
-      assert_bool err (Int256.compare (Int256.shift_left (ofs "1") 0) (ofs "1") = 0);
-      assert_bool err (Int256.compare (Int256.shift_left (ofs "1") 1) (ofs "2") = 0);
       assert_bool err
-        ( Int256.compare (Int256.shift_left (ofs "1") 129)
-            (ofs "680564733841876926926749214863536422912") = 0 );
+        (Int256.compare (Int256.logand (ofs "1") (ofs "1")) (ofs "1") = 0);
+      assert_bool err
+        (Int256.compare (Int256.logand (ofs "1") (ofs "0")) (ofs "0") = 0);
+      assert_bool err
+        (Int256.compare (Int256.logor (ofs "0") (ofs "1")) (ofs "1") = 0);
+      assert_bool err
+        (Int256.compare (Int256.logor (ofs "0") (ofs "0")) (ofs "0") = 0);
+      assert_bool err
+        (Int256.compare (Int256.logxor (ofs "0") (ofs "1")) (ofs "1") = 0);
+      assert_bool err
+        (Int256.compare (Int256.logxor (ofs "0") (ofs "0")) (ofs "0") = 0);
+      assert_bool err
+        (Int256.compare (Int256.logxor (ofs "1") (ofs "1")) (ofs "0") = 0);
+      assert_bool err
+        (Int256.compare (Int256.shift_left (ofs "1") 0) (ofs "1") = 0);
+      assert_bool err
+        (Int256.compare (Int256.shift_left (ofs "1") 1) (ofs "2") = 0);
+      assert_bool err
+        ( Int256.compare
+            (Int256.shift_left (ofs "1") 129)
+            (ofs "680564733841876926926749214863536422912")
+        = 0 );
       (* 2 ^ 129 *)
-      assert_bool err (Int256.compare (Int256.shift_left (ofs "1") 255) (ofs int256_min_str) = 0);
-      assert_bool err (Int256.compare (Int256.shift_left (ofs "1") 256) (ofs "0") = 0);
-      assert_bool err (Int256.compare (Int256.shift_right_logical (ofs "1") 1) (ofs "0") = 0);
       assert_bool err
-        (Int256.compare (Int256.shift_right_logical (ofs "-1") 1) (ofs int256_max_str) = 0);
+        ( Int256.compare (Int256.shift_left (ofs "1") 255) (ofs int256_min_str)
+        = 0 );
+      assert_bool err
+        (Int256.compare (Int256.shift_left (ofs "1") 256) (ofs "0") = 0);
+      assert_bool err
+        (Int256.compare (Int256.shift_right_logical (ofs "1") 1) (ofs "0") = 0);
+      assert_bool err
+        ( Int256.compare
+            (Int256.shift_right_logical (ofs "-1") 1)
+            (ofs int256_max_str)
+        = 0 );
 
       assert_bool err (Int256.compare (Int256.setbit (ofs "0") 0) (ofs "1") = 0);
-      assert_bool err (Int256.compare (Int256.setbit (ofs "0") 255) (ofs int256_min_str) = 0);
-      assert_bool err (Int256.compare (Int256.clearbit (ofs "1") 0) (ofs "0") = 0);
-      assert_bool err (Int256.compare (Int256.clearbit (ofs int256_min_str) 255) (ofs "0") = 0);
+      assert_bool err
+        (Int256.compare (Int256.setbit (ofs "0") 255) (ofs int256_min_str) = 0);
+      assert_bool err
+        (Int256.compare (Int256.clearbit (ofs "1") 0) (ofs "0") = 0);
+      assert_bool err
+        (Int256.compare (Int256.clearbit (ofs int256_min_str) 255) (ofs "0") = 0);
       (* Test little-endian. *)
       let buf = Bytes.create 32 in
       let _ = Int256.to_bytes_little_endian (ofs "1") buf 0 in
@@ -405,48 +428,87 @@ let non_arithmetic_tests =
       assert_bool err (Int256.compare Int256.max_int max_int' = 0);
 
       let ofs = Uint256.of_string in
-      assert_bool err (Uint256.compare (Uint256.logand (ofs "1") (ofs "1")) (ofs "1") = 0);
-      assert_bool err (Uint256.compare (Uint256.logand (ofs "1") (ofs "0")) (ofs "0") = 0);
-      assert_bool err (Uint256.compare (Uint256.logor (ofs "0") (ofs "1")) (ofs "1") = 0);
-      assert_bool err (Uint256.compare (Uint256.logor (ofs "0") (ofs "0")) (ofs "0") = 0);
-      assert_bool err (Uint256.compare (Uint256.logxor (ofs "0") (ofs "1")) (ofs "1") = 0);
-      assert_bool err (Uint256.compare (Uint256.logxor (ofs "0") (ofs "0")) (ofs "0") = 0);
-      assert_bool err (Uint256.compare (Uint256.logxor (ofs "1") (ofs "1")) (ofs "0") = 0);
-      assert_bool err (Uint256.compare (Uint256.shift_left (ofs "1") 0) (ofs "1") = 0);
-      assert_bool err (Uint256.compare (Uint256.shift_left (ofs "1") 1) (ofs "2") = 0);
       assert_bool err
-        (Uint256.compare (Uint256.shift_left (ofs "1") 129)
-           (ofs "680564733841876926926749214863536422912") = 0);
+        (Uint256.compare (Uint256.logand (ofs "1") (ofs "1")) (ofs "1") = 0);
+      assert_bool err
+        (Uint256.compare (Uint256.logand (ofs "1") (ofs "0")) (ofs "0") = 0);
+      assert_bool err
+        (Uint256.compare (Uint256.logor (ofs "0") (ofs "1")) (ofs "1") = 0);
+      assert_bool err
+        (Uint256.compare (Uint256.logor (ofs "0") (ofs "0")) (ofs "0") = 0);
+      assert_bool err
+        (Uint256.compare (Uint256.logxor (ofs "0") (ofs "1")) (ofs "1") = 0);
+      assert_bool err
+        (Uint256.compare (Uint256.logxor (ofs "0") (ofs "0")) (ofs "0") = 0);
+      assert_bool err
+        (Uint256.compare (Uint256.logxor (ofs "1") (ofs "1")) (ofs "0") = 0);
+      assert_bool err
+        (Uint256.compare (Uint256.shift_left (ofs "1") 0) (ofs "1") = 0);
+      assert_bool err
+        (Uint256.compare (Uint256.shift_left (ofs "1") 1) (ofs "2") = 0);
+      assert_bool err
+        ( Uint256.compare
+            (Uint256.shift_left (ofs "1") 129)
+            (ofs "680564733841876926926749214863536422912")
+        = 0 );
       (* 2 ^ 129 *)
       assert_bool err
-        (Uint256.compare (Uint256.shift_left (ofs "1") 255)
-           (Uint256.add (ofs "1") (ofs int256_max_str)) = 0);
-      assert_bool err (Uint256.compare (Uint256.shift_left (ofs "1") 256) (ofs "0") = 0);
-      assert_bool err (Uint256.compare (Uint256.shift_right_logical (ofs "1") 1) (ofs "0") = 0);
+        ( Uint256.compare
+            (Uint256.shift_left (ofs "1") 255)
+            (Uint256.add (ofs "1") (ofs int256_max_str))
+        = 0 );
       assert_bool err
-        (Uint256.compare (Uint256.shift_right_logical (ofs uint256_max_str) 255) (ofs "1") = 0);
+        (Uint256.compare (Uint256.shift_left (ofs "1") 256) (ofs "0") = 0);
       assert_bool err
-        (Uint256.compare (Uint256.shift_right_logical (ofs uint256_max_str) 256) (ofs "0") = 0);
+        (Uint256.compare (Uint256.shift_right_logical (ofs "1") 1) (ofs "0") = 0);
       assert_bool err
-        (Uint256.compare ( Uint256.shift_right_logical (ofs uint256_max_str) 128)
-           (ofs (Uint128.to_string Uint128.max_int) ) = 0);
+        ( Uint256.compare
+            (Uint256.shift_right_logical (ofs uint256_max_str) 255)
+            (ofs "1")
+        = 0 );
       assert_bool err
-        (Uint256.compare (Uint256.shift_right_logical (ofs uint256_max_str) 255) (ofs "1") = 0);
+        ( Uint256.compare
+            (Uint256.shift_right_logical (ofs uint256_max_str) 256)
+            (ofs "0")
+        = 0 );
+      assert_bool err
+        ( Uint256.compare
+            (Uint256.shift_right_logical (ofs uint256_max_str) 128)
+            (ofs (Uint128.to_string Uint128.max_int))
+        = 0 );
+      assert_bool err
+        ( Uint256.compare
+            (Uint256.shift_right_logical (ofs uint256_max_str) 255)
+            (ofs "1")
+        = 0 );
       (* both the "shift_right"s are same for unsigned integers *)
-      assert_bool err (Uint256.compare (Uint256.shift_right (ofs "1") 1) (ofs "0") = 0);
-      assert_bool err (Uint256.compare (Uint256.shift_right (ofs uint256_max_str) 255) (ofs "1") = 0);
-      assert_bool err (Uint256.compare (Uint256.setbit (ofs "0") 0) (ofs "1") = 0);
       assert_bool err
-        (Uint256.compare (Uint256.setbit (ofs "0") 255)
-        (Uint256.add (Uint256.div (ofs uint256_max_str) (ofs "2")) (ofs "1")) = 0);
-      assert_bool err (Uint256.compare (Uint256.clearbit (ofs "1") 0) (ofs "0") = 0);
+        (Uint256.compare (Uint256.shift_right (ofs "1") 1) (ofs "0") = 0);
       assert_bool err
-        (Uint256.compare (Uint256.clearbit
+        ( Uint256.compare
+            (Uint256.shift_right (ofs uint256_max_str) 255)
+            (ofs "1")
+        = 0 );
+      assert_bool err
+        (Uint256.compare (Uint256.setbit (ofs "0") 0) (ofs "1") = 0);
+      assert_bool err
+        ( Uint256.compare
+            (Uint256.setbit (ofs "0") 255)
             (Uint256.add
                (Uint256.div (ofs uint256_max_str) (ofs "2"))
                (ofs "1"))
-            255)
-        (ofs "0") = 0);
+        = 0 );
+      assert_bool err
+        (Uint256.compare (Uint256.clearbit (ofs "1") 0) (ofs "0") = 0);
+      assert_bool err
+        ( Uint256.compare
+            (Uint256.clearbit
+               (Uint256.add
+                  (Uint256.div (ofs uint256_max_str) (ofs "2"))
+                  (ofs "1"))
+               255)
+            (ofs "0")
+        = 0 );
       assert_bool err (Uint256.compare (Uint256.abs (ofs "1")) (ofs "1") = 0))
 
 module Uint256Tester = IntTester (Uint256) (Uint256_Emu)

--- a/tests/base/TestInteger256.ml
+++ b/tests/base/TestInteger256.ml
@@ -16,6 +16,9 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
+open Core_kernel
+open! Int.Replace_polymorphic_compare
+
 let uint256_max_str =
   "115792089237316195423570985008687907853269984665640564039457584007913129639935"
 

--- a/tests/base/TestInteger256.ml
+++ b/tests/base/TestInteger256.ml
@@ -144,13 +144,13 @@ open Stdint
 (* basic tests *)
 let t1_uint =
   test_case (fun _ ->
-      let b = Uint256.to_string Uint256.max_int = uint256_max_str in
+      let b = String.(Uint256.to_string Uint256.max_int = uint256_max_str) in
       assert_bool "Uint256.max_int invalid" b)
 
 let t2_uint =
   test_case (fun _ ->
       let c = Uint256.of_string (Uint256.to_string Uint256.max_int) in
-      let b = compare Uint256.max_int c = 0 in
+      let b = Uint256.(compare max_int c) = 0 in
       assert_bool "Uint256 string conversion fail" b)
 
 let t3_uint =
@@ -174,31 +174,31 @@ let t3_uint =
         "115792089237316195423570985008687907853269984665640564039457584007913129639936.000000"
       in
       assert_bool "Uint256.to_float failed max_int"
-        (max_float = do_conv Uint256.max_int);
-      assert_bool "Uint256.to_float failed one" (one_float = do_conv Uint256.one);
+        String.(max_float = do_conv Uint256.max_int);
+      assert_bool "Uint256.to_float failed one" String.(one_float = do_conv Uint256.one);
       assert_bool "Uint256.to_float failed zero"
-        (zero_float = do_conv Uint256.zero);
-      assert_bool "Uint256.to_float failed two" (two_float = do_conv uint256_two);
+        String.(zero_float = do_conv Uint256.zero);
+      assert_bool "Uint256.to_float failed two" String.(two_float = do_conv uint256_two);
       assert_bool "Uint256.to_float failed max_minus_one"
-        (max_minus_one_float = do_conv uint256_max_minus_one);
+        String.(max_minus_one_float = do_conv uint256_max_minus_one);
       assert_bool "Uint256.to_float failed max_minus_two"
-        (max_minus_two_float = do_conv uint256_max_minus_two))
+        String.(max_minus_two_float = do_conv uint256_max_minus_two))
 
 let t1_int =
   test_case (fun _ ->
-      let b = Int256.to_string Int256.max_int = int256_max_str in
+      let b = String.(Int256.to_string Int256.max_int = int256_max_str) in
       assert_bool "Int256.max_int invalid" b)
 
 let t2_int =
   test_case (fun _ ->
       let c = Int256.of_string (Int256.to_string Int256.max_int) in
-      let b = compare Int256.max_int c = 0 in
+      let b = Int256.(compare max_int c) = 0 in
       assert_bool "Int256 string conversion fail" b)
 
 let t3_int =
   test_case (fun _ ->
       let c = Int256.of_string (Int256.to_string Int256.min_int) in
-      let b = compare Int256.min_int c = 0 in
+      let b = Int256.(compare min_int c) = 0 in
       assert_bool "Int256 string conversion fail" b)
 
 module type IntRep = sig
@@ -333,12 +333,11 @@ module IntTester (IR1 : IntRep) (IR2 : IntRep) = struct
           ^ string_of_bool !fail1 ^ ") vs (" ^ str2 ^ ","
           ^ string_of_bool !fail2 ^ ")\n"
         in
-        let res = str1 = str2 && !fail1 = !fail2 in
+        let res = String.(str1 = str2) && Bool.(!fail1 = !fail2) in
         assert_bool fail_str res)
 
   let binary_tests inputs =
-    List.fold_left
-      (fun tl (lhs, rhs) ->
+    List.fold_left inputs ~init:[] ~f:(fun tl (lhs, rhs) ->
         (* all operations for all inputs *)
         let add = binary_test_create lhs rhs "add" in
         let sub = binary_test_create lhs rhs "sub" in
@@ -355,7 +354,6 @@ module IntTester (IR1 : IntRep) (IR2 : IntRep) = struct
         let compare_rev = binary_test_create rhs lhs "compare" in
         add :: sub :: mul :: div :: rem :: compare :: add_rev :: sub_rev
         :: mul_rev :: div_rev :: rem_rev :: compare_rev :: tl)
-      [] inputs
 end
 
 let non_arithmetic_tests =
@@ -363,29 +361,29 @@ let non_arithmetic_tests =
       let err = "Error in logical operation test(s)." in
 
       let ofs = Int256.of_string in
-      assert_bool err (Int256.logand (ofs "1") (ofs "1") = ofs "1");
-      assert_bool err (Int256.logand (ofs "1") (ofs "0") = ofs "0");
-      assert_bool err (Int256.logor (ofs "0") (ofs "1") = ofs "1");
-      assert_bool err (Int256.logor (ofs "0") (ofs "0") = ofs "0");
-      assert_bool err (Int256.logxor (ofs "0") (ofs "1") = ofs "1");
-      assert_bool err (Int256.logxor (ofs "0") (ofs "0") = ofs "0");
-      assert_bool err (Int256.logxor (ofs "1") (ofs "1") = ofs "0");
-      assert_bool err (Int256.shift_left (ofs "1") 0 = ofs "1");
-      assert_bool err (Int256.shift_left (ofs "1") 1 = ofs "2");
+      assert_bool err (Int256.compare (Int256.logand (ofs "1") (ofs "1")) (ofs "1") = 0);
+      assert_bool err (Int256.compare (Int256.logand (ofs "1") (ofs "0")) (ofs "0") = 0);
+      assert_bool err (Int256.compare (Int256.logor (ofs "0") (ofs "1")) (ofs "1") = 0);
+      assert_bool err (Int256.compare (Int256.logor (ofs "0") (ofs "0")) (ofs "0") = 0);
+      assert_bool err (Int256.compare (Int256.logxor (ofs "0") (ofs "1")) (ofs "1") = 0);
+      assert_bool err (Int256.compare (Int256.logxor (ofs "0") (ofs "0")) (ofs "0") = 0);
+      assert_bool err (Int256.compare (Int256.logxor (ofs "1") (ofs "1")) (ofs "0") = 0);
+      assert_bool err (Int256.compare (Int256.shift_left (ofs "1") 0) (ofs "1") = 0);
+      assert_bool err (Int256.compare (Int256.shift_left (ofs "1") 1) (ofs "2") = 0);
       assert_bool err
-        ( Int256.shift_left (ofs "1") 129
-        = ofs "680564733841876926926749214863536422912" );
+        ( Int256.compare (Int256.shift_left (ofs "1") 129)
+            (ofs "680564733841876926926749214863536422912") = 0 );
       (* 2 ^ 129 *)
-      assert_bool err (Int256.shift_left (ofs "1") 255 = ofs int256_min_str);
-      assert_bool err (Int256.shift_left (ofs "1") 256 = ofs "0");
-      assert_bool err (Int256.shift_right_logical (ofs "1") 1 = ofs "0");
+      assert_bool err (Int256.compare (Int256.shift_left (ofs "1") 255) (ofs int256_min_str) = 0);
+      assert_bool err (Int256.compare (Int256.shift_left (ofs "1") 256) (ofs "0") = 0);
+      assert_bool err (Int256.compare (Int256.shift_right_logical (ofs "1") 1) (ofs "0") = 0);
       assert_bool err
-        (Int256.shift_right_logical (ofs "-1") 1 = ofs int256_max_str);
+        (Int256.compare (Int256.shift_right_logical (ofs "-1") 1) (ofs int256_max_str) = 0);
 
-      assert_bool err (Int256.setbit (ofs "0") 0 = ofs "1");
-      assert_bool err (Int256.setbit (ofs "0") 255 = ofs int256_min_str);
-      assert_bool err (Int256.clearbit (ofs "1") 0 = ofs "0");
-      assert_bool err (Int256.clearbit (ofs int256_min_str) 255 = ofs "0");
+      assert_bool err (Int256.compare (Int256.setbit (ofs "0") 0) (ofs "1") = 0);
+      assert_bool err (Int256.compare (Int256.setbit (ofs "0") 255) (ofs int256_min_str) = 0);
+      assert_bool err (Int256.compare (Int256.clearbit (ofs "1") 0) (ofs "0") = 0);
+      assert_bool err (Int256.compare (Int256.clearbit (ofs int256_min_str) 255) (ofs "0") = 0);
       (* Test little-endian. *)
       let buf = Bytes.create 32 in
       let _ = Int256.to_bytes_little_endian (ofs "1") buf 0 in
@@ -394,8 +392,8 @@ let non_arithmetic_tests =
         Int256.to_bytes_big_endian (Int256.shift_left (ofs "1") 248) buf 0
       in
       let s2 = Bytes.to_string buf in
-      assert_bool err (s1 = s2);
-      assert_bool err (Int256.abs (ofs "-1") = ofs "1");
+      assert_bool err String.(s1 = s2);
+      assert_bool err (Int256.compare (Int256.abs (ofs "-1")) (ofs "1") = 0);
       let _ = Int256.to_bytes_big_endian Int256.max_int buf 0 in
       let max_int' = Int256.of_bytes_big_endian buf 0 in
       assert_bool err (Int256.compare Int256.max_int max_int' = 0);
@@ -404,49 +402,49 @@ let non_arithmetic_tests =
       assert_bool err (Int256.compare Int256.max_int max_int' = 0);
 
       let ofs = Uint256.of_string in
-      assert_bool err (Uint256.logand (ofs "1") (ofs "1") = ofs "1");
-      assert_bool err (Uint256.logand (ofs "1") (ofs "0") = ofs "0");
-      assert_bool err (Uint256.logor (ofs "0") (ofs "1") = ofs "1");
-      assert_bool err (Uint256.logor (ofs "0") (ofs "0") = ofs "0");
-      assert_bool err (Uint256.logxor (ofs "0") (ofs "1") = ofs "1");
-      assert_bool err (Uint256.logxor (ofs "0") (ofs "0") = ofs "0");
-      assert_bool err (Uint256.logxor (ofs "1") (ofs "1") = ofs "0");
-      assert_bool err (Uint256.shift_left (ofs "1") 0 = ofs "1");
-      assert_bool err (Uint256.shift_left (ofs "1") 1 = ofs "2");
+      assert_bool err (Uint256.compare (Uint256.logand (ofs "1") (ofs "1")) (ofs "1") = 0);
+      assert_bool err (Uint256.compare (Uint256.logand (ofs "1") (ofs "0")) (ofs "0") = 0);
+      assert_bool err (Uint256.compare (Uint256.logor (ofs "0") (ofs "1")) (ofs "1") = 0);
+      assert_bool err (Uint256.compare (Uint256.logor (ofs "0") (ofs "0")) (ofs "0") = 0);
+      assert_bool err (Uint256.compare (Uint256.logxor (ofs "0") (ofs "1")) (ofs "1") = 0);
+      assert_bool err (Uint256.compare (Uint256.logxor (ofs "0") (ofs "0")) (ofs "0") = 0);
+      assert_bool err (Uint256.compare (Uint256.logxor (ofs "1") (ofs "1")) (ofs "0") = 0);
+      assert_bool err (Uint256.compare (Uint256.shift_left (ofs "1") 0) (ofs "1") = 0);
+      assert_bool err (Uint256.compare (Uint256.shift_left (ofs "1") 1) (ofs "2") = 0);
       assert_bool err
-        ( Uint256.shift_left (ofs "1") 129
-        = ofs "680564733841876926926749214863536422912" );
+        (Uint256.compare (Uint256.shift_left (ofs "1") 129)
+           (ofs "680564733841876926926749214863536422912") = 0);
       (* 2 ^ 129 *)
       assert_bool err
-        ( Uint256.shift_left (ofs "1") 255
-        = Uint256.add (ofs "1") (ofs int256_max_str) );
-      assert_bool err (Uint256.shift_left (ofs "1") 256 = ofs "0");
-      assert_bool err (Uint256.shift_right_logical (ofs "1") 1 = ofs "0");
+        (Uint256.compare (Uint256.shift_left (ofs "1") 255)
+           (Uint256.add (ofs "1") (ofs int256_max_str)) = 0);
+      assert_bool err (Uint256.compare (Uint256.shift_left (ofs "1") 256) (ofs "0") = 0);
+      assert_bool err (Uint256.compare (Uint256.shift_right_logical (ofs "1") 1) (ofs "0") = 0);
       assert_bool err
-        (Uint256.shift_right_logical (ofs uint256_max_str) 255 = ofs "1");
+        (Uint256.compare (Uint256.shift_right_logical (ofs uint256_max_str) 255) (ofs "1") = 0);
       assert_bool err
-        (Uint256.shift_right_logical (ofs uint256_max_str) 256 = ofs "0");
+        (Uint256.compare (Uint256.shift_right_logical (ofs uint256_max_str) 256) (ofs "0") = 0);
       assert_bool err
-        ( Uint256.shift_right_logical (ofs uint256_max_str) 128
-        = ofs (Uint128.to_string Uint128.max_int) );
+        (Uint256.compare ( Uint256.shift_right_logical (ofs uint256_max_str) 128)
+           (ofs (Uint128.to_string Uint128.max_int) ) = 0);
       assert_bool err
-        (Uint256.shift_right_logical (ofs uint256_max_str) 255 = ofs "1");
+        (Uint256.compare (Uint256.shift_right_logical (ofs uint256_max_str) 255) (ofs "1") = 0);
       (* both the "shift_right"s are same for unsigned integers *)
-      assert_bool err (Uint256.shift_right (ofs "1") 1 = ofs "0");
-      assert_bool err (Uint256.shift_right (ofs uint256_max_str) 255 = ofs "1");
-      assert_bool err (Uint256.setbit (ofs "0") 0 = ofs "1");
+      assert_bool err (Uint256.compare (Uint256.shift_right (ofs "1") 1) (ofs "0") = 0);
+      assert_bool err (Uint256.compare (Uint256.shift_right (ofs uint256_max_str) 255) (ofs "1") = 0);
+      assert_bool err (Uint256.compare (Uint256.setbit (ofs "0") 0) (ofs "1") = 0);
       assert_bool err
-        ( Uint256.setbit (ofs "0") 255
-        = Uint256.add (Uint256.div (ofs uint256_max_str) (ofs "2")) (ofs "1") );
-      assert_bool err (Uint256.clearbit (ofs "1") 0 = ofs "0");
+        (Uint256.compare (Uint256.setbit (ofs "0") 255)
+        (Uint256.add (Uint256.div (ofs uint256_max_str) (ofs "2")) (ofs "1")) = 0);
+      assert_bool err (Uint256.compare (Uint256.clearbit (ofs "1") 0) (ofs "0") = 0);
       assert_bool err
-        ( Uint256.clearbit
+        (Uint256.compare (Uint256.clearbit
             (Uint256.add
                (Uint256.div (ofs uint256_max_str) (ofs "2"))
                (ofs "1"))
-            255
-        = ofs "0" );
-      assert_bool err (Uint256.abs (ofs "1") = ofs "1"))
+            255)
+        (ofs "0") = 0);
+      assert_bool err (Uint256.compare (Uint256.abs (ofs "1")) (ofs "1") = 0))
 
 module Uint256Tester = IntTester (Uint256) (Uint256_Emu)
 

--- a/tests/base/TestSafeArith.ml
+++ b/tests/base/TestSafeArith.ml
@@ -1,4 +1,5 @@
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open Stdint
 open OUnit2
 open SafeArith

--- a/tests/base/TestSafeArith.ml
+++ b/tests/base/TestSafeArith.ml
@@ -1,5 +1,5 @@
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open Stdint
 open OUnit2
 open SafeArith

--- a/tests/base/TestSignatures.ml
+++ b/tests/base/TestSignatures.ml
@@ -41,7 +41,7 @@ let t1' =
           let pubK' = pk_from_sk privK in
           let pubK'' = match pubK' with Ok pubK'' -> pubK'' | Error _ -> "" in
           assert_bool "Public key mis-match b/w Schnorr and ECDSA"
-            (pubK = pubK'');
+            String.(pubK = pubK'');
           let succ =
             match sign privK msg with
             | Ok signature -> (
@@ -70,7 +70,7 @@ let t2' =
           let pubK' = pk_from_sk privK in
           let pubK'' = match pubK' with Ok pubK'' -> pubK'' | Error _ -> "" in
           assert_bool "Public key mis-match b/w Schnorr and ECDSA"
-            (pubK = pubK'');
+            String.(pubK = pubK'');
           let succ =
             match sign privK msg with
             | Ok signature -> (

--- a/tests/base/TestSignatures.ml
+++ b/tests/base/TestSignatures.ml
@@ -1,5 +1,7 @@
+open Core_kernel
+open! Int.Replace_polymorphic_compare
+open Result
 open OUnit2
-open Core_kernel.Result
 
 let t1 =
   test_case (fun _ ->

--- a/tests/base/TestSnark.ml
+++ b/tests/base/TestSnark.ml
@@ -20,7 +20,6 @@
    https://github.com/ethereum/aleth/blob/master/test/unittests/libdevcrypto/LibSnark.cpp *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
 open OUnit2
 open Snark
 open Integer256

--- a/tests/base/TestSnark.ml
+++ b/tests/base/TestSnark.ml
@@ -20,6 +20,7 @@
    https://github.com/ethereum/aleth/blob/master/test/unittests/libdevcrypto/LibSnark.cpp *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open OUnit2
 open Snark
 open Integer256

--- a/tests/base/TestSyntax.ml
+++ b/tests/base/TestSyntax.ml
@@ -1,4 +1,5 @@
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open Stdint
 open OUnit2
 open Syntax

--- a/tests/base/TestSyntax.ml
+++ b/tests/base/TestSyntax.ml
@@ -1,5 +1,5 @@
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open Stdint
 open OUnit2
 open Syntax
@@ -12,8 +12,6 @@ let parse_expr_wrapper exprstr =
   | Ok expr -> expr
   | Error _ ->
       assert_failure ("Error parsing test expression:\n" ^ exprstr ^ "\n")
-
-let ident_list_cmp = List.equal (fun a b -> get_id a = get_id b)
 
 let ident_list_printer ls = String.concat ~sep:";" (List.map ~f:get_id ls)
 
@@ -80,21 +78,21 @@ let unannotated_syntax_tests =
                   (Map ((TypeVar "'X", TypeVar "'X"), Caml.Hashtbl.create 4)))
            );
            ( "free_tvars-1",
-             assert_equal ~printer:ident_list_printer ~cmp:ident_list_cmp
+             assert_equal ~printer:ident_list_printer ~cmp:(List.equal equal_id)
                [ asId "a" ]
                (free_vars_in_expr (parse_expr_wrapper "a")) );
            ( "free_tvars-2",
-             assert_equal ~printer:ident_list_printer ~cmp:ident_list_cmp
+             assert_equal ~printer:ident_list_printer ~cmp:(List.equal equal_id)
                [ asId "a" ]
                (let expr = "fun (b : Uint32) => a" in
                 free_vars_in_expr (parse_expr_wrapper expr)) );
            ( "free_tvars-3",
-             assert_equal ~printer:ident_list_printer ~cmp:ident_list_cmp
+             assert_equal ~printer:ident_list_printer ~cmp:(List.equal equal_id)
                [ asId "b" ]
                (let expr = "fun (a : Uint32) => b a" in
                 free_vars_in_expr (parse_expr_wrapper expr)) );
            ( "free_tvars-4",
-             assert_equal ~printer:ident_list_printer ~cmp:ident_list_cmp
+             assert_equal ~printer:ident_list_printer ~cmp:(List.equal equal_id)
                [ asId "a" ]
                (let expr =
                   "match a with \n\
@@ -103,7 +101,7 @@ let unannotated_syntax_tests =
                 in
                 free_vars_in_expr (parse_expr_wrapper expr)) );
            ( "free_tvars-5",
-             assert_equal ~printer:ident_list_printer ~cmp:ident_list_cmp
+             assert_equal ~printer:ident_list_printer ~cmp:(List.equal equal_id)
                [ asId "a" ]
                (let expr =
                   "match a with \n\
@@ -114,7 +112,7 @@ let unannotated_syntax_tests =
                 in
                 free_vars_in_expr (parse_expr_wrapper expr)) );
            ( "free_tvars-6",
-             assert_equal ~printer:ident_list_printer ~cmp:ident_list_cmp
+             assert_equal ~printer:ident_list_printer ~cmp:(List.equal equal_id)
                [ asId "a"; asId "d" ]
                (let expr =
                   "match a with \n\
@@ -125,7 +123,7 @@ let unannotated_syntax_tests =
                 in
                 free_vars_in_expr (parse_expr_wrapper expr)) );
            ( "free_tvars-7",
-             assert_equal ~printer:ident_list_printer ~cmp:ident_list_cmp
+             assert_equal ~printer:ident_list_printer ~cmp:(List.equal equal_id)
                [ asId "a" ]
                (let expr = "let b = a in\n                   Int32 0" in
                 free_vars_in_expr (parse_expr_wrapper expr)) );

--- a/tests/base/Testsuite_base.ml
+++ b/tests/base/Testsuite_base.ml
@@ -16,6 +16,8 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
+open Core_kernel
+open! Int.Replace_polymorphic_compare
 open TestUtil
 
 let () =

--- a/tests/base/dune
+++ b/tests/base/dune
@@ -1,5 +1,5 @@
 (executable
  (name testsuite_base)
  (preprocess
-  (pps ppx_sexp_conv ppx_let ppx_deriving.show))
+  (pps ppx_sexp_conv ppx_let ppx_deriving.show ppx_compare))
  (libraries core oUnit scilla_base testutil testparser))

--- a/tests/base/parser/Parser_dummy.ml
+++ b/tests/base/parser/Parser_dummy.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open FrontEndParser
 open GlobalConfig
 open ErrorUtils

--- a/tests/base/parser/Parser_dummy.ml
+++ b/tests/base/parser/Parser_dummy.ml
@@ -17,7 +17,7 @@
 *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open FrontEndParser
 open GlobalConfig
 open ErrorUtils
@@ -27,22 +27,21 @@ let raise_if_error = function Ok _ -> () | Error e -> fatal_error e
 
 let () =
   let r_input_file = ref "" in
-  let usage =
-    "Usage:\n" ^ Sys.argv.(0) ^ " input.scilla (or input.scillib)\n"
-  in
+  let usage = "Usage:\n" ^ Sys.argv.(0) ^ " input.scilla (or input.scillib)\n" in
   let anon_handler s = r_input_file := s in
   let () = Arg.parse [] anon_handler usage in
   let input_file = !r_input_file in
-  if input_file = "" then fatal_error_noformat usage
+  if String.is_empty input_file then fatal_error_noformat usage
   else set_use_json_errors true;
-  let extn = FilePath.get_extension input_file in
-  if extn = StdlibTracker.file_extn_library then
+  let open FilePath in
+  let open StdlibTracker in
+  if check_extension input_file file_extn_library then
     (* Check library modules. *)
     raise_if_error @@ parse_lmodule input_file
-  else if extn = StdlibTracker.file_extn_contract then
+  else if check_extension input_file file_extn_contract then
     (* Check contract modules. *)
     raise_if_error @@ parse_cmodule input_file
-  else if extn = StdlibTracker.file_extn_expression then
+  else if check_extension input_file file_extn_expression then
     (* Check expressions. *)
     raise_if_error @@ parse_expr_from_file input_file
-  else fatal_error (mk_error0 (sprintf "Unknown file extension %s\n" extn))
+  else fatal_error (mk_error0 (sprintf "Unknown file extension\n"))

--- a/tests/base/parser/Parser_dummy.ml
+++ b/tests/base/parser/Parser_dummy.ml
@@ -27,7 +27,9 @@ let raise_if_error = function Ok _ -> () | Error e -> fatal_error e
 
 let () =
   let r_input_file = ref "" in
-  let usage = "Usage:\n" ^ Sys.argv.(0) ^ " input.scilla (or input.scillib)\n" in
+  let usage =
+    "Usage:\n" ^ Sys.argv.(0) ^ " input.scilla (or input.scillib)\n"
+  in
   let anon_handler s = r_input_file := s in
   let () = Arg.parse [] anon_handler usage in
   let input_file = !r_input_file in

--- a/tests/base/parser/TestParser.ml
+++ b/tests/base/parser/TestParser.ml
@@ -16,6 +16,8 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
+open Core_kernel
+open! Int.Replace_polymorphic_compare
 open OUnit2
 
 let all_tests env =

--- a/tests/base/parser/bad/TestParserFail.ml
+++ b/tests/base/parser/bad/TestParserFail.ml
@@ -16,6 +16,9 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
+open Core_kernel
+open! Int.Replace_polymorphic_compare
+
 (* Add tests in alphabetical order *)
 
 module Tests = TestUtil.DiffBasedTests (struct

--- a/tests/checker/bad/TestCheckerFail.ml
+++ b/tests/checker/bad/TestCheckerFail.ml
@@ -16,6 +16,9 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
+open Core_kernel
+open! Int.Replace_polymorphic_compare
+
 module Tests = TestUtil.DiffBasedTests (struct
   let gold_path dir f = [ dir; "checker"; "bad"; "gold"; f ^ ".gold" ]
 

--- a/tests/checker/good/TestCheckerSuccess.ml
+++ b/tests/checker/good/TestCheckerSuccess.ml
@@ -16,6 +16,9 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
+open Core_kernel
+open! Int.Replace_polymorphic_compare
+
 module Tests = TestUtil.DiffBasedTests (struct
   let gold_path dir f = [ dir; "checker"; "good"; "gold"; f ^ ".gold" ]
 

--- a/tests/eval/bad/TestExpsFail.ml
+++ b/tests/eval/bad/TestExpsFail.ml
@@ -16,6 +16,8 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
+open Core_kernel
+open! Int.Replace_polymorphic_compare
 open OUnit2
 
 let explist =

--- a/tests/eval/good/TestExps.ml
+++ b/tests/eval/good/TestExps.ml
@@ -16,6 +16,9 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
+open Core_kernel
+open! Int.Replace_polymorphic_compare
+
 let explist =
   [
     "addr.scilexp";

--- a/tests/ipc/StateIPCTest.ml
+++ b/tests/ipc/StateIPCTest.ml
@@ -21,6 +21,7 @@
 
 open OUnit2
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open Syntax
 open Yojson
 

--- a/tests/ipc/StateIPCTest.ml
+++ b/tests/ipc/StateIPCTest.ml
@@ -21,7 +21,7 @@
 
 open OUnit2
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open Syntax
 open Yojson
 
@@ -128,7 +128,7 @@ let sort_mapkeys goldj outj =
               let corresponding_out =
                 List.find outlist ~f:(fun outelm ->
                     let outkey = json_member "key" outelm |> json_to_string in
-                    goldkey = outkey)
+                    String.(goldkey = outkey))
               in
               match corresponding_out with
               | Some out ->
@@ -152,7 +152,7 @@ let sort_mapkeys goldj outj =
            in
            assert_bool
              "sort_mapkeys: order of gold states and out states mismatch"
-             ( vname |> json_to_string
+             String.( vname |> json_to_string
              = (json_member "vname" outstate |> json_to_string) );
            let outval =
              map_sorter
@@ -171,7 +171,7 @@ let sort_mapkeys goldj outj =
   `Assoc
     (List.fold_right (json_to_assoc outj)
        ~f:(fun (s, j) acc ->
-         if s = "states" then (s, outstates') :: acc else (s, j) :: acc)
+         if String.(s = "states") then (s, outstates') :: acc else (s, j) :: acc)
        ~init:[])
 
 (* Start a mock server (if set) at ~sock_addr and initialize server
@@ -184,17 +184,16 @@ let setup_and_initialize ~start_mock_server ~sock_addr ~state_json_path =
 
   let fields =
     List.filter_map state ~f:(fun (s, t, _) ->
-        if s = ContractUtil.balance_label then None else Some (s, t))
+        if String.(s = ContractUtil.balance_label) then None else Some (s, t))
   in
   let () = StateIPCTestClient.initialize ~fields ~sock_addr in
   (* Update the server (via the test client) with the state values we want. *)
   List.iter state ~f:(fun (fname, _, value) ->
-      if fname <> ContractUtil.balance_label then
-        StateIPCTestClient.update ~fname ~value
-      else ());
+      if String.(fname <> ContractUtil.balance_label) then
+        StateIPCTestClient.update ~fname ~value);
   (* Find the balance from state and return it. *)
   match
-    List.find state ~f:(fun (fname, _, _) -> fname = ContractUtil.balance_label)
+    List.find state ~f:(fun (fname, _, _) -> String.(fname = ContractUtil.balance_label))
   with
   | Some (_, _, balpb) -> (
       match balpb with
@@ -223,10 +222,10 @@ let append_full_state ~goldoutput_file ~interpreter_output svars =
   let svars' =
     List.fold_right goldjs ~init:svars ~f:(fun goldv acc ->
         let golds = json_member "vname" goldv |> json_to_string in
-        if golds = ContractUtil.balance_label then acc
+        if String.(golds = ContractUtil.balance_label) then acc
         else
           let s', rest =
-            List.partition_tf acc ~f:(fun (s, _, _) -> s = golds)
+            List.partition_tf acc ~f:(fun (s, _, _) -> String.(s = golds))
           in
           s' @ rest)
   in
@@ -236,7 +235,7 @@ let append_full_state ~goldoutput_file ~interpreter_output svars =
   let unsorted_output_j =
     `Assoc
       (List.map items ~f:(fun (s, j) ->
-           if s <> "states" then (s, j)
+           if String.(s <> "states") then (s, j)
            else
              (* Just add our states to "_balance" that's in the output JSON. *)
              let svars_j = state_to_json svars' in

--- a/tests/ipc/StateIPCTest.ml
+++ b/tests/ipc/StateIPCTest.ml
@@ -152,8 +152,9 @@ let sort_mapkeys goldj outj =
            in
            assert_bool
              "sort_mapkeys: order of gold states and out states mismatch"
-             String.( vname |> json_to_string
-             = (json_member "vname" outstate |> json_to_string) );
+             String.(
+               vname |> json_to_string
+               = (json_member "vname" outstate |> json_to_string));
            let outval =
              map_sorter
                (json_member "value" goldstate)
@@ -193,7 +194,8 @@ let setup_and_initialize ~start_mock_server ~sock_addr ~state_json_path =
         StateIPCTestClient.update ~fname ~value);
   (* Find the balance from state and return it. *)
   match
-    List.find state ~f:(fun (fname, _, _) -> String.(fname = ContractUtil.balance_label))
+    List.find state ~f:(fun (fname, _, _) ->
+        String.(fname = ContractUtil.balance_label))
   with
   | Some (_, _, balpb) -> (
       match balpb with

--- a/tests/ipc/StateIPCTestClient.ml
+++ b/tests/ipc/StateIPCTestClient.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core
+open! Int.Replace_polymorphic_compare
 open Syntax
 open TypeUtil
 open StateIPCIdl

--- a/tests/ipc/StateIPCTestClient.ml
+++ b/tests/ipc/StateIPCTestClient.ml
@@ -106,7 +106,7 @@ let binary_rpc ~sock_addr (call : Rpc.call) : Rpc.response M.t =
 let fetch ~fname =
   let sock_addr, fields = assert_init () in
   let tp =
-    match List.Assoc.find fields ~equal:( = ) fname with
+    match List.Assoc.find fields ~equal:String.( = ) fname with
     | Some tp -> tp
     | None ->
         assert_failure ("StateIPCTestClient: Unable to find field " ^ fname)
@@ -135,7 +135,7 @@ let update ~fname ~value =
   let open Ipcmessage_types in
   let sock_addr, fields = assert_init () in
   let tp =
-    match List.Assoc.find fields ~equal:( = ) fname with
+    match List.Assoc.find fields fname ~equal:String.( = ) with
     | Some tp -> tp
     | None ->
         assert_failure ("StateIPCTestClient: Unable to find field " ^ fname)

--- a/tests/ipc/StateIPCTestServer.ml
+++ b/tests/ipc/StateIPCTestServer.ml
@@ -22,6 +22,7 @@
  * before the contract is executed. *)
 
 open Core
+open! Int.Replace_polymorphic_compare
 open Result.Let_syntax
 open MonadUtil
 open StateIPCIdl

--- a/tests/pm_check/bad/TestPMFail.ml
+++ b/tests/pm_check/bad/TestPMFail.ml
@@ -16,6 +16,8 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
+open Core_kernel
+open! Int.Replace_polymorphic_compare
 open OUnit2
 
 module Tests = TestUtil.DiffBasedTests (struct

--- a/tests/runner/Testcontracts.ml
+++ b/tests/runner/Testcontracts.ml
@@ -17,7 +17,7 @@
 *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open OUnit2
 open ScillaUtil.FilePathInfix
 open TestUtil
@@ -79,7 +79,7 @@ let rec build_contract_tests_with_init_file env name exit_code i n
 
       (* If an external IPC server is provided, we'll use that, otherwise
        * we'll have an in-testsuite mock server setup based on the shard-id. *)
-      let start_mock_server = env.ext_ipc_server test_ctxt = "" in
+      let start_mock_server = String.is_empty (env.ext_ipc_server test_ctxt) in
       let ipc_addr_thread =
         if start_mock_server then ipc_socket_addr ^ get_shard_id test_ctxt
           (* TODO: assert that "-runner sequential" CLI is provided to testsuite. *)
@@ -115,7 +115,7 @@ let rec build_contract_tests_with_init_file env name exit_code i n
           (* if the test is supposed to succeed we read the output from a file,
                  otherwise we read from the output stream *)
           let interpreter_output =
-            if exit_code = succ_code then In_channel.read_all output_file
+            if Poly.(exit_code = succ_code) then In_channel.read_all output_file
             else BatStream.to_string s
           in
           let out =
@@ -135,7 +135,7 @@ let rec build_contract_tests_with_init_file env name exit_code i n
     (* If this test is expected to succeed, we know that the JSONs are all "good".
      * So test both the JSON parsers, one that does validation, one that doesn't.
      * Both should succeed. *)
-    if exit_code = succ_code then
+    if Poly.(exit_code = succ_code) then
       test ~disable_validate_json:true ~ipc_mode:true
       :: test ~disable_validate_json:false ~ipc_mode:true
       :: test ~disable_validate_json:true ~ipc_mode:false
@@ -198,7 +198,7 @@ let build_contract_init_test env exit_code name init_name is_library =
       (* if the test is supposed to succeed we read the output from a file,
            otherwise we read from the output stream *)
       let out =
-        if exit_code = succ_code then In_channel.read_all output_file
+        if Poly.(exit_code = succ_code) then In_channel.read_all output_file
         else BatStream.to_string s
       in
       if env.update_gold test_ctxt then

--- a/tests/runner/Testcontracts.ml
+++ b/tests/runner/Testcontracts.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open OUnit2
 open ScillaUtil.FilePathInfix
 open TestUtil

--- a/tests/runner/dune
+++ b/tests/runner/dune
@@ -2,4 +2,5 @@
  (name testcontracts)
  (wrapped false)
  (libraries core oUnit testutil stateIPCTest)
- (preprocess (pps ppx_compare)))
+ (preprocess
+  (pps ppx_compare)))

--- a/tests/runner/dune
+++ b/tests/runner/dune
@@ -1,4 +1,5 @@
 (library
  (name testcontracts)
  (wrapped false)
- (libraries core oUnit testutil stateIPCTest))
+ (libraries core oUnit testutil stateIPCTest)
+ (preprocess (pps ppx_compare)))

--- a/tests/typecheck/bad/TestTypeFail.ml
+++ b/tests/typecheck/bad/TestTypeFail.ml
@@ -16,6 +16,8 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
+open Core_kernel
+open! Int.Replace_polymorphic_compare
 open OUnit2
 
 (* PART A: Test literal type checks. The only way to have malformed

--- a/tests/typecheck/good/Testtypes.ml
+++ b/tests/typecheck/good/Testtypes.ml
@@ -89,7 +89,8 @@ let make_ground_type_test ts exp_bool =
   in
   test_case (fun _ ->
       let b = is_ground_type t in
-      assert_bool "TypeUtil: is_ground_type test failed on type" Bool.(b = exp_bool))
+      assert_bool "TypeUtil: is_ground_type test failed on type"
+        Bool.(b = exp_bool))
 
 let ground_type_tests =
   [
@@ -143,7 +144,8 @@ let map_access_type_tests =
   ]
 
 let make_map_access_type_tests tlist =
-  List.map tlist ~f:(fun (t, at, nindices) -> make_map_access_type_test t at nindices)
+  List.map tlist ~f:(fun (t, at, nindices) ->
+      make_map_access_type_test t at nindices)
 
 let type_equiv_tests =
   "type_equiv_tests" >::: make_type_equiv_tests type_equiv_tests

--- a/tests/typecheck/good/Testtypes.ml
+++ b/tests/typecheck/good/Testtypes.ml
@@ -87,7 +87,7 @@ let make_ground_type_test ts exp_bool =
   in
   test_case (fun _ ->
       let b = is_ground_type t in
-      assert_bool "TypeUtil: is_ground_type test failed on type" (b = exp_bool))
+      assert_bool "TypeUtil: is_ground_type test failed on type" Bool.(b = exp_bool))
 
 let ground_type_tests =
   [

--- a/tests/typecheck/good/Testtypes.ml
+++ b/tests/typecheck/good/Testtypes.ml
@@ -16,6 +16,8 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
+open Core_kernel
+open! Int.Replace_polymorphic_compare
 open OUnit2
 open Syntax
 open ErrorUtils

--- a/tests/typecheck/good/Testtypes.ml
+++ b/tests/typecheck/good/Testtypes.ml
@@ -34,7 +34,7 @@ let make_type_equiv_test st1 st2 eq =
                dummy_loc ))
   in
   let b, bs =
-    if eq then (type_equiv t1 t2, "=") else (not (type_equiv t1 t2), "<>")
+    if eq then ([%equal: typ] t1 t2, "=") else (not ([%equal: typ] t1 t2), "<>")
   in
   let err_msg =
     "Assert " ^ pp_typ t1 ^ " " ^ bs ^ " " ^ pp_typ t2 ^ " test failed"
@@ -120,7 +120,7 @@ let make_map_access_type_test t at nindices =
           assert_failure
             "Failed map_access_type test. map_access_type returned failure."
       | Ok at_computed' ->
-          let b = type_equiv at' at_computed' in
+          let b = [%equal: typ] at' at_computed' in
           assert_bool
             (Printf.sprintf
                "Failed map_access_type test for %s[%d]. Expected %s, but got %s.\n"

--- a/tests/typecheck/good/Testtypes.ml
+++ b/tests/typecheck/good/Testtypes.ml
@@ -44,7 +44,7 @@ let make_type_equiv_test st1 st2 eq =
   test_case (fun _ -> assert_bool err_msg b)
 
 let make_type_equiv_tests tlist =
-  List.map (fun (st1, st2, eq) -> make_type_equiv_test st1 st2 eq) tlist
+  List.map tlist ~f:(fun (st1, st2, eq) -> make_type_equiv_test st1 st2 eq)
 
 let type_equiv_tests =
   [
@@ -103,7 +103,7 @@ let ground_type_tests =
   ]
 
 let make_ground_type_tests tlist =
-  List.map (fun (st, eq) -> make_ground_type_test st eq) tlist
+  List.map tlist ~f:(fun (st, eq) -> make_ground_type_test st eq)
 
 let make_map_access_type_test t at nindices =
   let open FrontEndParser in
@@ -143,9 +143,7 @@ let map_access_type_tests =
   ]
 
 let make_map_access_type_tests tlist =
-  List.map
-    (fun (t, at, nindices) -> make_map_access_type_test t at nindices)
-    tlist
+  List.map tlist ~f:(fun (t, at, nindices) -> make_map_access_type_test t at nindices)
 
 let type_equiv_tests =
   "type_equiv_tests" >::: make_type_equiv_tests type_equiv_tests

--- a/tests/typecheck/good/dune
+++ b/tests/typecheck/good/dune
@@ -2,4 +2,5 @@
  (name testtypes)
  (wrapped false)
  (libraries core oUnit testutil scilla_base)
- (preprocess (pps ppx_compare)))
+ (preprocess
+  (pps ppx_compare)))

--- a/tests/typecheck/good/dune
+++ b/tests/typecheck/good/dune
@@ -1,4 +1,5 @@
 (library
  (name testtypes)
  (wrapped false)
- (libraries core oUnit testutil scilla_base))
+ (libraries core oUnit testutil scilla_base)
+ (preprocess (pps ppx_compare)))

--- a/tests/util/TestUtil.ml
+++ b/tests/util/TestUtil.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Int.Replace_polymorphic_compare
 open OUnit2
 open ScillaUtil.FilePathInfix
 

--- a/tests/util/TestUtil.ml
+++ b/tests/util/TestUtil.ml
@@ -17,7 +17,7 @@
 *)
 
 open Core_kernel
-open Int.Replace_polymorphic_compare
+open! Int.Replace_polymorphic_compare
 open OUnit2
 open ScillaUtil.FilePathInfix
 
@@ -98,12 +98,12 @@ let output_verifier goldoutput_file msg print_diff output =
   in
   if print_diff then
     assert_equal
-      ~cmp:(fun e o -> String.strip e = String.strip o)
+      ~cmp:(fun e o -> String.(strip e = strip o))
       ~pp_diff:(fun fmt _ -> pp_diff fmt)
       gold_output output ~msg
   else
     assert_equal
-      ~cmp:(fun e o -> String.strip e = String.strip o)
+      ~cmp:(fun e o -> String.(strip e = strip o))
       ~printer:(fun s -> s)
       gold_output output ~msg
 


### PR DESCRIPTION
This is a followup PR for #770 -- it forbids using polymorphic comparison functions across the code base. In addition, the PR switches many more modules to using `Core_kernel` instead of the standard library, making code more uniform.

This PR add does not treat (for various) reasons:
- GasUseAnalysis.ml
- Polynomial.ml
- CFFICommon.ml
- schnorr.ml
- src/base/cpp/snark.ml
- TestGasContracts.ml
- TestGasExpr.ml
- Testsuite_polynomials.ml
- TestSnark.ml

These are left as future work.

As a by-product of this refactoring, we get some (~25%) performance improvement: tests/testsuite.exe runs on my machine:
- on `master` branch -- in 39.08 seconds;
- on this branch -- in 29.51 seconds.

It would be interesting to use the microbenchmarking framework to get more precise results.

Note to the reviewers: to use the reviewing burden I tried to group changes by type using different commits for each type.