### PR TITLE
Make Rep independent of Ident

### DIFF
--- a/src/base/Cashflow.ml
+++ b/src/base/Cashflow.ml
@@ -52,17 +52,17 @@ module CashflowRep (R : Rep) = struct
 
   let dummy_rep = (NoInfo, R.dummy_rep)
 
-  let mk_id s = add_tag_to_id s NoInfo
+  let mk_rep (t : money_tag) (s : R.rep) = (t, s)
 
-  let mk_id_address s = mk_id (R.mk_id_address s)
+  let address_rep = mk_rep NoInfo R.address_rep
 
-  let mk_id_uint128 s = mk_id (R.mk_id_uint128 s)
+  let uint128_rep = mk_rep NoInfo R.uint128_rep
 
-  let mk_id_uint32 s = mk_id (R.mk_id_uint32 s)
+  let uint32_rep = mk_rep NoInfo R.uint32_rep
 
-  let mk_id_bnum s = mk_id (R.mk_id_bnum s)
+  let bnum_rep = mk_rep NoInfo R.bnum_rep
 
-  let mk_id_string s = mk_id (R.mk_id_string s)
+  let string_rep = mk_rep NoInfo R.string_rep
 
   let parse_rep s = (NoInfo, R.parse_rep s)
 
@@ -88,7 +88,8 @@ struct
   (*******************************************************)
 
   (* Lift Ident (n, rep) to Ident (n, (NoInfo, rep)) *)
-  let add_noinfo_to_ident i = ECFR.mk_id i
+  let add_noinfo_to_ident = function
+    | Ident (i, r) -> asIdL i (ECFR.mk_rep NoInfo r)
 
   let add_money_or_mapmoney_to_ident i typ =
     let rec create_money_tag typ =

--- a/src/base/ContractUtil.ml
+++ b/src/base/ContractUtil.ml
@@ -129,9 +129,12 @@ module ScillaContractUtil (SR : Rep) (ER : Rep) = struct
   let append_implict_comp_params cparams =
     let open PrimTypes in
     let sender =
-      (asIdL MessagePayload.sender_label ER.address_rep, bystrx_typ address_length)
+      ( asIdL MessagePayload.sender_label ER.address_rep,
+        bystrx_typ address_length )
     in
-    let amount = (asIdL MessagePayload.amount_label ER.uint128_rep, uint128_typ) in
+    let amount =
+      (asIdL MessagePayload.amount_label ER.uint128_rep, uint128_typ)
+    in
     amount :: sender :: cparams
 
   let msg_mandatory_field_types =

--- a/src/base/ContractUtil.ml
+++ b/src/base/ContractUtil.ml
@@ -107,16 +107,16 @@ module ScillaContractUtil (SR : Rep) (ER : Rep) = struct
 
   let balance_field =
     let open PrimTypes in
-    (ER.mk_id_uint128 balance_label, uint128_typ)
+    (asIdL balance_label ER.uint128_rep, uint128_typ)
 
   let append_implict_contract_params tparams =
     let open PrimTypes in
-    let creation_block = (ER.mk_id_bnum creation_block_label, bnum_typ) in
+    let creation_block = (asIdL creation_block_label ER.bnum_rep, bnum_typ) in
     let this_address =
-      (ER.mk_id_address this_address_label, bystrx_typ address_length)
+      (asIdL this_address_label ER.address_rep, bystrx_typ address_length)
     in
     let scilla_version_init =
-      (ER.mk_id_uint32 scilla_version_label, uint32_typ)
+      (asIdL scilla_version_label ER.uint32_rep, uint32_typ)
     in
     creation_block :: scilla_version_init :: this_address :: tparams
 
@@ -129,9 +129,9 @@ module ScillaContractUtil (SR : Rep) (ER : Rep) = struct
   let append_implict_comp_params cparams =
     let open PrimTypes in
     let sender =
-      (ER.mk_id_address MessagePayload.sender_label, bystrx_typ address_length)
+      (asIdL MessagePayload.sender_label ER.address_rep, bystrx_typ address_length)
     in
-    let amount = (ER.mk_id_uint128 MessagePayload.amount_label, uint128_typ) in
+    let amount = (asIdL MessagePayload.amount_label ER.uint128_rep, uint128_typ) in
     amount :: sender :: cparams
 
   let msg_mandatory_field_types =

--- a/src/base/GasUseAnalysis.ml
+++ b/src/base/GasUseAnalysis.ml
@@ -42,7 +42,8 @@ struct
   module Gas = Gas.ScillaGas (SR) (ER)
   open GUASyntax
 
-  let mk_typed_id i t = asIdL i (ER.mk_rep dummy_loc (PlainTypes.mk_qualified_type t))
+  let mk_typed_id i t =
+    asIdL i (ER.mk_rep dummy_loc (PlainTypes.mk_qualified_type t))
 
   type sizeref =
     (* Refer to the size of a variable. *)

--- a/src/base/GasUseAnalysis.ml
+++ b/src/base/GasUseAnalysis.ml
@@ -32,7 +32,7 @@ module ScillaGUA
 
       val get_type : rep -> PlainTypes.t inferred_type
 
-      val mk_id : loc Identifier.t -> Type.t -> rep Identifier.t
+      val mk_rep : loc -> PlainTypes.t inferred_type -> rep
     end) =
 struct
   module SER = SR
@@ -41,6 +41,8 @@ struct
   module TU = TypeUtilities
   module Gas = Gas.ScillaGas (SR) (ER)
   open GUASyntax
+
+  let mk_typed_id i t = asIdL i (ER.mk_rep dummy_loc (PlainTypes.mk_qualified_type t))
 
   type sizeref =
     (* Refer to the size of a variable. *)
@@ -775,7 +777,7 @@ struct
 
     let tvar a = TypeVar a in
     (* Make a simple identifier of type 'A *)
-    let si a = ER.mk_id (asId a) (tvar "'A") in
+    let si a = mk_typed_id a (tvar "'A") in
     (* Make a simple polynomial from string a *)
     let sp a = single_simple_pn (SizeOf (Base (si a))) in
     let arg_err s = "Incorrect arguments to builtin " ^ pp_builtin s in
@@ -1086,12 +1088,12 @@ struct
   (* Hardcode signature for folds. *)
   let analyze_folds genv =
     (*  list_foldr: forall 'A . forall 'B . g:('A -> 'B -> 'B) -> b:'B -> a:(List 'A) -> 'B *)
-    let a = ER.mk_id (asId "a") (ADT (asId "List", [ TypeVar "'A" ])) in
+    let a = mk_typed_id "a" (ADT (asId "List", [ TypeVar "'A" ])) in
     let g =
-      ER.mk_id (asId "g")
+      mk_typed_id "g"
         (FunType (TypeVar "'A", FunType (TypeVar "'B", TypeVar "'B")))
     in
-    let b = ER.mk_id (asId "b") (TypeVar "'B") in
+    let b = mk_typed_id "b" (TypeVar "'B") in
     let lendep = SizeOf (Length (Base a)) in
     (* The final result size is after applying the fold "Length(a)" times. *)
     let ressize = RFoldAcc (g, Base a, Base b) in
@@ -1210,7 +1212,7 @@ struct
 
   let gua_component genv (comp : component) =
     let open PrimTypes in
-    let si a t = ER.mk_id (asId a) t in
+    let si a t = mk_typed_id a t in
     let all_params =
       [
         ( si ContractUtil.MessagePayload.sender_label (bystrx_typ 20),
@@ -1271,7 +1273,7 @@ struct
     in
 
     (* Bind contract parameters. *)
-    let si a t = ER.mk_id (asId a) t in
+    let si a t = mk_typed_id a t in
     let all_cparams =
       [
         ( si ContractUtil.creation_block_label PrimTypes.bnum_typ,

--- a/src/base/SanityChecker.ml
+++ b/src/base/SanityChecker.ml
@@ -105,7 +105,7 @@ struct
         e
         @ check_duplicate_ident
             (fun _ -> eloc)
-            (List.map msg ~f:(fun (s, _) -> SR.mk_id_string s))
+            (List.map msg ~f:(fun (s, _) -> asIdL s SR.string_rep))
       in
 
       (* Either "_tag" or "_eventname" must be present. *)

--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -199,15 +199,15 @@ module type Rep = sig
 
   val get_loc : rep -> loc
 
-  val mk_id_address : string -> rep Identifier.t
+  val address_rep : rep
 
-  val mk_id_uint128 : string -> rep Identifier.t
+  val uint128_rep : rep
 
-  val mk_id_uint32 : string -> rep Identifier.t
+  val uint32_rep : rep
 
-  val mk_id_bnum : string -> rep Identifier.t
+  val bnum_rep : rep
 
-  val mk_id_string : string -> rep Identifier.t
+  val string_rep : rep
 
   val rep_of_sexp : Sexp.t -> rep
 
@@ -606,15 +606,15 @@ module ParserRep = struct
 
   let get_loc l = l
 
-  let mk_id_address s = Ident (s, dummy_loc)
+  let address_rep = dummy_loc
 
-  let mk_id_uint128 s = Ident (s, dummy_loc)
+  let uint128_rep = dummy_loc
 
-  let mk_id_uint32 s = Ident (s, dummy_loc)
+  let uint32_rep = dummy_loc
 
-  let mk_id_bnum s = Ident (s, dummy_loc)
+  let bnum_rep = dummy_loc
 
-  let mk_id_string s = Ident (s, dummy_loc)
+  let string_rep = dummy_loc
 
   let parse_rep _ = dummy_loc
 

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -43,11 +43,15 @@ module TypecheckerERep (R : Rep) = struct
 
   let mk_rep (r : R.rep) (t : PlainTypes.t inferred_type) = (t, r)
 
-  let address_rep = mk_rep R.address_rep (PlainTypes.mk_qualified_type (bystrx_typ address_length))
+  let address_rep =
+    mk_rep R.address_rep
+      (PlainTypes.mk_qualified_type (bystrx_typ address_length))
 
-  let uint128_rep = mk_rep R.uint128_rep (PlainTypes.mk_qualified_type uint128_typ)
+  let uint128_rep =
+    mk_rep R.uint128_rep (PlainTypes.mk_qualified_type uint128_typ)
 
-  let uint32_rep = mk_rep R.uint128_rep (PlainTypes.mk_qualified_type uint32_typ)
+  let uint32_rep =
+    mk_rep R.uint128_rep (PlainTypes.mk_qualified_type uint32_typ)
 
   let bnum_rep = mk_rep R.bnum_rep (PlainTypes.mk_qualified_type bnum_typ)
 

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -41,20 +41,17 @@ module TypecheckerERep (R : Rep) = struct
 
   let get_loc r = match r with _, rr -> R.get_loc rr
 
-  let mk_id s t =
-    match s with Ident (n, r) -> Ident (n, (PlainTypes.mk_qualified_type t, r))
-
-  let mk_id_address s = mk_id (R.mk_id_address s) (bystrx_typ address_length)
-
-  let mk_id_uint128 s = mk_id (R.mk_id_uint128 s) uint128_typ
-
-  let mk_id_uint32 s = mk_id (R.mk_id_uint128 s) uint32_typ
-
-  let mk_id_bnum s = mk_id (R.mk_id_bnum s) bnum_typ
-
-  let mk_id_string s = mk_id (R.mk_id_string s) string_typ
-
   let mk_rep (r : R.rep) (t : PlainTypes.t inferred_type) = (t, r)
+
+  let address_rep = mk_rep R.address_rep (PlainTypes.mk_qualified_type (bystrx_typ address_length))
+
+  let uint128_rep = mk_rep R.uint128_rep (PlainTypes.mk_qualified_type uint128_typ)
+
+  let uint32_rep = mk_rep R.uint128_rep (PlainTypes.mk_qualified_type uint32_typ)
+
+  let bnum_rep = mk_rep R.bnum_rep (PlainTypes.mk_qualified_type bnum_typ)
+
+  let string_rep = mk_rep R.string_rep (PlainTypes.mk_qualified_type string_typ)
 
   let parse_rep s = (PlainTypes.mk_qualified_type uint128_typ, R.parse_rep s)
 


### PR DESCRIPTION
The Rep signature (used for AST annotations) is currently able to construct identifers not present in the AST after parsing. This is a problem once qualified names are added, because it introduces an annoying dependency between Type and Identifier.

I have therefore changed the Rep signature so that it only constructs annotations. The phase which uses a Rep structure must use the functions in Identifier.ml to construct the actual Ident AST node.