### PR TITLE
Drop dependency on Batteries and Extlib

### DIFF
--- a/scilla.opam
+++ b/scilla.opam
@@ -10,7 +10,6 @@ depends: [
   "dune" {build & >= "2.0"}
   "menhir"
   "core" {>= "v0.12.4" & < "v0.13~"}
-  "batteries" {>= "2.10.0" & < "2.11~"}
   "bitstring" {>= "3.1.0" & < "3.2~"}
   "angstrom" {>= "0.11.0" & < "0.13~"}
   "bisect_ppx" {>= "1.4.0" & < "1.5~"}

--- a/shell.nix
+++ b/shell.nix
@@ -13,7 +13,7 @@ let
   ];
   ocamlPkgs = with opkgs; [
     base core core_bench core_profiler ppx_deriving ppx_tools_versioned
-    ppx_sexp_conv bisect_ppx fileutils hex stdint batteries zarith cryptokit
+    ppx_sexp_conv bisect_ppx fileutils hex stdint zarith cryptokit
     bitstring ctypes findlib utop angstrom ounit expect_test_helpers patience_diff
     ocaml_pcre merlin ocp-indent ocp-index yojson menhir secp256k1 rpclib
     ppx_deriving_protobuf ocaml-protoc ppx_deriving_rpc result rresult xmlm

--- a/src/base/Integer256.ml
+++ b/src/base/Integer256.ml
@@ -250,7 +250,7 @@ module Uint256 = struct
   let neg _ = raise (Failure "Cannot negate Uint256")
 
   let of_string s =
-    let cl = Extlib.ExtString.String.to_list s in
+    let cl = String.to_list s in
     List.fold_left cl ~init:zero ~f:(fun i c ->
         let ten = { high = Uint128.zero; low = Uint128.of_string "10" } in
         let m = mul i ten in

--- a/src/base/JSON.ml
+++ b/src/base/JSON.ml
@@ -378,9 +378,9 @@ module Message = struct
     in
     `Assoc
       [
-        (tag_label, `String (BatOption.get tags));
-        (amount_label, `String (BatOption.get amounts));
-        (tofrom_label, `String (BatOption.get tofroms));
+        (tag_label, `String (Option.value_exn tags));
+        (amount_label, `String (Option.value_exn amounts));
+        (tofrom_label, `String (Option.value_exn tofroms));
         ("params", `List (slist_to_json filtered_list));
       ]
 
@@ -519,7 +519,7 @@ module Event = struct
     in
     `Assoc
       [
-        (eventname_label, `String (BatOption.get eventnames));
+        (eventname_label, `String (Option.value_exn eventnames));
         ("params", `List (slist_to_json filtered_list));
       ]
 

--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -329,7 +329,7 @@ stmt:
 | ACCEPT                 { (AcceptPayment, toLoc $startpos) }
 | SEND; m = sid;          { (SendMsgs (asIdL m (toLoc $startpos(m))), toLoc $startpos) }
 | EVENT; m = sid; { (CreateEvnt (asIdL m (toLoc $startpos(m))), toLoc $startpos) }
-| THROW; mopt = option(sid); { Throw (BatOption.map (fun m -> (asIdL m (toLoc $startpos))) mopt), toLoc $startpos }
+| THROW; mopt = option(sid); { Throw (Option.map (fun m -> (asIdL m (toLoc $startpos))) mopt), toLoc $startpos }
 | MATCH; x = sid; WITH; cs=list(stmt_pm_clause); END
   { (MatchStmt (Ident (x, toLoc $startpos(x)), cs), toLoc $startpos)  }
 | (* procedure call *)
@@ -406,7 +406,7 @@ contract:
   comps = list(component)
   { { cname   = asIdL c (toLoc $startpos(c));
       cparams = params;
-      cconstraint = BatOption.default (build_bool_literal true dummy_loc) ct;
+      cconstraint = Option.value ct ~default:(build_bool_literal true dummy_loc);
       cfields = fs;
       ccomps = comps } }
 

--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -37,8 +37,7 @@
     | "ByStr" -> Bystr_typ
     | _ -> let re = Str.regexp "ByStr\\([0-9]+\\)$" in
            if Str.string_match re d 0 then
-             let open Core_kernel in
-             let b = Int.of_string (Str.matched_group 1 d) in
+             let b = Core_kernel.Int.of_string (Str.matched_group 1 d) in
              Bystrx_typ b
            else raise (SyntaxError ("Invalid primitive type", loc))
 
@@ -270,7 +269,7 @@ lit :
 | s = STRING   { build_prim_literal_exn String_typ s (toLoc $startpos) }
 | EMP; kt = t_map_key; vt = t_map_value
 {
-  Map ((kt, vt), Hashtbl.create 4) (* 4 is arbitrary here. *)
+  Map ((kt, vt), Caml.Hashtbl.create 4) (* 4 is arbitrary here. *)
 }
 
 ctargs:
@@ -329,7 +328,7 @@ stmt:
 | ACCEPT                 { (AcceptPayment, toLoc $startpos) }
 | SEND; m = sid;          { (SendMsgs (asIdL m (toLoc $startpos(m))), toLoc $startpos) }
 | EVENT; m = sid; { (CreateEvnt (asIdL m (toLoc $startpos(m))), toLoc $startpos) }
-| THROW; mopt = option(sid); { Throw (Option.map (fun m -> (asIdL m (toLoc $startpos))) mopt), toLoc $startpos }
+| THROW; mopt = option(sid); { Throw (Core_kernel.Option.map mopt ~f:(fun m -> (asIdL m (toLoc $startpos)))), toLoc $startpos }
 | MATCH; x = sid; WITH; cs=list(stmt_pm_clause); END
   { (MatchStmt (Ident (x, toLoc $startpos(x)), cs), toLoc $startpos)  }
 | (* procedure call *)
@@ -406,7 +405,7 @@ contract:
   comps = list(component)
   { { cname   = asIdL c (toLoc $startpos(c));
       cparams = params;
-      cconstraint = Option.value ct ~default:(build_bool_literal true dummy_loc);
+      cconstraint = Core_kernel.Option.value ct ~default:(build_bool_literal true dummy_loc);
       cfields = fs;
       ccomps = comps } }
 

--- a/src/base/dune
+++ b/src/base/dune
@@ -18,8 +18,8 @@
 (library
  (name scilla_base)
  (wrapped false)
- (libraries core num hex stdint angstrom polynomials batteries cryptokit
-   secp256k1 bitstring yojson fileutils scilla_cpp_deps menhirLib)
+ (libraries core num hex stdint angstrom polynomials cryptokit secp256k1
+   bitstring yojson fileutils scilla_cpp_deps menhirLib)
  (preprocess
   (pps ppx_sexp_conv ppx_let ppx_deriving.show ppx_compare bisect_ppx
     -conditional))

--- a/src/checkers/dune
+++ b/src/checkers/dune
@@ -1,0 +1,8 @@
+(library
+ (name scilla_checkers)
+ (wrapped false)
+ (libraries core angstrom stdint polynomials yojson cryptokit scilla_base)
+ (preprocess
+  (pps ppx_sexp_conv ppx_let bisect_ppx ppx_compare -conditional
+    ppx_deriving.show))
+ (synopsis "Custom Scilla checkers"))

--- a/src/eval/dune
+++ b/src/eval/dune
@@ -1,8 +1,8 @@
 (library
  (name scilla_eval)
  (wrapped false)
- (libraries core angstrom stdint batteries yojson cryptokit scilla_base
-   rpclib unix rpclib.json rresult ocaml-protoc)
+ (libraries core angstrom stdint yojson cryptokit scilla_base rpclib unix
+   rpclib.json rresult ocaml-protoc)
  (preprocess
   (pps ppx_sexp_conv ppx_let bisect_ppx -conditional ppx_deriving_rpc
     ppx_deriving.show ppx_compare))

--- a/src/polynomials/Polynomial.ml
+++ b/src/polynomials/Polynomial.ml
@@ -189,7 +189,7 @@ let expand_parameters_pn (pn' : 'a polynomial) ~(f : 'a -> 'a polynomial option)
     | (svar, spow) :: restsub ->
         (* Substitute svar only (one substitution at-most to keep things simple). *)
         let rest_pol = [ (coef, nosubl @ restsub) ] in
-        let subst_pol = BatOption.get (f svar) in
+        let subst_pol = Option.value_exn (f svar) in
         if spow < 0 then
           raise
             (Polynomial_error "Cannot expand paramter with non-positive power")

--- a/src/polynomials/dune
+++ b/src/polynomials/dune
@@ -2,4 +2,4 @@
  (name polynomials)
  (wrapped false)
  (synopsis "Utility to deal with multivariate polynomials")
- (libraries core batteries))
+ (libraries core))

--- a/tests/base/TestSignatures.ml
+++ b/tests/base/TestSignatures.ml
@@ -7,12 +7,12 @@ let t1 =
   test_case (fun _ ->
       let open Schnorr in
       try
-        let privK, pubK = BatOption.get @@ genKeyPair () in
+        let privK, pubK = Option.value_exn (genKeyPair ()) in
         let msg = "Hello world\n" in
-        let signature = BatOption.get @@ sign privK pubK msg in
-        let succ = BatOption.get @@ verify pubK msg signature in
+        let signature = Option.value_exn (sign privK pubK msg) in
+        let succ = Option.value_exn (verify pubK msg signature) in
         assert_bool "Signature verification failed" succ
-      with (* Check if BatOption.get() failed. *)
+      with (* Check if Option.value_exn() failed. *)
       | Invalid_argument _ ->
         assert_failure "Schnorr function errored when called from testsuite")
 
@@ -20,12 +20,12 @@ let t2 =
   test_case (fun _ ->
       let open Schnorr in
       try
-        let privK, pubK = BatOption.get @@ genKeyPair () in
+        let privK, pubK = Option.value_exn (genKeyPair ()) in
         let msg = "Hello world\n" in
-        let signature = BatOption.get @@ sign privK pubK msg in
-        let succ = BatOption.get @@ verify pubK (msg ^ "\n") signature in
+        let signature = Option.value_exn (sign privK pubK msg) in
+        let succ = Option.value_exn (verify pubK (msg ^ "\n") signature) in
         assert_bool "Signature incorrectly verified" (not succ)
-      with (* Check if BatOption.get() failed. *)
+      with (* Check if Option.value_exn () failed. *)
       | Invalid_argument _ ->
         assert_failure "Schnorr function errored when called from testsuite")
 

--- a/tests/runner/Testcontracts.ml
+++ b/tests/runner/Testcontracts.ml
@@ -126,7 +126,7 @@ let rec build_contract_tests_with_init_file env name exit_code i n
           let interpreter_output =
             if Poly.(exit_code = succ_code) && not (env.server test_ctxt) then
               In_channel.read_all output_file
-            else BatStream.to_string s
+            else stream_to_string s
           in
           let out =
             if ipc_mode then
@@ -209,7 +209,7 @@ let build_contract_init_test env exit_code name init_name is_library =
            otherwise we read from the output stream *)
       let out =
         if Poly.(exit_code = succ_code) then In_channel.read_all output_file
-        else BatStream.to_string s
+        else stream_to_string s
       in
       if env.update_gold test_ctxt && not (env.server test_ctxt) then
         output_updater goldoutput_file test_name out

--- a/tests/typecheck/bad/TestTypeFail.ml
+++ b/tests/typecheck/bad/TestTypeFail.ml
@@ -45,7 +45,7 @@ let make_bad_lit_test l =
 
 exception IntBuilderInTestsuite of string
 
-let int_builder w s = BatOption.get (build_prim_literal (Int_typ w) s)
+let int_builder w s = Option.value_exn (build_prim_literal (Int_typ w) s)
 
 (* k/v types should match declared map type. *)
 let t1 =

--- a/tests/util/TestUtil.ml
+++ b/tests/util/TestUtil.ml
@@ -21,6 +21,12 @@ open! Int.Replace_polymorphic_compare
 open OUnit2
 open ScillaUtil.FilePathInfix
 
+(* Helper funcation borrowed from Batteries library *)
+let stream_to_string fl =
+  let buf = Buffer.create 4096 in
+  Stream.iter (Buffer.add_char buf) fl;
+  Buffer.contents buf
+
 type tsuite_env = {
   tests_dir : test_ctxt -> string;
   stdlib_dir : test_ctxt -> string;
@@ -175,7 +181,7 @@ module DiffBasedTests (Input : TestSuiteInput) = struct
         print_cli_usage (env.print_cli test_ctxt) runner args;
         assert_command
           ~foutput:(fun s ->
-            let out = BatStream.to_string s in
+            let out = stream_to_string s in
             if env.update_gold test_ctxt then
               output_updater goldoutput_file input_file out
             else

--- a/tests/util/dune
+++ b/tests/util/dune
@@ -1,4 +1,4 @@
 (library
  (name testutil)
  (wrapped false)
- (libraries core batteries oUnit fileutils scilla_base patdiff.lib))
+ (libraries core oUnit fileutils scilla_base patdiff.lib))


### PR DESCRIPTION
For consistency: we use mostly Core_kernel. This also should let us move faster with the OCaml compiler.

Dropping batteries revealed (by means of a compilation error) that we had unspecified dependency on Extlib.