### PR TITLE
_sender should have type `ByStr20 with end`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,14 @@ default: release
 release:
 	./scripts/libff.sh
 	dune build --profile release @install
+	@test -L bin || ln -s _build/install/default/bin .
 
 # Build only scilla-checker and scilla-runner
 slim:
 	./scripts/libff.sh
 	dune build --profile release src/runners/scilla_runner.exe
 	dune build --profile release src/runners/scilla_checker.exe
+	@test -L bin || ln -s _build/install/default/bin .
 
 dev:
 	./scripts/libff.sh
@@ -55,7 +57,7 @@ testbase: dev
 	ulimit -n 1024; dune exec -- tests/base/testsuite_base.exe -print-diff true
 
 goldbase: dev
-	ulimit -n 1024; dune exec tests/base/testsuite_base.exe -- -update-gold true
+	ulimit -n 4096; dune exec tests/base/testsuite_base.exe -- -update-gold true
 
 # Run all tests for all packages in the repo: scilla-base, polynomials, scilla
 test: dev
@@ -64,8 +66,8 @@ test: dev
 	ulimit -n 1024; dune exec -- tests/testsuite.exe -print-diff true
 
 gold: dev
-	ulimit -n 1024; dune exec -- tests/base/testsuite_base.exe -update-gold true
-	ulimit -n 1024; dune exec -- tests/testsuite.exe -update-gold true
+	ulimit -n 4096; dune exec -- tests/base/testsuite_base.exe -update-gold true
+	ulimit -n 4096; dune exec -- tests/testsuite.exe -update-gold true
 
 # This must be run only if there is an external IPC server available
 # that can handle access requests. It is important to use the sequential runner here as we

--- a/scripts/run_ipc_map_corner_tests.sh
+++ b/scripts/run_ipc_map_corner_tests.sh
@@ -4,7 +4,7 @@
 
 num_transitions=18
 ipcaddress=/tmp/zilliqa.sock
-scilla_runner=scilla-runner
+scilla_runner=../bin/scilla-runner
 test_source=../tests/contracts/map_corners_test.scilla
 libdir=../src/stdlib
 init_json_file=/tmp/ipc_map_corner_tests.init.json

--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -773,8 +773,12 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let eq_elab sc ts =
       match ts with
       | [ bstyp1; bstyp2 ]
+        when (* Addresses should be compared as ByStr20 *)
+          is_address_type bstyp1 || is_address_type bstyp2 ->
+          elab_tfun_with_args_no_gas sc [bystrx_typ address_length]
+      | [ bstyp1; bstyp2 ]
         when (* We want both types to be ByStr with equal width. *)
-             is_bystrx_type bstyp1 && [%equal: typ] bstyp1 bstyp2 ->
+          is_bystrx_type bstyp1 && [%equal: typ] bstyp1 bstyp2 ->
           elab_tfun_with_args_no_gas sc [ bstyp1 ]
       | _ -> fail0 "Failed to elaborate"
 

--- a/src/base/ContractUtil.ml
+++ b/src/base/ContractUtil.ml
@@ -128,7 +128,7 @@ module ScillaContractUtil (SR : Rep) (ER : Rep) = struct
   let append_implict_comp_params cparams =
     let open PrimTypes in
     let sender =
-      (ER.mk_id_address MessagePayload.sender_label, bystrx_typ address_length)
+      (ER.mk_id_address MessagePayload.sender_label, Address [ ] )
     in
     let amount = (ER.mk_id_uint128 MessagePayload.amount_label, uint128_typ) in
     amount :: sender :: cparams

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -331,15 +331,23 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
                (mk_qual_tp t, rep) ),
              remaining_gas )
     | TFun (tvar, body) ->
-        let tenv' = TEnv.addV (TEnv.copy tenv) tvar in
-        let%bind ((_, (bt, _)) as typed_b), remaining_gas =
-          type_expr tenv' body remaining_gas
-        in
-        let typed_tvar = add_type_to_ident tvar bt in
-        pure
-        @@ ( ( TypedSyntax.TFun (typed_tvar, typed_b),
-               (mk_qual_tp (PolyFun (get_id tvar, bt.tp)), rep) ),
-             remaining_gas )
+        let id = get_id tvar in
+        (* XXX this is a workaround for alpha-renaming *)
+        (* Make it illegal to declare a new type variable inside the scope of another type variable with the same name *)
+        if TEnv.existsV tenv id then
+          mark_error_as_type_error remaining_gas
+          @@ fail0
+          @@ sprintf "Type variable %s is already in use\n" id
+        else
+          let tenv' = TEnv.addV (TEnv.copy tenv) tvar in
+          let%bind ((_, (bt, _)) as typed_b), remaining_gas =
+            type_expr tenv' body remaining_gas
+          in
+          let typed_tvar = add_type_to_ident tvar bt in
+          pure
+          @@ ( ( TypedSyntax.TFun (typed_tvar, typed_b),
+                 (mk_qual_tp (PolyFun (get_id tvar, bt.tp)), rep) ),
+               remaining_gas )
     | TApp (tf, arg_types) ->
         let%bind _ =
           mark_error_as_type_error remaining_gas
@@ -1217,7 +1225,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
                   in
                   (* from t_env, retain only entries from t_lib and tenv0 *)
                   let env' =
-                    TEnv.filterTs (TEnv.copy t_env) ~f:(fun name ->
+                    TEnv.filterTs (TEnv.copy t_env) ~f:(fun name _ ->
                         List.exists t_lib.lentries ~f:(function
                           | LibTyp _ -> false
                           | LibVar (i, _, _) -> String.(get_id i = name))

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -74,8 +74,8 @@ module type MakeTEnvFunctor = functor (Q : QualifiedTypes) (R : Rep) -> sig
     (* Append env' to env in place. *)
     val append : t -> t -> t
 
-    (* Retain only those keys for which (fb k) is true. *)
-    val filterTs : t -> f:(string -> bool) -> t
+    (* Retain only those keys for which (fb k v) is true. *)
+    val filterTs : t -> f:(string -> resolve_result -> bool) -> t
 
     (* Check type for well-formedness in the type environment *)
     val is_wf_type : t -> typ -> (unit, scilla_error list) result
@@ -89,6 +89,9 @@ module type MakeTEnvFunctor = functor (Q : QualifiedTypes) (R : Rep) -> sig
 
     (* Is bound in environment? *)
     val existsT : t -> string -> bool
+
+    (* Is bound in tvars? *)
+    val existsV : t -> string -> bool
 
     (* Copy the environment *)
     val copy : t -> t
@@ -157,11 +160,11 @@ functor
         let _ = Hashtbl.iter (fun k v -> Hashtbl.add env.tenv k v) env'.tenv in
         env
 
-      (* Retain only those keys for which (fb k) is true. *)
+      (* Retain only those keys for which (fb k v) is true. *)
       let filterTs env ~f =
         let _ =
           Hashtbl.filter_map_inplace
-            (fun k v -> if f k then Some v else None)
+            (fun k v -> if f k v then Some v else None)
             env.tenv
         in
         env
@@ -196,8 +199,7 @@ functor
               (* Check if bound locally. *)
               if List.mem tb a ~equal:String.( = ) then pure ()
                 (* Check if bound in environment. *)
-              else if List.Assoc.mem (tvars tenv) a ~equal:String.( = ) then
-                pure ()
+              else if Caml.Hashtbl.mem tenv.tvars a then pure ()
               else
                 fail0
                 @@ sprintf "Unbound type variable %s in type %s" a (pp_typ t)
@@ -237,6 +239,8 @@ functor
             fail1 (sprintf "Couldn't resolve the identifier \"%s\".\n" id) sloc
 
       let existsT env id = Hashtbl.mem env.tenv id
+
+      let existsV env id = Hashtbl.mem env.tvars id
 
       let copy e = { tenv = Hashtbl.copy e.tenv; tvars = Hashtbl.copy e.tvars }
 

--- a/src/base/TypeUtil.mli
+++ b/src/base/TypeUtil.mli
@@ -66,8 +66,8 @@ module type MakeTEnvFunctor = functor (Q : QualifiedTypes) (R : Rep) -> sig
     (* Append env' to env in place. *)
     val append : t -> t -> t
 
-    (* Retain only those keys for which (fb k) is true. *)
-    val filterTs : t -> f:(string -> bool) -> t
+    (* Retain only those keys for which (fb k v) is true. *)
+    val filterTs : t -> f:(string -> resolve_result -> bool) -> t
 
     (* Check type for well-formedness in the type environment *)
     val is_wf_type : t -> typ -> (unit, scilla_error list) result
@@ -81,6 +81,9 @@ module type MakeTEnvFunctor = functor (Q : QualifiedTypes) (R : Rep) -> sig
 
     (* Is bound in environment? *)
     val existsT : t -> string -> bool
+
+    (* Is bound in tvars? *)
+    val existsV : t -> string -> bool
 
     (* Copy the environment *)
     val copy : t -> t

--- a/tests/base/TestSyntax.ml
+++ b/tests/base/TestSyntax.ml
@@ -51,6 +51,10 @@ let unannotated_syntax_tests =
                   (FunType
                      (PolyFun ("'X", TypeVar "'X"), PolyFun ("'X", TypeVar "'X")))
                   []) );
+           ( "refresh_tfun-4",
+             assert_equal ~printer:pp_typ
+               (PolyFun ("'X1", TypeVar "'X1"))
+               (refresh_tfun (PolyFun ("'X", TypeVar "'X")) [ "'X" ]) );
            ( "canonicalize_tfun-1",
              assert_equal ~printer:pp_typ
                (PolyFun ("'_A1", PolyFun ("'_A2", TypeVar "'_A2")))

--- a/tests/checker/bad/gold/event_bad1.scilla.gold
+++ b/tests/checker/bad/gold/event_bad1.scilla.gold
@@ -3,7 +3,7 @@
   "errors": [
     {
       "error_message":
-        "Parameter mismatch for event ClaimedBack. [(amount : Uint128); ] vs [(claimed_by : ByStr20); (amount : Uint128); ]\n",
+        "Parameter mismatch for event ClaimedBack. [(amount : Uint128); ] vs [(claimed_by : ByStr20 with end); (amount : Uint128); ]\n",
       "start_location": {
         "file": "checker/bad/event_bad1.scilla",
         "line": 165,

--- a/tests/checker/good/gold/auction.scilla.gold
+++ b/tests/checker/good/gold/auction.scilla.gold
@@ -42,13 +42,13 @@
       },
       {
         "vname": "Withdraw Successful",
-        "params": [ { "vname": "addr", "type": "ByStr20" } ]
+        "params": [ { "vname": "addr", "type": "ByStr20 with end" } ]
       },
       {
         "vname": "Bid",
         "params": [
           { "vname": "code", "type": "Int32" },
-          { "vname": "addr", "type": "ByStr20" },
+          { "vname": "addr", "type": "ByStr20 with end" },
           { "vname": "amount", "type": "Uint128" }
         ]
       }

--- a/tests/checker/good/gold/auction.scilla.typeinfo.gold
+++ b/tests/checker/good/gold/auction.scilla.typeinfo.gold
@@ -812,7 +812,7 @@
     },
     {
       "vname": "_sender",
-      "type": "ByStr20",
+      "type": "ByStr20 with end",
       "start_location": {
         "file": "contracts/auction.scilla",
         "line": 69,
@@ -924,7 +924,7 @@
     },
     {
       "vname": "_sender",
-      "type": "ByStr20",
+      "type": "ByStr20 with end",
       "start_location": {
         "file": "contracts/auction.scilla",
         "line": 75,
@@ -1106,7 +1106,7 @@
     },
     {
       "vname": "_sender",
-      "type": "ByStr20",
+      "type": "ByStr20 with end",
       "start_location": {
         "file": "contracts/auction.scilla",
         "line": 85,
@@ -1428,7 +1428,7 @@
     },
     {
       "vname": "_sender",
-      "type": "ByStr20",
+      "type": "ByStr20 with end",
       "start_location": {
         "file": "contracts/auction.scilla",
         "line": 107,
@@ -1526,7 +1526,7 @@
     },
     {
       "vname": "_sender",
-      "type": "ByStr20",
+      "type": "ByStr20 with end",
       "start_location": {
         "file": "contracts/auction.scilla",
         "line": 110,
@@ -1582,7 +1582,7 @@
     },
     {
       "vname": "_sender",
-      "type": "ByStr20",
+      "type": "ByStr20 with end",
       "start_location": {
         "file": "contracts/auction.scilla",
         "line": 114,
@@ -1680,7 +1680,7 @@
     },
     {
       "vname": "_sender",
-      "type": "ByStr20",
+      "type": "ByStr20 with end",
       "start_location": {
         "file": "contracts/auction.scilla",
         "line": 117,
@@ -1778,7 +1778,7 @@
     },
     {
       "vname": "_sender",
-      "type": "ByStr20",
+      "type": "ByStr20 with end",
       "start_location": {
         "file": "contracts/auction.scilla",
         "line": 129,
@@ -1820,7 +1820,7 @@
     },
     {
       "vname": "_sender",
-      "type": "ByStr20",
+      "type": "ByStr20 with end",
       "start_location": {
         "file": "contracts/auction.scilla",
         "line": 132,
@@ -1932,7 +1932,7 @@
     },
     {
       "vname": "_sender",
-      "type": "ByStr20",
+      "type": "ByStr20 with end",
       "start_location": {
         "file": "contracts/auction.scilla",
         "line": 136,
@@ -1960,7 +1960,7 @@
     },
     {
       "vname": "_sender",
-      "type": "ByStr20",
+      "type": "ByStr20 with end",
       "start_location": {
         "file": "contracts/auction.scilla",
         "line": 137,
@@ -2002,7 +2002,7 @@
     },
     {
       "vname": "_sender",
-      "type": "ByStr20",
+      "type": "ByStr20 with end",
       "start_location": {
         "file": "contracts/auction.scilla",
         "line": 139,
@@ -2366,7 +2366,7 @@
     },
     {
       "vname": "_sender",
-      "type": "ByStr20",
+      "type": "ByStr20 with end",
       "start_location": {
         "file": "contracts/auction.scilla",
         "line": 156,

--- a/tests/checker/good/gold/crowdfunding.scilla.gold
+++ b/tests/checker/good/gold/crowdfunding.scilla.gold
@@ -31,7 +31,7 @@
       {
         "vname": "ClaimBackSuccess",
         "params": [
-          { "vname": "caller", "type": "ByStr20" },
+          { "vname": "caller", "type": "ByStr20 with end" },
           { "vname": "amount", "type": "Uint128" },
           { "vname": "code", "type": "Int32" }
         ]
@@ -39,7 +39,7 @@
       {
         "vname": "ClaimBackFailure",
         "params": [
-          { "vname": "caller", "type": "ByStr20" },
+          { "vname": "caller", "type": "ByStr20 with end" },
           { "vname": "amount", "type": "Uint128" },
           { "vname": "code", "type": "Int32" }
         ]
@@ -55,7 +55,7 @@
       {
         "vname": "GetFundsFailure",
         "params": [
-          { "vname": "caller", "type": "ByStr20" },
+          { "vname": "caller", "type": "ByStr20 with end" },
           { "vname": "amount", "type": "Uint128" },
           { "vname": "code", "type": "Int32" }
         ]
@@ -63,7 +63,7 @@
       {
         "vname": "DonationSuccess",
         "params": [
-          { "vname": "donor", "type": "ByStr20" },
+          { "vname": "donor", "type": "ByStr20 with end" },
           { "vname": "amount", "type": "Uint128" },
           { "vname": "code", "type": "Int32" }
         ]
@@ -71,7 +71,7 @@
       {
         "vname": "DonationFailure",
         "params": [
-          { "vname": "donor", "type": "ByStr20" },
+          { "vname": "donor", "type": "ByStr20 with end" },
           { "vname": "amount", "type": "Uint128" },
           { "vname": "code", "type": "Int32" }
         ]

--- a/tests/checker/good/gold/crowdfunding_proc.scilla.gold
+++ b/tests/checker/good/gold/crowdfunding_proc.scilla.gold
@@ -53,7 +53,7 @@
       {
         "vname": "ClaimBackSuccess",
         "params": [
-          { "vname": "caller", "type": "ByStr20" },
+          { "vname": "caller", "type": "ByStr20 with end" },
           { "vname": "amount", "type": "Uint128" },
           { "vname": "code", "type": "Int32" }
         ]
@@ -61,7 +61,7 @@
       {
         "vname": "ClaimBackFailure",
         "params": [
-          { "vname": "caller", "type": "ByStr20" },
+          { "vname": "caller", "type": "ByStr20 with end" },
           { "vname": "amount", "type": "Uint128" },
           { "vname": "code", "type": "Int32" }
         ]
@@ -69,7 +69,7 @@
       {
         "vname": "GetFundsFailure",
         "params": [
-          { "vname": "caller", "type": "ByStr20" },
+          { "vname": "caller", "type": "ByStr20 with end" },
           { "vname": "amount", "type": "Uint128" },
           { "vname": "code", "type": "Int32" }
         ]
@@ -77,7 +77,7 @@
       {
         "vname": "DonationFailure",
         "params": [
-          { "vname": "donor", "type": "ByStr20" },
+          { "vname": "donor", "type": "ByStr20 with end" },
           { "vname": "amount", "type": "Uint128" },
           { "vname": "code", "type": "Int32" }
         ]
@@ -85,7 +85,7 @@
       {
         "vname": "DonationSuccess",
         "params": [
-          { "vname": "donor", "type": "ByStr20" },
+          { "vname": "donor", "type": "ByStr20 with end" },
           { "vname": "amount", "type": "Uint128" },
           { "vname": "code", "type": "Int32" }
         ]

--- a/tests/checker/good/gold/nonfungible-token.scilla.gold
+++ b/tests/checker/good/gold/nonfungible-token.scilla.gold
@@ -85,7 +85,7 @@
       {
         "vname": "setApprovalForAll successful",
         "params": [
-          { "vname": "from", "type": "ByStr20" },
+          { "vname": "from", "type": "ByStr20 with end" },
           { "vname": "recipient", "type": "ByStr20" },
           { "vname": "status", "type": "String" }
         ]
@@ -93,7 +93,7 @@
       {
         "vname": "Approve successful",
         "params": [
-          { "vname": "from", "type": "ByStr20" },
+          { "vname": "from", "type": "ByStr20 with end" },
           { "vname": "approvedTo", "type": "ByStr20" },
           { "vname": "token", "type": "Uint256" }
         ]
@@ -101,7 +101,7 @@
       {
         "vname": "transferFrom successful",
         "params": [
-          { "vname": "from", "type": "ByStr20" },
+          { "vname": "from", "type": "ByStr20 with end" },
           { "vname": "recipient", "type": "ByStr20" },
           { "vname": "token", "type": "Uint256" }
         ]
@@ -109,7 +109,7 @@
       {
         "vname": "Mint successful",
         "params": [
-          { "vname": "by", "type": "ByStr20" },
+          { "vname": "by", "type": "ByStr20 with end" },
           { "vname": "recipient", "type": "ByStr20" },
           { "vname": "token", "type": "Uint256" }
         ]

--- a/tests/checker/good/gold/simple-dex-shadowwarn.scilla.gold
+++ b/tests/checker/good/gold/simple-dex-shadowwarn.scilla.gold
@@ -67,7 +67,7 @@
       {
         "vname": "Claimback Successful",
         "params": [
-          { "vname": "caller", "type": "ByStr20" },
+          { "vname": "caller", "type": "ByStr20 with end" },
           { "vname": "tokenAddr", "type": "ByStr20" },
           { "vname": "amt", "type": "Uint128" }
         ]

--- a/tests/checker/good/gold/simple-dex.scilla.gold
+++ b/tests/checker/good/gold/simple-dex.scilla.gold
@@ -67,7 +67,7 @@
       {
         "vname": "Claimback Successful",
         "params": [
-          { "vname": "caller", "type": "ByStr20" },
+          { "vname": "caller", "type": "ByStr20 with end" },
           { "vname": "tokenAddr", "type": "ByStr20" },
           { "vname": "amt", "type": "Uint128" }
         ]

--- a/tests/runner/helloWorld/output_6.json
+++ b/tests/runner/helloWorld/output_6.json
@@ -3,7 +3,7 @@
   "errors": [
     {
       "error_message":
-        "Duplicate entries or mismatch b/w message entries:\n{ [_amount -> (Uint128 0)],\n  [_sender -> (ByStr20 0xa2345678901234567890123456789012345678ab)],\n  [Unknown -> (Int32 0)] }\nand expected transition parameters[_amount : (PrimType Uint128), _sender : (PrimType ByStr20)]\n",
+        "Duplicate entries or mismatch b/w message entries:\n{ [_amount -> (Uint128 0)],\n  [_sender -> (ByStr20 0xa2345678901234567890123456789012345678ab)],\n  [Unknown -> (Int32 0)] }\nand expected transition parameters[_amount : (PrimType Uint128), _sender : (Address())]\n",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/typecheck/bad/TestTypeFail.ml
+++ b/tests/typecheck/bad/TestTypeFail.ml
@@ -183,6 +183,8 @@ module Tests = TestUtil.DiffBasedTests (struct
       "str-bad-char-1.scilexp";
       "str-bad-char-2.scilexp";
       "str-bad-char-3.scilexp";
+      "type-renaming-really-bad.scilexp";
+      "type-renaming-should-be-allowed.scilexp";
     ]
 
   let exit_code : Unix.process_status = WEXITED 1

--- a/tests/typecheck/bad/gold/nth-error.scilexp.gold
+++ b/tests/typecheck/bad/gold/nth-error.scilexp.gold
@@ -5,7 +5,7 @@
         "Type error in the initialiser of `list_nth`:\nType error in the initialiser of `list_nth_helper`:\nType error in the initialiser of `iter`:\nADT type Pair expects 2 arguments but got 1.\n",
       "start_location": {
         "file": "typecheck/bad/nth-error.scilexp",
-        "line": 14,
+        "line": 13,
         "column": 20
       },
       "end_location": { "file": "", "line": 0, "column": 0 }

--- a/tests/typecheck/bad/gold/type-renaming-really-bad.scilexp.gold
+++ b/tests/typecheck/bad/gold/type-renaming-really-bad.scilexp.gold
@@ -1,0 +1,15 @@
+{
+  "errors": [
+    {
+      "error_message":
+        "Type error in the initialiser of `id`:\nType error in the initialiser of `inconsistency`:\nType variable 'A is already in use\n",
+      "start_location": {
+        "file": "typecheck/bad/type-renaming-really-bad.scilexp",
+        "line": 5,
+        "column": 7
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": []
+}

--- a/tests/typecheck/bad/gold/type-renaming-should-be-allowed.scilexp.gold
+++ b/tests/typecheck/bad/gold/type-renaming-should-be-allowed.scilexp.gold
@@ -1,0 +1,15 @@
+{
+  "errors": [
+    {
+      "error_message":
+        "Type error in the initialiser of `id`:\nType error in the initialiser of `consistent`:\nType variable 'A is already in use\n",
+      "start_location": {
+        "file": "typecheck/bad/type-renaming-should-be-allowed.scilexp",
+        "line": 10,
+        "column": 7
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": []
+}

--- a/tests/typecheck/bad/nth-error.scilexp
+++ b/tests/typecheck/bad/nth-error.scilexp
@@ -3,7 +3,6 @@ let list_nth =
   fun (n_h : Int32) =>
   fun (l_h : List 'A) =>
     let list_nth_helper =
-      tfun 'A =>
       fun (n : Int32) =>
       fun (l : List 'A) =>
         let folder = @list_foldl 'A (Pair Int32 (Option 'A)) in
@@ -29,8 +28,7 @@ let list_nth =
           in
           folder iter init l
     in
-    let nth = @list_nth_helper 'A in
-    let res = nth n_h l_h in
+    let res = list_nth_helper n_h l_h in
     match res with
     | Pair i oe =>
       oe

--- a/tests/typecheck/bad/type-renaming-really-bad.scilexp
+++ b/tests/typecheck/bad/type-renaming-really-bad.scilexp
@@ -1,0 +1,15 @@
+(* this file must not typecheck even if we allow alpha-renaming *)
+let id : forall 'A. 'A -> 'A =
+  tfun 'A => fun (x : 'A) =>
+    let inconsistency : forall 'A. 'A =
+      tfun 'A =>
+        x    (* type error! *)
+    in
+    let uh_oh = @inconsistency Uint32 in
+    let wow = builtin add uh_oh uh_oh in
+    x
+in
+let str = "baz" in
+let idstring = @id String in
+(* this will attempt to add two strings as uint32 *)
+idstring str

--- a/tests/typecheck/bad/type-renaming-should-be-allowed.scilexp
+++ b/tests/typecheck/bad/type-renaming-should-be-allowed.scilexp
@@ -1,0 +1,17 @@
+(* this file should typecheck if we allow reusing type names  *)
+let const : forall 'A. forall 'B. 'A -> 'B -> 'B =
+  tfun 'A => tfun 'B => fun (a : 'A) => fun (b : 'B) => b
+in
+
+let id : forall 'A. 'A -> 'A =
+  tfun 'A => fun (a : 'A) =>  (* this 'A is referred to as 'A1 below *)
+    let partial_const = @const 'A in
+    let consistent : forall 'A. 'A -> 'A  =
+      tfun 'A =>
+        fun (b : 'A) =>
+          let full_const = @partial_const 'A in
+          full_const a b (* not a type error: [(a : 'A1), (b : 'A)] *)
+    in
+    a
+in
+id

--- a/tests/typecheck/good/gold/zip.scilexp.gold
+++ b/tests/typecheck/good/gold/zip.scilexp.gold
@@ -483,7 +483,7 @@
     {
       "vname": "list_zip_helper",
       "type":
-        "forall 'A. forall 'B. List ('A) -> List ('B) -> Pair (List (Pair ('A) ('B))) (List ('B))",
+        "List ('A) -> List ('B) -> Pair (List (Pair ('A) ('B))) (List ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
         "line": 44,
@@ -496,46 +496,16 @@
       }
     },
     {
-      "vname": "'A",
-      "type":
-        "forall 'B. List ('A) -> List ('B) -> Pair (List (Pair ('A) ('B))) (List ('B))",
-      "start_location": {
-        "file": "typecheck/good/zip.scilexp",
-        "line": 45,
-        "column": 12
-      },
-      "end_location": {
-        "file": "typecheck/good/zip.scilexp",
-        "line": 45,
-        "column": 14
-      }
-    },
-    {
-      "vname": "'B",
-      "type":
-        "List ('A) -> List ('B) -> Pair (List (Pair ('A) ('B))) (List ('B))",
-      "start_location": {
-        "file": "typecheck/good/zip.scilexp",
-        "line": 46,
-        "column": 12
-      },
-      "end_location": {
-        "file": "typecheck/good/zip.scilexp",
-        "line": 46,
-        "column": 14
-      }
-    },
-    {
       "vname": "l1",
       "type": "List ('A)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 47,
+        "line": 45,
         "column": 12
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 47,
+        "line": 45,
         "column": 14
       }
     },
@@ -544,12 +514,12 @@
       "type": "List ('B)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 48,
+        "line": 46,
         "column": 12
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 48,
+        "line": 46,
         "column": 14
       }
     },
@@ -559,12 +529,12 @@
         "(Pair (List (Pair ('A) ('B))) (List ('B)) -> 'A -> Pair (List (Pair ('A) ('B))) (List ('B))) -> Pair (List (Pair ('A) ('B))) (List ('B)) -> List ('A) -> Pair (List (Pair ('A) ('B))) (List ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 49,
+        "line": 47,
         "column": 13
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 49,
+        "line": 47,
         "column": 19
       }
     },
@@ -574,12 +544,12 @@
         "forall 'A. forall 'B. ('B -> 'A -> 'B) -> 'B -> List ('A) -> 'B",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 49,
+        "line": 47,
         "column": 23
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 49,
+        "line": 47,
         "column": 33
       }
     },
@@ -588,12 +558,12 @@
       "type": "List (Pair ('A) ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 50,
+        "line": 48,
         "column": 13
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 50,
+        "line": 48,
         "column": 16
       }
     },
@@ -602,12 +572,12 @@
       "type": "Pair (List (Pair ('A) ('B))) (List ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 51,
+        "line": 49,
         "column": 13
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 51,
+        "line": 49,
         "column": 17
       }
     },
@@ -616,12 +586,12 @@
       "type": "List (Pair ('A) ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 51,
+        "line": 49,
         "column": 57
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 51,
+        "line": 49,
         "column": 60
       }
     },
@@ -630,12 +600,12 @@
       "type": "List ('B)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 51,
+        "line": 49,
         "column": 61
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 51,
+        "line": 49,
         "column": 63
       }
     },
@@ -645,12 +615,12 @@
         "Pair (List (Pair ('A) ('B))) (List ('B)) -> 'A -> Pair (List (Pair ('A) ('B))) (List ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 52,
+        "line": 50,
         "column": 13
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 52,
+        "line": 50,
         "column": 17
       }
     },
@@ -659,12 +629,12 @@
       "type": "Pair (List (Pair ('A) ('B))) (List ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 53,
+        "line": 51,
         "column": 16
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 53,
+        "line": 51,
         "column": 17
       }
     },
@@ -673,12 +643,12 @@
       "type": "'A",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 54,
+        "line": 52,
         "column": 16
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 54,
+        "line": 52,
         "column": 17
       }
     },
@@ -687,12 +657,12 @@
       "type": "Pair (List (Pair ('A) ('B))) (List ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 55,
+        "line": 53,
         "column": 19
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 55,
+        "line": 53,
         "column": 20
       }
     },
@@ -701,12 +671,12 @@
       "type": "List ('B)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 56,
+        "line": 54,
         "column": 22
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 56,
+        "line": 54,
         "column": 23
       }
     },
@@ -715,12 +685,12 @@
       "type": "List (Pair ('A) ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 56,
+        "line": 54,
         "column": 20
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 56,
+        "line": 54,
         "column": 21
       }
     },
@@ -729,12 +699,12 @@
       "type": "List ('B) -> Option ('B)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 58,
+        "line": 56,
         "column": 19
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 58,
+        "line": 56,
         "column": 25
       }
     },
@@ -743,12 +713,12 @@
       "type": "forall 'A. List ('A) -> Option ('A)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 58,
+        "line": 56,
         "column": 29
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 58,
+        "line": 56,
         "column": 38
       }
     },
@@ -757,12 +727,12 @@
       "type": "List ('B) -> Option (List ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 59,
+        "line": 57,
         "column": 19
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 59,
+        "line": 57,
         "column": 25
       }
     },
@@ -771,12 +741,12 @@
       "type": "forall 'A. List ('A) -> Option (List ('A))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 59,
+        "line": 57,
         "column": 29
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 59,
+        "line": 57,
         "column": 38
       }
     },
@@ -785,12 +755,12 @@
       "type": "Option ('B)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 60,
+        "line": 58,
         "column": 19
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 60,
+        "line": 58,
         "column": 24
       }
     },
@@ -799,12 +769,12 @@
       "type": "List ('B) -> Option ('B)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 60,
+        "line": 58,
         "column": 27
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 60,
+        "line": 58,
         "column": 33
       }
     },
@@ -813,12 +783,12 @@
       "type": "List ('B)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 60,
+        "line": 58,
         "column": 34
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 60,
+        "line": 58,
         "column": 35
       }
     },
@@ -827,12 +797,12 @@
       "type": "Option ('B)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 61,
+        "line": 59,
         "column": 21
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 61,
+        "line": 59,
         "column": 26
       }
     },
@@ -841,12 +811,12 @@
       "type": "'B",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 62,
+        "line": 60,
         "column": 22
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 62,
+        "line": 60,
         "column": 25
       }
     },
@@ -855,12 +825,12 @@
       "type": "Pair ('A) ('B)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 63,
+        "line": 61,
         "column": 21
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 63,
+        "line": 61,
         "column": 25
       }
     },
@@ -869,12 +839,12 @@
       "type": "'A",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 63,
+        "line": 61,
         "column": 41
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 63,
+        "line": 61,
         "column": 42
       }
     },
@@ -883,12 +853,12 @@
       "type": "'B",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 63,
+        "line": 61,
         "column": 43
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 63,
+        "line": 61,
         "column": 46
       }
     },
@@ -897,12 +867,12 @@
       "type": "List (Pair ('A) ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 64,
+        "line": 62,
         "column": 21
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 64,
+        "line": 62,
         "column": 32
       }
     },
@@ -911,12 +881,12 @@
       "type": "Pair ('A) ('B)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 64,
+        "line": 62,
         "column": 55
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 64,
+        "line": 62,
         "column": 59
       }
     },
@@ -925,12 +895,12 @@
       "type": "List (Pair ('A) ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 64,
+        "line": 62,
         "column": 60
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 64,
+        "line": 62,
         "column": 61
       }
     },
@@ -939,12 +909,12 @@
       "type": "Option (List ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 65,
+        "line": 63,
         "column": 21
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 65,
+        "line": 63,
         "column": 26
       }
     },
@@ -953,12 +923,12 @@
       "type": "List ('B) -> Option (List ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 65,
+        "line": 63,
         "column": 29
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 65,
+        "line": 63,
         "column": 35
       }
     },
@@ -967,12 +937,12 @@
       "type": "List ('B)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 65,
+        "line": 63,
         "column": 36
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 65,
+        "line": 63,
         "column": 37
       }
     },
@@ -981,12 +951,12 @@
       "type": "List ('B)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 66,
+        "line": 64,
         "column": 21
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 66,
+        "line": 64,
         "column": 25
       }
     },
@@ -995,12 +965,12 @@
       "type": "Option (List ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 67,
+        "line": 65,
         "column": 25
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 67,
+        "line": 65,
         "column": 30
       }
     },
@@ -1009,12 +979,12 @@
       "type": "List ('B)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 68,
+        "line": 66,
         "column": 26
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 68,
+        "line": 66,
         "column": 27
       }
     },
@@ -1023,12 +993,12 @@
       "type": "List ('B)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 69,
+        "line": 67,
         "column": 21
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 69,
+        "line": 67,
         "column": 22
       }
     },
@@ -1037,12 +1007,12 @@
       "type": "List ('B)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 71,
+        "line": 69,
         "column": 25
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 71,
+        "line": 69,
         "column": 29
       }
     },
@@ -1051,12 +1021,12 @@
       "type": "List ('B)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 72,
+        "line": 70,
         "column": 21
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 72,
+        "line": 70,
         "column": 25
       }
     },
@@ -1065,12 +1035,12 @@
       "type": "List (Pair ('A) ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 75,
+        "line": 73,
         "column": 54
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 75,
+        "line": 73,
         "column": 65
       }
     },
@@ -1079,12 +1049,12 @@
       "type": "List ('B)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 75,
+        "line": 73,
         "column": 66
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 75,
+        "line": 73,
         "column": 70
       }
     },
@@ -1093,12 +1063,12 @@
       "type": "Pair (List (Pair ('A) ('B))) (List ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 77,
+        "line": 75,
         "column": 17
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 77,
+        "line": 75,
         "column": 18
       }
     },
@@ -1108,12 +1078,12 @@
         "(Pair (List (Pair ('A) ('B))) (List ('B)) -> 'A -> Pair (List (Pair ('A) ('B))) (List ('B))) -> Pair (List (Pair ('A) ('B))) (List ('B)) -> List ('A) -> Pair (List (Pair ('A) ('B))) (List ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 81,
+        "line": 79,
         "column": 13
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 81,
+        "line": 79,
         "column": 19
       }
     },
@@ -1123,12 +1093,12 @@
         "Pair (List (Pair ('A) ('B))) (List ('B)) -> 'A -> Pair (List (Pair ('A) ('B))) (List ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 81,
+        "line": 79,
         "column": 20
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 81,
+        "line": 79,
         "column": 24
       }
     },
@@ -1137,12 +1107,12 @@
       "type": "Pair (List (Pair ('A) ('B))) (List ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 81,
+        "line": 79,
         "column": 25
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 81,
+        "line": 79,
         "column": 29
       }
     },
@@ -1151,8 +1121,37 @@
       "type": "List ('A)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 81,
+        "line": 79,
         "column": 30
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 79,
+        "column": 32
+      }
+    },
+    {
+      "vname": "res",
+      "type": "Pair (List (Pair ('A) ('B))) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 81,
+        "column": 11
+      },
+      "end_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 81,
+        "column": 14
+      }
+    },
+    {
+      "vname": "list_zip_helper",
+      "type":
+        "List ('A) -> List ('B) -> Pair (List (Pair ('A) ('B))) (List ('B))",
+      "start_location": {
+        "file": "typecheck/good/zip.scilexp",
+        "line": 81,
+        "column": 17
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
@@ -1161,76 +1160,17 @@
       }
     },
     {
-      "vname": "zipper",
-      "type":
-        "List ('A) -> List ('B) -> Pair (List (Pair ('A) ('B))) (List ('B))",
-      "start_location": {
-        "file": "typecheck/good/zip.scilexp",
-        "line": 83,
-        "column": 11
-      },
-      "end_location": {
-        "file": "typecheck/good/zip.scilexp",
-        "line": 83,
-        "column": 17
-      }
-    },
-    {
-      "vname": "list_zip_helper",
-      "type":
-        "forall 'A. forall 'B. List ('A) -> List ('B) -> Pair (List (Pair ('A) ('B))) (List ('B))",
-      "start_location": {
-        "file": "typecheck/good/zip.scilexp",
-        "line": 83,
-        "column": 21
-      },
-      "end_location": {
-        "file": "typecheck/good/zip.scilexp",
-        "line": 83,
-        "column": 36
-      }
-    },
-    {
-      "vname": "res",
-      "type": "Pair (List (Pair ('A) ('B))) (List ('B))",
-      "start_location": {
-        "file": "typecheck/good/zip.scilexp",
-        "line": 84,
-        "column": 11
-      },
-      "end_location": {
-        "file": "typecheck/good/zip.scilexp",
-        "line": 84,
-        "column": 14
-      }
-    },
-    {
-      "vname": "zipper",
-      "type":
-        "List ('A) -> List ('B) -> Pair (List (Pair ('A) ('B))) (List ('B))",
-      "start_location": {
-        "file": "typecheck/good/zip.scilexp",
-        "line": 84,
-        "column": 17
-      },
-      "end_location": {
-        "file": "typecheck/good/zip.scilexp",
-        "line": 84,
-        "column": 23
-      }
-    },
-    {
       "vname": "m1",
       "type": "List ('A)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 84,
-        "column": 24
+        "line": 81,
+        "column": 33
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 84,
-        "column": 26
+        "line": 81,
+        "column": 35
       }
     },
     {
@@ -1238,13 +1178,13 @@
       "type": "List ('B)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 84,
-        "column": 27
+        "line": 81,
+        "column": 36
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 84,
-        "column": 29
+        "line": 81,
+        "column": 38
       }
     },
     {
@@ -1252,12 +1192,12 @@
       "type": "Pair (List (Pair ('A) ('B))) (List ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 85,
+        "line": 82,
         "column": 13
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 85,
+        "line": 82,
         "column": 16
       }
     },
@@ -1266,12 +1206,12 @@
       "type": "List ('B)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 86,
+        "line": 83,
         "column": 16
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 86,
+        "line": 83,
         "column": 17
       }
     },
@@ -1280,12 +1220,12 @@
       "type": "List (Pair ('A) ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 86,
+        "line": 83,
         "column": 14
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 86,
+        "line": 83,
         "column": 15
       }
     },
@@ -1294,12 +1234,12 @@
       "type": "List (Pair ('A) ('B)) -> List (Pair ('A) ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 87,
+        "line": 84,
         "column": 13
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 87,
+        "line": 84,
         "column": 21
       }
     },
@@ -1308,12 +1248,12 @@
       "type": "forall 'A. List ('A) -> List ('A)",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 87,
+        "line": 84,
         "column": 25
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 87,
+        "line": 84,
         "column": 37
       }
     },
@@ -1322,12 +1262,12 @@
       "type": "List (Pair ('A) ('B)) -> List (Pair ('A) ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 88,
+        "line": 85,
         "column": 11
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 88,
+        "line": 85,
         "column": 19
       }
     },
@@ -1336,12 +1276,12 @@
       "type": "List (Pair ('A) ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 88,
+        "line": 85,
         "column": 20
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 88,
+        "line": 85,
         "column": 21
       }
     },
@@ -1351,12 +1291,12 @@
         "forall 'A. forall 'B. List ('A) -> List ('B) -> List (Pair ('A) ('B))",
       "start_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 90,
+        "line": 87,
         "column": 4
       },
       "end_location": {
         "file": "typecheck/good/zip.scilexp",
-        "line": 90,
+        "line": 87,
         "column": 12
       }
     }

--- a/tests/typecheck/good/zip.scilexp
+++ b/tests/typecheck/good/zip.scilexp
@@ -42,8 +42,6 @@ let list_zip =
   fun (m1 : List 'A) =>
   fun (m2 : List 'B) =>
     let list_zip_helper =
-      tfun 'A =>
-      tfun 'B =>
       fun (l1 : List 'A) =>
       fun (l2 : List 'B) =>
         let folder = @list_foldl 'A (Pair (List (Pair 'A 'B)) (List 'B)) in
@@ -80,8 +78,7 @@ let list_zip =
           in
             folder iter init l1
     in
-      let zipper = @list_zip_helper 'A 'B in
-      let res = zipper m1 m2 in
+      let res = list_zip_helper m1 m2 in
       match res with
       | Pair x y =>
         let reverser = @list_reverse (Pair 'A 'B) in


### PR DESCRIPTION
`_sender` is clearly always a legal address, but there is no way for a transition to declare this, so `_sender` can only be treated as a `ByStr20`.

I have changed this so that `_sender` is considered a `ByStr20 with end` (I don't think it should be possible to require `_sender` to have particular fields, and I don't see what the syntax should be anyway).

Making this change revealed a bug in the elaboration of `eq`. So far, `eq` required its two argument to have the same type, but since addresses should be compared using their `ByStr20` value, I have changed the elaboration to be `ByStr20` if an address is involved.