### PR TITLE
Provide an external_fetch function in StateService

### DIFF
--- a/src/base/JSON.mli
+++ b/src/base/JSON.mli
@@ -27,7 +27,7 @@ module ContractState : sig
    *  Returns a list of (vname:string,value:literal) items
    *  from the json in the input filename. Invalid inputs in the json are ignored 
    *)
-  val get_json_data : string -> (string * Syntax.literal) list
+  val get_json_data : string -> (string * Syntax.typ * Syntax.literal) list
 
   (* 
    * Prints a list of state variables (string, literal)
@@ -89,7 +89,7 @@ module Message : sig
 end
 
 module BlockChainState : sig
-  val get_json_data : string -> (string * Syntax.literal) list
+  val get_json_data : string -> (string * Syntax.typ * Syntax.literal) list
   (** 
    **  Returns a list of (vname:string,value:literal) items
    **  from the json in the input filename.

--- a/src/eval/RunnerCLI.ml
+++ b/src/eval/RunnerCLI.ml
@@ -31,6 +31,7 @@ type args = {
   balance : Stdint.uint128;
   pp_json : bool;
   ipc_address : string;
+  ext_states : string list
 }
 
 let f_input_init = ref ""
@@ -65,6 +66,8 @@ let b_validate_json = ref true
 
 let i_ipc_address = ref ""
 
+let f_ext_states = ref []
+
 let reset () =
   f_input_init := "";
   f_input_state := "";
@@ -81,7 +84,9 @@ let reset () =
   b_json_errors := false;
   b_pp_json := true;
   b_validate_json := true;
-  i_ipc_address := ""
+  i_ipc_address := "";
+  f_ext_states := []
+
 
 let process_trace () =
   match !f_trace_level with
@@ -173,6 +178,9 @@ let parse args ~exe_name =
       ( "-istate",
         Arg.String (fun x -> f_input_state := x),
         "Path to state input json" );
+      ( "-estate",
+        Arg.String (fun x -> f_ext_states := x :: !f_ext_states),
+        "Path to the state of another blockchain address");
       ( "-imessage",
         Arg.String (fun x -> f_input_message := x),
         "Path to message input json" );
@@ -276,4 +284,5 @@ let parse args ~exe_name =
     gas_limit = !v_gas_limit;
     pp_json = !b_pp_json;
     ipc_address = !i_ipc_address;
+    ext_states = List.rev !f_ext_states;
   }

--- a/src/eval/RunnerCLI.mli
+++ b/src/eval/RunnerCLI.mli
@@ -28,6 +28,7 @@ type args = {
   balance : Stdint.uint128;
   pp_json : bool;
   ipc_address : string;
+  ext_states : string list;
 }
 
 val parse : string list option -> exe_name:string -> args

--- a/src/eval/StateIPCClient.ml
+++ b/src/eval/StateIPCClient.ml
@@ -192,8 +192,11 @@ let external_fetch ~socket_addr ~caddr ~fname ~keys ~tp =
       let%bind tp' = TypeUtilities.map_access_type tp (List.length keys) in
       let%bind decoded_pb = decode_serialized_value (Bytes.of_string res') in
       let%bind res'' = deserialize_value decoded_pb tp' in
-      pure @@ (Some res'', field_typ)
-  | false, _, field_typ -> pure (None, field_typ)
+      let%bind stored_typ = FrontEndParser.parse_type field_typ in
+      pure @@ (Some res'', stored_typ)
+  | false, _, field_typ ->
+    let%bind stored_typ = FrontEndParser.parse_type field_typ in
+    pure (None, stored_typ)
 
 (* Update a field. "keys" is empty when updating non-map fields or an entire Map field. *)
 let update ~socket_addr ~fname ~keys ~value ~tp =

--- a/src/eval/StateIPCClient.mli
+++ b/src/eval/StateIPCClient.mli
@@ -36,7 +36,7 @@ val external_fetch :
   fname:'a ident ->
   keys:literal list ->
   tp:typ ->
-  (literal option * string, scilla_error list) result
+  (literal option * typ, scilla_error list) result
 
 (* Update a field. "keys" is empty when updating non-map fields or an entire Map field. *)
 val update :

--- a/src/eval/StateIPCClient.mli
+++ b/src/eval/StateIPCClient.mli
@@ -27,6 +27,17 @@ val fetch :
   tp:typ ->
   (literal option, scilla_error list) result
 
+(* Fetch from another contract's field. "keys" is empty when fetching non-map fields
+ * or an entire Map field. If a map key is not found, then None is returned, otherwise
+ * (Some value) is returned. *)
+val external_fetch :
+  socket_addr:string ->
+  caddr:string ->
+  fname:'a ident ->
+  keys:literal list ->
+  tp:typ ->
+  (literal option * string, scilla_error list) result
+
 (* Update a field. "keys" is empty when updating non-map fields or an entire Map field. *)
 val update :
   socket_addr:string ->
@@ -43,6 +54,15 @@ val is_member :
   keys:literal list ->
   tp:typ ->
   (bool, scilla_error list) result
+
+(* Does field fname exist in caddr? If yes and it's a map, do keys exist? *)
+val external_is_member :
+  socket_addr:string ->
+  caddr:string ->
+  fname:loc ident ->
+  keys:literal list ->
+  tp:typ ->
+  (bool * string, scilla_error list) result
 
 (* Remove a key from a map. keys must be non-empty. *)
 val remove :

--- a/src/eval/StateIPCIdl.ml
+++ b/src/eval/StateIPCIdl.ml
@@ -25,10 +25,17 @@ module IPCIdl (R : RPC) = struct
 
   let value = Param.mk ~name:"value" Rpc.Types.string
 
+  let addr = Param.mk ~name:"addr" Rpc.Types.string
+
   (* The return value for `fetchStateValue` will be a pair (found : bool, value : string)
    * "value" is valid only if "found && !query.ignoreval" *)
   (* TODO: [@warning "-32"] doesn't seem to work for "unused" types. *)
   type _fetch_ret_t = bool * string [@@deriving rpcty]
+
+  (* The return value for `fetchExternalStateValue will be a triple
+   * (found : bool, value : string, type : string). "value" is valid only
+   * if "found && !query.ignoreval" *)
+  type _fetch_ext_ret_t = bool * string * string [@@deriving rpcty]
 
   (* defines `typ_of__fetch_ret_t` *)
 
@@ -36,12 +43,25 @@ module IPCIdl (R : RPC) = struct
     Param.mk
       { name = ""; description = [ "(found,value)" ]; ty = typ_of__fetch_ret_t }
 
+  let return_ext_fetch =
+    Param.mk
+      {
+        name = "";
+        description = [ "(found,value,type)" ];
+        ty = typ_of__fetch_ext_ret_t;
+      }
+
   let return_update = Param.mk Rpc.Types.unit
 
   let fetch_state_value =
     declare "fetchStateValue"
       [ "Fetch state value from blockchain" ]
       (query @-> returning return_fetch RPCError.err)
+
+  let fetch_ext_state_value =
+    declare "fetchExternalStateValue"
+      [ "Fetch state value of another contract from the blockchain" ]
+      (addr @-> query @-> returning return_ext_fetch RPCError.err)
 
   let update_state_value =
     declare "updateStateValue"

--- a/src/eval/StateService.mli
+++ b/src/eval/StateService.mli
@@ -29,6 +29,8 @@ type ss_field = {
   fval : literal option; (* Value may not be available (in IPC mode) *)
 }
 
+type external_state = { caddr : string; cstate : ss_field list }
+
 type service_mode =
   | IPC of string
   (* port number for IPC *)
@@ -53,7 +55,11 @@ type service_mode =
 *)
 
 (* Sets up the state service object. Should be called before any queries. *)
-val initialize : sm:service_mode -> fields:ss_field list -> unit
+val initialize :
+  sm:service_mode ->
+  fields:ss_field list ->
+  ext_states:external_state list ->
+  unit
 
 (* Expensive operation, use with care. *)
 val get_full_state : unit -> ((string * literal) list, scilla_error list) result
@@ -89,7 +95,11 @@ val remove :
 
 (* Should rarely be used, and is useful only when multiple StateService objects are required *)
 module MakeStateService () : sig
-  val initialize : sm:service_mode -> fields:ss_field list -> unit
+  val initialize :
+    sm:service_mode ->
+    fields:ss_field list ->
+    ext_states:external_state list ->
+    unit
 
   val get_full_state :
     unit -> ((string * literal) list, scilla_error list) result

--- a/src/eval/StateService.mli
+++ b/src/eval/StateService.mli
@@ -126,4 +126,13 @@ module MakeStateService () : sig
     fname:loc ident ->
     keys:literal list ->
     (stmt_eval_context, scilla_error list) result
+
+  (* Fetch external contract state.
+   * Returns the value (if found) and its type as was stored. *)
+  val external_fetch :
+    caddr:string ->
+    fname:loc ident ->
+    keys:literal list ->
+    expected_field_tp:typ ->
+    (literal option * typ * stmt_eval_context, scilla_error list) result
 end

--- a/tests/ipc/StateIPCTestServer.ml
+++ b/tests/ipc/StateIPCTestServer.ml
@@ -162,6 +162,10 @@ module MakeServer () = struct
             let new_val = deserialize_value (decode_serialized_value value) in
             recurser_update ~new_val:(Some new_val) table
               (name :: string_indices_list) )
+
+  let fetch_ext_state_value _caddr _query =
+    fail RPCError.{ code = 0; message = "Unimplimented" }
+
 end
 
 let start_server ~sock_addr =
@@ -174,6 +178,8 @@ let start_server ~sock_addr =
           IDL.T.return @@ ServerModule.fetch_state_value q);
       ServerModule.IPCTestServer.update_state_value (fun q v ->
           IDL.T.return @@ ServerModule.update_state_value q v);
+      ServerModule.IPCTestServer.fetch_ext_state_value (fun a q ->
+          IDL.T.return @@ ServerModule.fetch_ext_state_value a q);
       let server = ServerModule.prepare_server sock_addr in
       let _ = Thread.create server () in
       Hashtbl.replace thread_pool sock_addr ServerModule.table

--- a/tests/runner/helloWorld/output_11.json
+++ b/tests/runner/helloWorld/output_11.json
@@ -2,7 +2,7 @@
   "gas_remaining": "7845",
   "errors": [
     {
-      "error_message": "_balance field missing",
+      "error_message": "_balance missing or invalid",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     },


### PR DESCRIPTION
This function takes in an expected type and returns the state field value (if found) and the type as was stored.

I'm not sure if it should take in an expected type. The earlier "fetch" functions took them because it was used to
  1. Compute map_depth to be sent to the server. But the server already stores it, so I'm not sure it needs it.
  2. Decode the protobuf value returned by the server. But this can be worked around by using the type returned from the server !

The comparison of expected type vs stored type isn't done. I think that must be done in `StateService.ml : external_fetch`. This is also the place from where I suggest the reviewer to start reviewing this PR.