### PR TITLE
Type inference rules for addresses

### DIFF
--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -1129,7 +1129,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let contains_elab sc ts =
       match ts with
-      | [ MapType (kt, vt); u ] when type_equiv kt u ->
+      | [ MapType (kt, vt); u ] when type_assignable kt u ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -1151,7 +1151,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let put_elab sc ts =
       match ts with
       | [ MapType (kt, vt); kt'; vt' ]
-        when type_equiv kt kt' && type_equiv vt vt' ->
+        when type_assignable kt kt' && type_assignable vt vt' ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -1174,7 +1174,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let get_elab sc ts =
       match ts with
-      | [ MapType (kt, vt); kt' ] when type_equiv kt kt' ->
+      | [ MapType (kt, vt); kt' ] when type_assignable kt kt' ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -1196,7 +1196,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let remove_elab sc ts =
       match ts with
-      | [ MapType (kt, vt); u ] when type_equiv kt u ->
+      | [ MapType (kt, vt); u ] when type_assignable kt u ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _ -> fail0 "Failed to elaborate"
 

--- a/src/base/Datatypes.ml
+++ b/src/base/Datatypes.ml
@@ -232,7 +232,7 @@ module SnarkTypes = struct
   let scilla_g1point_to_ocaml g1p =
     match g1p with
     | ADTValue ("Pair", [ pxt; pyt ], [ ByStrX px; ByStrX py ])
-      when type_assignable pxt scalar_type && type_assignable pyt scalar_type
+      when type_equiv pxt scalar_type && type_equiv pyt scalar_type
            && Bystrx.width px = scalar_len
            && Bystrx.width py = scalar_len ->
         pure { g1x = Bystrx.to_raw_bytes px; g1y = Bystrx.to_raw_bytes py }
@@ -241,7 +241,7 @@ module SnarkTypes = struct
   let scilla_g2point_to_ocaml g2p =
     match g2p with
     | ADTValue ("Pair", [ pxt; pyt ], [ ByStrX px; ByStrX py ])
-      when type_assignable pxt g2comp_type && type_assignable pyt g2comp_type
+      when type_equiv pxt g2comp_type && type_equiv pyt g2comp_type
            && Bystrx.width px = g2comp_len
            && Bystrx.width py = g2comp_len ->
         pure { g2x = Bystrx.to_raw_bytes px; g2y = Bystrx.to_raw_bytes py }
@@ -264,7 +264,7 @@ module SnarkTypes = struct
       mapM g1g2ol ~f:(fun g1g2p_lit ->
           match g1g2p_lit with
           | ADTValue ("Pair", [ g1pt; g2pt ], [ g1p; g2p ])
-            when type_assignable g1pt g1point_type && type_assignable g2pt g2point_type ->
+            when type_equiv g1pt g1point_type && type_equiv g2pt g2point_type ->
               let%bind g1p' = scilla_g1point_to_ocaml g1p in
               let%bind g2p' = scilla_g2point_to_ocaml g2p in
               pure (g1p', g2p')

--- a/src/base/Datatypes.ml
+++ b/src/base/Datatypes.ml
@@ -232,7 +232,7 @@ module SnarkTypes = struct
   let scilla_g1point_to_ocaml g1p =
     match g1p with
     | ADTValue ("Pair", [ pxt; pyt ], [ ByStrX px; ByStrX py ])
-      when type_equiv pxt scalar_type && type_equiv pyt scalar_type
+      when type_assignable pxt scalar_type && type_assignable pyt scalar_type
            && Bystrx.width px = scalar_len
            && Bystrx.width py = scalar_len ->
         pure { g1x = Bystrx.to_raw_bytes px; g1y = Bystrx.to_raw_bytes py }
@@ -241,7 +241,7 @@ module SnarkTypes = struct
   let scilla_g2point_to_ocaml g2p =
     match g2p with
     | ADTValue ("Pair", [ pxt; pyt ], [ ByStrX px; ByStrX py ])
-      when type_equiv pxt g2comp_type && type_equiv pyt g2comp_type
+      when type_assignable pxt g2comp_type && type_assignable pyt g2comp_type
            && Bystrx.width px = g2comp_len
            && Bystrx.width py = g2comp_len ->
         pure { g2x = Bystrx.to_raw_bytes px; g2y = Bystrx.to_raw_bytes py }
@@ -264,7 +264,7 @@ module SnarkTypes = struct
       mapM g1g2ol ~f:(fun g1g2p_lit ->
           match g1g2p_lit with
           | ADTValue ("Pair", [ g1pt; g2pt ], [ g1p; g2p ])
-            when type_equiv g1pt g1point_type && type_equiv g2pt g2point_type ->
+            when type_assignable g1pt g1point_type && type_assignable g2pt g2point_type ->
               let%bind g1p' = scilla_g1point_to_ocaml g1p in
               let%bind g2p' = scilla_g2point_to_ocaml g2p in
               pure (g1p', g2p')

--- a/src/base/Gas.ml
+++ b/src/base/Gas.ml
@@ -365,7 +365,7 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
         && List.for_all2_exn
              ~f:(fun t1 t2 ->
                (* the types should match *)
-               type_equiv t1 t2
+               type_assignable t1 t2
                ||
                (* or the built-in record is generic *)
                match t2 with TypeVar _ -> true | _ -> false)

--- a/src/base/Gas.ml
+++ b/src/base/Gas.ml
@@ -368,8 +368,8 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
                type_assignable t1 t2
                ||
                (* or the built-in record is generic *)
-               match t2 with TypeVar _ -> true | _ -> false)
-             arg_types types
+               match t1 with TypeVar _ -> true | _ -> false)
+              types arg_types
       then fcoster op arg_literals base (* this can fail too *)
       else fail0 @@ "Name or arity doesn't match"
     in

--- a/src/base/JSON.ml
+++ b/src/base/JSON.ml
@@ -82,12 +82,22 @@ let build_prim_lit_exn t v =
   let exn () =
     mk_invalid_json ("Invalid " ^ pp_typ t ^ " value " ^ v ^ " in JSON")
   in
+  let build_prim_literal_of_type t v =
+    match build_prim_literal t v with
+    | Some v' -> v'
+    | None -> raise (exn ())
+  in
   match t with
-  | PrimType pt -> (
-      match build_prim_literal pt v with
-      | Some v' -> v'
-      | None -> raise (exn ()) )
-  | _ -> raise (exn ())
+  | PrimType pt ->
+      build_prim_literal_of_type pt v
+  | Address _ ->
+      build_prim_literal_of_type (Bystrx_typ 20) v
+  | MapType _
+  | FunType _
+  | ADT _
+  | TypeVar _
+  | PolyFun _
+  | Unit -> raise (exn ())
 
 (****************************************************************)
 (*                    JSON parsing                              *)
@@ -213,10 +223,20 @@ and json_to_lit t v =
   | ADT (name, tlist) ->
       let vl = read_adt_json (get_id name) v tlist in
       vl
-  | _ ->
+  | PrimType _
+  | Address _ ->
       let tv = build_prim_lit_exn t (to_string_exn v) in
       tv
-
+  | FunType _
+  | TypeVar _
+  | PolyFun _
+  | Unit ->
+      let exn () =
+        mk_invalid_json ("Invalid type " ^ pp_typ t ^ " in JSON")
+      in
+      raise (exn ())
+       
+      
 let jobj_to_statevar json =
   let n = member_exn "vname" json |> to_string_exn in
   let tstring = member_exn "type" json |> to_string_exn in

--- a/src/base/JSON.ml
+++ b/src/base/JSON.ml
@@ -167,7 +167,7 @@ and read_adt_json name j tlist_verify =
   let verify_exn name tlist1 adt =
     match adt with
     | ADTValue (_, tlist2, _) ->
-        if type_equiv_list tlist1 tlist2 then ()
+        if type_assignable_list tlist1 tlist2 then ()
         else
           let expected = pp_typ_list tlist1 in
           let observed = pp_typ_list tlist2 in

--- a/src/base/ParserFaults.messages
+++ b/src/base/ParserFaults.messages
@@ -112,20 +112,6 @@ type_term: CID UNDERSCORE
 
 This is an invalid type term, it may be a bad ADT.
 
-type_term: CID WITH
-##
-## Ends in an error in state: 22.
-##
-## scid -> CID . [ UNDERSCORE TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN ID FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
-## scid -> CID . PERIOD CID [ UNDERSCORE TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN ID FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
-##
-## The known suffix of the stack is as follows:
-## CID
-##
-# see tests/parser/bad/type_t-cid-with.scilla
-
-This is an invalid type term, the ADT constructor arguments are likely incorrect. This necessitates a proper separated capital identifier, type identifier, type in brackets or a map.
-
 type_term: FORALL TID PERIOD TID WITH
 ##
 ## Ends in an error in state: 61.
@@ -534,7 +520,7 @@ This function is not terminated early enough or malformed. A possible alteration
 
 type_term: TID TARROW WITH
 ##
-## Ends in an error in state: 62.
+## Ends in an error in state: ?.
 ##
 ## typ -> typ TARROW . typ [ TARROW RPAREN EQ EOF COMMA ]
 ##
@@ -545,19 +531,34 @@ type_term: TID TARROW WITH
 
 This function type lacks a result type.
 
+type_term: CID WITH EOF
+##
+## Ends in an error in state: 62.
+##
+## 
+##
+## The known suffix of the stack is as follows:
+## 
+##
+# see tests/parser/bad/type_t-tid-arrow-with.scilla
+
+Invalid or incomplete type.
+
 type_term: TID WITH
 ##
-## Ends in an error in state: 312.
+## Ends in an error in state: 317.
 ##
 ## typ -> typ . TARROW typ [ TARROW EOF ]
 ## type_term -> typ . EOF [ # ]
-##
+## scid -> CID . [ UNDERSCORE TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN ID FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+## scid -> CID . PERIOD CID [ UNDERSCORE TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN ID FIELD EQ EOF END CONTRACT COMMA CID BAR AR##
 ## The known suffix of the stack is as follows:
 ## typ
+## CID
 ##
 # special case, only by type_term entry point should never happen
 
-This is an invalid type term, following the type it is complete and may only be extended by an arrow.
+This is an invalid type term, the ADT constructor arguments are likely incorrect. This necessitates a proper separated capital identifier, type identifier, type in brackets, or a map.
 
 type_term: WITH
 ##
@@ -1596,35 +1597,24 @@ This type annotation is not closed properly, or has a missing or misplaced '='.
 
 exp_term: FUN LPAREN ID COLON WITH
 ##
-## Ends in an error in state: 61.
+## Ends in an error in state: 64.
 ##
 ## simple_exp -> FUN LPAREN ID COLON . typ RPAREN ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ## type_annot -> COLON . typ [ EQ ]
 ## param_pair -> ID COLON . typ [ RPAREN COMMA ]
 ## field -> FIELD ID COLON . typ EQ exp [ TRANSITION PROCEDURE FIELD EOF ]
+## type_annot -> COLON . typ [ EQ ]
 ## 
 ## The known suffix of the stack is as follows:
 ## FUN LPAREN ID COLON
 ## LET ID COLON WITH
 ## SCILLA_VERSION NUMLIT CONTRACT CID LPAREN ID COLON WITH
 ## SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD ID COLON WITH
-##
-# see tests/parser/bad/exps/exp_t-fun-lparen-id-colon-with.scilexp
-
-Missing or invalid type in type annotation.
-
-cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN ID COLON ID RPAREN
-##
-## Ends in an error in state: 58.
-##
-## type_annot -> COLON . typ [ EQ ]
-## 
-## The known suffix of the stack is as follows:
 ## SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD ID COLON WITH
 ##
 # see tests/parser/bad/exps/exp_t-fun-lparen-id-colon-with.scilexp
 
-Invalid type in type annotation.
+Missing or invalid type in type annotation.
 
 exp_term: FUN LPAREN ID WITH
 ##

--- a/src/base/Recursion.ml
+++ b/src/base/Recursion.ml
@@ -56,7 +56,17 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
           forallM ~f:walk targs
       | PolyFun (_, t) -> walk t
       | Address fts ->
-          forallM fts ~f:(fun (_, t) -> walk t)
+          match List.find_a_dup fts
+                  ~compare:(fun (f1, _) (f2, _) ->
+                      Bytes.compare
+                        (Bytes.of_string (get_id f1))
+                        (Bytes.of_string (get_id f2))) with
+          | Some (dup_field, _) ->
+              fail1
+                (sprintf "Duplicate field %s in address type." (get_id dup_field))
+                (get_rep dup_field)
+          | None ->
+              forallM fts ~f:(fun (_, t) -> walk t)
     in
     walk t
 

--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -204,7 +204,7 @@ typ :
 | MAP; k=t_map_key; v = t_map_value; { MapType (k, v) }
 | t1 = typ; TARROW; t2 = typ; { FunType (t1, t2) }
 | LPAREN; t = typ; RPAREN; { t }
-| d = ID; WITH; fs = separated_list(COMMA, address_field_type); END;
+| d = CID; WITH; fs = separated_list(COMMA, address_field_type); END;
     { if d = "ByStr20"
       then Address fs
       else raise (SyntaxError ("Invalid primitive type", toLoc $startpos(d))) }

--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -552,6 +552,17 @@ let rec type_equal t1 t2 =
       type_equal t1_1 t2_1 && type_equal t1_2 t2_2
   | PolyFun (v1, t1''), PolyFun (v2, t2'') ->
       String.equal v1 v2 && type_equal t1'' t2''
+  | Address fts1, Address fts2 ->
+      let traverse fts_first fts_second =
+        List.for_all fts_first ~f:(fun (f1, t1) ->
+            let f1_id = get_id f1 in
+            match List.find fts_second ~f:(fun (f2, _) -> String.(f1_id = get_id f2)) with
+            | None -> false
+            | Some (_, t2) -> type_equal t1 t2)
+      in
+      List.length fts1 = List.length fts2
+      && traverse fts1 fts2
+      && traverse fts2 fts1
   | _ -> false
 
 (* Type equivalence *)

--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -130,7 +130,7 @@ let rec pp_typ = function
       let elems = List.map fts ~f:(fun (f, t) -> sprintf "%s : %s" (get_id f) (pp_typ t)) |>
                   String.concat ~sep:", "
       in
-      sprintf "ByStr20 with %s end" elems
+      sprintf "ByStr20 with %s%send" elems (if List.is_empty fts then "" else " ")
 
 and with_paren t =
   match t with

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -845,6 +845,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
     @@
     let param_checker =
       match comp_type with
+      (* TODO: Check for duplicate fields in address types *)
       | CompTrans -> is_legal_transition_parameter_type
       | CompProc -> is_legal_procedure_parameter_type
     in

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -845,7 +845,6 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
     @@
     let param_checker =
       match comp_type with
-      (* TODO: Check for duplicate fields in address types *)
       | CompTrans -> is_legal_transition_parameter_type
       | CompProc -> is_legal_procedure_parameter_type
     in

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -845,8 +845,8 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
     @@
     let param_checker =
       match comp_type with
-      | CompTrans -> is_legal_parameter_type
-      | CompProc -> is_non_map_ground_type
+      | CompTrans -> is_legal_transition_parameter_type
+      | CompProc -> is_legal_procedure_parameter_type
     in
     let%bind typed_cparams =
       mark_error_as_type_error remaining_gas

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -229,15 +229,17 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
         let%bind ((_, (ityp, _)) as checked_lhs), remaining_gas =
           wrap_type_err erep @@ type_expr tenv lhs remaining_gas
         in
-        let%bind () =
+        let%bind actual_typ =
           match topt with
           | Some tannot ->
               mark_error_as_type_error remaining_gas
-              @@ assert_type_equiv tannot ityp.tp
-          | None -> pure ()
+              @@
+              let%bind _ = assert_type_assignable tannot ityp.tp in
+              pure (mk_qual_tp tannot)
+          | None -> pure ityp
         in
-        let tenv' = TEnv.addT (TEnv.copy tenv) i ityp.tp in
-        let typed_i = add_type_to_ident i ityp in
+        let tenv' = TEnv.addT (TEnv.copy tenv) i actual_typ.tp in
+        let typed_i = add_type_to_ident i actual_typ in
         let%bind ((_, (rhstyp, _)) as checked_rhs), remaining_gas =
           type_expr tenv' rhs remaining_gas
         in
@@ -320,7 +322,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
           type_expr tenv' body remaining_gas
         in
         let%bind _ =
-          mark_error_as_type_error remaining_gas @@ assert_type_equiv t bt.tp
+          mark_error_as_type_error remaining_gas @@ assert_type_assignable t bt.tp
         in
         pure
         @@ ( ( TypedSyntax.Fixpoint
@@ -366,7 +368,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
         let payload_type fld pld remaining_gas =
           let check_field_type seen_type =
             match Caml.List.assoc_opt fld CU.msg_mandatory_field_types with
-            | Some fld_t when fld_t <> seen_type ->
+            | Some fld_t when not @@ type_assignable fld_t seen_type ->
                 fail1
                   (sprintf
                      "Type mismatch for Message field %s. Expected %s but got \
@@ -489,7 +491,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
           let%bind k_t =
             TEnv.resolveT env.pure (get_id k) ~lopt:(Some (get_rep k))
           in
-          let%bind _ = assert_type_equiv kt (rr_typ k_t).tp in
+          let%bind _ = assert_type_assignable kt (rr_typ k_t).tp in
           let%bind typed_keys, res = helper vt rest in
           let typed_k = add_type_to_ident k (rr_typ k_t) in
           pure @@ (typed_k :: typed_keys, res)
@@ -562,7 +564,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
                    in
                    let%bind _ =
                      mark_error_as_type_error remaining_gas
-                     @@ assert_type_equiv (rr_typ fr).tp (rr_typ r).tp
+                     @@ assert_type_assignable (rr_typ fr).tp (rr_typ r).tp
                    in
                    let%bind checked_stmts, remaining_gas =
                      type_stmts env sts get_loc remaining_gas
@@ -607,7 +609,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
                        let typed_v = rr_typ v_resolv in
                        let%bind _ =
                          mark_error_as_type_error remaining_gas
-                         @@ assert_type_equiv v_type typed_v.tp
+                         @@ assert_type_assignable v_type typed_v.tp
                        in
                        let typed_v' = add_type_to_ident v typed_v in
                        pure @@ Some typed_v'
@@ -726,7 +728,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
             let%bind _ =
               wrap_type_serr stmt
               @@ mark_error_as_type_error remaining_gas
-              @@ assert_type_equiv expected i_type.tp
+              @@ assert_type_assignable expected i_type.tp
             in
             let typed_i = add_type_to_ident i i_type in
             let%bind checked_stmts, remaining_gas =
@@ -746,7 +748,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
             let%bind _ =
               wrap_type_serr stmt
               @@ mark_error_as_type_error remaining_gas
-              @@ assert_type_equiv event_typ i_type.tp
+              @@ assert_type_assignable event_typ i_type.tp
             in
             let typed_i = add_type_to_ident i i_type in
             let%bind checked_stmts, remaining_gas =
@@ -802,7 +804,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
                 let%bind _ =
                   wrap_type_serr stmt
                   @@ mark_error_as_type_error remaining_gas
-                  @@ assert_type_equiv exception_typ i_type.tp
+                  @@ assert_type_assignable exception_typ i_type.tp
                 in
                 let typed_i = add_type_to_ident i i_type in
                 pure
@@ -898,7 +900,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
              let actual = ar.tp in
              let%bind _ =
                mark_error_as_type_error remaining_gas'
-               @@ assert_type_equiv ft actual
+               @@ assert_type_assignable ft actual
              in
              let typed_fs = add_type_to_ident fn ar in
              if is_legal_field_type ft then
@@ -950,7 +952,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
              match topt with
              | Some tannot ->
                  mark_error_as_type_error remaining_gas'
-                 @@ assert_type_equiv tannot ar.tp
+                 @@ assert_type_assignable tannot ar.tp
              | None -> pure ()
            in
            let typed_rn = add_type_to_ident rn ar in
@@ -1014,7 +1016,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
                          match ltopt with
                          | Some tannot ->
                              mark_error_as_type_error remaining_gas
-                             @@ assert_type_equiv tannot tr.tp
+                             @@ assert_type_assignable tannot tr.tp
                          | None -> pure ()
                        in
                        let typed_ln = add_type_to_ident ln tr in
@@ -1249,7 +1251,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
               in
               let%bind _ =
                 mark_error_as_type_error remaining_gas
-                @@ assert_type_equiv (ADT (asId "Bool", [])) ityp.tp
+                @@ assert_type_assignable (ADT (asId "Bool", [])) ityp.tp
               in
               pure (checked_constraint, remaining_gas)
          in

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -380,19 +380,14 @@ module TypeUtilities = struct
                     ~f:(fun t ->
                         recurser t seen_adts)
                     ts ) )
-      | Address fts ->
-          let duplicate_fields = List.contains_dup fts
-              ~compare:(fun (f1, _) (f2, _) ->
-                  Bytes.compare
-                    (Bytes.of_string (get_id f1))
-                    (Bytes.of_string (get_id f2)))
-          in
-          (* No duplicate fields allowed. *)
-          duplicate_fields &&
-          (not check_addresses || 
-           (* If check_addresses is true, then all field types in the address type should be legal field types. 
-                No need to check for serialisability or storability, since addresses are stored and passed as ByStr20. *)
-           List.for_all fts ~f:(fun (_, t) -> is_legal_field_type t))
+      | Address fts
+        when check_addresses -> 
+          (* If check_addresses is true, then all field types in the address type should be legal field types. 
+             No need to check for serialisability or storability, since addresses are stored and passed as ByStr20. *)
+          List.for_all fts ~f:(fun (_, t) -> is_legal_field_type t)
+      | Address _ ->
+          true
+
     in
     recurser t seen_adts
 

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -331,6 +331,17 @@ module TypeUtilities = struct
                (pp_typ expected) (pp_typ given)),
           remaining_gas )
 
+  let rec is_ground_type t =
+    match t with
+    | FunType (a, r) -> is_ground_type a && is_ground_type r
+    | MapType (k, v) -> is_ground_type k && is_ground_type v
+    | ADT (_, ts) -> List.for_all ~f:(fun t -> is_ground_type t) ts
+    | PolyFun _ | TypeVar _ -> false
+    | Address _ ->
+        (* Addresses are represented as ByStr20 *)
+        true 
+    | _ -> true
+  
   let rec is_serializable_storable_helper accept_maps allow_unserializable check_addresses t seen_adts =
     let rec recurser t seen_adts =
       match t with

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -329,7 +329,8 @@ module TypeUtilities = struct
     match t with
     | FunType (a, r) -> is_ground_type a && is_ground_type r
     | MapType (k, v) -> is_ground_type k && is_ground_type v
-    | ADT (_, ts) -> List.for_all ~f:(fun t -> is_ground_type t) ts
+    | ADT (_, ts) -> List.for_all ts ~f:(fun t -> is_ground_type t)
+    | Address fts -> List.for_all fts ~f:(fun (_, t) -> is_ground_type t)
     | PolyFun _ | TypeVar _ -> false
     | _ -> true
 
@@ -337,8 +338,13 @@ module TypeUtilities = struct
     match t with
     | FunType (a, r) -> is_non_map_ground_type a && is_non_map_ground_type r
     | MapType (_, _) -> false
-    | ADT (_, ts) -> List.for_all ~f:(fun t -> is_non_map_ground_type t) ts
+    | ADT (_, ts) -> List.for_all ts ~f:(fun t -> is_non_map_ground_type t)
     | PolyFun _ | TypeVar _ -> false
+    | Address fts ->
+        (* Addresses are passed as ByStr20, so they do not contain maps,
+           even if they contain a field of map type. However, the fields
+           must still be of ground types.*)
+        List.for_all fts ~f:(fun (_, t) -> is_ground_type t)
     | _ -> true
 
   let rec is_serializable_storable_helper accept_maps check_addresses t seen_adts =

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -387,7 +387,6 @@ module TypeUtilities = struct
           List.for_all fts ~f:(fun (_, t) -> is_legal_field_type t)
       | Address _ ->
           true
-
     in
     recurser t seen_adts
 

--- a/src/base/TypeUtil.mli
+++ b/src/base/TypeUtil.mli
@@ -128,6 +128,8 @@ module TypeUtilities : sig
 
   val is_legal_field_type : typ -> bool
 
+  val is_ground_type : typ -> bool
+
   val get_msgevnt_type :
     (string * 'a) sexp_list -> (typ, scilla_error sexp_list) result
 

--- a/src/base/TypeUtil.mli
+++ b/src/base/TypeUtil.mli
@@ -169,6 +169,8 @@ module TypeUtilities : sig
 
   val assert_type_equiv : typ -> typ -> (unit, scilla_error list) result
 
+  val assert_type_assignable : typ -> typ -> (unit, scilla_error list) result
+  
   val assert_type_equiv_with_gas :
     typ ->
     typ ->

--- a/src/base/TypeUtil.mli
+++ b/src/base/TypeUtil.mli
@@ -122,13 +122,11 @@ module TypeUtilities : sig
 
   val is_legal_message_field_type : typ -> bool
 
-  val is_legal_parameter_type : typ -> bool
+  val is_legal_transition_parameter_type : typ -> bool
   
+  val is_legal_procedure_parameter_type : typ -> bool
+
   val is_legal_field_type : typ -> bool
-
-  val is_ground_type : typ -> bool
-
-  val is_non_map_ground_type : typ -> bool
 
   val get_msgevnt_type :
     (string * 'a) sexp_list -> (typ, scilla_error sexp_list) result
@@ -168,6 +166,8 @@ module TypeUtilities : sig
     ('a, typeCheckerErrorType * 'b * Stdint.uint64) result
 
   val assert_type_equiv : typ -> typ -> (unit, scilla_error list) result
+
+  val type_assignable_list : typ list -> typ list -> bool
 
   val assert_type_assignable : typ -> typ -> (unit, scilla_error list) result
   

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -572,7 +572,7 @@ let create_cur_state_fields initcstate curcstate =
             ~f:(fun (t, li) ->
               let%bind t1 = fromR @@ literal_type lc in
               let%bind t2 = fromR @@ literal_type li in
-              if s = t && type_assignable t1 t2 then pure true else fail0 "")
+              if s = t && type_equiv t1 t2 then pure true else fail0 "")
             initcstate ~msg:emsg
         in
         pure ex)

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -523,7 +523,7 @@ let init_contract clibs elibs cconstraint' cparams' cfields args' init_bal =
           tryM
             ~f:(fun (ps, pt) ->
               let%bind at = fromR @@ literal_type (snd a) in
-              if get_id ps = fst a && type_equiv pt at then pure true
+              if get_id ps = fst a && type_assignable pt at then pure true
               else fail0 "")
             cparams ~msg:emsg
         in
@@ -572,7 +572,7 @@ let create_cur_state_fields initcstate curcstate =
             ~f:(fun (t, li) ->
               let%bind t1 = fromR @@ literal_type lc in
               let%bind t2 = fromR @@ literal_type li in
-              if s = t && type_equiv t1 t2 then pure true else fail0 "")
+              if s = t && type_assignable t1 t2 then pure true else fail0 "")
             initcstate ~msg:emsg
         in
         pure ex)

--- a/tests/base/parser/bad/gold/cmodule-contract-cid-lparen-id-colon-with.scilla.gold
+++ b/tests/base/parser/bad/gold/cmodule-contract-cid-lparen-id-colon-with.scilla.gold
@@ -1,12 +1,12 @@
 {
   "errors": [
     {
-      "error_message": "Invalid type in type annotation.\n",
+      "error_message": "Missing or invalid type in type annotation.\n",
       "start_location": {
         "file":
           "base/parser/bad/cmodule-contract-cid-lparen-id-colon-with.scilla",
         "line": 5,
-        "column": 20
+        "column": 19
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/base/parser/bad/gold/cmodule-field-id-colon-with.scilla.gold
+++ b/tests/base/parser/bad/gold/cmodule-field-id-colon-with.scilla.gold
@@ -1,11 +1,11 @@
 {
   "errors": [
     {
-      "error_message": "Invalid type in type annotation.\n",
+      "error_message": "Missing or invalid type in type annotation.\n",
       "start_location": {
         "file": "base/parser/bad/cmodule-field-id-colon-with.scilla",
         "line": 9,
-        "column": 21
+        "column": 19
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/base/parser/bad/gold/exp_t-fun-lparen-id-colon-with.scilexp.gold
+++ b/tests/base/parser/bad/gold/exp_t-fun-lparen-id-colon-with.scilexp.gold
@@ -1,11 +1,11 @@
 {
   "errors": [
     {
-      "error_message": "Invalid type in type annotation.\n",
+      "error_message": "Missing or invalid type in type annotation.\n",
       "start_location": {
         "file": "base/parser/bad/exps/exp_t-fun-lparen-id-colon-with.scilexp",
         "line": 1,
-        "column": 14
+        "column": 13
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/base/parser/bad/gold/exp_t-let-id-colon-with.scilexp.gold
+++ b/tests/base/parser/bad/gold/exp_t-let-id-colon-with.scilexp.gold
@@ -1,11 +1,11 @@
 {
   "errors": [
     {
-      "error_message": "Invalid type in type annotation.\n",
+      "error_message": "Missing or invalid type in type annotation.\n",
       "start_location": {
         "file": "base/parser/bad/exps/exp_t-let-id-colon-with.scilexp",
         "line": 1,
-        "column": 15
+        "column": 13
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/base/parser/bad/gold/type_t-cid-lparen-with.scilla.gold
+++ b/tests/base/parser/bad/gold/type_t-cid-lparen-with.scilla.gold
@@ -1,11 +1,12 @@
 {
   "errors": [
     {
-      "error_message": "Invalid type in type annotation.\n",
+      "error_message":
+        "This is an invalid type term, it is likely an ADT missing a valid type as an argument in brackets.\n",
       "start_location": {
         "file": "base/parser/bad/type_t-cid-lparen-with.scilla",
         "line": 5,
-        "column": 31
+        "column": 30
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/base/parser/bad/gold/type_t-cid-with.scilla.gold
+++ b/tests/base/parser/bad/gold/type_t-cid-with.scilla.gold
@@ -1,12 +1,11 @@
 {
   "errors": [
     {
-      "error_message":
-        "This is an invalid type term, the ADT constructor arguments are likely incorrect. This necessitates a proper separated capital identifier, type identifier, type in brackets or a map.\n",
+      "error_message": "Invalid or incomplete type.\n",
       "start_location": {
         "file": "base/parser/bad/type_t-cid-with.scilla",
-        "line": 6,
-        "column": 31
+        "line": 7,
+        "column": 1
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/base/parser/bad/gold/type_t-forall-tid-period-with.scilla.gold
+++ b/tests/base/parser/bad/gold/type_t-forall-tid-period-with.scilla.gold
@@ -1,11 +1,12 @@
 {
   "errors": [
     {
-      "error_message": "Invalid type in type annotation.\n",
+      "error_message":
+        "This is an invalid forall type, after the period (following forall and a type id) the parser expects a valid type.\n",
       "start_location": {
         "file": "base/parser/bad/type_t-forall-tid-period-with.scilla",
-        "line": 8,
-        "column": 9
+        "line": 6,
+        "column": 27
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/base/parser/bad/gold/type_t-tid-arrow-with.scilla.gold
+++ b/tests/base/parser/bad/gold/type_t-tid-arrow-with.scilla.gold
@@ -1,11 +1,11 @@
 {
   "errors": [
     {
-      "error_message": "Invalid type in type annotation.\n",
+      "error_message": "This function type lacks a result type.\n",
       "start_location": {
         "file": "base/parser/bad/type_t-tid-arrow-with.scilla",
-        "line": 8,
-        "column": 1
+        "line": 7,
+        "column": 24
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/checker/bad/gold/bad-exception1.scilla.gold
+++ b/tests/checker/bad/gold/bad-exception1.scilla.gold
@@ -59,7 +59,7 @@
     },
     {
       "error_message":
-        "Error in throw of 'e':\nType mismatch: Exception expected, but Event provided.",
+        "Error in throw of 'e':\nTypes not equivalent: Exception expected, but Event provided.",
       "start_location": {
         "file": "checker/bad/bad-exception1.scilla",
         "line": 25,

--- a/tests/checker/bad/gold/bad-exception1.scilla.gold
+++ b/tests/checker/bad/gold/bad-exception1.scilla.gold
@@ -59,7 +59,7 @@
     },
     {
       "error_message":
-        "Error in throw of 'e':\nTypes not equivalent: Exception expected, but Event provided.",
+        "Error in throw of 'e':\nType unassignable: Exception expected, but Event provided.",
       "start_location": {
         "file": "checker/bad/bad-exception1.scilla",
         "line": 25,

--- a/tests/checker/bad/gold/bad_lib_type.scilla.gold
+++ b/tests/checker/bad/gold/bad_lib_type.scilla.gold
@@ -20,7 +20,8 @@
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message": "Type mismatch: Int128 expected, but Uint32 provided.",
+      "error_message":
+        "Types not equivalent: Int128 expected, but Uint32 provided.",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/checker/bad/gold/bad_lib_type.scilla.gold
+++ b/tests/checker/bad/gold/bad_lib_type.scilla.gold
@@ -21,7 +21,7 @@
     },
     {
       "error_message":
-        "Types not equivalent: Int128 expected, but Uint32 provided.",
+        "Type unassignable: Int128 expected, but Uint32 provided.",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/checker/bad/gold/bad_lib_type2.scilla.gold
+++ b/tests/checker/bad/gold/bad_lib_type2.scilla.gold
@@ -21,7 +21,7 @@
     },
     {
       "error_message":
-        "Types not equivalent: forall 'A. forall 'B. ('A -> Uint128) -> List ('A) -> List (Uint128) expected, but forall 'A. forall 'B. ('A -> 'B) -> List ('A) -> List ('B) provided.",
+        "Type unassignable: forall 'A. forall 'B. ('A -> Uint128) -> List ('A) -> List (Uint128) expected, but forall 'A. forall 'B. ('A -> 'B) -> List ('A) -> List ('B) provided.",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/checker/bad/gold/bad_lib_type2.scilla.gold
+++ b/tests/checker/bad/gold/bad_lib_type2.scilla.gold
@@ -21,7 +21,7 @@
     },
     {
       "error_message":
-        "Type mismatch: forall 'A. forall 'B. ('A -> Uint128) -> List ('A) -> List (Uint128) expected, but forall 'A. forall 'B. ('A -> 'B) -> List ('A) -> List ('B) provided.",
+        "Types not equivalent: forall 'A. forall 'B. ('A -> Uint128) -> List ('A) -> List (Uint128) expected, but forall 'A. forall 'B. ('A -> 'B) -> List ('A) -> List ('B) provided.",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/checker/bad/gold/bad_lib_type3.scilla.gold
+++ b/tests/checker/bad/gold/bad_lib_type3.scilla.gold
@@ -21,7 +21,7 @@
     },
     {
       "error_message":
-        "Type mismatch: forall 'A. forall 'B. ('A -> 'B) -> List ('A) -> List ('B) expected, but forall 'A. forall 'B. ('A -> Uint128) -> List ('A) -> List (Uint128) provided.",
+        "Types not equivalent: forall 'A. forall 'B. ('A -> 'B) -> List ('A) -> List ('B) expected, but forall 'A. forall 'B. ('A -> Uint128) -> List ('A) -> List (Uint128) provided.",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/checker/bad/gold/bad_lib_type3.scilla.gold
+++ b/tests/checker/bad/gold/bad_lib_type3.scilla.gold
@@ -21,7 +21,7 @@
     },
     {
       "error_message":
-        "Types not equivalent: forall 'A. forall 'B. ('A -> 'B) -> List ('A) -> List ('B) expected, but forall 'A. forall 'B. ('A -> Uint128) -> List ('A) -> List (Uint128) provided.",
+        "Type unassignable: forall 'A. forall 'B. ('A -> 'B) -> List ('A) -> List ('B) expected, but forall 'A. forall 'B. ('A -> Uint128) -> List ('A) -> List (Uint128) provided.",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/checker/bad/gold/constraint_type_illegal.scilla.gold
+++ b/tests/checker/bad/gold/constraint_type_illegal.scilla.gold
@@ -21,7 +21,7 @@
     },
     {
       "error_message":
-        "Types not equivalent: Bool expected, but Uint128 provided.",
+        "Type unassignable: Bool expected, but Uint128 provided.",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/checker/bad/gold/constraint_type_illegal.scilla.gold
+++ b/tests/checker/bad/gold/constraint_type_illegal.scilla.gold
@@ -20,7 +20,8 @@
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message": "Type mismatch: Bool expected, but Uint128 provided.",
+      "error_message":
+        "Types not equivalent: Bool expected, but Uint128 provided.",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/checker/bad/gold/inplace-map.scilla.gold
+++ b/tests/checker/bad/gold/inplace-map.scilla.gold
@@ -30,7 +30,7 @@
     },
     {
       "error_message":
-        "Type error in updating map gmap[k]\nTypes not equivalent: Int32 expected, but String provided.",
+        "Type error in updating map gmap[k]\nType unassignable: Int32 expected, but String provided.",
       "start_location": {
         "file": "checker/bad/inplace-map.scilla",
         "line": 19,
@@ -49,7 +49,7 @@
     },
     {
       "error_message":
-        "Type error in updating map gmap3[c][b][c]\nTypes not equivalent: String expected, but Int64 provided.",
+        "Type error in updating map gmap3[c][b][c]\nType unassignable: String expected, but Int64 provided.",
       "start_location": {
         "file": "checker/bad/inplace-map.scilla",
         "line": 38,
@@ -68,7 +68,7 @@
     },
     {
       "error_message":
-        "Type error in updating map gmap3[a]\nTypes not equivalent: Map (Int32) (Map (Int64) (String)) expected, but String provided.",
+        "Type error in updating map gmap3[a]\nType unassignable: Map (Int32) (Map (Int64) (String)) expected, but String provided.",
       "start_location": {
         "file": "checker/bad/inplace-map.scilla",
         "line": 45,
@@ -116,7 +116,7 @@
     },
     {
       "error_message":
-        "Type error in updating map gmap[dd]\nTypes not equivalent: String expected, but Map (Int64) (String) provided.",
+        "Type error in updating map gmap[dd]\nType unassignable: String expected, but Map (Int64) (String) provided.",
       "start_location": {
         "file": "checker/bad/inplace-map.scilla",
         "line": 70,
@@ -154,7 +154,7 @@
     },
     {
       "error_message":
-        "Type error in updating map gmap3[b]\nTypes not equivalent: String expected, but Int32 provided.",
+        "Type error in updating map gmap3[b]\nType unassignable: String expected, but Int32 provided.",
       "start_location": {
         "file": "checker/bad/inplace-map.scilla",
         "line": 95,
@@ -173,7 +173,7 @@
     },
     {
       "error_message":
-        "Type error in getting map value gmap3[a][c][c]\nTypes not equivalent: Int32 expected, but Int64 provided.",
+        "Type error in getting map value gmap3[a][c][c]\nType unassignable: Int32 expected, but Int64 provided.",
       "start_location": {
         "file": "checker/bad/inplace-map.scilla",
         "line": 102,

--- a/tests/checker/bad/gold/inplace-map.scilla.gold
+++ b/tests/checker/bad/gold/inplace-map.scilla.gold
@@ -30,7 +30,7 @@
     },
     {
       "error_message":
-        "Type error in updating map gmap[k]\nType mismatch: Int32 expected, but String provided.",
+        "Type error in updating map gmap[k]\nTypes not equivalent: Int32 expected, but String provided.",
       "start_location": {
         "file": "checker/bad/inplace-map.scilla",
         "line": 19,
@@ -49,7 +49,7 @@
     },
     {
       "error_message":
-        "Type error in updating map gmap3[c][b][c]\nType mismatch: String expected, but Int64 provided.",
+        "Type error in updating map gmap3[c][b][c]\nTypes not equivalent: String expected, but Int64 provided.",
       "start_location": {
         "file": "checker/bad/inplace-map.scilla",
         "line": 38,
@@ -68,7 +68,7 @@
     },
     {
       "error_message":
-        "Type error in updating map gmap3[a]\nType mismatch: Map (Int32) (Map (Int64) (String)) expected, but String provided.",
+        "Type error in updating map gmap3[a]\nTypes not equivalent: Map (Int32) (Map (Int64) (String)) expected, but String provided.",
       "start_location": {
         "file": "checker/bad/inplace-map.scilla",
         "line": 45,
@@ -116,7 +116,7 @@
     },
     {
       "error_message":
-        "Type error in updating map gmap[dd]\nType mismatch: String expected, but Map (Int64) (String) provided.",
+        "Type error in updating map gmap[dd]\nTypes not equivalent: String expected, but Map (Int64) (String) provided.",
       "start_location": {
         "file": "checker/bad/inplace-map.scilla",
         "line": 70,
@@ -154,7 +154,7 @@
     },
     {
       "error_message":
-        "Type error in updating map gmap3[b]\nType mismatch: String expected, but Int32 provided.",
+        "Type error in updating map gmap3[b]\nTypes not equivalent: String expected, but Int32 provided.",
       "start_location": {
         "file": "checker/bad/inplace-map.scilla",
         "line": 95,
@@ -173,7 +173,7 @@
     },
     {
       "error_message":
-        "Type error in getting map value gmap3[a][c][c]\nType mismatch: Int32 expected, but Int64 provided.",
+        "Type error in getting map value gmap3[a][c][c]\nTypes not equivalent: Int32 expected, but Int64 provided.",
       "start_location": {
         "file": "checker/bad/inplace-map.scilla",
         "line": 102,

--- a/tests/checker/bad/gold/lib_bad1.scilla.gold
+++ b/tests/checker/bad/gold/lib_bad1.scilla.gold
@@ -30,7 +30,7 @@
     },
     {
       "error_message":
-        "Type mismatch: Message expected, but Uint128 provided.",
+        "Type unassignable: Message expected, but Uint128 provided.",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
@@ -45,7 +45,7 @@
     },
     {
       "error_message":
-        "Type mismatch: Message expected, but Uint128 provided.",
+        "Type unassignable: Message expected, but Uint128 provided.",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     },

--- a/tests/checker/bad/gold/mappair.scilla.gold
+++ b/tests/checker/bad/gold/mappair.scilla.gold
@@ -30,7 +30,7 @@
     },
     {
       "error_message":
-        "Type error in the binding to into `p`:\nType mismatch: Int32 expected, but Int64 provided.",
+        "Type error in the binding to into `p`:\nType unassignable: Int32 expected, but Int64 provided.",
       "start_location": {
         "file": "checker/bad/mappair.scilla",
         "line": 56,
@@ -49,7 +49,7 @@
     },
     {
       "error_message":
-        "Type error in the binding to into `l2`:\nType mismatch: Int32 expected, but Int64 provided.",
+        "Type error in the binding to into `l2`:\nType unassignable: Int32 expected, but Int64 provided.",
       "start_location": {
         "file": "checker/bad/mappair.scilla",
         "line": 72,

--- a/tests/checker/bad/gold/procedure_bad_type.scilla.gold
+++ b/tests/checker/bad/gold/procedure_bad_type.scilla.gold
@@ -30,7 +30,7 @@
     },
     {
       "error_message":
-        "Type mismatch: Int32 expected, but List (Bool) provided.",
+        "Type unassignable: Int32 expected, but List (Bool) provided.",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/checker/bad/gold/send_event1.scilla.gold
+++ b/tests/checker/bad/gold/send_event1.scilla.gold
@@ -39,7 +39,7 @@
     },
     {
       "error_message":
-        "Error in create event `msgs`:\nTypes not equivalent: Event expected, but List (Message) provided.",
+        "Error in create event `msgs`:\nType unassignable: Event expected, but List (Message) provided.",
       "start_location": {
         "file": "checker/bad/send_event1.scilla",
         "line": 222,
@@ -68,7 +68,7 @@
     },
     {
       "error_message":
-        "Error in sending messages `e`:\nTypes not equivalent: List (Message) expected, but Event provided.",
+        "Error in sending messages `e`:\nType unassignable: List (Message) expected, but Event provided.",
       "start_location": {
         "file": "checker/bad/send_event1.scilla",
         "line": 247,

--- a/tests/checker/bad/gold/send_event1.scilla.gold
+++ b/tests/checker/bad/gold/send_event1.scilla.gold
@@ -39,7 +39,7 @@
     },
     {
       "error_message":
-        "Error in create event `msgs`:\nType mismatch: Event expected, but List (Message) provided.",
+        "Error in create event `msgs`:\nTypes not equivalent: Event expected, but List (Message) provided.",
       "start_location": {
         "file": "checker/bad/send_event1.scilla",
         "line": 222,
@@ -68,7 +68,7 @@
     },
     {
       "error_message":
-        "Error in sending messages `e`:\nType mismatch: List (Message) expected, but Event provided.",
+        "Error in sending messages `e`:\nTypes not equivalent: List (Message) expected, but Event provided.",
       "start_location": {
         "file": "checker/bad/send_event1.scilla",
         "line": 247,

--- a/tests/checker/bad/gold/send_event2.scilla.gold
+++ b/tests/checker/bad/gold/send_event2.scilla.gold
@@ -105,7 +105,7 @@
     },
     {
       "error_message":
-        "Error in create event `e`:\nTypes not equivalent: Event expected, but Message provided.",
+        "Error in create event `e`:\nType unassignable: Event expected, but Message provided.",
       "start_location": {
         "file": "checker/bad/send_event2.scilla",
         "line": 247,

--- a/tests/checker/bad/gold/send_event2.scilla.gold
+++ b/tests/checker/bad/gold/send_event2.scilla.gold
@@ -39,7 +39,7 @@
     },
     {
       "error_message":
-        "Type error in storing value of `hopt` into the field `player_a_hash`:\nType error in storing value of `tm1` into the field `timer`:\nType error in the binding to into `msgs`:\nType error in application of `one_msg`:\nType mismatch: Message expected, but Event provided.",
+        "Type error in storing value of `hopt` into the field `player_a_hash`:\nType error in storing value of `tm1` into the field `timer`:\nType error in the binding to into `msgs`:\nType error in application of `one_msg`:\nType unassignable: Message expected, but Event provided.",
       "start_location": {
         "file": "checker/bad/send_event2.scilla",
         "line": 178,
@@ -105,7 +105,7 @@
     },
     {
       "error_message":
-        "Error in create event `e`:\nType mismatch: Event expected, but Message provided.",
+        "Error in create event `e`:\nTypes not equivalent: Event expected, but Message provided.",
       "start_location": {
         "file": "checker/bad/send_event2.scilla",
         "line": 247,

--- a/tests/typecheck/bad/gold/builtin-alt-bn128-pairing-product.scilexp.gold
+++ b/tests/typecheck/bad/gold/builtin-alt-bn128-pairing-product.scilexp.gold
@@ -2,7 +2,7 @@
   "errors": [
     {
       "error_message":
-        "Type error in the initialiser of `pair2`:\nType mismatch: Pair (ByStr32) (ByStr32) expected, but Pair (ByStr64) (ByStr64) provided.",
+        "Type error in the initialiser of `pair2`:\nType unassignable: Pair (ByStr32) (ByStr32) expected, but Pair (ByStr64) (ByStr64) provided.",
       "start_location": {
         "file": "typecheck/bad/builtin-alt-bn128-pairing-product.scilexp",
         "line": 18,

--- a/tests/typecheck/bad/gold/let-error.scilexp.gold
+++ b/tests/typecheck/bad/gold/let-error.scilexp.gold
@@ -2,7 +2,7 @@
   "errors": [
     {
       "error_message":
-        "Types not equivalent: Int32 expected, but Uint32 provided.",
+        "Type unassignable: Int32 expected, but Uint32 provided.",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/typecheck/bad/gold/let-error.scilexp.gold
+++ b/tests/typecheck/bad/gold/let-error.scilexp.gold
@@ -1,7 +1,8 @@
 {
   "errors": [
     {
-      "error_message": "Type mismatch: Int32 expected, but Uint32 provided.",
+      "error_message":
+        "Types not equivalent: Int32 expected, but Uint32 provided.",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/typecheck/bad/gold/list-lit.scilexp.gold
+++ b/tests/typecheck/bad/gold/list-lit.scilexp.gold
@@ -2,7 +2,7 @@
   "errors": [
     {
       "error_message":
-        "Type error in the initialiser of `l3`:\nType mismatch: List (Int32) expected, but List (Int64) provided.",
+        "Type error in the initialiser of `l3`:\nType unassignable: List (Int32) expected, but List (Int64) provided.",
       "start_location": {
         "file": "typecheck/bad/list-lit.scilexp",
         "line": 6,

--- a/tests/typecheck/bad/gold/list-lit2.scilexp.gold
+++ b/tests/typecheck/bad/gold/list-lit2.scilexp.gold
@@ -2,7 +2,7 @@
   "errors": [
     {
       "error_message":
-        "Type error in the initialiser of `l3`:\nType mismatch: Int64 expected, but Int32 provided.",
+        "Type error in the initialiser of `l3`:\nType unassignable: Int64 expected, but Int32 provided.",
       "start_location": {
         "file": "typecheck/bad/list-lit2.scilexp",
         "line": 6,

--- a/tests/typecheck/bad/gold/map-error.scilexp.gold
+++ b/tests/typecheck/bad/gold/map-error.scilexp.gold
@@ -2,7 +2,7 @@
   "errors": [
     {
       "error_message":
-        "Type error in the initialiser of `list_map`:\nType error in application of `folder`:\nType mismatch: 'A -> 'B -> 'B expected, but 'A -> List ('B) -> List ('B) provided.",
+        "Type error in the initialiser of `list_map`:\nType error in application of `folder`:\nType unassignable: 'A -> 'B -> 'B expected, but 'A -> List ('B) -> List ('B) provided.",
       "start_location": {
         "file": "typecheck/bad/map-error.scilexp",
         "line": 8,

--- a/tests/typecheck/bad/gold/some.scilexp.gold
+++ b/tests/typecheck/bad/gold/some.scilexp.gold
@@ -2,7 +2,7 @@
   "errors": [
     {
       "error_message":
-        "Type error in the initialiser of `p`:\nType mismatch: Option (Bool) expected, but Bool provided.",
+        "Type error in the initialiser of `p`:\nType unassignable: Option (Bool) expected, but Bool provided.",
       "start_location": {
         "file": "typecheck/bad/some.scilexp",
         "line": 4,

--- a/tests/typecheck/good/Testtypes.ml
+++ b/tests/typecheck/good/Testtypes.ml
@@ -66,14 +66,37 @@ let equivalent_types =
       "forall 'B. 'B -> (forall 'C. List ('C)) -> 'B");
     ( "forall 'A. 'A -> (forall 'A. List ('A)) -> 'B",
       "forall 'C. 'C -> (forall 'C. List ('C)) -> 'B");
+    (* Addresses *)
+    ( "ByStr20", "ByStr20");
+    ( "ByStr20 with end",
+      "ByStr20 with end");
     ( "ByStr20 with x : Uint32 end",
       "ByStr20 with x : Uint32 end");
+    ( "ByStr20 with x : Uint32, y : Bool end",
+      "ByStr20 with x : Uint32, y : Bool end");
+    ( "ByStr20 with y : Bool, x : Uint32 end",
+      "ByStr20 with x : Uint32, y : Bool end");
+    ( "ByStr20 with x : Uint32, y : ByStr20 with end end",
+      "ByStr20 with x : Uint32, y : ByStr20 with end end");
+    ( "ByStr20 with x : Uint32, y : ByStr20 with y2 : ByStr20, y1 : Option Int256 end end",
+      "ByStr20 with x : Uint32, y : ByStr20 with y1 : Option Int256, y2 : ByStr20 end end");
   ]
   
 let assignable_but_not_equivalent_types =
   [
+    (* Addresses *)
+    ( "ByStr20", 
+      "ByStr20 with end");
+    ( "ByStr20 with end",
+      "ByStr20 with x : Uint32 end");
     ( "ByStr20 with x : Uint32 end",
       "ByStr20 with x : Uint32, y : Uint32 end");
+    ( "ByStr20 with x : Uint32 end",
+      "ByStr20 with x : Uint32, y : Uint32, z : ByStr20 with end end");
+    ( "ByStr20 with y : Uint32, x : Uint32 end",
+      "ByStr20 with x : Uint32, y : Uint32, z : ByStr20 with end end");
+    ( "ByStr20 with x : Uint32, y : ByStr20 with y1 : Int32 end end",
+      "ByStr20 with x : Uint32, y : ByStr20 with y2 : Bool, y1 : Int32 end end");
   ]
 
 let not_assignable_types =
@@ -85,10 +108,15 @@ let not_assignable_types =
       "forall 'B. forall 'A. ('B -> 'A -> 'B) -> 'B -> List ('A) -> 'B");
     ( "forall 'A. 'A -> (forall 'A. List ('A)) -> 'B",
       "forall 'B. 'B -> (forall 'C. List ('C)) -> 'B");
+    (* Addresses *)
     ( "ByStr20 with x : Int32 end",
       "ByStr20 with x : Uint32 end");
-    ( "ByStr20 with x : Uint32, y : Uint32 end",
-      "ByStr20 with x : Uint32 end");
+    ( "ByStr20 with x : Int32 end",
+      "ByStr20 with y : Int32 end");
+    ( "ByStr20 with x : ByStr20 with y1 : Int32 end end",
+      "ByStr20 with x : ByStr20 with y1 : Uint32 end end");
+    ( "ByStr20 with x : ByStr20 with y1 : Int32 end end",
+      "ByStr20 with x : ByStr20 with y2 : Int32 end end");
   ]
 
 let make_test eq (t1, t2) = (t1, t2, eq)
@@ -120,7 +148,9 @@ let all_type_assignable_tests =
   @ List.map assignable_but_not_equivalent_types ~f:(reverse_test false)
   (* Non-assignable *)
   @ List.map not_assignable_types ~f:(make_test false)
-  (* Non-assignable and non-equivalent does not imply anything *)
+  (* Non-assignable and non-equivalent is reflexive 
+     - if it becomes assignable, then it should be place in assignable_but_not_equivalent_types. *)
+  @ List.map not_assignable_types ~f:(reverse_test false)
 
 let make_map_access_type_test t at nindices =
   let open FrontEndParser in

--- a/tests/typecheck/good/Testtypes.ml
+++ b/tests/typecheck/good/Testtypes.ml
@@ -92,10 +92,17 @@ let all_type_equiv_tests =
     ( "ByStr20 with x : Uint32 end",
       "ByStr20 with x : Uint32, y : Uint32 end",
       false );
+    ( "ByStr20",
+      "ByStr20 with x : Uint32 end",
+      false );
+    ( "ByStr20 with x : Uint32 end",
+      "ByStr20",
+      false );
   ]
 
 let all_type_assignable_tests =
   [
+    (* TODO: These need to be done properly. They are currently a copy of the equiv tests *)
     ("Uint32", "Uint32", true);
     ("Int32", "Uint32", false);
     ( "forall 'A. List ('A) -> List ('A)",
@@ -123,6 +130,8 @@ let all_type_assignable_tests =
       "forall 'C. 'C -> (forall 'C. List ('C)) -> 'B",
       true );
   ]
+  @ List.filter (fun (_, _, eq) -> eq) all_type_equiv_tests  (* Equivalence should imply assignable *)
+(* TODO: Swap all true equiv tests, and run again. Also add swapped version to equiv tests *)
 
 let make_map_access_type_test t at nindices =
   let open FrontEndParser in
@@ -170,7 +179,7 @@ let type_equiv_tests =
   "type_equiv_tests" >::: make_type_equiv_tests all_type_equiv_tests
 
 let type_assignable_tests =
-  "type_assignable_tests" >::: make_type_assignable_tests all_type_equiv_tests
+  "type_assignable_tests" >::: make_type_assignable_tests all_type_assignable_tests
 
 let map_access_type_tests =
   "map_access_type_tests" >::: make_map_access_type_tests map_access_type_tests


### PR DESCRIPTION
This PR implements type inference rules for address types, and fixes a bug in the parsing of address types.

Addresses are legal if they do not contain duplicate fields, and all field types in the Address type are legal field types.

The general rule for assignability is that an address type T2 can be assigned to an address type T1 if every field declared in T1 with type T1T are also declared in T2 with types T2T such that T2T can be assigned to T1T.

Example:

```
field f : ByStr20 with x : Uint32, y : Int32 end = ...
field g : ByStr20 with x : Uint32 end = ...
field h : ByStr20 with x : Int32 end = ...
```

`f` is assignable to `g`, because every field declared in `g` exists in `f` with a type that is assignable from `f` to `g`.

`g` is not assignable to `f`, because `f` contains a field `y`, which does not exist in `g`.

`h` is not assignable to either of the other two fields, nor vice versa, since the type of `x` in `h` is not assignable to the types of `x` in `f` or `g`, or vice versa.

More elaborate example:
```
field f : ByStr20 with x : ByStr20 with x1 : Int32, y1 : Int32 end end = ...
field g : ByStr20 with x : ByStr20 with x1 : Int32 end end = ...
```

Since `ByStr20 with x1 : Int32, y1 : Int32 end` is assignable to `ByStr20 with x1 : Int32 end` but not vice versa, `f` is assignable to `g` but not vice versa.

All addresses are also assignable to ByStr20, though I think we ought to change that in the next version, since this in essence amounts to an implicit type coercion. Instead, we ought to have two new builtins:
- `bystr20_of_address : ByStr20 with end -> ByStr20` : Takes any address, and returns the raw ByStr20 value.
- `address_of_bystr20 : forall 'A => ByStr20 -> Option 'A`: Takes an address type and a ByStr20, checks (using IPC) whether the ByStr20 corresponds to an address of a contract satisfying the address type, and returns either `Some A`, if the address type was satisfied, where A is a "verified" address, or `None` if the ByStr20 did not correspond to the provided type (this could happen if 'A is instantiated with a non-address type).

`is_serializable_storable_helper` has been rewritten, so that it can distinguish between cases where address types need to be checked for content (such as when they occur as transition parameters) or when they can just be considered a ByStr20 (such as when they are used to initialise a message field).

This also eliminates the need for the functions is_ground_type and is_non_map_ground_type, so I have removed those functions.

I have refactored tests/typecheck/good/Testttypes.ml, and addedtest cases for assignability, which hopefully catches all the corner cases.

I have also had to make some changes to the parser error messages. It's still dark magic to me how to identify the states that relate to which error messages, but it seems to work.