### PR TITLE
Provide a `make debug` target for debugging with ocamldebug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 OCAML_VERSION_RECOMMENDED=4.07.1
 IPC_SOCK_PATH="/tmp/zilliqa.sock"
+CPPLIB_DIR=${PWD}/_build/default/src/base/cpp
 
 .PHONY: default release utop dev clean docker zilliqa-docker
 
@@ -53,10 +54,10 @@ uninstall : release
 debug :
 	dune build --profile dev src/runners/scilla_runner.bc
 	dune build --profile dev src/runners/scilla_checker.bc
-	@test -d bin || mkdir bin
-	@test bin/scilla_runner.bc || ln -s _build/default/src/runners/scilla_runner.bc bin/
-	@test bin/scilla_runner.bc || ln -s _build/default/src/runners/scilla_checker.bc bin/
-	@echo "Before executing bytecode, set LD_LIBRARY_PATH to ${PWD}/_build/default/src/cpp"
+	dune build --profile dev src/runners/type_checker.bc
+	dune build --profile dev src/runners/eval_runner.bc
+	@echo "Note: LD_LIBRARY_PATH must be set to ${CPPLIB_DIR}  before execution"
+	@echo "Example: LD_LIBRARY_PATH=${CPPLIB_DIR} ocamldebug _build/default/src/runners/scilla_checker.bc -libdir src/stdlib -gaslimit 10000 tests/contracts/helloworld.scilla"
 
 # === TESTS (begin) ===========================================================
 # Build and run tests

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,15 @@ test_install : install
 uninstall : release
 	dune uninstall
 
+# Debug with ocamldebug: Build byte code instead of native code.
+debug :
+	dune build --profile dev src/runners/scilla_runner.bc
+	dune build --profile dev src/runners/scilla_checker.bc
+	@test -d bin || mkdir bin
+	@test bin/scilla_runner.bc || ln -s _build/default/src/runners/scilla_runner.bc bin/
+	@test bin/scilla_runner.bc || ln -s _build/default/src/runners/scilla_checker.bc bin/
+	@echo "Before executing bytecode, set LD_LIBRARY_PATH to ${PWD}/_build/default/src/cpp"
+
 # === TESTS (begin) ===========================================================
 # Build and run tests
 

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ debug :
 	dune build --profile dev src/runners/scilla_checker.bc
 	dune build --profile dev src/runners/type_checker.bc
 	dune build --profile dev src/runners/eval_runner.bc
-	@echo "Note: LD_LIBRARY_PATH must be set to ${CPPLIB_DIR}  before execution"
+	@echo "Note: LD_LIBRARY_PATH must be set to ${CPPLIB_DIR} before execution"
 	@echo "Example: LD_LIBRARY_PATH=${CPPLIB_DIR} ocamldebug _build/default/src/runners/scilla_checker.bc -libdir src/stdlib -gaslimit 10000 tests/contracts/helloworld.scilla"
 
 # === TESTS (begin) ===========================================================

--- a/README.md
+++ b/README.md
@@ -171,6 +171,18 @@ dune exec tests/testsuite.exe -- -only-test all_tests:1:exptests:14:let.scilla -
 The optional `-print-cli true` argument is to produce the command line
 that has been used to run the test.
 
+#### Debugging
+To debug scilla-checker or scilla-runner, you must build `make debug`, which will generate
+the OCaml bytecode versions of the binaries. These can be debugged using `ocamldebug`.
+Executing a bytecode executable also requires the environment variable `LD_LIBRARY_PATH` to
+be set to `_build/default/src/base/cpp`. An example debug command line is provided below.
+
+
+```shell
+LD_LIBRARY_PATH=${PWD}/_build/default/src/base/cpp ocamldebug _build/default/src/runners/scilla_checker.bc -libdir src/stdlib -gaslimit 10000 tests/contracts/helloworld.scilla
+
+```
+
 ## Developer Tools
 ### Emacs mode
 

--- a/src/base/cpp/config/dune
+++ b/src/base/cpp/config/dune
@@ -1,3 +1,4 @@
 (executable
  (name discover)
+ (modes byte native)
  (libraries base stdio dune.configurator))

--- a/src/base/cpp/dune
+++ b/src/base/cpp/dune
@@ -4,6 +4,7 @@
  (libraries ctypes ctypes.foreign cryptokit)
  (preprocess
   (pps ppx_compare))
+ (modes byte native)
  (foreign_stubs
   (language c)
   (names generate_dsa_nonce)

--- a/src/base/dune
+++ b/src/base/dune
@@ -1,6 +1,5 @@
 (ocamllex
  (modules ScillaLexer))
-
 (menhir
  (flags "--table")
  (modules ScillaParser))
@@ -17,6 +16,7 @@
 
 (library
  (name scilla_base)
+ (modes byte native)
  (wrapped false)
  (libraries core num hex stdint angstrom polynomials cryptokit secp256k1
    bitstring yojson fileutils scilla_cpp_deps menhirLib)

--- a/src/base/dune
+++ b/src/base/dune
@@ -1,5 +1,6 @@
 (ocamllex
  (modules ScillaLexer))
+
 (menhir
  (flags "--table")
  (modules ScillaParser))

--- a/src/checkers/dune
+++ b/src/checkers/dune
@@ -1,6 +1,7 @@
 (library
  (name scilla_checkers)
  (wrapped false)
+ (modes byte native)
  (libraries core angstrom stdint polynomials yojson cryptokit scilla_base)
  (preprocess
   (pps ppx_sexp_conv ppx_let bisect_ppx ppx_compare --conditional

--- a/src/eval/dune
+++ b/src/eval/dune
@@ -1,6 +1,7 @@
 (library
  (name scilla_eval)
  (wrapped false)
+ (modes byte native)
  (libraries core angstrom stdint yojson cryptokit scilla_base rpclib unix
    rpclib.json rresult ocaml-protoc)
  (preprocess

--- a/src/polynomials/dune
+++ b/src/polynomials/dune
@@ -1,5 +1,6 @@
 (library
  (name polynomials)
  (wrapped false)
+ (modes byte native)
  (synopsis "Utility to deal with multivariate polynomials")
  (libraries core))

--- a/src/runners/dune
+++ b/src/runners/dune
@@ -6,5 +6,6 @@
  (modules scilla_runner eval_runner type_checker scilla_checker scilla_server)
  (libraries core angstrom yojson cryptokit fileutils scilla_base scilla_eval
    scilla_server_lib scilla_cpp_deps)
+ (modes byte native)
  (preprocess
   (pps ppx_sexp_conv ppx_let ppx_deriving.show bisect_ppx --conditional)))

--- a/src/server/dune
+++ b/src/server/dune
@@ -4,7 +4,8 @@
    scilla_base scilla_eval)
  (modes byte native)
  (preprocess
-(pps ppx_sexp_conv ppx_deriving_rpc ppx_deriving.show)))
+  (pps ppx_sexp_conv ppx_deriving_rpc ppx_deriving.show)))
+
 (env
  (dev
   (flags

--- a/src/server/dune
+++ b/src/server/dune
@@ -2,9 +2,9 @@
  (name scilla_server_lib)
  (libraries core threads unix rresult rpclib rpclib.json rpclib.cmdliner
    scilla_base scilla_eval)
+ (modes byte native)
  (preprocess
-  (pps ppx_sexp_conv ppx_deriving_rpc ppx_deriving.show)))
-
+(pps ppx_sexp_conv ppx_deriving_rpc ppx_deriving.show)))
 (env
  (dev
   (flags

--- a/tests/base/dune
+++ b/tests/base/dune
@@ -1,4 +1,5 @@
 (executable
+ (modes byte native)
  (name testsuite_base)
  (preprocess
   (pps ppx_sexp_conv ppx_let ppx_deriving.show ppx_compare))

--- a/tests/base/parser/bad/dune
+++ b/tests/base/parser/bad/dune
@@ -1,4 +1,5 @@
 (library
+ (modes byte native)
  (name testparserfail)
  (wrapped false)
  (libraries core oUnit testutil))

--- a/tests/base/parser/dune
+++ b/tests/base/parser/dune
@@ -1,10 +1,12 @@
 (library
+ (modes byte native)
  (name testparser)
  (modules TestParser)
  (wrapped false)
  (libraries core_kernel oUnit testutil testparserfail))
 
 (executable
+ (modes byte native)
  (name parser_dummy)
  (public_name parser-dummy)
  (modules Parser_dummy)

--- a/tests/checker/bad/dune
+++ b/tests/checker/bad/dune
@@ -1,4 +1,5 @@
 (library
+ (modes byte native)
  (name testcheckerfail)
  (wrapped false)
  (libraries core oUnit testutil))

--- a/tests/checker/dune
+++ b/tests/checker/dune
@@ -1,4 +1,5 @@
 (library
+ (modes byte native)
  (name testchecker)
  (wrapped false)
  (libraries core oUnit testutil testcheckersuccess testcheckerfail))

--- a/tests/checker/good/dune
+++ b/tests/checker/good/dune
@@ -1,4 +1,5 @@
 (library
+ (modes byte native)
  (name testcheckersuccess)
  (wrapped false)
  (libraries core oUnit testutil))

--- a/tests/dune
+++ b/tests/dune
@@ -1,4 +1,5 @@
 (executables
+ (modes byte native)
  (names testsuite scilla_client)
  (preprocess
   (pps ppx_sexp_conv ppx_let ppx_deriving.show))

--- a/tests/eval/bad/dune
+++ b/tests/eval/bad/dune
@@ -1,4 +1,5 @@
 (library
+ (modes byte native)
  (name testexpsfail)
  (wrapped false)
  (libraries core oUnit testutil))

--- a/tests/eval/good/dune
+++ b/tests/eval/good/dune
@@ -1,4 +1,5 @@
 (library
+ (modes byte native)
  (name testexps)
  (wrapped false)
  (libraries core oUnit testutil))

--- a/tests/gas_use_analysis/contracts/dune
+++ b/tests/gas_use_analysis/contracts/dune
@@ -1,4 +1,5 @@
 (library
+ (modes byte native)
  (name testgascontracts)
  (wrapped false)
  (libraries core oUnit testutil scilla_base))

--- a/tests/gas_use_analysis/expr/dune
+++ b/tests/gas_use_analysis/expr/dune
@@ -1,4 +1,5 @@
 (library
+ (modes byte native)
  (name testgasexpr)
  (wrapped false)
  (libraries core oUnit testutil scilla_base))

--- a/tests/ipc/dune
+++ b/tests/ipc/dune
@@ -1,4 +1,5 @@
 (library
+ (modes byte native)
  (name stateIPCTest)
  (preprocess
   (pps ppx_sexp_conv ppx_let ppx_deriving.show))

--- a/tests/pm_check/bad/dune
+++ b/tests/pm_check/bad/dune
@@ -1,4 +1,5 @@
 (library
  (name testpmfail)
+ (modes byte native)
  (wrapped false)
  (libraries core oUnit testutil scilla_base))

--- a/tests/polynomials/dune
+++ b/tests/polynomials/dune
@@ -1,4 +1,5 @@
 (executable
+ (modes byte native)
  (name testsuite_polynomials)
  (preprocess
   (pps ppx_sexp_conv ppx_let ppx_deriving.show))

--- a/tests/runner/dune
+++ b/tests/runner/dune
@@ -1,4 +1,5 @@
 (library
+ (modes byte native)
  (name testcontracts)
  (wrapped false)
  (libraries core oUnit testutil stateIPCTest scilla_server_lib)

--- a/tests/typecheck/bad/dune
+++ b/tests/typecheck/bad/dune
@@ -1,4 +1,5 @@
 (library
+ (modes byte native)
  (name testtypefail)
  (wrapped false)
  (libraries core oUnit testutil scilla_base))

--- a/tests/typecheck/good/dune
+++ b/tests/typecheck/good/dune
@@ -1,4 +1,5 @@
 (library
+ (modes byte native)
  (name testtypes)
  (wrapped false)
  (libraries core oUnit testutil scilla_base)

--- a/tests/util/dune
+++ b/tests/util/dune
@@ -1,4 +1,5 @@
 (library
+ (modes byte native)
  (name testutil)
  (wrapped false)
  (libraries core oUnit fileutils scilla_base patdiff.lib))


### PR DESCRIPTION
OCaml bytecode executables are now built at
`_build/default/src/runners/scilla_(runner|checker).bc`.
These can be executed inside an ocamldebug session.

Fixes #639