### PR TITLE
Qualified names, illustrated

### DIFF
--- a/src/base/Accept.ml
+++ b/src/base/Accept.ml
@@ -27,6 +27,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
+open Names
 open TypeUtil
 open ErrorUtils
 open Syntax
@@ -38,7 +39,10 @@ module ScillaAcceptChecker
       val get_type : rep -> PlainTypes.t inferred_type [@@warning "-32"]
     end) =
 struct
-  module EISyntax = ScillaSyntax (SR) (ER)
+  module EINames = FlattenedNames
+  module EIIdentifiers = ScillaIdentifiers (EINames)
+  module EISyntax = ScillaSyntax (SR) (ER) (EINames)
+  open EIIdentifiers
   open EISyntax
 
   (* Warning level to use when contract has code paths with potentially
@@ -103,7 +107,7 @@ struct
           ( sprintf
               "transition %s had a potential code path with duplicate accept \
                statements:\n"
-              (get_id transition.comp_name)
+              (as_error_string transition.comp_name)
           ^ String.concat ~sep:""
               (List.map group ~f:(fun loc ->
                    sprintf "  Accept at %s\n" (get_loc_str loc))) )
@@ -124,7 +128,7 @@ struct
     if List.for_all all_accept_groups ~f:List.is_empty then
       warn0
         (sprintf "No transition in contract %s contains an accept statement\n"
-           (get_id contr.cname))
+           (as_error_string contr.cname))
         warning_level_missing_accept
 
   (* ************************************** *)

--- a/src/base/BuiltIns.mli
+++ b/src/base/BuiltIns.mli
@@ -20,6 +20,11 @@ open Syntax
 open ErrorUtils
 open Core_kernel
 
+module BITypes : Types
+module BILiterals : Literals
+open BITypes
+open BILiterals
+
 module UsefulLiterals : sig
   val true_lit : literal
 

--- a/src/base/Datatypes.mli
+++ b/src/base/Datatypes.mli
@@ -20,6 +20,11 @@ open Syntax
 open ErrorUtils
 open Core_kernel
 
+module DTTypes : Types
+module DTLiterals : Literals
+open DTTypes
+open DTLiterals
+
 (**********************************************************)
 (*                 Built-in Algebraic Data Types          *)
 (**********************************************************)

--- a/src/base/JSON.mli
+++ b/src/base/JSON.mli
@@ -21,29 +21,35 @@
  *    "vname" : "variable name"
  *    "type" : "valid scilla type"
  *    "value" : "value of the variable as a string"
- *)
+*)
+
+module JSONLiterals : Syntax.Literals
+module JSONTypes : Syntax.Types
+open JSONLiterals
+open JSONTypes
+
 module ContractState : sig
   (* 
    *  Returns a list of (vname:string,value:literal) items
    *  from the json in the input filename. Invalid inputs in the json are ignored 
    *)
-  val get_json_data : string -> (string * Syntax.literal) list
+  val get_json_data : string -> (string * literal) list
 
   (* 
    * Prints a list of state variables (string, literal)
    * as a json and returns it as a string.
    * pp enables pretty printing.
    *)
-  val state_to_string : ?pp:bool -> (string * Syntax.literal) list -> string
+  val state_to_string : ?pp:bool -> (string * literal) list -> string
 
   (* Get a json object from given states *)
-  val state_to_json : (string * Syntax.literal) list -> Yojson.Basic.t
+  val state_to_json : (string * literal) list -> Yojson.Basic.t
 
   (* Given an init.json filename, return extlib fields *)
   val get_init_extlibs : string -> (string * string) list
 
   (* Convert a single JSON serialized literal back to its Scilla value. *)
-  val jstring_to_literal : string -> Syntax.typ -> Syntax.literal
+  val jstring_to_literal : string -> typ -> literal
 end
 
 (*  Message json parsing and printing. A message json has three mandatory
@@ -69,12 +75,12 @@ end
     }
  *)
 module Message : sig
-  val get_json_data : string -> (string * Syntax.literal) list
+  val get_json_data : string -> (string * literal) list
   (** Parses and returns a list of (pname,pval), with
   "_tag", "_sender" and "_amount" at the beginning of this list.
   Invalid inputs in the json are ignored **)
 
-  val message_to_jstring : ?pp:bool -> (string * Syntax.literal) list -> string
+  val message_to_jstring : ?pp:bool -> (string * literal) list -> string
   (** 
    ** Prints a message (string, literal) as a json to the 
    ** and returns the string. pp enables pretty printing.
@@ -85,11 +91,11 @@ module Message : sig
    **)
 
   (* Same as message_to_jstring, but instead gives out raw json, not it's string *)
-  val message_to_json : (string * Syntax.literal) list -> Yojson.Basic.t
+  val message_to_json : (string * literal) list -> Yojson.Basic.t
 end
 
 module BlockChainState : sig
-  val get_json_data : string -> (string * Syntax.literal) list
+  val get_json_data : string -> (string * literal) list
   (** 
    **  Returns a list of (vname:string,value:literal) items
    **  from the json in the input filename.
@@ -133,34 +139,34 @@ module ContractInfo : sig
         }
   *)
   val get_string :
-    int -> contract -> (string * (string * Syntax.typ) list) list -> string
+    int -> contract -> (string * (string * typ) list) list -> string
 
   val get_json :
     int ->
     contract ->
-    (string * (string * Syntax.typ) list) list ->
+    (string * (string * typ) list) list ->
     Yojson.Basic.t
 end
 
 module Event : sig
-  val event_to_jstring : ?pp:bool -> (string * Syntax.literal) list -> string
+  val event_to_jstring : ?pp:bool -> (string * literal) list -> string
   (** 
    ** Prints an Event "(string, literal) list" as a json to the 
    ** and returns the string. pp enables pretty printing.
    **)
 
   (* Same as Event_to_jstring, but instead gives out raw json, not it's string *)
-  val event_to_json : (string * Syntax.literal) list -> Yojson.Basic.t
+  val event_to_json : (string * literal) list -> Yojson.Basic.t
 end
 
 module TypeInfo : sig
   val type_info_to_json :
-    (string * Syntax.typ * ErrorUtils.loc * ErrorUtils.loc) list ->
+    (string * typ * ErrorUtils.loc * ErrorUtils.loc) list ->
     Yojson.Basic.t
 
   val type_info_to_jstring :
     ?pp:bool ->
-    (string * Syntax.typ * ErrorUtils.loc * ErrorUtils.loc) list ->
+    (string * typ * ErrorUtils.loc * ErrorUtils.loc) list ->
     string
 end
 

--- a/src/base/Names.ml
+++ b/src/base/Names.ml
@@ -1,0 +1,104 @@
+(*
+  This file is part of scilla.
+
+  Copyright (c) 2020 - present Zilliqa Research Pvt. Ltd.
+  
+  scilla is free software: you can redistribute it and/or modify it under the
+  terms of the GNU General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option) any later
+  version.
+ 
+  scilla is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License along with
+  scilla.  If not, see <http://www.gnu.org/licenses/>.
+*)
+
+open Core_kernel
+open! Int.Replace_polymorphic_compare
+
+(* Signature for qualified names *)
+module type QualifiedNames = sig
+  type name [@@deriving sexp]
+
+  val as_string : name -> string
+
+  val as_error_string : name -> string
+  
+  val equal_name : name -> name -> bool
+
+  val compare_name : name -> name -> int
+end
+
+let concat_qualifer_and_name q id = q ^ "." ^ id
+
+(* Flattened names. This will be removed later *)
+module FlattenedNames : QualifiedNames =
+struct
+  type name = string [@@deriving sexp]
+
+  let as_string n = n
+
+  let as_error_string n = n
+  
+  let equal_name = String.(=)
+
+  let compare_name = String.compare
+end
+
+(* Locally defined qualified names *)
+module LocalNames : QualifiedNames =
+struct
+  type name =
+    | Simple of string
+    | NamespaceQualified of string * string
+  [@@deriving sexp]
+
+  let as_string = function
+    | Simple n -> n
+    | NamespaceQualified (ns, n) -> concat_qualifer_and_name ns n
+
+  let as_error_string = as_string
+  
+  let equal_name a b =
+    match a, b with
+    | Simple an, Simple bn
+      when String.(an = bn)
+      -> true
+    | NamespaceQualified (ans, an), NamespaceQualified (bns, bn)
+      when String.(ans = bns) && String.(an = bn)
+      -> true
+    | _, _ -> false
+
+  let compare_name a b = String.compare (as_string a) (as_string b)
+end
+
+(* Canonical (i.e., globally uniquely) defined qualified names *)
+module CanonicalNames : QualifiedNames =
+struct
+  type name =
+    | Simple of string
+    | AddressQualified of string * string
+  [@@deriving sexp]
+
+  let as_string = function
+    | Simple n -> n
+    | AddressQualified (adr, n) -> concat_qualifer_and_name adr n
+
+  (* TODO: Report local names rather than canonical names *)
+  let as_error_string = as_string
+  
+  let equal_name a b =
+    match a, b with
+    | Simple an, Simple bn
+      when String.(an = bn)
+      -> true
+    | AddressQualified (aadr, an), AddressQualified (badr, bn)
+      when String.(aadr = badr) && String.(an = bn)
+      -> true
+    | _, _ -> false
+
+  let compare_name a b = String.compare (as_string a) (as_string b)
+end

--- a/src/base/PrettyPrinters.ml
+++ b/src/base/PrettyPrinters.ml
@@ -18,11 +18,19 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
+open Names
 open Syntax
 open Yojson
 open PrimTypes
 open ErrorUtils
 open Stdint
+
+module PPNames = FlattenedNames
+module PPTypes = ScillaTypes (PPNames)
+module PPPrimTypes = 
+module PPLiterals = ScillaLiterals (PPNames)
+open PPTypes
+open PPLiterals
 
 (****************************************************************)
 (*                    Exception wrappers                        *)

--- a/src/base/PrimTypes.ml
+++ b/src/base/PrimTypes.ml
@@ -2,16 +2,16 @@
   This file is part of scilla.
 
   Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
-  
+
   scilla is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software
   Foundation, either version 3 of the License, or (at your option) any later
   version.
- 
+
   scilla is distributed in the hope that it will be useful, but WITHOUT ANY
   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
   A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
- 
+
   You should have received a copy of the GNU General Public License along with
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
@@ -22,142 +22,155 @@ open Syntax
 open Stdint
 open Integer256
 
-let int32_typ = PrimType (Int_typ Bits32)
+module PrimTypes
+    (Types : Types)
+    (Literals : sig
+       include Literals
+       type uint_lit
+       type int_lit
+     end) = struct
 
-let int64_typ = PrimType (Int_typ Bits64)
+  open Types
+  open Literals
+  
+  let int32_typ = PrimType (Int_typ Bits32)
 
-let int128_typ = PrimType (Int_typ Bits128)
+  let int64_typ = PrimType (Int_typ Bits64)
 
-let int256_typ = PrimType (Int_typ Bits256)
+  let int128_typ = PrimType (Int_typ Bits128)
 
-let uint32_typ = PrimType (Uint_typ Bits32)
+  let int256_typ = PrimType (Int_typ Bits256)
 
-let uint64_typ = PrimType (Uint_typ Bits64)
+  let uint32_typ = PrimType (Uint_typ Bits32)
 
-let uint128_typ = PrimType (Uint_typ Bits128)
+  let uint64_typ = PrimType (Uint_typ Bits64)
 
-let uint256_typ = PrimType (Uint_typ Bits256)
+  let uint128_typ = PrimType (Uint_typ Bits128)
 
-let string_typ = PrimType String_typ
+  let uint256_typ = PrimType (Uint_typ Bits256)
 
-let bnum_typ = PrimType Bnum_typ
+  let string_typ = PrimType String_typ
 
-let msg_typ = PrimType Msg_typ
+  let bnum_typ = PrimType Bnum_typ
 
-let event_typ = PrimType Event_typ
+  let msg_typ = PrimType Msg_typ
 
-let exception_typ = PrimType Exception_typ
+  let event_typ = PrimType Event_typ
 
-let bystr_typ = PrimType Bystr_typ
+  let exception_typ = PrimType Exception_typ
 
-let bystrx_typ b = PrimType (Bystrx_typ b)
+  let bystr_typ = PrimType Bystr_typ
 
-let int_width = function
-  | PrimType (Int_typ Bits32) | PrimType (Uint_typ Bits32) -> Some 32
-  | PrimType (Int_typ Bits64) | PrimType (Uint_typ Bits64) -> Some 64
-  | PrimType (Int_typ Bits128) | PrimType (Uint_typ Bits128) -> Some 128
-  | PrimType (Int_typ Bits256) | PrimType (Uint_typ Bits256) -> Some 256
-  | _ -> None
+  let bystrx_typ b = PrimType (Bystrx_typ b)
 
-(* Given a ByStrX string, return integer X *)
-let bystrx_width = function PrimType (Bystrx_typ w) -> Some w | _ -> None
-
-let is_prim_type = function PrimType _ -> true | _ -> false
-
-let is_int_type = function PrimType (Int_typ _) -> true | _ -> false
-
-let is_uint_type = function PrimType (Uint_typ _) -> true | _ -> false
-
-let is_bystrx_type = function PrimType (Bystrx_typ _) -> true | _ -> false
-
-(****************************************************************)
-(*                 Primitive Literal Utilities                  *)
-(****************************************************************)
-
-(* Is string representation of integer valid for integer typ. *)
-let validate_int_string pt x =
-  let open String in
-  try
-    match pt with
-    | Int_typ Bits32 -> Int32.to_string (Int32.of_string x) = x
-    | Int_typ Bits64 -> Int64.to_string (Int64.of_string x) = x
-    | Int_typ Bits128 -> Int128.to_string (Int128.of_string x) = x
-    | Int_typ Bits256 -> Int256.to_string (Int256.of_string x) = x
-    | Uint_typ Bits32 -> Uint32.to_string (Uint32.of_string x) = x
-    | Uint_typ Bits64 -> Uint64.to_string (Uint64.of_string x) = x
-    | Uint_typ Bits128 -> Uint128.to_string (Uint128.of_string x) = x
-    | Uint_typ Bits256 -> Uint256.to_string (Uint256.of_string x) = x
-    | _ -> false
-  with _ -> false
-
-(* Given an integer type and the value (as string),
-   build IntLit or UintLit out of it. *)
-let build_int pt v =
-  let validator_wrapper l = Option.some_if (validate_int_string pt v) l in
-  try
-    match pt with
-    | Int_typ Bits32 -> validator_wrapper (IntLit (Int32L (Int32.of_string v)))
-    | Int_typ Bits64 -> validator_wrapper (IntLit (Int64L (Int64.of_string v)))
-    | Int_typ Bits128 ->
-        validator_wrapper (IntLit (Int128L (Stdint.Int128.of_string v)))
-    | Int_typ Bits256 ->
-        validator_wrapper (IntLit (Int256L (Int256.of_string v)))
-    | Uint_typ Bits32 ->
-        validator_wrapper (UintLit (Uint32L (Stdint.Uint32.of_string v)))
-    | Uint_typ Bits64 ->
-        validator_wrapper (UintLit (Uint64L (Stdint.Uint64.of_string v)))
-    | Uint_typ Bits128 ->
-        validator_wrapper (UintLit (Uint128L (Stdint.Uint128.of_string v)))
-    | Uint_typ Bits256 ->
-        validator_wrapper (UintLit (Uint256L (Uint256.of_string v)))
+  let int_width = function
+    | PrimType (Int_typ Bits32) | PrimType (Uint_typ Bits32) -> Some 32
+    | PrimType (Int_typ Bits64) | PrimType (Uint_typ Bits64) -> Some 64
+    | PrimType (Int_typ Bits128) | PrimType (Uint_typ Bits128) -> Some 128
+    | PrimType (Int_typ Bits256) | PrimType (Uint_typ Bits256) -> Some 256
     | _ -> None
-  with _ -> None
 
-let int_lit_width = function
-  | Int32L _ -> 32
-  | Int64L _ -> 64
-  | Int128L _ -> 128
-  | Int256L _ -> 256
+  (* Given a ByStrX string, return integer X *)
+  let bystrx_width = function PrimType (Bystrx_typ w) -> Some w | _ -> None
 
-let string_of_int_lit = function
-  | Int32L i' -> Int32.to_string i'
-  | Int64L i' -> Int64.to_string i'
-  | Int128L i' -> Int128.to_string i'
-  | Int256L i' -> Int256.to_string i'
+  let is_prim_type = function PrimType _ -> true | _ -> false
 
-let uint_lit_width = function
-  | Uint32L _ -> 32
-  | Uint64L _ -> 64
-  | Uint128L _ -> 128
-  | Uint256L _ -> 256
+  let is_int_type = function PrimType (Int_typ _) -> true | _ -> false
 
-let string_of_uint_lit = function
-  | Uint32L i' -> Uint32.to_string i'
-  | Uint64L i' -> Uint64.to_string i'
-  | Uint128L i' -> Uint128.to_string i'
-  | Uint256L i' -> Uint256.to_string i'
+  let is_uint_type = function PrimType (Uint_typ _) -> true | _ -> false
 
-(* Scilla only allows printable ASCII characters from 32 (0x20) up-to 126 (0x7e).
- * The only exceptions allowed are various whitespaces: \b \f \n \r \t. *)
-let validate_string_literal s =
-  let specials = [ '\b'; '\012'; '\n'; '\r'; '\t' ] in
-  String.fold s ~init:true ~f:(fun safe c ->
-      if not safe then false
-      else
-        let c_int = Char.to_int c in
-        if c_int >= 32 && c_int <= 126 then true
-        else if List.mem specials c ~equal:Char.( = ) then true
-        else false)
+  let is_bystrx_type = function PrimType (Bystrx_typ _) -> true | _ -> false
 
-let build_prim_literal pt v =
-  match pt with
-  | Int_typ _ | Uint_typ _ -> build_int pt v
-  | String_typ -> Option.some_if (validate_string_literal v) (StringLit v)
-  | Bnum_typ ->
-      Option.some_if
-        (let re = Str.regexp "[0-9]+$" in
-         Str.string_match re v 0)
-        (BNum v)
-  | Bystr_typ -> Some (ByStr (Bystr.parse_hex v))
-  | Bystrx_typ _ -> Some (ByStrX (Bystrx.parse_hex v))
-  | _ -> None
+  (****************************************************************)
+  (*                 Primitive Literal Utilities                  *)
+  (****************************************************************)
+
+  (* Is string representation of integer valid for integer typ. *)
+  let validate_int_string pt x =
+    let open String in
+    try
+      match pt with
+      | Int_typ Bits32 -> Int32.to_string (Int32.of_string x) = x
+      | Int_typ Bits64 -> Int64.to_string (Int64.of_string x) = x
+      | Int_typ Bits128 -> Int128.to_string (Int128.of_string x) = x
+      | Int_typ Bits256 -> Int256.to_string (Int256.of_string x) = x
+      | Uint_typ Bits32 -> Uint32.to_string (Uint32.of_string x) = x
+      | Uint_typ Bits64 -> Uint64.to_string (Uint64.of_string x) = x
+      | Uint_typ Bits128 -> Uint128.to_string (Uint128.of_string x) = x
+      | Uint_typ Bits256 -> Uint256.to_string (Uint256.of_string x) = x
+      | _ -> false
+    with _ -> false
+
+  (* Given an integer type and the value (as string),
+     build IntLit or UintLit out of it. *)
+  let build_int pt v =
+    let validator_wrapper l = Option.some_if (validate_int_string pt v) l in
+    try
+      match pt with
+      | Int_typ Bits32 -> validator_wrapper (IntLit (Int32L (Int32.of_string v)))
+      | Int_typ Bits64 -> validator_wrapper (IntLit (Int64L (Int64.of_string v)))
+      | Int_typ Bits128 ->
+          validator_wrapper (IntLit (Int128L (Stdint.Int128.of_string v)))
+      | Int_typ Bits256 ->
+          validator_wrapper (IntLit (Int256L (Int256.of_string v)))
+      | Uint_typ Bits32 ->
+          validator_wrapper (UintLit (Uint32L (Stdint.Uint32.of_string v)))
+      | Uint_typ Bits64 ->
+          validator_wrapper (UintLit (Uint64L (Stdint.Uint64.of_string v)))
+      | Uint_typ Bits128 ->
+          validator_wrapper (UintLit (Uint128L (Stdint.Uint128.of_string v)))
+      | Uint_typ Bits256 ->
+          validator_wrapper (UintLit (Uint256L (Uint256.of_string v)))
+      | _ -> None
+    with _ -> None
+
+  let int_lit_width = function
+    | Int32L _ -> 32
+    | Int64L _ -> 64
+    | Int128L _ -> 128
+    | Int256L _ -> 256
+
+  let string_of_int_lit = function
+    | Int32L i' -> Int32.to_string i'
+    | Int64L i' -> Int64.to_string i'
+    | Int128L i' -> Int128.to_string i'
+    | Int256L i' -> Int256.to_string i'
+
+  let uint_lit_width = function
+    | Uint32L _ -> 32
+    | Uint64L _ -> 64
+    | Uint128L _ -> 128
+    | Uint256L _ -> 256
+
+  let string_of_uint_lit = function
+    | Uint32L i' -> Uint32.to_string i'
+    | Uint64L i' -> Uint64.to_string i'
+    | Uint128L i' -> Uint128.to_string i'
+    | Uint256L i' -> Uint256.to_string i'
+
+  (* Scilla only allows printable ASCII characters from 32 (0x20) up-to 126 (0x7e).
+   * The only exceptions allowed are various whitespaces: \b \f \n \r \t. *)
+  let validate_string_literal s =
+    let specials = [ '\b'; '\012'; '\n'; '\r'; '\t' ] in
+    String.fold s ~init:true ~f:(fun safe c ->
+        if not safe then false
+        else
+          let c_int = Char.to_int c in
+          if c_int >= 32 && c_int <= 126 then true
+          else if List.mem specials c ~equal:Char.( = ) then true
+          else false)
+
+  let build_prim_literal pt v =
+    match pt with
+    | Int_typ _ | Uint_typ _ -> build_int pt v
+    | String_typ -> Option.some_if (validate_string_literal v) (StringLit v)
+    | Bnum_typ ->
+        Option.some_if
+          (let re = Str.regexp "[0-9]+$" in
+           Str.string_match re v 0)
+          (BNum v)
+    | Bystr_typ -> Some (ByStr (Bystr.parse_hex v))
+    | Bystrx_typ _ -> Some (ByStrX (Bystrx.parse_hex v))
+    | _ -> None
+
+end

--- a/src/base/PrimTypes.mli
+++ b/src/base/PrimTypes.mli
@@ -2,86 +2,103 @@
   This file is part of scilla.
 
   Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
-  
+
   scilla is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software
   Foundation, either version 3 of the License, or (at your option) any later
   version.
- 
+
   scilla is distributed in the hope that it will be useful, but WITHOUT ANY
   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
   A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
- 
+
   You should have received a copy of the GNU General Public License along with
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
 open Syntax
 
-(****************************************************************)
-(*                     PrimType utilities                       *)
-(****************************************************************)
+module type PrimTypes = functor
+  (Types : sig
+     include Types
+     val PrimType : prim_typ -> typ
+   end
+  )
+  (Literals : sig
+     include Literals
+     type uint_lit
+     type int_lit
+     end) -> sig
 
-val is_prim_type : typ -> bool
+  open Types
+  open Literals
+  
+  (****************************************************************)
+  (*                     PrimType utilities                       *)
+  (****************************************************************)
 
-val is_int_type : typ -> bool
+  val is_prim_type : typ -> bool
 
-val is_uint_type : typ -> bool
+  val is_int_type : typ -> bool
 
-val is_bystrx_type : typ -> bool
+  val is_uint_type : typ -> bool
 
-val int_width : typ -> int option
+  val is_bystrx_type : typ -> bool
 
-val int32_typ : typ
+  val int_width : typ -> int option
 
-val int64_typ : typ
+  val int32_typ : typ
 
-val int128_typ : typ
+  val int64_typ : typ
 
-val int256_typ : typ
+  val int128_typ : typ
 
-val uint32_typ : typ
+  val int256_typ : typ
 
-val uint64_typ : typ
+  val uint32_typ : typ
 
-val uint128_typ : typ
+  val uint64_typ : typ
 
-val uint256_typ : typ
+  val uint128_typ : typ
 
-val string_typ : typ
+  val uint256_typ : typ
 
-val bnum_typ : typ
+  val string_typ : typ
 
-val msg_typ : typ
+  val bnum_typ : typ
 
-val event_typ : typ
+  val msg_typ : typ
 
-val exception_typ : typ
+  val event_typ : typ
 
-val bystr_typ : typ
+  val exception_typ : typ
 
-val bystrx_typ : int -> typ
+  val bystr_typ : typ
 
-(* Given a ByStrX, return integer X *)
-val bystrx_width : typ -> int option
+  val bystrx_typ : int -> typ
 
-(****************************************************************)
-(*            PrimType Literal utilities                        *)
-(****************************************************************)
+  (* Given a ByStrX, return integer X *)
+  val bystrx_width : typ -> int option
 
-val build_prim_literal : prim_typ -> string -> literal option
+  (****************************************************************)
+  (*            PrimType Literal utilities                        *)
+  (****************************************************************)
 
-(* Is string representation of integer valid for integer typ. *)
-val validate_int_string : prim_typ -> string -> bool
+  val build_prim_literal : prim_typ -> string -> literal option
 
-(* Get bit-width if int_lit. *)
-val int_lit_width : int_lit -> int
+  (* Is string representation of integer valid for integer typ. *)
+  val validate_int_string : prim_typ -> string -> bool
 
-(* Get bit-width if uint_lit. *)
-val uint_lit_width : uint_lit -> int
+  (* Get bit-width if int_lit. *)
+  val int_lit_width : int_lit -> int
 
-(* String conversion from int_typ *)
-val string_of_int_lit : int_lit -> string
+  (* Get bit-width if uint_lit. *)
+  val uint_lit_width : uint_lit -> int
 
-(* String conversion from uint_typ *)
-val string_of_uint_lit : uint_lit -> string
+  (* String conversion from int_typ *)
+  val string_of_int_lit : int_lit -> string
+
+  (* String conversion from uint_typ *)
+  val string_of_uint_lit : uint_lit -> string
+
+end

--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -29,6 +29,10 @@ exception SyntaxError of string * loc
 (* Version of the interpreter (major, minor, patch) *)
 let scilla_version = (0, 6, 0)
 
+module type Identifiers = sig
+  type 'a ident
+end
+
 module ScillaIdentifiers (Names : QualifiedNames) = struct
   type 'rep ident = Ident of Names.name * 'rep [@@deriving sexp]
 
@@ -55,6 +59,7 @@ module ScillaIdentifiers (Names : QualifiedNames) = struct
 
   let as_string i = Names.as_string (get_id i)
 
+  let as_error_string i = Names.as_error_string (get_id i)
 end
 
 (*******************************************************)
@@ -95,10 +100,14 @@ let sexp_of_prim_typ = function
 
 let prim_typ_of_sexp _ = failwith "prim_typ_of_sexp is not implemented"
 
+module type Types = sig
+  type typ
+end
+
 module ScillaTypes (Names : QualifiedNames) = struct
 
-  module TypeIdentifiers = ScillaIdentifiers (Names)
-  open TypeIdentifiers
+  module Identifiers = ScillaIdentifiers (Names)
+  open Identifiers
   
   type typ =
     | PrimType of prim_typ
@@ -260,6 +269,9 @@ end
 (*******************************************************)
 (*                      Literals                       *)
 (*******************************************************)
+module type Literals = sig
+  type literal
+end
 
 module ScillaLiterals (Names : QualifiedNames) = struct
 
@@ -933,7 +945,7 @@ module ScillaSyntax (SR : Rep) (ER : Rep) (Names : QualifiedNames) = struct
   (*                  Better error reporting                      *)
   (****************************************************************)
   let get_failure_msg erep phase opt =
-    let as_error_string i = Names.as_error_string (get_id i) in
+    let as_error_string i = as_error_string i in
     let e, rep = erep in
     let sloc = ER.get_loc rep in
     ( ( match e with

--- a/src/base/TypeUtil.mli
+++ b/src/base/TypeUtil.mli
@@ -20,6 +20,13 @@ open Core_kernel
 open ErrorUtils
 open Syntax
 
+module TUIdentifiers : Identifiers
+module TUTypes : Types
+module TULiterals : Literals
+open TUIdentifiers
+open TUTypes
+open TULiterals
+
 (* An inferred type with possible qualifiers *)
 type 'rep inferred_type = { tp : typ; qual : 'rep } [@@deriving sexp]
 


### PR DESCRIPTION
This draft shows how I intend to fix the problem with qualified names.

Start by looking at the newly introduced Names.ml. This file defined 3 structs, each of which defines a way of representing a qualified name.

The first struct `FlattenedNames` is the way we are doing it currently. I have added that so that I can do the refactoring without changing the semantics. Once the bug has been fixed, and the database migration has been dealt with, `FlattenedNames` can be removed.

The other two structs define local names and canonical names. 

In Syntax.ml I have parameterised identifiers, types, literals and syntax with a Names module, so that the AST definition stays the same, and only the representation of names is changed.

The idea is for the parser to use `ScillaSyntax(LocalNames)`, and then add a pass that translates from `ScillaSyntax(LocalNames)` to `ScillaSyntax(CanonicalNames)`. Once that has been done, all subsequent phases (including the evaluator post parsing) can use `ScillaSyntax(CanonicalNames)`.

Importantly, the JSON reader and writer will be forced to use `CanonicalNames`, so that the OCaml type system ensures that we can only ever read and write canonical names from and to JSONs.

For the database migration we can simply write a small utility that instantiates the JSON reader with `LocalNames`, write a small translation from `LocalNames` to `CanonicalNames`, and then output the result using the JSON writer instantiated with `CanonicalNames`.

I am pretty happy with this. :-)