### PR TITLE
Introduce map2M function and apply it in PatternMatching and TypeUtil

### DIFF
--- a/src/base/MonadUtil.ml
+++ b/src/base/MonadUtil.ml
@@ -91,6 +91,16 @@ let rec mapM ~f ls =
       pure (z :: zs)
   | [] -> pure []
 
+(* Monadic map2 *)
+let rec map2M ~f ls ms ~msg =
+  match (ls, ms) with
+  | x :: ls', y :: ms' ->
+      let%bind z = f x y in
+      let%bind zs = map2M ~f ls' ms' ~msg in
+      pure (z :: zs)
+  | [], [] -> pure []
+  | _ -> fail @@ msg ()
+
 let rec iterM ~f ls =
   match ls with
   | x :: ls' ->
@@ -186,6 +196,16 @@ module EvalMonad = struct
         let%bind zs = mapM ~f ls' in
         pure (z :: zs)
     | [] -> pure []
+
+  (* Monadic map2 *)
+  let rec map2M ~f ls ms ~msg =
+    match (ls, ms) with
+    | x :: ls', y :: ms' ->
+        let%bind z = f x y in
+        let%bind zs = map2M ~f ls' ms' ~msg in
+        pure (z :: zs)
+    | [], [] -> pure []
+    | _ -> fail @@ msg ()
 
   let liftPair1 m x =
     let%bind z = m in

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -410,11 +410,8 @@ module TypeUtilities = struct
              (pp_typ ft) (pp_typ_list argtypes)
 
   let proc_type_applies formals actuals =
-    match List.zip formals actuals with
-    | Ok arg_pairs ->
-        mapM arg_pairs ~f:(fun (formal, actual) ->
-            assert_type_equiv formal actual)
-    | Unequal_lengths -> fail0 "Incorrect number of arguments to procedure"
+    map2M formals actuals ~f:assert_type_equiv ~msg:(fun () ->
+        mk_error0 "Incorrect number of arguments to procedure")
 
   let rec elab_tfun_with_args_no_gas tf args =
     match (tf, args) with


### PR DESCRIPTION
While thinking about compiling Scilla's pattern-matching to TLA+ I read the code and tried to do so improvements w.r.t readability.

Using `map2M` avoids creating a zipped intermediate list.