### PR TITLE
Remote state read read syntax

### DIFF
--- a/src/base/ContractUtil.ml
+++ b/src/base/ContractUtil.ml
@@ -87,6 +87,8 @@ end
 
 let balance_label = "_balance"
 
+let balance_typ = PrimTypes.uint128_typ
+
 let creation_block_label = "_creation_block"
 
 let this_address_label = "_this_address"
@@ -104,8 +106,7 @@ module ScillaContractUtil (SR : Rep) (ER : Rep) = struct
   open ContractUtilSyntax
 
   let balance_field =
-    let open PrimTypes in
-    (ER.mk_id_uint128 balance_label, uint128_typ)
+    (ER.mk_id_uint128 balance_label, balance_typ)
 
   let append_implict_contract_params tparams =
     let open PrimTypes in

--- a/src/base/ParserFaults.messages
+++ b/src/base/ParserFaults.messages
@@ -34,26 +34,6 @@ type_term: CID LPAREN WITH
 
 This is an invalid type term, it is likely an ADT missing a valid type as an argument in brackets.
 
-type_term: CID MAP CID UNDERSCORE
-##
-## Ends in an error in state: 27.
-##
-## targ -> MAP t_map_key . t_map_value [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
-##
-## The known suffix of the stack is as follows:
-## MAP t_map_key
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 22, spurious reduction of production scid -> CID 
-## In state 44, spurious reduction of production t_map_key -> scid 
-##
-# see tests/parser/bad/type_t-cid-map-cid-underscore.scilla
-
-This is an invalid type term, the ADT constructor has an invalid type argument that is a map with a faulty map value type.
-
 type_term: CID MAP WITH
 ##
 ## Ends in an error in state: 20.
@@ -192,46 +172,6 @@ type_term: LPAREN WITH
 
 This is an invalid type term, please put a valid type term in the brackets.
 
-type_term: MAP CID CID CID UNDERSCORE
-##
-## Ends in an error in state: 41.
-##
-## list(t_map_value_args) -> t_map_value_args . list(t_map_value_args) [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
-##
-## The known suffix of the stack is as follows:
-## t_map_value_args
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 22, spurious reduction of production scid -> CID 
-## In state 40, spurious reduction of production t_map_value_args -> scid 
-##
-# see tests/parser/bad/type_t-map-cid-cid-cid-underscore.scilla
-
-This is an invalid map type, the map value is incorrect. The map value is likely an ADT constructor with incorrect constructor arguments.
-
-type_term: MAP CID CID LPAREN CID UNDERSCORE
-##
-## Ends in an error in state: 38.
-##
-## t_map_value_args -> LPAREN t_map_value_args . RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN t_map_value_args
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 22, spurious reduction of production scid -> CID 
-## In state 40, spurious reduction of production t_map_value_args -> scid 
-##
-# see tests/parser/bad/type_t-map-cid-cid-lparen-cid-underscore.scilla
-
-This is an invalid map type, the map value type is incorrect. It is possible that the key type is a nested ADT where the inner constructor arguments are faulty.
-
 type_term: MAP CID CID LPAREN WITH
 ##
 ## Ends in an error in state: 37.
@@ -244,26 +184,6 @@ type_term: MAP CID CID LPAREN WITH
 # see tests/parser/bad/type_t-map-cid-cid-lparen-with.scilla
 
 This is an invalid map type, the map value type is likely incorrect. In the brackets we expect a separated capital identifier.
-
-type_term: MAP CID CID MAP CID UNDERSCORE
-##
-## Ends in an error in state: 34.
-##
-## t_map_value_args -> MAP t_map_key . t_map_value [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
-##
-## The known suffix of the stack is as follows:
-## MAP t_map_key
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 22, spurious reduction of production scid -> CID 
-## In state 44, spurious reduction of production t_map_key -> scid 
-##
-# see tests/parser/bad/type_t-map-cid-cid-map-cid-underscore.scilla
-
-This is invalid map type, the map value is incorrect. It is likely that there is an ADT constructor with an invalid argument (a map with an invalid map value).
 
 type_term: MAP CID CID MAP WITH
 ##
@@ -339,46 +259,6 @@ type_term: MAP CID LPAREN CID UNDERSCORE
 
 This is an invalid map type, the map value is likely incorrect. If the map value is an ADT in brackets, then we expect valid ADT arguments or a closing bracket.
 
-type_term: MAP CID LPAREN MAP CID CID UNDERSCORE
-##
-## Ends in an error in state: 45.
-##
-## t_map_value -> LPAREN MAP t_map_key t_map_value_args . RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN MAP t_map_key t_map_value_args
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 22, spurious reduction of production scid -> CID 
-## In state 40, spurious reduction of production t_map_value_args -> scid 
-##
-# see tests/parser/bad/type_t-map-cid-lparen-map-cid-cid-underscore.scilla
-
-This is an invalid map type, the map value is likely incorrect. The map value being a map itself with an invalid map value (possible malformed ADT).
-
-type_term: MAP CID LPAREN MAP CID UNDERSCORE
-##
-## Ends in an error in state: 32.
-##
-## t_map_value -> LPAREN MAP t_map_key . t_map_value_args RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN MAP t_map_key
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 22, spurious reduction of production scid -> CID 
-## In state 44, spurious reduction of production t_map_key -> scid 
-##
-# see tests/parser/bad/type_t-map-cid-lparen-map-cid-underscore.scilla
-
-This is an invalid map type, the map value is likely incorrect. The map value being likely a map in brackets with an invalid map value.
-
 type_term: MAP CID LPAREN MAP WITH
 ##
 ## Ends in an error in state: 31.
@@ -406,26 +286,6 @@ type_term: MAP CID LPAREN WITH
 
 In this map type, the map value is likely incorrect. In the brackets only an ADT or map may be placed.
 
-type_term: MAP CID MAP CID UNDERSCORE
-##
-## Ends in an error in state: 29.
-##
-## t_map_value -> MAP t_map_key . t_map_value [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
-##
-## The known suffix of the stack is as follows:
-## MAP t_map_key
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 22, spurious reduction of production scid -> CID 
-## In state 44, spurious reduction of production t_map_key -> scid 
-##
-# see tests/parser/bad/type_t-map-cid-map-cid-underscore.scilla
-
-This map type likely has an incorrect map value type. The map value is a map with a malformed map value.
-
 type_term: MAP CID MAP WITH
 ##
 ## Ends in an error in state: 28.
@@ -438,26 +298,6 @@ type_term: MAP CID MAP WITH
 # see tests/parser/bad/type_t-map-cid-map-with.scilla
 
 This map type likely has an invalid map value type. The map value type is a map with a malformed map key type.
-
-type_term: MAP CID UNDERSCORE
-##
-## Ends in an error in state: 55.
-##
-## typ -> MAP t_map_key . t_map_value [ TARROW RPAREN EQ EOF COMMA ]
-##
-## The known suffix of the stack is as follows:
-## MAP t_map_key
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 22, spurious reduction of production scid -> CID 
-## In state 44, spurious reduction of production t_map_key -> scid 
-##
-# see tests/eval/bad/list_to_map.scilexp
-
-This map type likely has an invalid map value type.
 
 type_term: MAP LPAREN CID UNDERSCORE
 ##
@@ -1515,26 +1355,6 @@ exp_term: CID WITH
 # see tests/parser/bad/exps/exp_t-cid-with.scilexp
 
 This is a malformed expression, it may be an incorrect data constructor usage.
-
-exp_term: EMP CID UNDERSCORE
-##
-## Ends in an error in state: 117.
-##
-## lit -> EMP t_map_key . t_map_value [ TYPE TRANSITION SEMICOLON RBRACE PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
-##
-## The known suffix of the stack is as follows:
-## EMP t_map_key
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 22, spurious reduction of production scid -> CID 
-## In state 44, spurious reduction of production t_map_key -> scid 
-##
-# see tests/parser/bad/exps/exp_t-emp-cid-underscore.scilexp
-
-This empty map has invalid value type.
 
 exp_term: EMP WITH
 ##

--- a/src/base/Recursion.ml
+++ b/src/base/Recursion.ml
@@ -154,6 +154,8 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
       let%bind new_s =
         match s with
         | Load (x, f) -> pure @@ RecursionSyntax.Load (x, f)
+        | RemoteLoad (x, adr, f) ->
+            pure @@ RecursionSyntax.RemoteLoad (x, adr, f)
         | Store (f, x) -> pure @@ RecursionSyntax.Store (f, x)
         | Bind (x, e) ->
             let%bind new_e = rec_exp e in
@@ -162,6 +164,8 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
             pure @@ RecursionSyntax.MapUpdate (m, is, vopt)
         | MapGet (x, m, is, del) ->
             pure @@ RecursionSyntax.MapGet (x, m, is, del)
+        | RemoteMapGet (x, adr, m, is, del) ->
+            pure @@ RecursionSyntax.RemoteMapGet (x, adr, m, is, del)
         | MatchStmt (x, pss) ->
             let%bind new_pss =
               mapM

--- a/src/base/ScillaLexer.mll
+++ b/src/base/ScillaLexer.mll
@@ -109,6 +109,7 @@ rule read =
   | "="           { EQ }                  
   | "&"           { AND }                  
   | "<-"          { FETCH }                  
+  | "<--"         { REMOTEFETCH }                  
   | ":="          { ASSIGN }                  
   | "@"           { AT }                  
   | "_"           { UNDERSCORE } 

--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -328,14 +328,26 @@ type_term :
 (***********************************************)
 
 stmt:
-| l = ID; FETCH; r = sid   { (Load (asIdL l (toLoc $startpos(l)), asIdL r (toLoc $startpos(r))), toLoc $startpos) }
+| l = ID; FETCH; r = sid
+    { (Load (asIdL l (toLoc $startpos(l)),
+             asIdL r (toLoc $startpos(r))),
+       toLoc $startpos) }
+| l = ID; FETCH; adr = sid; PERIOD; r = sid
+    { (RemoteLoad (asIdL l (toLoc $startpos(l)),
+                   asIdL adr (toLoc $startpos(adr)),
+                   asIdL r (toLoc $startpos(r))),
+       toLoc $startpos) }
 | l = ID; ASSIGN; r = sid { (Store (asIdL l (toLoc $startpos(l)), asIdL r (toLoc $startpos(r))), toLoc $startpos) }
 | l = ID; EQ; r = exp    { (Bind (asIdL l (toLoc $startpos(l)), r), toLoc $startpos) }
 | l = ID; FETCH; AND; c = CID { (ReadFromBC (asIdL l (toLoc $startpos(l)), c), toLoc $startpos) }
 | l = ID; FETCH; r = ID; keys = nonempty_list(map_access)
   { MapGet(asIdL l (toLoc $startpos(l)), asIdL r (toLoc $startpos(r)), keys, true), toLoc $startpos }
+| l = ID; FETCH; adr = ID; PERIOD; r = ID; keys = nonempty_list(map_access)
+  { RemoteMapGet(asIdL l (toLoc $startpos(l)), asIdL adr (toLoc $startpos(adr)), asIdL r (toLoc $startpos(r)), keys, true), toLoc $startpos }
 | l = ID; FETCH; EXISTS; r = ID; keys = nonempty_list(map_access)
   { MapGet(asIdL l (toLoc $startpos(l)), asIdL r (toLoc $startpos(r)), keys, false), toLoc $startpos }
+| l = ID; FETCH; EXISTS; adr = ID; PERIOD; r = ID; keys = nonempty_list(map_access)
+  { RemoteMapGet(asIdL l (toLoc $startpos(l)), asIdL adr (toLoc $startpos(adr)), asIdL r (toLoc $startpos(r)), keys, false), toLoc $startpos }
 | l = ID; keys = nonempty_list(map_access); ASSIGN; r = sid
   { MapUpdate(asIdL l (toLoc $startpos(l)), keys, Some (asIdL r (toLoc $startpos(r)))), toLoc $startpos }
 | DELETE; l = ID; keys = nonempty_list(map_access)

--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -96,6 +96,7 @@
 %token EQ
 %token AND
 %token FETCH
+%token REMOTEFETCH
 %token ASSIGN
 (* %token LANGLE
  * %token RANGLE *)
@@ -332,7 +333,7 @@ stmt:
     { (Load (asIdL l (toLoc $startpos(l)),
              asIdL r (toLoc $startpos(r))),
        toLoc $startpos) }
-| l = ID; FETCH; adr = sid; PERIOD; r = sid
+| l = ID; REMOTEFETCH; adr = sid; PERIOD; r = sid
     { (RemoteLoad (asIdL l (toLoc $startpos(l)),
                    asIdL adr (toLoc $startpos(adr)),
                    asIdL r (toLoc $startpos(r))),
@@ -342,11 +343,11 @@ stmt:
 | l = ID; FETCH; AND; c = CID { (ReadFromBC (asIdL l (toLoc $startpos(l)), c), toLoc $startpos) }
 | l = ID; FETCH; r = ID; keys = nonempty_list(map_access)
   { MapGet(asIdL l (toLoc $startpos(l)), asIdL r (toLoc $startpos(r)), keys, true), toLoc $startpos }
-| l = ID; FETCH; adr = ID; PERIOD; r = ID; keys = nonempty_list(map_access)
+| l = ID; REMOTEFETCH; adr = ID; PERIOD; r = ID; keys = nonempty_list(map_access)
   { RemoteMapGet(asIdL l (toLoc $startpos(l)), asIdL adr (toLoc $startpos(adr)), asIdL r (toLoc $startpos(r)), keys, true), toLoc $startpos }
 | l = ID; FETCH; EXISTS; r = ID; keys = nonempty_list(map_access)
   { MapGet(asIdL l (toLoc $startpos(l)), asIdL r (toLoc $startpos(r)), keys, false), toLoc $startpos }
-| l = ID; FETCH; EXISTS; adr = ID; PERIOD; r = ID; keys = nonempty_list(map_access)
+| l = ID; REMOTEFETCH; EXISTS; adr = ID; PERIOD; r = ID; keys = nonempty_list(map_access)
   { RemoteMapGet(asIdL l (toLoc $startpos(l)), asIdL adr (toLoc $startpos(adr)), asIdL r (toLoc $startpos(r)), keys, false), toLoc $startpos }
 | l = ID; keys = nonempty_list(map_access); ASSIGN; r = sid
   { MapUpdate(asIdL l (toLoc $startpos(l)), keys, Some (asIdL r (toLoc $startpos(r)))), toLoc $startpos }

--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -738,6 +738,7 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
 
   and stmt =
     | Load of ER.rep ident * ER.rep ident
+    | RemoteLoad of ER.rep ident * ER.rep ident * ER.rep ident
     | Store of ER.rep ident * ER.rep ident
     | Bind of ER.rep ident * expr_annot
     (* m[k1][k2][..] := v OR delete m[k1][k2][...] *)
@@ -746,6 +747,7 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
     (* If the bool is set, then we interpret this as value retrieve,
        otherwise as an "exists" query. *)
     | MapGet of ER.rep ident * ER.rep ident * ER.rep ident list * bool
+    | RemoteMapGet of ER.rep ident * ER.rep ident * ER.rep ident * ER.rep ident list * bool
     | MatchStmt of ER.rep ident * (pattern * stmt_annot list) list
     | ReadFromBC of ER.rep ident * string
     | AcceptPayment
@@ -985,6 +987,9 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
       | Load (x, f) ->
           sprintf "Type error in reading value of `%s` into `%s`:\n %s"
             (get_id f) (get_id x) phase
+      | RemoteLoad (x, adr, f) ->
+          sprintf "Type error in reading value of `%s.%s` into `%s`:\n %s"
+            (get_id adr) (get_id f) (get_id x) phase
       | Store (f, r) ->
           sprintf "Type error in storing value of `%s` into the field `%s`:\n"
             (get_id r) (get_id f)
@@ -992,6 +997,10 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
           sprintf "Type error in the binding to into `%s`:\n" (get_id x)
       | MapGet (_, m, keys, _) ->
           sprintf "Type error in getting map value %s" (get_id m)
+          ^ List.fold keys ~init:"" ~f:(fun acc k -> acc ^ "[" ^ get_id k ^ "]")
+          ^ "\n"
+      | RemoteMapGet (_, adr, m, keys, _) ->
+          sprintf "Type error in getting map value %s.%s" (get_id adr) (get_id m)
           ^ List.fold keys ~init:"" ~f:(fun acc k -> acc ^ "[" ^ get_id k ^ "]")
           ^ "\n"
       | MapUpdate (m, keys, _) ->

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -443,6 +443,23 @@ module TypeUtilities = struct
   let rec map_depth mt =
     match mt with MapType (_, vt) -> 1 + map_depth vt | _ -> 0
 
+  let address_field_type f t =
+    match t with
+    | Address fts ->
+        let loc_removed = List.map fts ~f:(fun (f, t) -> (get_id f, t)) in
+        (match List.Assoc.find loc_removed (get_id f)
+                 ~equal:String.( = ) with
+        | Some ft ->
+            pure ft
+        | None -> 
+            fail0 @@
+            sprintf "Field %s is not declared in address type %s."
+              (get_id f) (pp_typ t))
+    | _ ->
+        fail0 @@
+        sprintf "Attempting to read field from non-address type %s."
+          (pp_typ t)
+  
   let pp_typ_list ts =
     let tss = List.map ~f:(fun t -> pp_typ t) ts in
     sprintf "[%s]" (String.concat ~sep:"; " tss)

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -446,15 +446,20 @@ module TypeUtilities = struct
   let address_field_type f t =
     match t with
     | Address fts ->
-        let loc_removed = List.map fts ~f:(fun (f, t) -> (get_id f, t)) in
-        (match List.Assoc.find loc_removed (get_id f)
-                 ~equal:String.( = ) with
-        | Some ft ->
-            pure ft
-        | None -> 
-            fail0 @@
-            sprintf "Field %s is not declared in address type %s."
-              (get_id f) (pp_typ t))
+        if String.(get_id f = ContractUtil.balance_label)
+        then
+          pure ContractUtil.balance_typ
+        else
+          let loc_removed = List.map fts ~f:(fun (f, t) -> (get_id f, t)) in
+          (match List.Assoc.find loc_removed (get_id f)
+                   ~equal:String.( = ) with
+          | Some ft ->
+              pure ft
+          | None ->
+              (* May be the _balance field, which is accessible but cannot be declared *)
+              fail0 @@
+              sprintf "Field %s is not declared in address type %s."
+                (get_id f) (pp_typ t))
     | _ ->
         fail0 @@
         sprintf "Attempting to read field from non-address type %s."

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -456,7 +456,6 @@ module TypeUtilities = struct
           | Some ft ->
               pure ft
           | None ->
-              (* May be the _balance field, which is accessible but cannot be declared *)
               fail0 @@
               sprintf "Field %s is not declared in address type %s."
                 (get_id f) (pp_typ t))

--- a/src/base/TypeUtil.mli
+++ b/src/base/TypeUtil.mli
@@ -137,6 +137,8 @@ module TypeUtilities : sig
 
   val map_depth : typ -> int
 
+  val address_field_type : 'a ident -> typ -> (typ, scilla_error list) result
+    
   (****************************************************************)
   (*             Utility function for matching types              *)
   (****************************************************************)

--- a/src/checkers/Cashflow.ml
+++ b/src/checkers/Cashflow.ml
@@ -155,6 +155,10 @@ struct
       match s with
       | Load (x, y) ->
           CFSyntax.Load (add_noinfo_to_ident x, add_noinfo_to_ident y)
+      | RemoteLoad (x, adr, y) ->
+          CFSyntax.RemoteLoad (add_noinfo_to_ident x,
+                               add_noinfo_to_ident adr,
+                               add_noinfo_to_ident y)
       | Store (x, y) ->
           CFSyntax.Store (add_noinfo_to_ident x, add_noinfo_to_ident y)
       | Bind (x, e) -> CFSyntax.Bind (add_noinfo_to_ident x, cf_init_tag_expr e)
@@ -168,6 +172,13 @@ struct
       | MapGet (x, m, ks, retrieve) ->
           CFSyntax.MapGet
             ( add_noinfo_to_ident x,
+              add_noinfo_to_ident m,
+              List.map ~f:add_noinfo_to_ident ks,
+              retrieve )
+      | RemoteMapGet (x, adr, m, ks, retrieve) ->
+          CFSyntax.RemoteMapGet
+            ( add_noinfo_to_ident x,
+              add_noinfo_to_ident adr,
               add_noinfo_to_ident m,
               List.map ~f:add_noinfo_to_ident ks,
               retrieve )
@@ -1525,6 +1536,16 @@ struct
             (not @@ [%equal: ECFR.money_tag] (get_id_tag new_x) (get_id_tag x))
             || not
                @@ [%equal: ECFR.money_tag] (get_id_tag new_f) (get_id_tag f) )
+      | RemoteLoad (x, adr, f) ->
+          (* TODO - see Load case for inspiration *)
+          (* x is no longer in scope, so remove from local_env *)
+          let new_local_env = AssocDictionary.remove (get_id x) local_env in
+          ( RemoteLoad (x, adr, f),
+            param_env,
+            field_env,
+            new_local_env,
+            ctr_tag_map,
+            false)
       | Store (f, x) ->
           let new_f, new_x, new_param_env, new_field_env, new_local_env =
             cf_update_tag_for_field_assignment f x param_env field_env local_env
@@ -1647,6 +1668,16 @@ struct
             (not @@ [%equal: ECFR.money_tag] (get_id_tag x) new_x_tag)
             || (not @@ [%equal: ECFR.money_tag] (get_id_tag m) m_tag)
             || (not @@ [%equal: _] new_ks ks) )
+      | RemoteMapGet (x, adr, m, ks, fetch) ->
+          (* TODO - see MapGet case for inspiration *)
+          (* x is no longer in scope, so remove from local_env *)
+          let new_local_env = AssocDictionary.remove (get_id x) local_env in
+          ( RemoteMapGet (x, adr, m, ks, fetch),
+            param_env,
+            field_env,
+            new_local_env,
+            ctr_tag_map,
+            false )
       | MatchStmt (x, clauses) ->
           let ( res_clauses,
                 new_param_env,

--- a/src/checkers/PatternChecker.ml
+++ b/src/checkers/PatternChecker.ml
@@ -193,11 +193,15 @@ struct
         let%bind checked_s =
           match s with
           | Load (i, x) -> pure @@ (CheckedPatternSyntax.Load (i, x), rep)
+          | RemoteLoad (i, adr, x) ->
+              pure @@ (CheckedPatternSyntax.RemoteLoad (i, adr, x), rep)
           | Store (i, x) -> pure @@ (CheckedPatternSyntax.Store (i, x), rep)
           | MapUpdate (m, klist, v) ->
               pure @@ (CheckedPatternSyntax.MapUpdate (m, klist, v), rep)
           | MapGet (v, m, klist, valfetch) ->
               pure @@ (CheckedPatternSyntax.MapGet (v, m, klist, valfetch), rep)
+          | RemoteMapGet (v, adr, m, klist, valfetch) ->
+              pure @@ (CheckedPatternSyntax.RemoteMapGet (v, adr, m, klist, valfetch), rep)
           | Bind (i, e) ->
               wrap_pmcheck_serr srep
               @@ let%bind checked_e = pm_check_expr e in

--- a/src/checkers/SanityChecker.ml
+++ b/src/checkers/SanityChecker.ml
@@ -318,7 +318,9 @@ struct
             iterM
               ~f:(fun (s, _) ->
                 match s with
-                | Load (x, _) | MapGet (x, _, _, _) | ReadFromBC (x, _) ->
+                  | Load (x, _) | RemoteLoad (x, _, _)
+                  | MapGet (x, _, _, _) | RemoteMapGet (x, _, _, _, _)
+                  | ReadFromBC (x, _) ->
                     check_warn_redef cparams cfields pnames x;
                     pure ()
                 | Store _ | MapUpdate _ | SendMsgs _ | AcceptPayment

--- a/src/checkers/TypeInfo.ml
+++ b/src/checkers/TypeInfo.ml
@@ -94,6 +94,7 @@ struct
     List.fold_right stmts ~init:[] ~f:(fun (stmt, _srep) acc ->
         ( match stmt with
         | Load (x, f) | Store (f, x) -> [ calc_ident_locs x; calc_ident_locs f ]
+        | RemoteLoad (x, adr, f) -> [ calc_ident_locs x; calc_ident_locs adr; calc_ident_locs f ]
         | Bind (x, e) -> calc_ident_locs x :: type_info_expr e
         (* m[k1][k2][..] := v OR delete m[k1][k2][...] *)
         | MapUpdate (m, il, vopt) -> (
@@ -103,6 +104,9 @@ struct
         (* v <- m[k1][k2][...] OR b <- exists m[k1][k2][...] *)
         | MapGet (x, m, il, _) ->
             [ calc_ident_locs x; calc_ident_locs m ]
+            @ List.map il ~f:calc_ident_locs
+        | RemoteMapGet (x, adr, m, il, _) ->
+            [ calc_ident_locs x; calc_ident_locs adr; calc_ident_locs m ]
             @ List.map il ~f:calc_ident_locs
         | MatchStmt (o, clauses) ->
             let ots = calc_ident_locs o in

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -257,6 +257,12 @@ let rec stmt_eval conf stmts =
           let conf' = Configuration.bind conf (get_id x) l in
           let%bind _ = stmt_gas_wrap scon sloc in
           stmt_eval conf' sts
+      | RemoteLoad (x, adr, r) ->
+          let%bind a = Configuration.lookup conf adr in
+          let%bind l, scon = Configuration.remote_load conf a r in 
+          let conf' = Configuration.bind conf (get_id x) l in
+          let%bind _ = stmt_gas_wrap scon sloc in
+          stmt_eval conf' sts
       | Store (x, r) ->
           let%bind v = Configuration.lookup conf r in
           let%bind scon = Configuration.store x v in
@@ -286,6 +292,15 @@ let rec stmt_eval conf stmts =
             mapM ~f:(fun k -> Configuration.lookup conf k) klist
           in
           let%bind l, scon = Configuration.map_get conf m klist' fetchval in
+          let conf' = Configuration.bind conf (get_id x) l in
+          let%bind _ = stmt_gas_wrap scon sloc in
+          stmt_eval conf' sts
+      | RemoteMapGet (x, adr, m, klist, fetchval) ->
+          let%bind a = Configuration.lookup conf adr in
+          let%bind klist' =
+            mapM ~f:(fun k -> Configuration.lookup conf k) klist
+          in
+          let%bind l, scon = Configuration.remote_map_get conf a m klist' fetchval in
           let conf' = Configuration.bind conf (get_id x) l in
           let%bind _ = stmt_gas_wrap scon sloc in
           stmt_eval conf' sts

--- a/src/eval/EvalUtil.ml
+++ b/src/eval/EvalUtil.ml
@@ -193,6 +193,11 @@ module Configuration = struct
             (Printf.sprintf "Error loading field %s" i)
             (ER.get_loc (get_rep k))
 
+  let remote_load _st _adr k =
+    (* TODO - maybe useful to refactor load to avoid code duplicateion *)
+    (* Note that adr has already been typechecked, so we know the field k is there. *)
+    fail1 ("Remote load not implemented.") (ER.get_loc (get_rep k))
+    
   (* Update a map. If "vopt" is None, delete the key, else replace the key value with Some v. *)
   let map_update m klist vopt =
     match vopt with
@@ -244,6 +249,11 @@ module Configuration = struct
             (sprintf "Unable to check exists for map field %s" (get_id m))
             (ER.get_loc (get_rep m))
 
+  let remote_map_get _st _adr m _klist _fetchval =
+    (* TODO - probably useful to refactor map_get to avoid code duplicateion *)
+    (* Note that adr has already been typechecked, so we know the map m is there. *)
+    fail1 ("Remote map get not implemented.") (ER.get_loc (get_rep m))
+  
   let bind st k v =
     let e = st.env in
     { st with env = List.Assoc.add e k v ~equal:String.( = ) }

--- a/tests/base/parser/bad/gold/exp_t-emp-cid-underscore.scilexp.gold
+++ b/tests/base/parser/bad/gold/exp_t-emp-cid-underscore.scilexp.gold
@@ -1,7 +1,7 @@
 {
   "errors": [
     {
-      "error_message": "This empty map has invalid value type.\n",
+      "error_message": "This is an invalid type term, it may be a bad ADT.\n",
       "start_location": {
         "file": "base/parser/bad/exps/exp_t-emp-cid-underscore.scilexp",
         "line": 1,

--- a/tests/base/parser/bad/gold/type_t-cid-map-cid-underscore.scilla.gold
+++ b/tests/base/parser/bad/gold/type_t-cid-map-cid-underscore.scilla.gold
@@ -1,8 +1,7 @@
 {
   "errors": [
     {
-      "error_message":
-        "This is an invalid type term, the ADT constructor has an invalid type argument that is a map with a faulty map value type.\n",
+      "error_message": "This is an invalid type term, it may be a bad ADT.\n",
       "start_location": {
         "file": "base/parser/bad/type_t-cid-map-cid-underscore.scilla",
         "line": 6,

--- a/tests/base/parser/bad/gold/type_t-map-cid-cid-cid-underscore.scilla.gold
+++ b/tests/base/parser/bad/gold/type_t-map-cid-cid-cid-underscore.scilla.gold
@@ -1,8 +1,7 @@
 {
   "errors": [
     {
-      "error_message":
-        "This is an invalid map type, the map value is incorrect. The map value is likely an ADT constructor with incorrect constructor arguments.\n",
+      "error_message": "This is an invalid type term, it may be a bad ADT.\n",
       "start_location": {
         "file": "base/parser/bad/type_t-map-cid-cid-cid-underscore.scilla",
         "line": 6,

--- a/tests/base/parser/bad/gold/type_t-map-cid-cid-lparen-cid-underscore.scilla.gold
+++ b/tests/base/parser/bad/gold/type_t-map-cid-cid-lparen-cid-underscore.scilla.gold
@@ -1,8 +1,7 @@
 {
   "errors": [
     {
-      "error_message":
-        "This is an invalid map type, the map value type is incorrect. It is possible that the key type is a nested ADT where the inner constructor arguments are faulty.\n",
+      "error_message": "This is an invalid type term, it may be a bad ADT.\n",
       "start_location": {
         "file":
           "base/parser/bad/type_t-map-cid-cid-lparen-cid-underscore.scilla",

--- a/tests/base/parser/bad/gold/type_t-map-cid-cid-map-cid-underscore.scilla.gold
+++ b/tests/base/parser/bad/gold/type_t-map-cid-cid-map-cid-underscore.scilla.gold
@@ -1,8 +1,7 @@
 {
   "errors": [
     {
-      "error_message":
-        "This is invalid map type, the map value is incorrect. It is likely that there is an ADT constructor with an invalid argument (a map with an invalid map value).\n",
+      "error_message": "This is an invalid type term, it may be a bad ADT.\n",
       "start_location": {
         "file":
           "base/parser/bad/type_t-map-cid-cid-map-cid-underscore.scilla",

--- a/tests/base/parser/bad/gold/type_t-map-cid-lparen-map-cid-cid-underscore.scilla.gold
+++ b/tests/base/parser/bad/gold/type_t-map-cid-lparen-map-cid-cid-underscore.scilla.gold
@@ -1,8 +1,7 @@
 {
   "errors": [
     {
-      "error_message":
-        "This is an invalid map type, the map value is likely incorrect. The map value being a map itself with an invalid map value (possible malformed ADT).\n",
+      "error_message": "This is an invalid type term, it may be a bad ADT.\n",
       "start_location": {
         "file":
           "base/parser/bad/type_t-map-cid-lparen-map-cid-cid-underscore.scilla",

--- a/tests/base/parser/bad/gold/type_t-map-cid-lparen-map-cid-underscore.scilla.gold
+++ b/tests/base/parser/bad/gold/type_t-map-cid-lparen-map-cid-underscore.scilla.gold
@@ -1,8 +1,7 @@
 {
   "errors": [
     {
-      "error_message":
-        "This is an invalid map type, the map value is likely incorrect. The map value being likely a map in brackets with an invalid map value.\n",
+      "error_message": "This is an invalid type term, it may be a bad ADT.\n",
       "start_location": {
         "file":
           "base/parser/bad/type_t-map-cid-lparen-map-cid-underscore.scilla",

--- a/tests/base/parser/bad/gold/type_t-map-cid-map-cid-underscore.scilla.gold
+++ b/tests/base/parser/bad/gold/type_t-map-cid-map-cid-underscore.scilla.gold
@@ -1,8 +1,7 @@
 {
   "errors": [
     {
-      "error_message":
-        "This map type likely has an incorrect map value type. The map value is a map with a malformed map value.\n",
+      "error_message": "This is an invalid type term, it may be a bad ADT.\n",
       "start_location": {
         "file": "base/parser/bad/type_t-map-cid-map-cid-underscore.scilla",
         "line": 7,

--- a/tests/eval/bad/gold/list_to_map.scilexp.gold
+++ b/tests/eval/bad/gold/list_to_map.scilexp.gold
@@ -1,8 +1,7 @@
 {
   "errors": [
     {
-      "error_message":
-        "This map type likely has an invalid map value type.\n",
+      "error_message": "Syntax error, state number 33",
       "start_location": {
         "file": "eval/bad/list_to_map.scilexp",
         "line": 7,


### PR DESCRIPTION
This PR implements the syntax and typecheck of accessing fields of remote contracts, provided that the address value has already been verified to point to an address containing a contract which has a field with the appropriate name and type.

Note that I am using lists to represent the fields of an address type. We could change this to use type environments, but I want to make sure that it works correctly before we start playing with optimisation.

I have made the `_balance` field accessible in all address types, regardless of the fact that is impossible to declare it in the type. This will also allow contracts to access the balance of a user address, because a user address satisfies the type restriction `ByStr20 with end`.

There are two gaping holes marked as TODOs in the evaluator. If anyone (I'm guessing @vaivaswatha) has the time to work on this feature, then it should be relatively easy to start there while I write tests and documentation.