### PR TITLE
Addressing Anton's comments on the refactoring of Syntax.ml

### DIFF
--- a/src/base/Accept.ml
+++ b/src/base/Accept.ml
@@ -29,7 +29,7 @@ open Core_kernel
 open! Int.Replace_polymorphic_compare
 open TypeUtil
 open ErrorUtils
-open Identifiers
+open Identifier
 open Syntax
 
 module ScillaAcceptChecker

--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -20,7 +20,7 @@ open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Identifiers
 open Types
-open Literals
+open Literal
 open Syntax
 open ErrorUtils
 open MonadUtil
@@ -612,7 +612,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let to_nat ls _ =
       match ls with
       | [ UintLit (Uint32L n) ] ->
-          let rec nat_builder (i : Uint32.t) (acc : Literals.literal) =
+          let rec nat_builder (i : Uint32.t) (acc : Literal.t) =
             if [%equal: uint32] i Uint32.zero then acc
             else nat_builder (Uint32.pred i) (ADTValue ("Succ", [], [ acc ]))
           in
@@ -1269,7 +1269,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     (* Takes the expected type as an argument to elaborate the result *)
     type built_in_executor =
-      literal list -> typ -> (literal, scilla_error list) result
+      Literal.t list -> typ -> (Literal.t, scilla_error list) result
 
     (* A built-in record type:
        * arity

--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -19,7 +19,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Identifier
-open Types
+open Type
 open Literal
 open Syntax
 open ErrorUtils
@@ -204,7 +204,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let eq_elab t ts =
       match ts with
-      | [ i1; i2 ] when [%equal: typ] i1 i2 && is_int_type i1 ->
+      | [ i1; i2 ] when [%equal: Type.t] i1 i2 && is_int_type i1 ->
           elab_tfun_with_args_no_gas t [ i1 ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -215,7 +215,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let binop_elab t ts =
       match ts with
-      | [ i1; i2 ] when [%equal: typ] i1 i2 && is_int_type i1 ->
+      | [ i1; i2 ] when [%equal: Type.t] i1 i2 && is_int_type i1 ->
           elab_tfun_with_args_no_gas t [ i1 ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -321,7 +321,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let pow_elab t ts =
       match ts with
-      | [ i1; i2 ] when is_int_type i1 && [%equal: typ] i2 uint32_typ ->
+      | [ i1; i2 ] when is_int_type i1 && [%equal: Type.t] i2 uint32_typ ->
           elab_tfun_with_args_no_gas t [ i1 ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -408,7 +408,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let eq_elab sc ts =
       match ts with
-      | [ i1; i2 ] when [%equal: typ] i1 i2 && is_uint_type i1 ->
+      | [ i1; i2 ] when [%equal: Type.t] i1 i2 && is_uint_type i1 ->
           elab_tfun_with_args_no_gas sc [ i1 ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -419,7 +419,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let binop_elab sc ts =
       match ts with
-      | [ i1; i2 ] when [%equal: typ] i1 i2 && is_uint_type i1 ->
+      | [ i1; i2 ] when [%equal: Type.t] i1 i2 && is_uint_type i1 ->
           elab_tfun_with_args_no_gas sc [ i1 ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -526,7 +526,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let pow_elab t ts =
       match ts with
-      | [ i1; i2 ] when is_uint_type i1 && [%equal: typ] i2 uint32_typ ->
+      | [ i1; i2 ] when is_uint_type i1 && [%equal: Type.t] i2 uint32_typ ->
           elab_tfun_with_args_no_gas t [ i1 ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -777,7 +777,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       match ts with
       | [ bstyp1; bstyp2 ]
         when (* We want both types to be ByStr with equal width. *)
-             is_bystrx_type bstyp1 && [%equal: typ] bstyp1 bstyp2 ->
+             is_bystrx_type bstyp1 && [%equal: Type.t] bstyp1 bstyp2 ->
           elab_tfun_with_args_no_gas sc [ bstyp1 ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -1126,7 +1126,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let contains_elab sc ts =
       match ts with
-      | [ MapType (kt, vt); u ] when [%equal: typ] kt u ->
+      | [ MapType (kt, vt); u ] when [%equal: Type.t] kt u ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -1148,7 +1148,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let put_elab sc ts =
       match ts with
       | [ MapType (kt, vt); kt'; vt' ]
-        when [%equal: typ] kt kt' && [%equal: typ] vt vt' ->
+        when [%equal: Type.t] kt kt' && [%equal: Type.t] vt vt' ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -1171,7 +1171,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let get_elab sc ts =
       match ts with
-      | [ MapType (kt, vt); kt' ] when [%equal: typ] kt kt' ->
+      | [ MapType (kt, vt); kt' ] when [%equal: Type.t] kt kt' ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -1193,7 +1193,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let remove_elab sc ts =
       match ts with
-      | [ MapType (kt, vt); u ] when [%equal: typ] kt u ->
+      | [ MapType (kt, vt); u ] when [%equal: Type.t] kt u ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -1265,11 +1265,11 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
   module BuiltInDictionary = struct
     (* Elaborates the operation type based on the arguments types *)
-    type elaborator = typ -> typ list -> (typ, scilla_error list) result
+    type elaborator = Type.t -> Type.t list -> (Type.t, scilla_error list) result
 
     (* Takes the expected type as an argument to elaborate the result *)
     type built_in_executor =
-      Literal.t list -> typ -> (Literal.t, scilla_error list) result
+      Literal.t list -> Type.t -> (Literal.t, scilla_error list) result
 
     (* A built-in record type:
        * arity
@@ -1278,7 +1278,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
          to support polymorphism -- e.g., for ints and maps
        * executor - operational semantics of the built-in
     *)
-    type built_in_record = int * typ * elaborator * built_in_executor
+    type built_in_record = int * Type.t * elaborator * built_in_executor
 
     [@@@ocamlformat "disable"]
 

--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -1265,7 +1265,8 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
   module BuiltInDictionary = struct
     (* Elaborates the operation type based on the arguments types *)
-    type elaborator = Type.t -> Type.t list -> (Type.t, scilla_error list) result
+    type elaborator =
+      Type.t -> Type.t list -> (Type.t, scilla_error list) result
 
     (* Takes the expected type as an argument to elaborate the result *)
     type built_in_executor =

--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -18,7 +18,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
-open Identifiers
+open Identifier
 open Types
 open Literal
 open Syntax

--- a/src/base/BuiltIns.mli
+++ b/src/base/BuiltIns.mli
@@ -16,7 +16,6 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Types
 open Syntax
 open ErrorUtils
 open Core_kernel
@@ -30,7 +29,7 @@ module UsefulLiterals : sig
 
   val some_lit : Literal.t -> (Literal.t, ErrorUtils.scilla_error list) result
 
-  val none_lit : typ -> Literal.t
+  val none_lit : Type.t -> Literal.t
 
   val pair_lit :
     Literal.t -> Literal.t -> (Literal.t, ErrorUtils.scilla_error list) result
@@ -39,7 +38,7 @@ end
 module ScillaBuiltIns (SR : Rep) (ER : Rep) : sig
   module BuiltInDictionary : sig
     type built_in_executor =
-      Literal.t list -> typ -> (Literal.t, scilla_error list) result
+      Literal.t list -> Type.t -> (Literal.t, scilla_error list) result
 
     (* The return result is a triple:
      * The full elaborated type of the operation, e.g., string -> Bool
@@ -48,10 +47,10 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) : sig
      *)
     val find_builtin_op :
       ER.rep builtin_annot ->
-      typ list ->
-      (typ * typ * built_in_executor, scilla_error list) result
+      Type.t list ->
+      (Type.t * Type.t * built_in_executor, scilla_error list) result
   end
 
   (* Elaborator for the built-in typ *)
-  val elab_id : typ -> typ list -> (typ, scilla_error list) result
+  val elab_id : Type.t -> Type.t list -> (Type.t, scilla_error list) result
 end

--- a/src/base/BuiltIns.mli
+++ b/src/base/BuiltIns.mli
@@ -17,30 +17,29 @@
 *)
 
 open Types
-open Literals
 open Syntax
 open ErrorUtils
 open Core_kernel
 
 module UsefulLiterals : sig
-  val true_lit : literal
+  val true_lit : Literal.t
 
-  val false_lit : literal
+  val false_lit : Literal.t
 
-  val to_Bool : bool -> literal
+  val to_Bool : bool -> Literal.t
 
-  val some_lit : literal -> (literal, ErrorUtils.scilla_error list) result
+  val some_lit : Literal.t -> (Literal.t, ErrorUtils.scilla_error list) result
 
-  val none_lit : typ -> literal
+  val none_lit : typ -> Literal.t
 
   val pair_lit :
-    literal -> literal -> (literal, ErrorUtils.scilla_error list) result
+    Literal.t -> Literal.t -> (Literal.t, ErrorUtils.scilla_error list) result
 end
 
 module ScillaBuiltIns (SR : Rep) (ER : Rep) : sig
   module BuiltInDictionary : sig
     type built_in_executor =
-      literal list -> typ -> (literal, scilla_error list) result
+      Literal.t list -> typ -> (Literal.t, scilla_error list) result
 
     (* The return result is a triple:
      * The full elaborated type of the operation, e.g., string -> Bool

--- a/src/base/Cashflow.ml
+++ b/src/base/Cashflow.ml
@@ -18,7 +18,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Sexplib.Std
-open Identifiers
+open Identifier
 open Types
 open Syntax
 open Datatypes

--- a/src/base/Cashflow.ml
+++ b/src/base/Cashflow.ml
@@ -19,7 +19,7 @@ open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Sexplib.Std
 open Identifier
-open Types
+open Type
 open Syntax
 open Datatypes
 open TypeUtil

--- a/src/base/Checker.ml
+++ b/src/base/Checker.ml
@@ -18,7 +18,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
-open Identifiers
+open Identifier
 open Syntax
 open ErrorUtils
 open PrettyPrinters

--- a/src/base/ContractUtil.ml
+++ b/src/base/ContractUtil.ml
@@ -18,7 +18,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
-open Identifiers
+open Identifier
 open Literal
 open Syntax
 open MonadUtil

--- a/src/base/ContractUtil.ml
+++ b/src/base/ContractUtil.ml
@@ -19,7 +19,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Identifiers
-open Literals
+open Literal
 open Syntax
 open MonadUtil
 open Stdint

--- a/src/base/Datatypes.ml
+++ b/src/base/Datatypes.ml
@@ -18,7 +18,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
-open Identifiers
+open Identifier
 open Types
 open Literal
 open MonadUtil

--- a/src/base/Datatypes.ml
+++ b/src/base/Datatypes.ml
@@ -19,7 +19,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Identifier
-open Types
+open Type
 open Literal
 open MonadUtil
 open Result.Let_syntax
@@ -48,7 +48,7 @@ type adt = {
   (* Mapping for constructors' types
      The arity of the constructor is the same as the length
      of the list, so the types are mapped correspondingly. *)
-  tmap : (string * typ list) list;
+  tmap : (string * Type.t list) list;
 }
 [@@deriving equal]
 
@@ -237,8 +237,8 @@ module SnarkTypes = struct
   let scilla_g1point_to_ocaml g1p =
     match g1p with
     | ADTValue ("Pair", [ pxt; pyt ], [ ByStrX px; ByStrX py ])
-      when [%equal: typ] pxt scalar_type
-           && [%equal: typ] pyt scalar_type
+      when [%equal: Type.t] pxt scalar_type
+           && [%equal: Type.t] pyt scalar_type
            && Bystrx.width px = scalar_len
            && Bystrx.width py = scalar_len ->
         pure { g1x = Bystrx.to_raw_bytes px; g1y = Bystrx.to_raw_bytes py }
@@ -247,8 +247,8 @@ module SnarkTypes = struct
   let scilla_g2point_to_ocaml g2p =
     match g2p with
     | ADTValue ("Pair", [ pxt; pyt ], [ ByStrX px; ByStrX py ])
-      when [%equal: typ] pxt g2comp_type
-           && [%equal: typ] pyt g2comp_type
+      when [%equal: Type.t] pxt g2comp_type
+           && [%equal: Type.t] pyt g2comp_type
            && Bystrx.width px = g2comp_len
            && Bystrx.width py = g2comp_len ->
         pure { g2x = Bystrx.to_raw_bytes px; g2y = Bystrx.to_raw_bytes py }
@@ -271,8 +271,8 @@ module SnarkTypes = struct
       mapM g1g2ol ~f:(fun g1g2p_lit ->
           match g1g2p_lit with
           | ADTValue ("Pair", [ g1pt; g2pt ], [ g1p; g2p ])
-            when [%equal: typ] g1pt g1point_type
-                 && [%equal: typ] g2pt g2point_type ->
+            when [%equal: Type.t] g1pt g1point_type
+                 && [%equal: Type.t] g2pt g2point_type ->
               let%bind g1p' = scilla_g1point_to_ocaml g1p in
               let%bind g2p' = scilla_g2point_to_ocaml g2p in
               pure (g1p', g2p')

--- a/src/base/Datatypes.ml
+++ b/src/base/Datatypes.ml
@@ -20,7 +20,7 @@ open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Identifiers
 open Types
-open Literals
+open Literal
 open MonadUtil
 open Result.Let_syntax
 

--- a/src/base/Datatypes.mli
+++ b/src/base/Datatypes.mli
@@ -77,7 +77,8 @@ module DataTypeDictionary : sig
   val pair_typ : Type.t -> Type.t -> Type.t
 end
 
-val scilla_list_to_ocaml : Literal.t -> (Literal.t list, scilla_error list) result
+val scilla_list_to_ocaml :
+  Literal.t -> (Literal.t list, scilla_error list) result
 
 val scilla_list_to_ocaml_rev :
   Literal.t -> (Literal.t list, scilla_error list) result

--- a/src/base/Datatypes.mli
+++ b/src/base/Datatypes.mli
@@ -16,7 +16,6 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Types
 open ErrorUtils
 open Core_kernel
 
@@ -35,7 +34,7 @@ type adt = {
   tname : string;
   tparams : string list;
   tconstr : constructor list;
-  tmap : (string * typ list) list;
+  tmap : (string * Type.t list) list;
 }
 [@@deriving equal]
 
@@ -56,7 +55,7 @@ module DataTypeDictionary : sig
     (adt * constructor, scilla_error list) result
 
   (* Get typing map for a constructor *)
-  val constr_tmap : adt -> string -> typ list option
+  val constr_tmap : adt -> string -> Type.t list option
 
   (* Get all known ADTs *)
   val get_all_adts : unit -> adt list
@@ -67,15 +66,15 @@ module DataTypeDictionary : sig
   val add_adt : adt -> loc -> (unit, scilla_error list) result
 
   (*  Built-in ADTs  *)
-  val bool_typ : typ
+  val bool_typ : Type.t
 
-  val nat_typ : typ
+  val nat_typ : Type.t
 
-  val option_typ : typ -> typ
+  val option_typ : Type.t -> Type.t
 
-  val list_typ : typ -> typ
+  val list_typ : Type.t -> Type.t
 
-  val pair_typ : typ -> typ -> typ
+  val pair_typ : Type.t -> Type.t -> Type.t
 end
 
 val scilla_list_to_ocaml : Literal.t -> (Literal.t list, scilla_error list) result
@@ -86,17 +85,17 @@ val scilla_list_to_ocaml_rev :
 open Snark
 
 module SnarkTypes : sig
-  val scalar_type : typ
+  val scalar_type : Type.t
 
-  val g1point_type : typ
+  val g1point_type : Type.t
 
-  val g2point_type : typ
+  val g2point_type : Type.t
 
-  val g2comp_type : typ
+  val g2comp_type : Type.t
 
-  val g1g2pair_type : typ
+  val g1g2pair_type : Type.t
 
-  val g1g2pair_list_type : typ
+  val g1g2pair_list_type : Type.t
 
   val scilla_scalar_to_ocaml : Literal.t -> (scalar, scilla_error list) result
 

--- a/src/base/Datatypes.mli
+++ b/src/base/Datatypes.mli
@@ -17,7 +17,6 @@
 *)
 
 open Types
-open Literals
 open ErrorUtils
 open Core_kernel
 
@@ -79,10 +78,10 @@ module DataTypeDictionary : sig
   val pair_typ : typ -> typ -> typ
 end
 
-val scilla_list_to_ocaml : literal -> (literal list, scilla_error list) result
+val scilla_list_to_ocaml : Literal.t -> (Literal.t list, scilla_error list) result
 
 val scilla_list_to_ocaml_rev :
-  literal -> (literal list, scilla_error list) result
+  Literal.t -> (Literal.t list, scilla_error list) result
 
 open Snark
 
@@ -99,13 +98,13 @@ module SnarkTypes : sig
 
   val g1g2pair_list_type : typ
 
-  val scilla_scalar_to_ocaml : literal -> (scalar, scilla_error list) result
+  val scilla_scalar_to_ocaml : Literal.t -> (scalar, scilla_error list) result
 
-  val scilla_g1point_to_ocaml : literal -> (g1point, scilla_error list) result
+  val scilla_g1point_to_ocaml : Literal.t -> (g1point, scilla_error list) result
 
   val scilla_g1g2pairlist_to_ocaml :
-    literal -> ((g1point * g2point) list, scilla_error list) result
+    Literal.t -> ((g1point * g2point) list, scilla_error list) result
 
   val ocaml_g1point_to_scilla_lit :
-    g1point -> (literal, scilla_error list) result
+    g1point -> (Literal.t, scilla_error list) result
 end

--- a/src/base/EventInfo.ml
+++ b/src/base/EventInfo.ml
@@ -2,7 +2,7 @@ open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Result.Let_syntax
 open TypeUtil
-open Identifiers
+open Identifier
 open Types
 open Syntax
 open ContractUtil.MessagePayload

--- a/src/base/EventInfo.ml
+++ b/src/base/EventInfo.ml
@@ -3,7 +3,7 @@ open! Int.Replace_polymorphic_compare
 open Result.Let_syntax
 open TypeUtil
 open Identifier
-open Types
+open Type
 open Syntax
 open ContractUtil.MessagePayload
 open MonadUtil
@@ -77,7 +77,7 @@ struct
                 && (* Check that each entry in tlist is equal to the same entry in m_types. *)
                 List.for_all tlist ~f:(fun (n1, t1) ->
                     List.exists m_types ~f:(fun (n2, t2) ->
-                        String.(n1 = n2) && [%equal: typ] t2 t1))
+                        String.(n1 = n2) && [%equal: Type.t] t2 t1))
               in
               if not @@ matcher m_types tlist then
                 fail1

--- a/src/base/FrontEndParser.mli
+++ b/src/base/FrontEndParser.mli
@@ -16,7 +16,6 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Types
 open Syntax
 open ErrorUtils
 open Lexing
@@ -38,7 +37,7 @@ val parse_file :
   (position -> 'a MInter.checkpoint) -> string -> ('a, scilla_error list) result
 
 (* Parse a Scilla type *)
-val parse_type : string -> (typ, scilla_error list) result
+val parse_type : string -> (Type.t, scilla_error list) result
 
 (* Parse an expression *)
 val parse_expr : string -> (ParsedSyntax.expr_annot, scilla_error list) result

--- a/src/base/Gas.ml
+++ b/src/base/Gas.ml
@@ -21,7 +21,7 @@ open! Int.Replace_polymorphic_compare
 open ErrorUtils
 open Result.Let_syntax
 open MonadUtil
-open Types
+open Type
 open Literal
 open Syntax
 open TypeUtil
@@ -164,7 +164,7 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
     builtin -> Literal.t list -> int -> (int, scilla_error list) result
 
   (* op, arg types, coster, base cost. *)
-  type builtin_record = builtin * typ list * coster * int
+  type builtin_record = builtin * Type.t list * coster * int
 
   (* a static coster that only looks at base cost. *)
   let base_coster (_ : builtin) (_ : Literal.t list) base = pure base
@@ -370,7 +370,7 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
         && List.for_all2_exn
              ~f:(fun t1 t2 ->
                (* the types should match *)
-               [%equal: typ] t1 t2
+               [%equal: Type.t] t1 t2
                ||
                (* or the built-in record is generic *)
                match t2 with TypeVar _ -> true | _ -> false)

--- a/src/base/Gas.ml
+++ b/src/base/Gas.ml
@@ -22,7 +22,7 @@ open ErrorUtils
 open Result.Let_syntax
 open MonadUtil
 open Types
-open Literals
+open Literal
 open Syntax
 open TypeUtil
 open PrimTypes
@@ -161,13 +161,13 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
   (* A signature for functions that determine dynamic cost of built-in ops. *)
   (* op -> arguments -> base cost -> total cost *)
   type coster =
-    builtin -> literal list -> int -> (int, scilla_error list) result
+    builtin -> Literal.t list -> int -> (int, scilla_error list) result
 
   (* op, arg types, coster, base cost. *)
   type builtin_record = builtin * typ list * coster * int
 
   (* a static coster that only looks at base cost. *)
-  let base_coster (_ : builtin) (_ : literal list) base = pure base
+  let base_coster (_ : builtin) (_ : Literal.t list) base = pure base
 
   let string_coster op args base =
     match (op, args) with

--- a/src/base/GasUseAnalysis.ml
+++ b/src/base/GasUseAnalysis.ml
@@ -20,7 +20,7 @@
 open Core_kernel.Result.Let_syntax
 open TypeUtil
 open Identifier
-open Types
+open Type
 open Syntax
 open ErrorUtils
 open MonadUtil
@@ -32,7 +32,7 @@ module ScillaGUA
 
       val get_type : rep -> PlainTypes.t inferred_type
 
-      val mk_id : loc Identifier.t -> typ -> rep Identifier.t
+      val mk_id : loc Identifier.t -> Type.t -> rep Identifier.t
     end) =
 struct
   module SER = SR

--- a/src/base/GasUseAnalysis.ml
+++ b/src/base/GasUseAnalysis.ml
@@ -19,7 +19,7 @@
 
 open Core_kernel.Result.Let_syntax
 open TypeUtil
-open Identifiers
+open Identifier
 open Types
 open Syntax
 open ErrorUtils
@@ -32,7 +32,7 @@ module ScillaGUA
 
       val get_type : rep -> PlainTypes.t inferred_type
 
-      val mk_id : loc ident -> typ -> rep ident
+      val mk_id : loc Identifier.t -> typ -> rep Identifier.t
     end) =
 struct
   module SER = SR
@@ -44,7 +44,7 @@ struct
 
   type sizeref =
     (* Refer to the size of a variable. *)
-    | Base of ER.rep ident
+    | Base of ER.rep Identifier.t
     (* For Lengths of Lists and Maps. *)
     | Length of sizeref
     (* For Elements of Lists and Maps. *)
@@ -62,17 +62,17 @@ struct
     | BApp of builtin * sizeref list
     (* The growth of accummulator (a recurrence) in list_foldr.
      * The semantics is similar to SApp, except that, the ressize of
-     * applying "ident" is taken as a recurence and solved for the
+     * applying "Identifier.t" is taken as a recurence and solved for the
      * length of the second sizeref (accumulator) actual. The first
      * sizeref actual is Element(list being folded). *)
-    | RFoldAcc of ER.rep ident * sizeref * sizeref
+    | RFoldAcc of ER.rep Identifier.t * sizeref * sizeref
     (* Same as RFoldAcc, but for list_foldl:
      * order of the two sizeref actuals are reversed. *)
-    | LFoldAcc of ER.rep ident * sizeref * sizeref
+    | LFoldAcc of ER.rep Identifier.t * sizeref * sizeref
     (* Lambda for unknown sizeref (from applying higher order functions). 
-     * TODO: Use "sizeref" instead of "ident" to handle applying wrapped functions,
+     * TODO: Use "sizeref" instead of "Identifier.t" to handle applying wrapped functions,
              where for example `x = fst arg` and we're applying `x`. *)
-    | SApp of ER.rep ident * sizeref list
+    | SApp of ER.rep Identifier.t * sizeref list
     (* When we cannot determine the size *)
     | Intractable of string
 
@@ -81,9 +81,9 @@ struct
     (* Gas use depends on size of a value *)
     | SizeOf of sizeref
     (* Applying a higher order argument (function) and its arguments. *)
-    (* TODO: Use "sizeref" instead of "ident" to handle applying wrapped functions,
+    (* TODO: Use "sizeref" instead of "Identifier.t" to handle applying wrapped functions,
              where for example `x = fst arg` and we're applying `x`. *)
-    | GApp of ER.rep ident * sizeref list
+    | GApp of ER.rep Identifier.t * sizeref list
     (* Gas usage polynomial which is known and needs to be expanded. 
      * When a GApp resolves successfully, we replace it with GPol. *)
     | GPol of guref polynomial
@@ -92,7 +92,7 @@ struct
    * The identifier list specifies the arguments which must be substituted.
    * Signatures that contain "GApp/SApp" will (recursively) be substituted for
    * the final signature to not have these lambdas. *)
-  type signature = ER.rep ident list * sizeref * guref polynomial
+  type signature = ER.rep Identifier.t list * sizeref * guref polynomial
 
   (* Given a size reference, print a description for it. *)
   let rec sprint_sizeref = function

--- a/src/base/Identifier.ml
+++ b/src/base/Identifier.ml
@@ -19,7 +19,7 @@
 open Core_kernel
 open ErrorUtils
 
-type 'rep ident = Ident of string * 'rep [@@deriving sexp]
+type 'rep t = Ident of string * 'rep [@@deriving sexp]
 
 let asId i = Ident (i, dummy_loc)
 

--- a/src/base/Identifier.mli
+++ b/src/base/Identifier.mli
@@ -18,21 +18,21 @@
 
 open ErrorUtils
 
-type 'rep ident = Ident of string * 'rep [@@deriving sexp]
+type 'rep t = Ident of string * 'rep [@@deriving sexp]
 
-val asId : string -> loc ident
+val asId : string -> loc t
 
-val asIdL : string -> 'a -> 'a ident
+val asIdL : string -> 'a -> 'a t
 
-val get_id : 'a ident -> string
+val get_id : 'a t -> string
 
-val get_rep : 'a ident -> 'a
+val get_rep : 'a t -> 'a
 
 (* A few utilities on id. *)
-val equal_id : 'a ident -> 'b ident -> bool
+val equal_id : 'a t -> 'b t -> bool
 
-val compare_id : 'a ident -> 'b ident -> int
+val compare_id : 'a t -> 'b t -> int
 
-val dedup_id_list : 'a ident list -> 'a ident list
+val dedup_id_list : 'a t list -> 'a t list
 
-val is_mem_id : 'a ident -> 'a ident list -> bool
+val is_mem_id : 'a t -> 'a t list -> bool

--- a/src/base/JSON.ml
+++ b/src/base/JSON.ml
@@ -20,7 +20,7 @@ open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Identifiers
 open Types
-open Literals
+open Literal
 open Syntax
 open ErrorUtils
 open Yojson

--- a/src/base/JSON.ml
+++ b/src/base/JSON.ml
@@ -311,7 +311,8 @@ module ContractState = struct
                 match sp with
                 | ADTValue ("Pair", [ t1; t2 ], [ StringLit name; ByStrX bs ])
                   when [%equal: Type.t] t1 PrimTypes.string_typ
-                       && [%equal: Type.t] t2 (PrimTypes.bystrx_typ address_length)
+                       && [%equal: Type.t] t2
+                            (PrimTypes.bystrx_typ address_length)
                        && Bystrx.width bs = address_length ->
                     (name, Bystrx.hex_encoding bs)
                 | _ ->

--- a/src/base/JSON.ml
+++ b/src/base/JSON.ml
@@ -18,7 +18,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
-open Identifiers
+open Identifier
 open Types
 open Literal
 open Syntax

--- a/src/base/JSON.ml
+++ b/src/base/JSON.ml
@@ -19,7 +19,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Identifier
-open Types
+open Type
 open Literal
 open Syntax
 open ErrorUtils
@@ -310,8 +310,8 @@ module ContractState = struct
             List.map lit' ~f:(fun sp ->
                 match sp with
                 | ADTValue ("Pair", [ t1; t2 ], [ StringLit name; ByStrX bs ])
-                  when [%equal: typ] t1 PrimTypes.string_typ
-                       && [%equal: typ] t2 (PrimTypes.bystrx_typ address_length)
+                  when [%equal: Type.t] t1 PrimTypes.string_typ
+                       && [%equal: Type.t] t2 (PrimTypes.bystrx_typ address_length)
                        && Bystrx.width bs = address_length ->
                     (name, Bystrx.hex_encoding bs)
                 | _ ->
@@ -417,7 +417,7 @@ module ContractInfo = struct
   open Syntax.ParsedSyntax
 
   let get_json cmver (contr : contract)
-      (event_info : (string * (string * typ) list) list) =
+      (event_info : (string * (string * Type.t) list) list) =
     (* 0. contract version *)
     let verj = ("scilla_major_version", `String (Int.to_string cmver)) in
     (* 1. contract name *)
@@ -512,7 +512,7 @@ module ContractInfo = struct
     finalj
 
   let get_string cver (contr : contract)
-      (event_info : (string * (string * typ) list) list) =
+      (event_info : (string * (string * Type.t) list) list) =
     pretty_to_string (get_json cver contr event_info)
 end
 

--- a/src/base/JSON.mli
+++ b/src/base/JSON.mli
@@ -74,8 +74,7 @@ module Message : sig
   "_tag", "_sender" and "_amount" at the beginning of this list.
   Invalid inputs in the json are ignored **)
 
-  val message_to_jstring :
-    ?pp:bool -> (string * Literal.t) list -> string
+  val message_to_jstring : ?pp:bool -> (string * Literal.t) list -> string
   (** 
    ** Prints a message (string, literal) as a json to the 
    ** and returns the string. pp enables pretty printing.
@@ -137,10 +136,7 @@ module ContractInfo : sig
     int -> contract -> (string * (string * Type.t) list) list -> string
 
   val get_json :
-    int ->
-    contract ->
-    (string * (string * Type.t) list) list ->
-    Yojson.Basic.t
+    int -> contract -> (string * (string * Type.t) list) list -> Yojson.Basic.t
 end
 
 module Event : sig
@@ -156,8 +152,7 @@ end
 
 module TypeInfo : sig
   val type_info_to_json :
-    (string * Type.t * ErrorUtils.loc * ErrorUtils.loc) list ->
-    Yojson.Basic.t
+    (string * Type.t * ErrorUtils.loc * ErrorUtils.loc) list -> Yojson.Basic.t
 
   val type_info_to_jstring :
     ?pp:bool ->

--- a/src/base/JSON.mli
+++ b/src/base/JSON.mli
@@ -27,23 +27,23 @@ module ContractState : sig
    *  Returns a list of (vname:string,value:literal) items
    *  from the json in the input filename. Invalid inputs in the json are ignored 
    *)
-  val get_json_data : string -> (string * Literals.literal) list
+  val get_json_data : string -> (string * Literal.t) list
 
   (* 
    * Prints a list of state variables (string, literal)
    * as a json and returns it as a string.
    * pp enables pretty printing.
    *)
-  val state_to_string : ?pp:bool -> (string * Literals.literal) list -> string
+  val state_to_string : ?pp:bool -> (string * Literal.t) list -> string
 
   (* Get a json object from given states *)
-  val state_to_json : (string * Literals.literal) list -> Yojson.Basic.t
+  val state_to_json : (string * Literal.t) list -> Yojson.Basic.t
 
   (* Given an init.json filename, return extlib fields *)
   val get_init_extlibs : string -> (string * string) list
 
   (* Convert a single JSON serialized literal back to its Scilla value. *)
-  val jstring_to_literal : string -> Types.typ -> Literals.literal
+  val jstring_to_literal : string -> Types.typ -> Literal.t
 end
 
 (*  Message json parsing and printing. A message json has three mandatory
@@ -69,13 +69,13 @@ end
     }
  *)
 module Message : sig
-  val get_json_data : string -> (string * Literals.literal) list
+  val get_json_data : string -> (string * Literal.t) list
   (** Parses and returns a list of (pname,pval), with
   "_tag", "_sender" and "_amount" at the beginning of this list.
   Invalid inputs in the json are ignored **)
 
   val message_to_jstring :
-    ?pp:bool -> (string * Literals.literal) list -> string
+    ?pp:bool -> (string * Literal.t) list -> string
   (** 
    ** Prints a message (string, literal) as a json to the 
    ** and returns the string. pp enables pretty printing.
@@ -86,11 +86,11 @@ module Message : sig
    **)
 
   (* Same as message_to_jstring, but instead gives out raw json, not it's string *)
-  val message_to_json : (string * Literals.literal) list -> Yojson.Basic.t
+  val message_to_json : (string * Literal.t) list -> Yojson.Basic.t
 end
 
 module BlockChainState : sig
-  val get_json_data : string -> (string * Literals.literal) list
+  val get_json_data : string -> (string * Literal.t) list
   (** 
    **  Returns a list of (vname:string,value:literal) items
    **  from the json in the input filename.
@@ -144,14 +144,14 @@ module ContractInfo : sig
 end
 
 module Event : sig
-  val event_to_jstring : ?pp:bool -> (string * Literals.literal) list -> string
+  val event_to_jstring : ?pp:bool -> (string * Literal.t) list -> string
   (** 
    ** Prints an Event "(string, literal) list" as a json to the 
    ** and returns the string. pp enables pretty printing.
    **)
 
   (* Same as Event_to_jstring, but instead gives out raw json, not it's string *)
-  val event_to_json : (string * Literals.literal) list -> Yojson.Basic.t
+  val event_to_json : (string * Literal.t) list -> Yojson.Basic.t
 end
 
 module TypeInfo : sig

--- a/src/base/JSON.mli
+++ b/src/base/JSON.mli
@@ -43,7 +43,7 @@ module ContractState : sig
   val get_init_extlibs : string -> (string * string) list
 
   (* Convert a single JSON serialized literal back to its Scilla value. *)
-  val jstring_to_literal : string -> Types.typ -> Literal.t
+  val jstring_to_literal : string -> Type.t -> Literal.t
 end
 
 (*  Message json parsing and printing. A message json has three mandatory
@@ -134,12 +134,12 @@ module ContractInfo : sig
         }
   *)
   val get_string :
-    int -> contract -> (string * (string * Types.typ) list) list -> string
+    int -> contract -> (string * (string * Type.t) list) list -> string
 
   val get_json :
     int ->
     contract ->
-    (string * (string * Types.typ) list) list ->
+    (string * (string * Type.t) list) list ->
     Yojson.Basic.t
 end
 
@@ -156,12 +156,12 @@ end
 
 module TypeInfo : sig
   val type_info_to_json :
-    (string * Types.typ * ErrorUtils.loc * ErrorUtils.loc) list ->
+    (string * Type.t * ErrorUtils.loc * ErrorUtils.loc) list ->
     Yojson.Basic.t
 
   val type_info_to_jstring :
     ?pp:bool ->
-    (string * Types.typ * ErrorUtils.loc * ErrorUtils.loc) list ->
+    (string * Type.t * ErrorUtils.loc * ErrorUtils.loc) list ->
     string
 end
 

--- a/src/base/JSONParser.ml
+++ b/src/base/JSONParser.ml
@@ -23,7 +23,7 @@ open! Int.Replace_polymorphic_compare
 open Yojson
 open Identifier
 open Literal
-open Types
+open Type
 open ErrorUtils
 open TypeUtil
 open Datatypes
@@ -84,7 +84,7 @@ let lookup_adt_parser adt_name =
 (*************************************)
 
 (* Generate a parser. *)
-let gen_parser (t' : typ) : Basic.t -> Literal.t =
+let gen_parser (t' : Type.t) : Basic.t -> Literal.t =
   let open Basic in
   let rec recurser t =
     match t with

--- a/src/base/JSONParser.ml
+++ b/src/base/JSONParser.ml
@@ -22,7 +22,7 @@ open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Yojson
 open Identifiers
-open Literals
+open Literal
 open Types
 open ErrorUtils
 open TypeUtil
@@ -57,7 +57,7 @@ let lookup_adt_name_exn name =
 
 type adt_parser_entry =
   | Incomplete (* Parser not completely constructed. *)
-  | Parser of (Basic.t -> literal)
+  | Parser of (Basic.t -> Literal.t)
 
 let adt_parsers =
   let open Caml in
@@ -84,7 +84,7 @@ let lookup_adt_parser adt_name =
 (*************************************)
 
 (* Generate a parser. *)
-let gen_parser (t' : typ) : Basic.t -> literal =
+let gen_parser (t' : typ) : Basic.t -> Literal.t =
   let open Basic in
   let rec recurser t =
     match t with

--- a/src/base/JSONParser.ml
+++ b/src/base/JSONParser.ml
@@ -21,7 +21,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Yojson
-open Identifiers
+open Identifier
 open Literal
 open Types
 open ErrorUtils

--- a/src/base/JSONParser.mli
+++ b/src/base/JSONParser.mli
@@ -17,7 +17,6 @@
 *)
 
 open Core_kernel
-open Identifiers
 open Types
 open Yojson
 module JSONTypeUtilities = TypeUtil.TypeUtilities
@@ -34,7 +33,7 @@ val member_exn : string -> Basic.t -> Basic.t
 val constr_pattern_arg_types_exn : typ -> string -> typ list
 
 (*  Wrapper for DataTypeDictionary.lookup_name  *)
-val lookup_adt_name_exn : 'a ident -> Datatypes.adt
+val lookup_adt_name_exn : 'a Identifier.t -> Datatypes.adt
 
 (*************************************)
 (*********** ADT parsers *************)

--- a/src/base/JSONParser.mli
+++ b/src/base/JSONParser.mli
@@ -17,7 +17,6 @@
 *)
 
 open Core_kernel
-open Types
 open Yojson
 module JSONTypeUtilities = TypeUtil.TypeUtilities
 
@@ -30,7 +29,7 @@ module JSONTypeUtilities = TypeUtil.TypeUtilities
 val member_exn : string -> Basic.t -> Basic.t
 
 (* Wrapper for constr_pattern_arg_types. Throws Invalid_json exception instead of using result type *)
-val constr_pattern_arg_types_exn : typ -> string -> typ list
+val constr_pattern_arg_types_exn : Type.t -> string -> Type.t list
 
 (*  Wrapper for DataTypeDictionary.lookup_name  *)
 val lookup_adt_name_exn : 'a Identifier.t -> Datatypes.adt
@@ -54,7 +53,7 @@ val lookup_adt_parser_opt : string -> adt_parser_entry option
 val lookup_adt_parser : string -> adt_parser_entry
 
 (* Generate a parser *)
-val gen_parser : typ -> Basic.t -> Literal.t
+val gen_parser : Type.t -> Basic.t -> Literal.t
 
 (* Parse JSON *)
-val parse_json : typ -> Basic.t -> Literal.t
+val parse_json : Type.t -> Basic.t -> Literal.t

--- a/src/base/JSONParser.mli
+++ b/src/base/JSONParser.mli
@@ -19,7 +19,6 @@
 open Core_kernel
 open Identifiers
 open Types
-open Literals
 open Yojson
 module JSONTypeUtilities = TypeUtil.TypeUtilities
 
@@ -41,7 +40,7 @@ val lookup_adt_name_exn : 'a ident -> Datatypes.adt
 (*********** ADT parsers *************)
 (*************************************)
 
-type adt_parser_entry = Incomplete | Parser of (Basic.t -> literal)
+type adt_parser_entry = Incomplete | Parser of (Basic.t -> Literal.t)
 
 (* ADT parsers table *)
 val adt_parsers : (string, adt_parser_entry) Caml.Hashtbl.t
@@ -56,7 +55,7 @@ val lookup_adt_parser_opt : string -> adt_parser_entry option
 val lookup_adt_parser : string -> adt_parser_entry
 
 (* Generate a parser *)
-val gen_parser : typ -> Basic.t -> literal
+val gen_parser : typ -> Basic.t -> Literal.t
 
 (* Parse JSON *)
-val parse_json : typ -> Basic.t -> literal
+val parse_json : typ -> Basic.t -> Literal.t

--- a/src/base/Literal.ml
+++ b/src/base/Literal.ml
@@ -162,7 +162,7 @@ module Bystrx : BYSTRX = struct
   let to_bystr = Fn.id
 end
 
-type literal =
+type t =
   | StringLit of string
   (* Cannot have different integer literals here directly as Stdint does not derive sexp. *)
   | IntLit of int_lit
@@ -173,28 +173,28 @@ type literal =
   (* Byte string without a statically known length. *)
   | ByStr of Bystr.t
   (* Message: an associative array *)
-  | Msg of (string * literal) list
+  | Msg of (string * t) list
   (* A dynamic map of literals *)
-  | Map of mtype * (literal, literal) Hashtbl.t
+  | Map of mtype * (t, t) Hashtbl.t
   (* A constructor in HNF *)
-  | ADTValue of string * typ list * literal list
+  | ADTValue of string * typ list * t list
   (* An embedded closure *)
   | Clo of
-      (literal ->
-      ( literal,
+      (t ->
+      ( t,
         scilla_error list,
         uint64 ->
-        ( (literal * (string * literal) list) * uint64,
+        ( (t * (string * t) list) * uint64,
           scilla_error list * uint64 )
         result )
       CPSMonad.t)
   (* A type abstraction *)
   | TAbs of
       (typ ->
-      ( literal,
+      ( t,
         scilla_error list,
         uint64 ->
-        ( (literal * (string * literal) list) * uint64,
+        ( (t * (string * t) list) * uint64,
           scilla_error list * uint64 )
         result )
       CPSMonad.t)

--- a/src/base/Literal.ml
+++ b/src/base/Literal.ml
@@ -184,9 +184,8 @@ type t =
       ( t,
         scilla_error list,
         uint64 ->
-        ( (t * (string * t) list) * uint64,
-          scilla_error list * uint64 )
-        result )
+        ((t * (string * t) list) * uint64, scilla_error list * uint64) result
+      )
       CPSMonad.t)
   (* A type abstraction *)
   | TAbs of
@@ -194,9 +193,8 @@ type t =
       ( t,
         scilla_error list,
         uint64 ->
-        ( (t * (string * t) list) * uint64,
-          scilla_error list * uint64 )
-        result )
+        ((t * (string * t) list) * uint64, scilla_error list * uint64) result
+      )
       CPSMonad.t)
 [@@deriving sexp]
 

--- a/src/base/Literal.ml
+++ b/src/base/Literal.ml
@@ -39,14 +39,14 @@ open Sexplib.Std
 open Stdint
 open MonadUtil
 open ErrorUtils
-open Types
+open Type
 
 (*******************************************************)
 (*                      Literals                       *)
 (*******************************************************)
 
 (* The first component is a primitive type *)
-type mtype = typ * typ [@@deriving sexp]
+type mtype = Type.t * Type.t [@@deriving sexp]
 
 open Integer256
 
@@ -177,7 +177,7 @@ type t =
   (* A dynamic map of literals *)
   | Map of mtype * (t, t) Hashtbl.t
   (* A constructor in HNF *)
-  | ADTValue of string * typ list * t list
+  | ADTValue of string * Type.t list * t list
   (* An embedded closure *)
   | Clo of
       (t ->
@@ -190,7 +190,7 @@ type t =
       CPSMonad.t)
   (* A type abstraction *)
   | TAbs of
-      (typ ->
+      (Type.t ->
       ( t,
         scilla_error list,
         uint64 ->

--- a/src/base/Literal.mli
+++ b/src/base/Literal.mli
@@ -84,7 +84,7 @@ end
 
 module Bystrx : BYSTRX
 
-type literal =
+type t =
   | StringLit of string
   (* Cannot have different integer literals here directly as Stdint does not derive sexp. *)
   | IntLit of int_lit
@@ -95,31 +95,31 @@ type literal =
   (* Byte string without a statically known length. *)
   | ByStr of Bystr.t
   (* Message: an associative array *)
-  | Msg of (string * literal) list
+  | Msg of (string * t) list
   (* A dynamic map of literals *)
-  | Map of mtype * (literal, literal) Hashtbl.t
+  | Map of mtype * (t, t) Hashtbl.t
   (* A constructor in HNF *)
-  | ADTValue of string * typ list * literal list
+  | ADTValue of string * typ list * t list
   (* An embedded closure *)
   | Clo of
-      (literal ->
-      ( literal,
+      (t ->
+      ( t,
         scilla_error list,
         uint64 ->
-        ( (literal * (string * literal) list) * uint64,
+        ( (t * (string * t) list) * uint64,
           scilla_error list * uint64 )
         result )
       CPSMonad.t)
   (* A type abstraction *)
   | TAbs of
       (typ ->
-      ( literal,
+      ( t,
         scilla_error list,
         uint64 ->
-        ( (literal * (string * literal) list) * uint64,
+        ( (t * (string * t) list) * uint64,
           scilla_error list * uint64 )
         result )
       CPSMonad.t)
 [@@deriving sexp]
 
-val subst_type_in_literal : 'a ident -> typ -> literal -> literal
+val subst_type_in_literal : 'a ident -> typ -> t -> t

--- a/src/base/Literal.mli
+++ b/src/base/Literal.mli
@@ -104,9 +104,8 @@ type t =
       ( t,
         scilla_error list,
         uint64 ->
-        ( (t * (string * t) list) * uint64,
-          scilla_error list * uint64 )
-        result )
+        ((t * (string * t) list) * uint64, scilla_error list * uint64) result
+      )
       CPSMonad.t)
   (* A type abstraction *)
   | TAbs of
@@ -114,9 +113,8 @@ type t =
       ( t,
         scilla_error list,
         uint64 ->
-        ( (t * (string * t) list) * uint64,
-          scilla_error list * uint64 )
-        result )
+        ((t * (string * t) list) * uint64, scilla_error list * uint64) result
+      )
       CPSMonad.t)
 [@@deriving sexp]
 

--- a/src/base/Literal.mli
+++ b/src/base/Literal.mli
@@ -19,7 +19,6 @@
 open Stdint
 open MonadUtil
 open ErrorUtils
-open Identifiers
 open Types
 
 type mtype = typ * typ [@@deriving sexp]
@@ -122,4 +121,4 @@ type t =
       CPSMonad.t)
 [@@deriving sexp]
 
-val subst_type_in_literal : 'a ident -> typ -> t -> t
+val subst_type_in_literal : 'a Identifier.t -> typ -> t -> t

--- a/src/base/Literal.mli
+++ b/src/base/Literal.mli
@@ -19,9 +19,8 @@
 open Stdint
 open MonadUtil
 open ErrorUtils
-open Types
 
-type mtype = typ * typ [@@deriving sexp]
+type mtype = Type.t * Type.t [@@deriving sexp]
 
 open Integer256
 
@@ -98,7 +97,7 @@ type t =
   (* A dynamic map of literals *)
   | Map of mtype * (t, t) Hashtbl.t
   (* A constructor in HNF *)
-  | ADTValue of string * typ list * t list
+  | ADTValue of string * Type.t list * t list
   (* An embedded closure *)
   | Clo of
       (t ->
@@ -111,7 +110,7 @@ type t =
       CPSMonad.t)
   (* A type abstraction *)
   | TAbs of
-      (typ ->
+      (Type.t ->
       ( t,
         scilla_error list,
         uint64 ->
@@ -121,4 +120,4 @@ type t =
       CPSMonad.t)
 [@@deriving sexp]
 
-val subst_type_in_literal : 'a Identifier.t -> typ -> t -> t
+val subst_type_in_literal : 'a Identifier.t -> Type.t -> t -> t

--- a/src/base/PatternChecker.ml
+++ b/src/base/PatternChecker.ml
@@ -14,7 +14,7 @@
  * Reference: ML pattern match compilation and partial evaluation - Peter Sestoft
  *)
 
-open Identifiers
+open Identifier
 open Types
 open Syntax
 open Core_kernel

--- a/src/base/PatternChecker.ml
+++ b/src/base/PatternChecker.ml
@@ -15,7 +15,7 @@
  *)
 
 open Identifier
-open Types
+open Type
 open Syntax
 open Core_kernel
 open! Int.Replace_polymorphic_compare

--- a/src/base/PrettyPrinters.ml
+++ b/src/base/PrettyPrinters.ml
@@ -18,7 +18,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
-open Types
+open Type
 open Literal
 open Syntax
 open Yojson

--- a/src/base/PrettyPrinters.ml
+++ b/src/base/PrettyPrinters.ml
@@ -19,7 +19,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Types
-open Literals
+open Literal
 open Syntax
 open Yojson
 open PrimTypes

--- a/src/base/PrimTypes.ml
+++ b/src/base/PrimTypes.ml
@@ -19,7 +19,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Types
-open Literals
+open Literal
 open Stdint
 open Integer256
 

--- a/src/base/PrimTypes.ml
+++ b/src/base/PrimTypes.ml
@@ -18,7 +18,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
-open Types
+open Type
 open Literal
 open Stdint
 open Integer256

--- a/src/base/PrimTypes.mli
+++ b/src/base/PrimTypes.mli
@@ -16,55 +16,55 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Types
+open Type
 open Literal
 
 (****************************************************************)
 (*                     PrimType utilities                       *)
 (****************************************************************)
 
-val is_prim_type : typ -> bool
+val is_prim_type : Type.t -> bool
 
-val is_int_type : typ -> bool
+val is_int_type : Type.t -> bool
 
-val is_uint_type : typ -> bool
+val is_uint_type : Type.t -> bool
 
-val is_bystrx_type : typ -> bool
+val is_bystrx_type : Type.t -> bool
 
-val int_width : typ -> int option
+val int_width : Type.t -> int option
 
-val int32_typ : typ
+val int32_typ : Type.t
 
-val int64_typ : typ
+val int64_typ : Type.t
 
-val int128_typ : typ
+val int128_typ : Type.t
 
-val int256_typ : typ
+val int256_typ : Type.t
 
-val uint32_typ : typ
+val uint32_typ : Type.t
 
-val uint64_typ : typ
+val uint64_typ : Type.t
 
-val uint128_typ : typ
+val uint128_typ : Type.t
 
-val uint256_typ : typ
+val uint256_typ : Type.t
 
-val string_typ : typ
+val string_typ : Type.t
 
-val bnum_typ : typ
+val bnum_typ : Type.t
 
-val msg_typ : typ
+val msg_typ : Type.t
 
-val event_typ : typ
+val event_typ : Type.t
 
-val exception_typ : typ
+val exception_typ : Type.t
 
-val bystr_typ : typ
+val bystr_typ : Type.t
 
-val bystrx_typ : int -> typ
+val bystrx_typ : int -> Type.t
 
 (* Given a ByStrX, return integer X *)
-val bystrx_width : typ -> int option
+val bystrx_width : Type.t -> int option
 
 (****************************************************************)
 (*            PrimType Literal utilities                        *)

--- a/src/base/PrimTypes.mli
+++ b/src/base/PrimTypes.mli
@@ -17,7 +17,7 @@
 *)
 
 open Types
-open Literals
+open Literal
 
 (****************************************************************)
 (*                     PrimType utilities                       *)
@@ -70,7 +70,7 @@ val bystrx_width : typ -> int option
 (*            PrimType Literal utilities                        *)
 (****************************************************************)
 
-val build_prim_literal : prim_typ -> string -> literal option
+val build_prim_literal : prim_typ -> string -> Literal.t option
 
 (* Is string representation of integer valid for integer typ. *)
 val validate_int_string : prim_typ -> string -> bool

--- a/src/base/Recursion.ml
+++ b/src/base/Recursion.ml
@@ -19,7 +19,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Identifier
-open Types
+open Type
 open Syntax
 open ErrorUtils
 open MonadUtil

--- a/src/base/Recursion.ml
+++ b/src/base/Recursion.ml
@@ -18,7 +18,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
-open Identifiers
+open Identifier
 open Types
 open Syntax
 open ErrorUtils

--- a/src/base/RecursionPrinciples.ml
+++ b/src/base/RecursionPrinciples.ml
@@ -16,7 +16,7 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Identifiers
+open Identifier
 open Types
 open Syntax
 open Core_kernel

--- a/src/base/RecursionPrinciples.ml
+++ b/src/base/RecursionPrinciples.ml
@@ -17,7 +17,7 @@
 *)
 
 open Identifier
-open Types
+open Type
 open Syntax
 open Core_kernel
 open! Int.Replace_polymorphic_compare

--- a/src/base/RunnerUtil.ml
+++ b/src/base/RunnerUtil.ml
@@ -19,7 +19,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Printf
-open Identifiers
+open Identifier
 open Types
 open Syntax
 open ParsedSyntax
@@ -74,7 +74,7 @@ let import_lib id =
 (* An auxiliary data structure that is homomorphic to libtree, but for namespaces.
    Think of this as a field "namespace" in the "Syntax.libtree". It isn't added
    to the type itself because we want to eliminate the idea of namespaces right here. *)
-type 'a nspace_tree = { nspace : 'a ident option; dep_ns : 'a nspace_tree list }
+type 'a nspace_tree = { nspace : 'a Identifier.t option; dep_ns : 'a nspace_tree list }
 
 (* light-weight namespaces. prefix all entries in lib with their namespace. *)
 let eliminate_namespaces lib_tree ns_tree =

--- a/src/base/RunnerUtil.ml
+++ b/src/base/RunnerUtil.ml
@@ -20,7 +20,7 @@ open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Printf
 open Identifier
-open Types
+open Type
 open Syntax
 open ParsedSyntax
 open GlobalConfig

--- a/src/base/RunnerUtil.ml
+++ b/src/base/RunnerUtil.ml
@@ -74,7 +74,10 @@ let import_lib id =
 (* An auxiliary data structure that is homomorphic to libtree, but for namespaces.
    Think of this as a field "namespace" in the "Syntax.libtree". It isn't added
    to the type itself because we want to eliminate the idea of namespaces right here. *)
-type 'a nspace_tree = { nspace : 'a Identifier.t option; dep_ns : 'a nspace_tree list }
+type 'a nspace_tree = {
+  nspace : 'a Identifier.t option;
+  dep_ns : 'a nspace_tree list;
+}
 
 (* light-weight namespaces. prefix all entries in lib with their namespace. *)
 let eliminate_namespaces lib_tree ns_tree =

--- a/src/base/SanityChecker.ml
+++ b/src/base/SanityChecker.ml
@@ -19,7 +19,7 @@ open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Result.Let_syntax
 open TypeUtil
-open Identifiers
+open Identifier
 open Syntax
 open ErrorUtils
 open MonadUtil

--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -18,7 +18,7 @@
 
 %{
   open Identifier
-  open Types
+  open Type
   open Literal
   open Syntax
   open ErrorUtils
@@ -142,7 +142,7 @@
 %right TARROW
 
 %start <Syntax.ParsedSyntax.expr_annot> exp_term
-%start <Types.typ> type_term
+%start <Type.t> type_term
 %start <Syntax.ParsedSyntax.stmt_annot list> stmts_term
 %start <Syntax.ParsedSyntax.cmodule> cmodule
 %start <Syntax.ParsedSyntax.lmodule> lmodule

--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -19,7 +19,7 @@
 %{
   open Identifiers
   open Types
-  open Literals
+  open Literal
   open Syntax
   open ErrorUtils
   open ParsedSyntax

--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -17,7 +17,7 @@
 *)
 
 %{
-  open Identifiers
+  open Identifier
   open Types
   open Literal
   open Syntax

--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -20,7 +20,7 @@ open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Sexplib.Std
 open ErrorUtils
-open Identifiers
+open Identifier
 open Types
 open Literal
 
@@ -199,15 +199,15 @@ module type Rep = sig
 
   val get_loc : rep -> loc
 
-  val mk_id_address : string -> rep ident
+  val mk_id_address : string -> rep Identifier.t
 
-  val mk_id_uint128 : string -> rep ident
+  val mk_id_uint128 : string -> rep Identifier.t
 
-  val mk_id_uint32 : string -> rep ident
+  val mk_id_uint32 : string -> rep Identifier.t
 
-  val mk_id_bnum : string -> rep ident
+  val mk_id_bnum : string -> rep Identifier.t
 
-  val mk_id_string : string -> rep ident
+  val mk_id_string : string -> rep Identifier.t
 
   val rep_of_sexp : Sexp.t -> rep
 
@@ -229,31 +229,31 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
   (*                   Expressions                       *)
   (*******************************************************)
 
-  type payload = MLit of Literal.t | MVar of ER.rep ident [@@deriving sexp]
+  type payload = MLit of Literal.t | MVar of ER.rep Identifier.t [@@deriving sexp]
 
   type pattern =
     | Wildcard
-    | Binder of ER.rep ident
-    | Constructor of SR.rep ident * pattern list
+    | Binder of ER.rep Identifier.t
+    | Constructor of SR.rep Identifier.t * pattern list
   [@@deriving sexp]
 
   type expr_annot = expr * ER.rep
 
   and expr =
     | Literal of Literal.t
-    | Var of ER.rep ident
-    | Let of ER.rep ident * typ option * expr_annot * expr_annot
+    | Var of ER.rep Identifier.t
+    | Let of ER.rep Identifier.t * typ option * expr_annot * expr_annot
     | Message of (string * payload) list
-    | Fun of ER.rep ident * typ * expr_annot
-    | App of ER.rep ident * ER.rep ident list
-    | Constr of SR.rep ident * typ list * ER.rep ident list
-    | MatchExpr of ER.rep ident * (pattern * expr_annot) list
-    | Builtin of ER.rep builtin_annot * ER.rep ident list
+    | Fun of ER.rep Identifier.t * typ * expr_annot
+    | App of ER.rep Identifier.t * ER.rep Identifier.t list
+    | Constr of SR.rep Identifier.t * typ list * ER.rep Identifier.t list
+    | MatchExpr of ER.rep Identifier.t * (pattern * expr_annot) list
+    | Builtin of ER.rep builtin_annot * ER.rep Identifier.t list
     (* Advanced features: to be added in Scilla 0.2 *)
-    | TFun of ER.rep ident * expr_annot
-    | TApp of ER.rep ident * typ list
+    | TFun of ER.rep Identifier.t * expr_annot
+    | TApp of ER.rep Identifier.t * typ list
     (* Fixpoint combinator: used to implement recursion principles *)
-    | Fixpoint of ER.rep ident * typ * expr_annot
+    | Fixpoint of ER.rep Identifier.t * typ * expr_annot
   [@@deriving sexp]
 
   let expr_rep erep = snd erep
@@ -274,24 +274,24 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
   type stmt_annot = stmt * SR.rep
 
   and stmt =
-    | Load of ER.rep ident * ER.rep ident
-    | Store of ER.rep ident * ER.rep ident
-    | Bind of ER.rep ident * expr_annot
+    | Load of ER.rep Identifier.t * ER.rep Identifier.t
+    | Store of ER.rep Identifier.t * ER.rep Identifier.t
+    | Bind of ER.rep Identifier.t * expr_annot
     (* m[k1][k2][..] := v OR delete m[k1][k2][...] *)
-    | MapUpdate of ER.rep ident * ER.rep ident list * ER.rep ident option
+    | MapUpdate of ER.rep Identifier.t * ER.rep Identifier.t list * ER.rep Identifier.t option
     (* v <- m[k1][k2][...] OR b <- exists m[k1][k2][...] *)
     (* If the bool is set, then we interpret this as value retrieve,
        otherwise as an "exists" query. *)
-    | MapGet of ER.rep ident * ER.rep ident * ER.rep ident list * bool
-    | MatchStmt of ER.rep ident * (pattern * stmt_annot list) list
-    | ReadFromBC of ER.rep ident * string
+    | MapGet of ER.rep Identifier.t * ER.rep Identifier.t * ER.rep Identifier.t list * bool
+    | MatchStmt of ER.rep Identifier.t * (pattern * stmt_annot list) list
+    | ReadFromBC of ER.rep Identifier.t * string
     | AcceptPayment
     (* forall l p *)
-    | Iterate of ER.rep ident * SR.rep ident
-    | SendMsgs of ER.rep ident
-    | CreateEvnt of ER.rep ident
-    | CallProc of SR.rep ident * ER.rep ident list
-    | Throw of ER.rep ident option
+    | Iterate of ER.rep Identifier.t * SR.rep Identifier.t
+    | SendMsgs of ER.rep Identifier.t
+    | CreateEvnt of ER.rep Identifier.t
+    | CallProc of SR.rep Identifier.t * ER.rep Identifier.t list
+    | Throw of ER.rep Identifier.t option
   [@@deriving sexp]
 
   let stmt_rep srep = snd srep
@@ -330,24 +330,24 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
 
   type component = {
     comp_type : component_type;
-    comp_name : SR.rep ident;
-    comp_params : (ER.rep ident * typ) list;
+    comp_name : SR.rep Identifier.t;
+    comp_params : (ER.rep Identifier.t * typ) list;
     comp_body : stmt_annot list;
   }
 
-  type ctr_def = { cname : ER.rep ident; c_arg_types : typ list }
+  type ctr_def = { cname : ER.rep Identifier.t; c_arg_types : typ list }
 
   type lib_entry =
-    | LibVar of ER.rep ident * typ option * expr_annot
-    | LibTyp of ER.rep ident * ctr_def list
+    | LibVar of ER.rep Identifier.t * typ option * expr_annot
+    | LibTyp of ER.rep Identifier.t * ctr_def list
 
-  type library = { lname : SR.rep ident; lentries : lib_entry list }
+  type library = { lname : SR.rep Identifier.t; lentries : lib_entry list }
 
   type contract = {
-    cname : SR.rep ident;
-    cparams : (ER.rep ident * typ) list;
+    cname : SR.rep Identifier.t;
+    cparams : (ER.rep Identifier.t * typ) list;
     cconstraint : expr_annot;
-    cfields : (ER.rep ident * typ * expr_annot) list;
+    cfields : (ER.rep Identifier.t * typ * expr_annot) list;
     ccomps : component list;
   }
 
@@ -355,11 +355,11 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
   type cmodule = {
     smver : int;
     (* Scilla major version of the contract. *)
-    cname : SR.rep ident;
+    cname : SR.rep Identifier.t;
     libs : library option;
     (* lib functions defined in the module *)
     (* List of imports / external libs with an optional namespace. *)
-    elibs : (SR.rep ident * SR.rep ident option) list;
+    elibs : (SR.rep Identifier.t * SR.rep Identifier.t option) list;
     contr : contract;
   }
 
@@ -368,7 +368,7 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
     smver : int;
     (* Scilla major version of the library. *)
     (* List of imports / external libs with an optional namespace. *)
-    elibs : (SR.rep ident * SR.rep ident option) list;
+    elibs : (SR.rep Identifier.t * SR.rep Identifier.t option) list;
     libs : library; (* lib functions defined in the module *)
   }
 

--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -22,7 +22,7 @@ open Sexplib.Std
 open ErrorUtils
 open Identifiers
 open Types
-open Literals
+open Literal
 
 exception SyntaxError of string * loc
 
@@ -229,7 +229,7 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
   (*                   Expressions                       *)
   (*******************************************************)
 
-  type payload = MLit of literal | MVar of ER.rep ident [@@deriving sexp]
+  type payload = MLit of Literal.t | MVar of ER.rep ident [@@deriving sexp]
 
   type pattern =
     | Wildcard
@@ -240,7 +240,7 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
   type expr_annot = expr * ER.rep
 
   and expr =
-    | Literal of literal
+    | Literal of Literal.t
     | Var of ER.rep ident
     | Let of ER.rep ident * typ option * expr_annot * expr_annot
     | Message of (string * payload) list
@@ -307,21 +307,21 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
   (**************************************************)
   type stmt_eval_context =
     (* literal being loaded *)
-    | G_Load of literal
+    | G_Load of Literal.t
     (* literal being stored *)
-    | G_Store of literal
+    | G_Store of Literal.t
     (* none *)
     | G_Bind
     (* nesting depth, new value *)
-    | G_MapUpdate of int * literal option
+    | G_MapUpdate of int * Literal.t option
     (* nesting depth, literal retrieved *)
-    | G_MapGet of int * literal option
+    | G_MapGet of int * Literal.t option
     (* number of clauses *)
     | G_MatchStmt of int
     | G_ReadFromBC
     | G_AcceptPayment
-    | G_SendMsgs of literal list
-    | G_CreateEvnt of literal
+    | G_SendMsgs of Literal.t list
+    | G_CreateEvnt of Literal.t
     | G_CallProc
 
   (*******************************************************)

--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -21,7 +21,7 @@ open! Int.Replace_polymorphic_compare
 open Sexplib.Std
 open ErrorUtils
 open Identifier
-open Types
+open Type
 open Literal
 
 exception SyntaxError of string * loc
@@ -242,18 +242,18 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
   and expr =
     | Literal of Literal.t
     | Var of ER.rep Identifier.t
-    | Let of ER.rep Identifier.t * typ option * expr_annot * expr_annot
+    | Let of ER.rep Identifier.t * Type.t option * expr_annot * expr_annot
     | Message of (string * payload) list
-    | Fun of ER.rep Identifier.t * typ * expr_annot
+    | Fun of ER.rep Identifier.t * Type.t * expr_annot
     | App of ER.rep Identifier.t * ER.rep Identifier.t list
-    | Constr of SR.rep Identifier.t * typ list * ER.rep Identifier.t list
+    | Constr of SR.rep Identifier.t * Type.t list * ER.rep Identifier.t list
     | MatchExpr of ER.rep Identifier.t * (pattern * expr_annot) list
     | Builtin of ER.rep builtin_annot * ER.rep Identifier.t list
     (* Advanced features: to be added in Scilla 0.2 *)
     | TFun of ER.rep Identifier.t * expr_annot
-    | TApp of ER.rep Identifier.t * typ list
+    | TApp of ER.rep Identifier.t * Type.t list
     (* Fixpoint combinator: used to implement recursion principles *)
-    | Fixpoint of ER.rep Identifier.t * typ * expr_annot
+    | Fixpoint of ER.rep Identifier.t * Type.t * expr_annot
   [@@deriving sexp]
 
   let expr_rep erep = snd erep
@@ -331,23 +331,23 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
   type component = {
     comp_type : component_type;
     comp_name : SR.rep Identifier.t;
-    comp_params : (ER.rep Identifier.t * typ) list;
+    comp_params : (ER.rep Identifier.t * Type.t) list;
     comp_body : stmt_annot list;
   }
 
-  type ctr_def = { cname : ER.rep Identifier.t; c_arg_types : typ list }
+  type ctr_def = { cname : ER.rep Identifier.t; c_arg_types : Type.t list }
 
   type lib_entry =
-    | LibVar of ER.rep Identifier.t * typ option * expr_annot
+    | LibVar of ER.rep Identifier.t * Type.t option * expr_annot
     | LibTyp of ER.rep Identifier.t * ctr_def list
 
   type library = { lname : SR.rep Identifier.t; lentries : lib_entry list }
 
   type contract = {
     cname : SR.rep Identifier.t;
-    cparams : (ER.rep Identifier.t * typ) list;
+    cparams : (ER.rep Identifier.t * Type.t) list;
     cconstraint : expr_annot;
-    cfields : (ER.rep Identifier.t * typ * expr_annot) list;
+    cfields : (ER.rep Identifier.t * Type.t * expr_annot) list;
     ccomps : component list;
   }
 
@@ -382,7 +382,7 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
   let pp_cparams ps =
     let cs =
       List.map ps ~f:(fun (i, t) ->
-          get_id i ^ " : " ^ (sexp_of_typ t |> Sexplib.Sexp.to_string))
+          get_id i ^ " : " ^ (Type.sexp_of_t t |> Sexplib.Sexp.to_string))
     in
     "[" ^ String.concat ~sep:", " cs ^ "]"
 

--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -229,7 +229,8 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
   (*                   Expressions                       *)
   (*******************************************************)
 
-  type payload = MLit of Literal.t | MVar of ER.rep Identifier.t [@@deriving sexp]
+  type payload = MLit of Literal.t | MVar of ER.rep Identifier.t
+  [@@deriving sexp]
 
   type pattern =
     | Wildcard
@@ -278,11 +279,18 @@ module ScillaSyntax (SR : Rep) (ER : Rep) = struct
     | Store of ER.rep Identifier.t * ER.rep Identifier.t
     | Bind of ER.rep Identifier.t * expr_annot
     (* m[k1][k2][..] := v OR delete m[k1][k2][...] *)
-    | MapUpdate of ER.rep Identifier.t * ER.rep Identifier.t list * ER.rep Identifier.t option
+    | MapUpdate of
+        ER.rep Identifier.t
+        * ER.rep Identifier.t list
+        * ER.rep Identifier.t option
     (* v <- m[k1][k2][...] OR b <- exists m[k1][k2][...] *)
     (* If the bool is set, then we interpret this as value retrieve,
        otherwise as an "exists" query. *)
-    | MapGet of ER.rep Identifier.t * ER.rep Identifier.t * ER.rep Identifier.t list * bool
+    | MapGet of
+        ER.rep Identifier.t
+        * ER.rep Identifier.t
+        * ER.rep Identifier.t list
+        * bool
     | MatchStmt of ER.rep Identifier.t * (pattern * stmt_annot list) list
     | ReadFromBC of ER.rep Identifier.t * string
     | AcceptPayment

--- a/src/base/Type.ml
+++ b/src/base/Type.ml
@@ -60,13 +60,13 @@ let sexp_of_prim_typ = function
 
 let prim_typ_of_sexp _ = failwith "prim_typ_of_sexp is not implemented"
 
-type typ =
+type t =
   | PrimType of prim_typ
-  | MapType of typ * typ
-  | FunType of typ * typ
-  | ADT of loc Identifier.t * typ list
+  | MapType of t * t
+  | FunType of t * t
+  | ADT of loc Identifier.t * t list
   | TypeVar of string
-  | PolyFun of string * typ
+  | PolyFun of string * t
   | Unit
 [@@deriving sexp]
 
@@ -189,7 +189,7 @@ let canonicalize_tfun t =
   rename_bound_vars mk_new_name (const @@ Int.succ) t 1
 
 (* Type equivalence *)
-let equal_typ t1 t2 =
+let equal t1 t2 =
   let t1' = canonicalize_tfun t1 in
   let t2' = canonicalize_tfun t2 in
   let rec equiv t1 t2 =

--- a/src/base/Type.mli
+++ b/src/base/Type.mli
@@ -36,34 +36,34 @@ type prim_typ =
 
 val pp_prim_typ : prim_typ -> string
 
-type typ =
+type t =
   | PrimType of prim_typ
-  | MapType of typ * typ
-  | FunType of typ * typ
-  | ADT of loc Identifier.t * typ list
+  | MapType of t * t
+  | FunType of t * t
+  | ADT of loc Identifier.t * t list
   | TypeVar of string
-  | PolyFun of string * typ
+  | PolyFun of string * t
   | Unit
 [@@deriving sexp]
 
-val pp_typ : typ -> string
+val pp_typ : t -> string
 
 (****************************************************************)
 (*                     Type substitutions                       *)
 (****************************************************************)
 
-val free_tvars : typ -> string list
+val free_tvars : t -> string list
 
 val mk_fresh_var : string list -> string -> string
 
-val refresh_tfun : typ -> string list -> typ
+val refresh_tfun : t -> string list -> t
 
-val canonicalize_tfun : typ -> typ
+val canonicalize_tfun : t -> t
 
-val equal_typ : typ -> typ -> bool
+val equal : t -> t -> bool
 
-val subst_type_in_type : string -> typ -> typ -> typ
+val subst_type_in_type : string -> t -> t -> t
 
-val subst_types_in_type : (string * typ) list -> typ -> typ
+val subst_types_in_type : (string * t) list -> t -> t
 
-val subst_type_in_type' : 'a Identifier.t -> typ -> typ -> typ
+val subst_type_in_type' : 'a Identifier.t -> t -> t -> t

--- a/src/base/TypeCache.ml
+++ b/src/base/TypeCache.ml
@@ -18,7 +18,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
-open Identifiers
+open Identifier
 open Syntax
 open ErrorUtils
 open TypeUtil

--- a/src/base/TypeCache.mli
+++ b/src/base/TypeCache.mli
@@ -20,7 +20,6 @@
 (*                    Library type caching                       *)
 (*****************************************************************)
 
-open Types
 open Syntax
 open TypeUtil
 
@@ -35,7 +34,7 @@ module StdlibTypeCacher
     type ctr_def
 
     type lib_entry =
-      | LibVar of ER.rep Identifier.t * typ option * expr_annot
+      | LibVar of ER.rep Identifier.t * Type.t option * expr_annot
       | LibTyp of ER.rep Identifier.t * ctr_def list
 
     type library = { lname : SR.rep Identifier.t; lentries : lib_entry list }

--- a/src/base/TypeCache.mli
+++ b/src/base/TypeCache.mli
@@ -20,7 +20,6 @@
 (*                    Library type caching                       *)
 (*****************************************************************)
 
-open Identifiers
 open Types
 open Syntax
 open TypeUtil
@@ -36,10 +35,10 @@ module StdlibTypeCacher
     type ctr_def
 
     type lib_entry =
-      | LibVar of ER.rep ident * typ option * expr_annot
-      | LibTyp of ER.rep ident * ctr_def list
+      | LibVar of ER.rep Identifier.t * typ option * expr_annot
+      | LibTyp of ER.rep Identifier.t * ctr_def list
 
-    type library = { lname : SR.rep ident; lentries : lib_entry list }
+    type library = { lname : SR.rep Identifier.t; lentries : lib_entry list }
   end
 
   type t = Q(R)(ER).TEnv.t

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -18,7 +18,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
-open Identifiers
+open Identifier
 open Types
 open Syntax
 open ErrorUtils

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -19,7 +19,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Identifier
-open Types
+open Type
 open Syntax
 open ErrorUtils
 open MonadUtil
@@ -380,7 +380,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
               List.Assoc.find CU.msg_mandatory_field_types fld
                 ~equal:String.( = )
             with
-            | Some fld_t when not ([%equal: typ] fld_t seen_type) ->
+            | Some fld_t when not ([%equal: Type.t] fld_t seen_type) ->
                 fail1
                   (sprintf
                      "Type mismatch for Message field %s. Expected %s but got \
@@ -487,7 +487,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
   type stmt_tenv = {
     pure : TEnv.t;
     fields : TEnv.t;
-    procedures : (string * typ list) list;
+    procedures : (string * Type.t list) list;
   }
 
   let lookup_proc env pname =
@@ -870,7 +870,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
     pure @@ ((new_p, new_stmts), remaining_gas)
 
   let type_component env0 tr remaining_gas :
-      ( (TypedSyntax.component * (string * typ list) list) * Stdint.uint64,
+      ( (TypedSyntax.component * (string * Type.t list) list) * Stdint.uint64,
         typeCheckerErrorType * scilla_error list * Stdint.uint64 )
       result =
     let { comp_type; comp_name; comp_params; comp_body } = tr in

--- a/src/base/TypeInfo.ml
+++ b/src/base/TypeInfo.ml
@@ -19,7 +19,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open TypeUtil
-open Identifiers
+open Identifier
 open Syntax
 open ErrorUtils
 

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -21,7 +21,7 @@ open! Int.Replace_polymorphic_compare
 open ErrorUtils
 open Sexplib.Std
 open Identifier
-open Types
+open Type
 open Literal
 open Syntax
 open MonadUtil
@@ -33,7 +33,7 @@ open PrettyPrinters
 (*                Inferred types and qualifiers                 *)
 (****************************************************************)
 
-type 'rep inferred_type = { tp : typ; qual : 'rep } [@@deriving sexp]
+type 'rep inferred_type = { tp : Type.t; qual : 'rep } [@@deriving sexp]
 
 module type QualifiedTypes = sig
   type t
@@ -42,7 +42,7 @@ module type QualifiedTypes = sig
 
   val sexp_of_t : t -> Sexp.t
 
-  val mk_qualified_type : typ -> t inferred_type
+  val mk_qualified_type : Type.t -> t inferred_type
 end
 
 module type MakeTEnvFunctor = functor (Q : QualifiedTypes) (R : Rep) -> sig
@@ -57,7 +57,7 @@ module type MakeTEnvFunctor = functor (Q : QualifiedTypes) (R : Rep) -> sig
 
   val rr_pp : resolve_result -> string
 
-  val mk_qual_tp : typ -> Q.t inferred_type
+  val mk_qual_tp : Type.t -> Q.t inferred_type
 
   module TEnv : sig
     type t
@@ -66,10 +66,10 @@ module type MakeTEnvFunctor = functor (Q : QualifiedTypes) (R : Rep) -> sig
     val mk : t
 
     (* Add to type environment *)
-    val addT : t -> R.rep Identifier.t -> typ -> t
+    val addT : t -> R.rep Identifier.t -> Type.t -> t
 
     (* Add to many type bindings *)
-    val addTs : t -> (R.rep Identifier.t * typ) list -> t
+    val addTs : t -> (R.rep Identifier.t * Type.t) list -> t
 
     (* Add type variable to the environment *)
     val addV : t -> R.rep Identifier.t -> t
@@ -81,7 +81,7 @@ module type MakeTEnvFunctor = functor (Q : QualifiedTypes) (R : Rep) -> sig
     val filterTs : t -> f:(string -> resolve_result -> bool) -> t
 
     (* Check type for well-formedness in the type environment *)
-    val is_wf_type : t -> typ -> (unit, scilla_error list) result
+    val is_wf_type : t -> Type.t -> (unit, scilla_error list) result
 
     (* Resolve the identifier *)
     val resolveT :
@@ -289,10 +289,10 @@ module TypeUtilities = struct
     List.length tlist1 = List.length tlist2
     && not
          (List.exists2_exn tlist1 tlist2 ~f:(fun t1 t2 ->
-              not ([%equal: typ] t1 t2)))
+              not ([%equal: Type.t] t1 t2)))
 
   let assert_type_equiv expected given =
-    if [%equal: typ] expected given then pure ()
+    if [%equal: Type.t] expected given then pure ()
     else
       fail0
       @@ sprintf "Type mismatch: %s expected, but %s provided."
@@ -300,7 +300,7 @@ module TypeUtilities = struct
 
   (* TODO: make this charge gas *)
   let assert_type_equiv_with_gas expected given remaining_gas =
-    if [%equal: typ] expected given then pure remaining_gas
+    if [%equal: Type.t] expected given then pure remaining_gas
     else
       Error
         ( TypeError,
@@ -339,7 +339,7 @@ module TypeUtilities = struct
     | PrimType _ ->
         (* Messages and Events are not serialisable in terms of contract parameters *)
         PrimTypes.(
-          (not @@ [%equal: typ] t msg_typ) || [%equal: typ] t event_typ)
+          (not @@ [%equal: Type.t] t msg_typ) || [%equal: Type.t] t event_typ)
     | ADT (tname, ts) -> (
         if List.mem seen_adts tname ~equal:equal_id then true
           (* Inductive ADT - ignore this branch *)
@@ -610,7 +610,7 @@ module TypeUtilities = struct
     match ts with
     | [] -> fail0 "Checking an empty type list."
     | t :: ts' -> (
-        match List.find ts' ~f:(fun t' -> not ([%equal: typ] t t')) with
+        match List.find ts' ~f:(fun t' -> not ([%equal: Type.t] t t')) with
         | None -> pure ()
         | Some _ ->
             fail0
@@ -685,7 +685,7 @@ module TypeUtilities = struct
                 else
                   let%bind kt' = is_wellformed_lit k in
                   let%bind vt' = is_wellformed_lit v in
-                  pure @@ ([%equal: typ] kt kt' && [%equal: typ] vt vt'))
+                  pure @@ ([%equal: Type.t] kt kt' && [%equal: Type.t] vt vt'))
               kv (pure true)
           in
           if not valid then
@@ -713,7 +713,7 @@ module TypeUtilities = struct
           let res = ADT (asId tname, ts) in
           let%bind tmap = constr_pattern_arg_types res cname in
           let%bind arg_typs = mapM ~f:(fun l -> is_wellformed_lit l) args in
-          let args_valid = List.for_all2_exn tmap arg_typs ~f:[%equal: typ] in
+          let args_valid = List.for_all2_exn tmap arg_typs ~f:[%equal: Type.t] in
           if not args_valid then
             fail0
             @@ sprintf "Malformed ADT %s. Arguments do not match expected types"

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -20,7 +20,7 @@ open Core_kernel
 open! Int.Replace_polymorphic_compare
 open ErrorUtils
 open Sexplib.Std
-open Identifiers
+open Identifier
 open Types
 open Literal
 open Syntax
@@ -66,13 +66,13 @@ module type MakeTEnvFunctor = functor (Q : QualifiedTypes) (R : Rep) -> sig
     val mk : t
 
     (* Add to type environment *)
-    val addT : t -> R.rep ident -> typ -> t
+    val addT : t -> R.rep Identifier.t -> typ -> t
 
     (* Add to many type bindings *)
-    val addTs : t -> (R.rep ident * typ) list -> t
+    val addTs : t -> (R.rep Identifier.t * typ) list -> t
 
     (* Add type variable to the environment *)
-    val addV : t -> R.rep ident -> t
+    val addV : t -> R.rep Identifier.t -> t
 
     (* Append env' to env in place. *)
     val append : t -> t -> t

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -22,7 +22,7 @@ open ErrorUtils
 open Sexplib.Std
 open Identifiers
 open Types
-open Literals
+open Literal
 open Syntax
 open MonadUtil
 open Result.Let_syntax

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -713,7 +713,9 @@ module TypeUtilities = struct
           let res = ADT (asId tname, ts) in
           let%bind tmap = constr_pattern_arg_types res cname in
           let%bind arg_typs = mapM ~f:(fun l -> is_wellformed_lit l) args in
-          let args_valid = List.for_all2_exn tmap arg_typs ~f:[%equal: Type.t] in
+          let args_valid =
+            List.for_all2_exn tmap arg_typs ~f:[%equal: Type.t]
+          in
           if not args_valid then
             fail0
             @@ sprintf "Malformed ADT %s. Arguments do not match expected types"

--- a/src/base/TypeUtil.mli
+++ b/src/base/TypeUtil.mli
@@ -20,7 +20,6 @@ open Core_kernel
 open ErrorUtils
 open Identifiers
 open Types
-open Literals
 open Syntax
 
 (* An inferred type with possible qualifiers *)
@@ -107,9 +106,9 @@ module PlainTypes : QualifiedTypes
 module TypeUtilities : sig
   module MakeTEnv : MakeTEnvFunctor
 
-  val literal_type : literal -> (typ, scilla_error list) result
+  val literal_type : Literal.t -> (typ, scilla_error list) result
 
-  val is_wellformed_lit : literal -> (typ, scilla_error list) result
+  val is_wellformed_lit : Literal.t -> (typ, scilla_error list) result
 
   (* Useful generic types *)
   val fun_typ : typ -> typ -> typ

--- a/src/base/TypeUtil.mli
+++ b/src/base/TypeUtil.mli
@@ -179,7 +179,8 @@ module TypeUtilities : sig
     result
 
   (* Applying a function type *)
-  val fun_type_applies : Type.t -> Type.t list -> (Type.t, scilla_error list) result
+  val fun_type_applies :
+    Type.t -> Type.t list -> (Type.t, scilla_error list) result
 
   (* Applying a procedure "type" *)
   val proc_type_applies :
@@ -208,7 +209,8 @@ module TypeUtilities : sig
   val apply_type_subst : (string * Type.t) list -> Type.t -> Type.t
 
   (*  Get elaborated type for a constructor and list of type arguments *)
-  val elab_constr_type : string -> Type.t list -> (Type.t, scilla_error list) result
+  val elab_constr_type :
+    string -> Type.t list -> (Type.t, scilla_error list) result
 
   (* For a given instantiated ADT and a construtor name, get type *
      assignments. This is the main working horse of type-checking

--- a/src/base/TypeUtil.mli
+++ b/src/base/TypeUtil.mli
@@ -18,11 +18,10 @@
 
 open Core_kernel
 open ErrorUtils
-open Types
 open Syntax
 
 (* An inferred type with possible qualifiers *)
-type 'rep inferred_type = { tp : typ; qual : 'rep } [@@deriving sexp]
+type 'rep inferred_type = { tp : Type.t; qual : 'rep } [@@deriving sexp]
 
 (* Qualifiers to type inference with additional information *)
 module type QualifiedTypes = sig
@@ -32,7 +31,7 @@ module type QualifiedTypes = sig
 
   val sexp_of_t : t -> Sexp.t
 
-  val mk_qualified_type : typ -> t inferred_type
+  val mk_qualified_type : Type.t -> t inferred_type
 end
 
 module type MakeTEnvFunctor = functor (Q : QualifiedTypes) (R : Rep) -> sig
@@ -47,7 +46,7 @@ module type MakeTEnvFunctor = functor (Q : QualifiedTypes) (R : Rep) -> sig
 
   val rr_pp : resolve_result -> string
 
-  val mk_qual_tp : typ -> Q.t inferred_type
+  val mk_qual_tp : Type.t -> Q.t inferred_type
 
   module TEnv : sig
     type t
@@ -56,10 +55,10 @@ module type MakeTEnvFunctor = functor (Q : QualifiedTypes) (R : Rep) -> sig
     val mk : t
 
     (* Add to type environment *)
-    val addT : t -> R.rep Identifier.t -> typ -> t
+    val addT : t -> R.rep Identifier.t -> Type.t -> t
 
     (* Add to many type bindings *)
-    val addTs : t -> (R.rep Identifier.t * typ) list -> t
+    val addTs : t -> (R.rep Identifier.t * Type.t) list -> t
 
     (* Add type variable to the environment *)
     val addV : t -> R.rep Identifier.t -> t
@@ -71,7 +70,7 @@ module type MakeTEnvFunctor = functor (Q : QualifiedTypes) (R : Rep) -> sig
     val filterTs : t -> f:(string -> resolve_result -> bool) -> t
 
     (* Check type for well-formedness in the type environment *)
-    val is_wf_type : t -> typ -> (unit, scilla_error list) result
+    val is_wf_type : t -> Type.t -> (unit, scilla_error list) result
 
     (* Resolve the identifier *)
     val resolveT :
@@ -105,45 +104,45 @@ module PlainTypes : QualifiedTypes
 module TypeUtilities : sig
   module MakeTEnv : MakeTEnvFunctor
 
-  val literal_type : Literal.t -> (typ, scilla_error list) result
+  val literal_type : Literal.t -> (Type.t, scilla_error list) result
 
-  val is_wellformed_lit : Literal.t -> (typ, scilla_error list) result
+  val is_wellformed_lit : Literal.t -> (Type.t, scilla_error list) result
 
   (* Useful generic types *)
-  val fun_typ : typ -> typ -> typ
+  val fun_typ : Type.t -> Type.t -> Type.t
 
-  val tvar : string -> typ
+  val tvar : string -> Type.t
 
-  val tfun_typ : string -> typ -> typ
+  val tfun_typ : string -> Type.t -> Type.t
 
-  val map_typ : typ -> typ -> typ
+  val map_typ : Type.t -> Type.t -> Type.t
 
-  val unit_typ : typ
+  val unit_typ : Type.t
 
   (****************************************************************)
   (*                       Type sanitization                      *)
   (****************************************************************)
 
-  val is_storable_type : typ -> bool
+  val is_storable_type : Type.t -> bool
 
-  val is_serializable_type : typ -> bool
+  val is_serializable_type : Type.t -> bool
 
-  val is_ground_type : typ -> bool
+  val is_ground_type : Type.t -> bool
 
-  val is_non_map_ground_type : typ -> bool
+  val is_non_map_ground_type : Type.t -> bool
 
   val get_msgevnt_type :
-    (string * 'a) sexp_list -> (typ, scilla_error sexp_list) result
+    (string * 'a) sexp_list -> (Type.t, scilla_error sexp_list) result
 
-  val map_access_type : typ -> int -> (typ, scilla_error list) result
+  val map_access_type : Type.t -> int -> (Type.t, scilla_error list) result
 
-  val map_depth : typ -> int
+  val map_depth : Type.t -> int
 
   (****************************************************************)
   (*             Utility function for matching types              *)
   (****************************************************************)
 
-  val type_equiv_list : typ list -> typ list -> bool
+  val type_equiv_list : Type.t list -> Type.t list -> bool
 
   type typeCheckerErrorType = TypeError | GasError
 
@@ -169,58 +168,58 @@ module TypeUtilities : sig
     ('a, 'b) result ->
     ('a, typeCheckerErrorType * 'b * Stdint.uint64) result
 
-  val assert_type_equiv : typ -> typ -> (unit, scilla_error list) result
+  val assert_type_equiv : Type.t -> Type.t -> (unit, scilla_error list) result
 
   val assert_type_equiv_with_gas :
-    typ ->
-    typ ->
+    Type.t ->
+    Type.t ->
     Stdint.uint64 ->
     ( Stdint.uint64,
       typeCheckerErrorType * scilla_error list * Stdint.uint64 )
     result
 
   (* Applying a function type *)
-  val fun_type_applies : typ -> typ list -> (typ, scilla_error list) result
+  val fun_type_applies : Type.t -> Type.t list -> (Type.t, scilla_error list) result
 
   (* Applying a procedure "type" *)
   val proc_type_applies :
-    typ list -> typ list -> (unit list, scilla_error list) result
+    Type.t list -> Type.t list -> (unit list, scilla_error list) result
 
   (* Applying a type function without gas charge (for builtins) *)
   val elab_tfun_with_args_no_gas :
-    typ -> typ list -> (typ, scilla_error list) result
+    Type.t -> Type.t list -> (Type.t, scilla_error list) result
 
   (* Applying a type function *)
   val elab_tfun_with_args :
-    typ ->
-    typ list ->
+    Type.t ->
+    Type.t list ->
     Stdint.uint64 ->
-    ( typ * Stdint.uint64,
+    ( Type.t * Stdint.uint64,
       typeCheckerErrorType * scilla_error list * Stdint.uint64 )
     result
 
-  val pp_typ_list : typ list -> string
+  val pp_typ_list : Type.t list -> string
 
   (****************************************************************)
   (*                        Working with ADTs                     *)
   (****************************************************************)
 
   (*  Apply type substitution  *)
-  val apply_type_subst : (string * typ) list -> typ -> typ
+  val apply_type_subst : (string * Type.t) list -> Type.t -> Type.t
 
   (*  Get elaborated type for a constructor and list of type arguments *)
-  val elab_constr_type : string -> typ list -> (typ, scilla_error list) result
+  val elab_constr_type : string -> Type.t list -> (Type.t, scilla_error list) result
 
   (* For a given instantiated ADT and a construtor name, get type *
      assignments. This is the main working horse of type-checking
      pattern-matching. *)
   val constr_pattern_arg_types :
-    typ -> string -> (typ list, scilla_error list) result
+    Type.t -> string -> (Type.t list, scilla_error list) result
 
   val validate_param_length :
     string -> int -> int -> (unit, scilla_error list) result
 
-  val assert_all_same_type : typ list -> (unit, scilla_error list) result
+  val assert_all_same_type : Type.t list -> (unit, scilla_error list) result
 end
 
 (****************************************************************)

--- a/src/base/TypeUtil.mli
+++ b/src/base/TypeUtil.mli
@@ -18,7 +18,6 @@
 
 open Core_kernel
 open ErrorUtils
-open Identifiers
 open Types
 open Syntax
 
@@ -57,13 +56,13 @@ module type MakeTEnvFunctor = functor (Q : QualifiedTypes) (R : Rep) -> sig
     val mk : t
 
     (* Add to type environment *)
-    val addT : t -> R.rep ident -> typ -> t
+    val addT : t -> R.rep Identifier.t -> typ -> t
 
     (* Add to many type bindings *)
-    val addTs : t -> (R.rep ident * typ) list -> t
+    val addTs : t -> (R.rep Identifier.t * typ) list -> t
 
     (* Add type variable to the environment *)
-    val addV : t -> R.rep ident -> t
+    val addV : t -> R.rep Identifier.t -> t
 
     (* Append env' to env in place. *)
     val append : t -> t -> t

--- a/src/base/Types.ml
+++ b/src/base/Types.ml
@@ -20,7 +20,7 @@ open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Sexplib.Std
 open ErrorUtils
-open Identifiers
+open Identifier
 
 (*******************************************************)
 (*                         Types                       *)
@@ -64,7 +64,7 @@ type typ =
   | PrimType of prim_typ
   | MapType of typ * typ
   | FunType of typ * typ
-  | ADT of loc ident * typ list
+  | ADT of loc Identifier.t * typ list
   | TypeVar of string
   | PolyFun of string * typ
   | Unit

--- a/src/base/Types.mli
+++ b/src/base/Types.mli
@@ -17,7 +17,6 @@
 *)
 
 open ErrorUtils
-open Identifiers
 
 type int_bit_width = Bits32 | Bits64 | Bits128 | Bits256
 
@@ -41,7 +40,7 @@ type typ =
   | PrimType of prim_typ
   | MapType of typ * typ
   | FunType of typ * typ
-  | ADT of loc ident * typ list
+  | ADT of loc Identifier.t * typ list
   | TypeVar of string
   | PolyFun of string * typ
   | Unit
@@ -67,4 +66,4 @@ val subst_type_in_type : string -> typ -> typ -> typ
 
 val subst_types_in_type : (string * typ) list -> typ -> typ
 
-val subst_type_in_type' : 'a ident -> typ -> typ -> typ
+val subst_type_in_type' : 'a Identifier.t -> typ -> typ -> typ

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -19,7 +19,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Identifier
-open Types
+open Type
 open Literal
 open Syntax
 open ErrorUtils
@@ -542,7 +542,7 @@ let init_contract clibs elibs cconstraint' cparams' cfields args' init_bal =
           tryM
             ~f:(fun (ps, pt) ->
               let%bind at = fromR @@ literal_type (snd a) in
-              if String.(get_id ps = fst a) && [%equal: typ] pt at then
+              if String.(get_id ps = fst a) && [%equal: Type.t] pt at then
                 pure true
               else fail0 "")
             cparams ~msg:emsg
@@ -592,7 +592,7 @@ let create_cur_state_fields initcstate curcstate =
             ~f:(fun (t, li) ->
               let%bind t1 = fromR @@ literal_type lc in
               let%bind t2 = fromR @@ literal_type li in
-              if String.(s = t) && [%equal: typ] t1 t2 then pure true
+              if String.(s = t) && [%equal: Type.t] t1 t2 then pure true
               else fail0 "")
             initcstate ~msg:emsg
         in

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -18,7 +18,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
-open Identifiers
+open Identifier
 open Types
 open Literal
 open Syntax

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -20,7 +20,7 @@ open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Identifiers
 open Types
-open Literals
+open Literal
 open Syntax
 open ErrorUtils
 open EvalUtil

--- a/src/eval/EvalUtil.ml
+++ b/src/eval/EvalUtil.ml
@@ -18,7 +18,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
-open Identifiers
+open Identifier
 open Types
 open Literal
 open Syntax
@@ -141,7 +141,7 @@ module Configuration = struct
        procedures available to p. *)
     procedures : EvalSyntax.component list;
     (* The stack of procedure call, starting from the externally invoked transition. *)
-    component_stack : ER.rep ident list;
+    component_stack : ER.rep Identifier.t list;
     (* Emitted messages *)
     emitted : Literal.t list;
     (* Emitted events *)

--- a/src/eval/EvalUtil.ml
+++ b/src/eval/EvalUtil.ml
@@ -19,7 +19,6 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Identifier
-open Types
 open Literal
 open Syntax
 open ErrorUtils
@@ -126,7 +125,7 @@ module Configuration = struct
     (* Current environment parameters and local variables *)
     env : Env.t;
     (* Contract fields *)
-    fields : (string * typ) list;
+    fields : (string * Type.t) list;
     (* Contract balance *)
     balance : uint128;
     (* Was incoming money accepted? *)
@@ -397,7 +396,7 @@ module ContractState = struct
     (* Immutable parameters *)
     env : Env.t;
     (* Contract fields *)
-    fields : (string * typ) list;
+    fields : (string * Type.t) list;
     (* Contract balance *)
     balance : uint128;
   }

--- a/src/eval/EvalUtil.ml
+++ b/src/eval/EvalUtil.ml
@@ -20,7 +20,7 @@ open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Identifiers
 open Types
-open Literals
+open Literal
 open Syntax
 open ErrorUtils
 open MonadUtil
@@ -64,12 +64,12 @@ module Env = struct
   type ident = string
 
   (* Environment *)
-  type t = (string * literal) list [@@deriving sexp]
+  type t = (string * Literal.t) list [@@deriving sexp]
 
   (* Pretty-printing *)
   let rec pp_value = pp_literal
 
-  and pp ?(f = fun (_ : string * literal) -> true) e =
+  and pp ?(f = fun (_ : string * Literal.t) -> true) e =
     (* FIXME: Do not print folds *)
     let e_filtered = List.filter e ~f in
     let ps =
@@ -104,7 +104,7 @@ end
 (*                 Blockchain State               *)
 (**************************************************)
 module BlockchainState = struct
-  type t = (string * literal) list
+  type t = (string * Literal.t) list
 
   let lookup e k =
     match List.Assoc.find e k ~equal:String.( = ) with
@@ -143,9 +143,9 @@ module Configuration = struct
     (* The stack of procedure call, starting from the externally invoked transition. *)
     component_stack : ER.rep ident list;
     (* Emitted messages *)
-    emitted : literal list;
+    emitted : Literal.t list;
     (* Emitted events *)
-    events : literal list;
+    events : Literal.t list;
   }
 
   let pp conf =
@@ -390,7 +390,7 @@ end
 (*****************************************************)
 
 module ContractState = struct
-  type init_args = (string * literal) list
+  type init_args = (string * Literal.t) list
 
   (* Runtime contract configuration and operations with it *)
   type t = {

--- a/src/eval/PatternMatching.ml
+++ b/src/eval/PatternMatching.ml
@@ -20,7 +20,7 @@ open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Datatypes
 open Identifiers
-open Literals
+open Literal
 open EvalUtil
 open MonadUtil
 open Result.Let_syntax

--- a/src/eval/PatternMatching.ml
+++ b/src/eval/PatternMatching.ml
@@ -19,7 +19,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Datatypes
-open Identifiers
+open Identifier
 open Literal
 open EvalUtil
 open MonadUtil

--- a/src/eval/Runner.ml
+++ b/src/eval/Runner.ml
@@ -18,7 +18,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
-open Identifiers
+open Identifier
 open Literal
 open Syntax
 open FrontEndParser

--- a/src/eval/Runner.ml
+++ b/src/eval/Runner.ml
@@ -19,7 +19,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Identifiers
-open Literals
+open Literal
 open Syntax
 open FrontEndParser
 open ErrorUtils

--- a/src/eval/StateIPCClient.ml
+++ b/src/eval/StateIPCClient.ml
@@ -20,7 +20,7 @@ open! Int.Replace_polymorphic_compare
 open Result.Let_syntax
 open MonadUtil
 open Identifiers
-open Literals
+open Literal
 open Syntax
 open JSON
 open TypeUtil

--- a/src/eval/StateIPCClient.ml
+++ b/src/eval/StateIPCClient.ml
@@ -19,7 +19,7 @@ open Core
 open! Int.Replace_polymorphic_compare
 open Result.Let_syntax
 open MonadUtil
-open Identifiers
+open Identifier
 open Literal
 open Syntax
 open JSON

--- a/src/eval/StateIPCClient.mli
+++ b/src/eval/StateIPCClient.mli
@@ -18,7 +18,6 @@
 
 open Identifiers
 open Types
-open Literals
 open ErrorUtils
 
 (* Fetch from a field. "keys" is empty when fetching non-map fields or an entire Map field.
@@ -26,16 +25,16 @@ open ErrorUtils
 val fetch :
   socket_addr:string ->
   fname:loc ident ->
-  keys:literal list ->
+  keys:Literal.t list ->
   tp:typ ->
-  (literal option, scilla_error list) result
+  (Literal.t option, scilla_error list) result
 
 (* Update a field. "keys" is empty when updating non-map fields or an entire Map field. *)
 val update :
   socket_addr:string ->
   fname:loc ident ->
-  keys:literal list ->
-  value:literal ->
+  keys:Literal.t list ->
+  value:Literal.t ->
   tp:typ ->
   (unit, scilla_error list) result
 
@@ -43,7 +42,7 @@ val update :
 val is_member :
   socket_addr:string ->
   fname:loc ident ->
-  keys:literal list ->
+  keys:Literal.t list ->
   tp:typ ->
   (bool, scilla_error list) result
 
@@ -51,6 +50,6 @@ val is_member :
 val remove :
   socket_addr:string ->
   fname:loc ident ->
-  keys:literal list ->
+  keys:Literal.t list ->
   tp:typ ->
   (unit, scilla_error list) result

--- a/src/eval/StateIPCClient.mli
+++ b/src/eval/StateIPCClient.mli
@@ -16,7 +16,6 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Types
 open ErrorUtils
 
 (* Fetch from a field. "keys" is empty when fetching non-map fields or an entire Map field.
@@ -25,7 +24,7 @@ val fetch :
   socket_addr:string ->
   fname:loc Identifier.t ->
   keys:Literal.t list ->
-  tp:typ ->
+  tp:Type.t ->
   (Literal.t option, scilla_error list) result
 
 (* Update a field. "keys" is empty when updating non-map fields or an entire Map field. *)
@@ -34,7 +33,7 @@ val update :
   fname:loc Identifier.t ->
   keys:Literal.t list ->
   value:Literal.t ->
-  tp:typ ->
+  tp:Type.t ->
   (unit, scilla_error list) result
 
 (* Is a key in a map. keys must be non-empty. *)
@@ -42,7 +41,7 @@ val is_member :
   socket_addr:string ->
   fname:loc Identifier.t ->
   keys:Literal.t list ->
-  tp:typ ->
+  tp:Type.t ->
   (bool, scilla_error list) result
 
 (* Remove a key from a map. keys must be non-empty. *)
@@ -50,5 +49,5 @@ val remove :
   socket_addr:string ->
   fname:loc Identifier.t ->
   keys:Literal.t list ->
-  tp:typ ->
+  tp:Type.t ->
   (unit, scilla_error list) result

--- a/src/eval/StateIPCClient.mli
+++ b/src/eval/StateIPCClient.mli
@@ -16,7 +16,6 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Identifiers
 open Types
 open ErrorUtils
 
@@ -24,7 +23,7 @@ open ErrorUtils
  * If a map key is not found, then None is returned, otherwise (Some value) is returned. *)
 val fetch :
   socket_addr:string ->
-  fname:loc ident ->
+  fname:loc Identifier.t ->
   keys:Literal.t list ->
   tp:typ ->
   (Literal.t option, scilla_error list) result
@@ -32,7 +31,7 @@ val fetch :
 (* Update a field. "keys" is empty when updating non-map fields or an entire Map field. *)
 val update :
   socket_addr:string ->
-  fname:loc ident ->
+  fname:loc Identifier.t ->
   keys:Literal.t list ->
   value:Literal.t ->
   tp:typ ->
@@ -41,7 +40,7 @@ val update :
 (* Is a key in a map. keys must be non-empty. *)
 val is_member :
   socket_addr:string ->
-  fname:loc ident ->
+  fname:loc Identifier.t ->
   keys:Literal.t list ->
   tp:typ ->
   (bool, scilla_error list) result
@@ -49,7 +48,7 @@ val is_member :
 (* Remove a key from a map. keys must be non-empty. *)
 val remove :
   socket_addr:string ->
-  fname:loc ident ->
+  fname:loc Identifier.t ->
   keys:Literal.t list ->
   tp:typ ->
   (unit, scilla_error list) result

--- a/src/eval/StateService.ml
+++ b/src/eval/StateService.ml
@@ -21,7 +21,7 @@ open! Int.Replace_polymorphic_compare
 open Result.Let_syntax
 open MonadUtil
 open TypeUtil
-open Identifiers
+open Identifier
 open Types
 open Literal
 open Syntax

--- a/src/eval/StateService.ml
+++ b/src/eval/StateService.ml
@@ -23,7 +23,7 @@ open MonadUtil
 open TypeUtil
 open Identifiers
 open Types
-open Literals
+open Literal
 open Syntax
 module ER = ParserRep
 module SR = ParserRep
@@ -34,7 +34,7 @@ open EvalSyntax
 type ss_field = {
   fname : string;
   ftyp : typ;
-  fval : literal option; (* We may or may not have the value in memory. *)
+  fval : Literal.t option; (* We may or may not have the value in memory. *)
 }
 
 type service_mode =

--- a/src/eval/StateService.ml
+++ b/src/eval/StateService.ml
@@ -22,7 +22,7 @@ open Result.Let_syntax
 open MonadUtil
 open TypeUtil
 open Identifier
-open Types
+open Type
 open Literal
 open Syntax
 module ER = ParserRep
@@ -33,7 +33,7 @@ open EvalSyntax
 
 type ss_field = {
   fname : string;
-  ftyp : typ;
+  ftyp : Type.t;
   fval : Literal.t option; (* We may or may not have the value in memory. *)
 }
 
@@ -81,7 +81,7 @@ module MakeStateService () = struct
           match klist' with
           | [ k ] ->
               (* Just an assert. *)
-              if not @@ [%equal: typ] vt' ret_val_type then
+              if not @@ [%equal: Type.t] vt' ret_val_type then
                 fail1
                   (sprintf
                      "StateService: Failed indexing into map %s. Internal \

--- a/src/eval/StateService.mli
+++ b/src/eval/StateService.mli
@@ -21,7 +21,6 @@
 
 open Identifiers
 open Types
-open Literals
 open Syntax
 open ParsedSyntax
 open ErrorUtils
@@ -29,7 +28,7 @@ open ErrorUtils
 type ss_field = {
   fname : string;
   ftyp : typ;
-  fval : literal option; (* Value may not be available (in IPC mode) *)
+  fval : Literal.t option; (* Value may not be available (in IPC mode) *)
 }
 
 type service_mode =
@@ -59,7 +58,7 @@ type service_mode =
 val initialize : sm:service_mode -> fields:ss_field list -> unit
 
 (* Expensive operation, use with care. *)
-val get_full_state : unit -> ((string * literal) list, scilla_error list) result
+val get_full_state : unit -> ((string * Literal.t) list, scilla_error list) result
 
 (* Finalize: no more queries. *)
 val finalize : unit -> (unit, scilla_error list) result
@@ -68,26 +67,26 @@ val finalize : unit -> (unit, scilla_error list) result
  * If a map key is not found, then None is returned, otherwise (Some value) is returned. *)
 val fetch :
   fname:loc ident ->
-  keys:literal list ->
-  (literal option * stmt_eval_context, scilla_error list) result
+  keys:Literal.t list ->
+  (Literal.t option * stmt_eval_context, scilla_error list) result
 
 (* Update a field. "keys" is empty when updating non-map fields or an entire Map field. *)
 val update :
   fname:loc ident ->
-  keys:literal list ->
-  value:literal ->
+  keys:Literal.t list ->
+  value:Literal.t ->
   (stmt_eval_context, scilla_error list) result
 
 (* Is a key in a map. keys must be non-empty. *)
 val is_member :
   fname:loc ident ->
-  keys:literal list ->
+  keys:Literal.t list ->
   (bool * stmt_eval_context, scilla_error list) result
 
 (* Remove a key from a map. keys must be non-empty. *)
 val remove :
   fname:loc ident ->
-  keys:literal list ->
+  keys:Literal.t list ->
   (stmt_eval_context, scilla_error list) result
 
 (* Should rarely be used, and is useful only when multiple StateService objects are required *)
@@ -95,28 +94,28 @@ module MakeStateService () : sig
   val initialize : sm:service_mode -> fields:ss_field list -> unit
 
   val get_full_state :
-    unit -> ((string * literal) list, scilla_error list) result
+    unit -> ((string * Literal.t) list, scilla_error list) result
 
   val finalize : unit -> (unit, scilla_error list) result
 
   val fetch :
     fname:loc ident ->
-    keys:literal list ->
-    (literal option * stmt_eval_context, scilla_error list) result
+    keys:Literal.t list ->
+    (Literal.t option * stmt_eval_context, scilla_error list) result
 
   val update :
     fname:loc ident ->
-    keys:literal list ->
-    value:literal ->
+    keys:Literal.t list ->
+    value:Literal.t ->
     (stmt_eval_context, scilla_error list) result
 
   val is_member :
     fname:loc ident ->
-    keys:literal list ->
+    keys:Literal.t list ->
     (bool * stmt_eval_context, scilla_error list) result
 
   val remove :
     fname:loc ident ->
-    keys:literal list ->
+    keys:Literal.t list ->
     (stmt_eval_context, scilla_error list) result
 end

--- a/src/eval/StateService.mli
+++ b/src/eval/StateService.mli
@@ -56,7 +56,8 @@ type service_mode =
 val initialize : sm:service_mode -> fields:ss_field list -> unit
 
 (* Expensive operation, use with care. *)
-val get_full_state : unit -> ((string * Literal.t) list, scilla_error list) result
+val get_full_state :
+  unit -> ((string * Literal.t) list, scilla_error list) result
 
 (* Finalize: no more queries. *)
 val finalize : unit -> (unit, scilla_error list) result

--- a/src/eval/StateService.mli
+++ b/src/eval/StateService.mli
@@ -19,7 +19,6 @@
 (* This file describes function that communicate with the blockchain to fetch
  * and update state variables on demand. *)
 
-open Identifiers
 open Types
 open Syntax
 open ParsedSyntax
@@ -66,26 +65,26 @@ val finalize : unit -> (unit, scilla_error list) result
 (* Fetch from a field. "keys" is empty when fetching non-map fields or an entire Map field.
  * If a map key is not found, then None is returned, otherwise (Some value) is returned. *)
 val fetch :
-  fname:loc ident ->
+  fname:loc Identifier.t ->
   keys:Literal.t list ->
   (Literal.t option * stmt_eval_context, scilla_error list) result
 
 (* Update a field. "keys" is empty when updating non-map fields or an entire Map field. *)
 val update :
-  fname:loc ident ->
+  fname:loc Identifier.t ->
   keys:Literal.t list ->
   value:Literal.t ->
   (stmt_eval_context, scilla_error list) result
 
 (* Is a key in a map. keys must be non-empty. *)
 val is_member :
-  fname:loc ident ->
+  fname:loc Identifier.t ->
   keys:Literal.t list ->
   (bool * stmt_eval_context, scilla_error list) result
 
 (* Remove a key from a map. keys must be non-empty. *)
 val remove :
-  fname:loc ident ->
+  fname:loc Identifier.t ->
   keys:Literal.t list ->
   (stmt_eval_context, scilla_error list) result
 
@@ -99,23 +98,23 @@ module MakeStateService () : sig
   val finalize : unit -> (unit, scilla_error list) result
 
   val fetch :
-    fname:loc ident ->
+    fname:loc Identifier.t ->
     keys:Literal.t list ->
     (Literal.t option * stmt_eval_context, scilla_error list) result
 
   val update :
-    fname:loc ident ->
+    fname:loc Identifier.t ->
     keys:Literal.t list ->
     value:Literal.t ->
     (stmt_eval_context, scilla_error list) result
 
   val is_member :
-    fname:loc ident ->
+    fname:loc Identifier.t ->
     keys:Literal.t list ->
     (bool * stmt_eval_context, scilla_error list) result
 
   val remove :
-    fname:loc ident ->
+    fname:loc Identifier.t ->
     keys:Literal.t list ->
     (stmt_eval_context, scilla_error list) result
 end

--- a/src/eval/StateService.mli
+++ b/src/eval/StateService.mli
@@ -19,14 +19,13 @@
 (* This file describes function that communicate with the blockchain to fetch
  * and update state variables on demand. *)
 
-open Types
 open Syntax
 open ParsedSyntax
 open ErrorUtils
 
 type ss_field = {
   fname : string;
-  ftyp : typ;
+  ftyp : Type.t;
   fval : Literal.t option; (* Value may not be available (in IPC mode) *)
 }
 

--- a/src/runners/eval_runner.ml
+++ b/src/runners/eval_runner.ml
@@ -18,7 +18,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
-open Identifiers
+open Identifier
 open Syntax
 open FrontEndParser
 open RunnerUtil

--- a/src/runners/type_checker.ml
+++ b/src/runners/type_checker.ml
@@ -19,7 +19,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Printf
-open Identifiers
+open Identifier
 open Types
 open Syntax
 open TypeUtil

--- a/src/runners/type_checker.ml
+++ b/src/runners/type_checker.ml
@@ -20,7 +20,7 @@ open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Printf
 open Identifier
-open Types
+open Type
 open Syntax
 open TypeUtil
 open RecursionPrinciples

--- a/tests/base/TestBech32.ml
+++ b/tests/base/TestBech32.ml
@@ -20,7 +20,7 @@ open Core_kernel
 open! Int.Replace_polymorphic_compare
 open OUnit2
 open Bech32
-open Literals
+open Literal
 open Utils
 
 let hex_to_raw_bytes h = Bystr.parse_hex h |> Bystr.to_raw_bytes

--- a/tests/base/TestSnark.ml
+++ b/tests/base/TestSnark.ml
@@ -23,7 +23,7 @@ open Core_kernel
 open OUnit2
 open Snark
 open Integer256
-open Literals
+open Literal
 
 (* Convert a decimal string to a binary string of 32 bytes. *)
 let dec2bystr32 s =

--- a/tests/base/TestSyntax.ml
+++ b/tests/base/TestSyntax.ml
@@ -4,7 +4,7 @@ open Stdint
 open OUnit2
 open Identifiers
 open Types
-open Literals
+open Literal
 open Syntax
 open ParsedSyntax
 open PrimTypes

--- a/tests/base/TestSyntax.ml
+++ b/tests/base/TestSyntax.ml
@@ -3,7 +3,7 @@ open! Int.Replace_polymorphic_compare
 open Stdint
 open OUnit2
 open Identifier
-open Types
+open Type
 open Literal
 open Syntax
 open ParsedSyntax

--- a/tests/base/TestSyntax.ml
+++ b/tests/base/TestSyntax.ml
@@ -2,7 +2,7 @@ open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Stdint
 open OUnit2
-open Identifiers
+open Identifier
 open Types
 open Literal
 open Syntax

--- a/tests/ipc/StateIPCTest.ml
+++ b/tests/ipc/StateIPCTest.ml
@@ -22,7 +22,7 @@
 open OUnit2
 open Core_kernel
 open! Int.Replace_polymorphic_compare
-open Types
+open Type
 open Yojson
 
 let parse_typ_wrapper t =

--- a/tests/ipc/StateIPCTest.mli
+++ b/tests/ipc/StateIPCTest.mli
@@ -27,13 +27,13 @@ val setup_and_initialize :
 (* Get full state, and if a server was started in ~setup_and_initialize, shut it down. *)
 val get_final_finish :
   sock_addr:string ->
-  (string * Types.typ * Ipcmessage_types.proto_scilla_val) list
+  (string * Type.t * Ipcmessage_types.proto_scilla_val) list
 
 (* Given the interpreter's output, parse the JSON, append svars to it and print out new JSON. *)
 val append_full_state :
   goldoutput_file:string ->
   interpreter_output:string ->
-  (string * Types.typ * Ipcmessage_types.proto_scilla_val) list ->
+  (string * Type.t * Ipcmessage_types.proto_scilla_val) list ->
   string
 
 val json_from_string : string -> Yojson.Basic.t

--- a/tests/ipc/StateIPCTest.mli
+++ b/tests/ipc/StateIPCTest.mli
@@ -26,8 +26,7 @@ val setup_and_initialize :
 
 (* Get full state, and if a server was started in ~setup_and_initialize, shut it down. *)
 val get_final_finish :
-  sock_addr:string ->
-  (string * Type.t * Ipcmessage_types.proto_scilla_val) list
+  sock_addr:string -> (string * Type.t * Ipcmessage_types.proto_scilla_val) list
 
 (* Given the interpreter's output, parse the JSON, append svars to it and print out new JSON. *)
 val append_full_state :

--- a/tests/ipc/StateIPCTestClient.ml
+++ b/tests/ipc/StateIPCTestClient.ml
@@ -18,7 +18,6 @@
 
 open Core
 open! Int.Replace_polymorphic_compare
-open Types
 open TypeUtil
 open StateIPCIdl
 open OUnit2
@@ -33,7 +32,7 @@ module IPCClient = IPCIdl (IDL.GenClient ())
  * with Scilla literals, which we cannot always parse from the JSONs. Parsing it requires the
  * definitions of custom ADTs that are only available in the source file. *)
 
-type state_info = (string * typ) list
+type state_info = (string * Type.t) list
 
 (* For persistance b/w multiple queries. *)
 let stateref = ref None

--- a/tests/typecheck/bad/TestTypeFail.ml
+++ b/tests/typecheck/bad/TestTypeFail.ml
@@ -24,7 +24,7 @@ open OUnit2
  * literals is by constructing them ourselves as there are checks
  * in both Scilla source parser and the JSON parser against
  * building bad literals. *)
-open Literals
+open Literal
 open PrimTypes
 open PrettyPrinters
 module TestTypeUtils = TypeUtil.TypeUtilities

--- a/tests/typecheck/good/Testtypes.ml
+++ b/tests/typecheck/good/Testtypes.ml
@@ -37,7 +37,8 @@ let make_type_equiv_test st1 st2 eq =
                dummy_loc ))
   in
   let b, bs =
-    if eq then ([%equal: Type.t] t1 t2, "=") else (not ([%equal: Type.t] t1 t2), "<>")
+    if eq then ([%equal: Type.t] t1 t2, "=")
+    else (not ([%equal: Type.t] t1 t2), "<>")
   in
   let err_msg =
     "Assert " ^ pp_typ t1 ^ " " ^ bs ^ " " ^ pp_typ t2 ^ " test failed"

--- a/tests/typecheck/good/Testtypes.ml
+++ b/tests/typecheck/good/Testtypes.ml
@@ -19,7 +19,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open OUnit2
-open Types
+open Type
 open Syntax
 open ErrorUtils
 module TestTypeUtils = TypeUtil.TypeUtilities
@@ -37,7 +37,7 @@ let make_type_equiv_test st1 st2 eq =
                dummy_loc ))
   in
   let b, bs =
-    if eq then ([%equal: typ] t1 t2, "=") else (not ([%equal: typ] t1 t2), "<>")
+    if eq then ([%equal: Type.t] t1 t2, "=") else (not ([%equal: Type.t] t1 t2), "<>")
   in
   let err_msg =
     "Assert " ^ pp_typ t1 ^ " " ^ bs ^ " " ^ pp_typ t2 ^ " test failed"
@@ -124,7 +124,7 @@ let make_map_access_type_test t at nindices =
           assert_failure
             "Failed map_access_type test. map_access_type returned failure."
       | Ok at_computed' ->
-          let b = [%equal: typ] at' at_computed' in
+          let b = [%equal: Type.t] at' at_computed' in
           assert_bool
             (Printf.sprintf
                "Failed map_access_type test for %s[%d]. Expected %s, but got %s.\n"


### PR DESCRIPTION
This addresses the comments made by @anton-trunov on the previous refactoring of Syntax.ml:

- Identifiers.ml, Types.ml and Literal.ml and their associated .mli files have been renamed to the singular forms Identifier, Type and Literal.
- The main types of those files (`ident`, `typ` and `literal`) have been renamed to `t`.

Two comments have not been addressed:

- Separate module for `prim_type`: I'll look into this when I do the qualified names issue. I suspect the type is too closely connected to `Type.t` to be separated out, but let's see.
- `mk_id` is always applied to the result of `asId`: `Rep` really ought not to construct identifiers. It really just ought to construct an annotation, which can then be added to an identifier by the caller. I tried to quickly fix that, but `GasUseAnalysis.ml` needs a bit of thought, and I'd prefer to fix the names bug first.