### PR TITLE
Prefix all the top level modules with Scilla*

### DIFF
--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -736,7 +736,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     open UsefulLiterals
     open Cryptokit
     open Datatypes.DataTypeDictionary
-    open Schnorr
+    open Scilla_crypto.Schnorr
 
     (* Hash raw bytes / binary string. *)
     let sha256_hasher s = hash_string (Hash.sha2 256) s
@@ -1072,6 +1072,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       | _ -> builtin_fail "schnorr_get_address" ls
 
     open Datatypes.SnarkTypes
+    open Scilla_crypto
 
     (* alt_bn128_G1_add : zksnark_g1point_typ -> zksnark_g1point_type ->
                           Option {zksnark_g1point_type} *)

--- a/src/base/Datatypes.ml
+++ b/src/base/Datatypes.ml
@@ -212,7 +212,7 @@ let scilla_list_to_ocaml_rev v =
   convert_to_list v []
 
 module SnarkTypes = struct
-  open Snark
+  open Scilla_crypto.Snark
   open DataTypeDictionary
 
   let scalar_type = bystrx_typ scalar_len

--- a/src/base/Datatypes.mli
+++ b/src/base/Datatypes.mli
@@ -83,9 +83,9 @@ val scilla_list_to_ocaml :
 val scilla_list_to_ocaml_rev :
   Literal.t -> (Literal.t list, scilla_error list) result
 
-open Snark
-
 module SnarkTypes : sig
+  open Scilla_crypto.Snark
+
   val scalar_type : Type.t
 
   val g1point_type : Type.t

--- a/src/base/Gas.ml
+++ b/src/base/Gas.ml
@@ -25,7 +25,7 @@ open Type
 open Literal
 open Syntax
 open TypeUtil
-open Schnorr
+open Scilla_crypto.Schnorr
 open PrettyPrinters
 open Datatypes.SnarkTypes
 

--- a/src/base/GasUseAnalysis.ml
+++ b/src/base/GasUseAnalysis.ml
@@ -24,7 +24,7 @@ open Type
 open Syntax
 open ErrorUtils
 open MonadUtil
-open Polynomial
+open Polynomials.Polynomial
 
 module ScillaGUA
     (SR : Rep) (ER : sig

--- a/src/base/cpp/dune
+++ b/src/base/cpp/dune
@@ -1,7 +1,7 @@
 (library
- (name scilla_cpp_deps)
- (public_name scilla.cpp_deps)
- (wrapped false)
+ (name scilla_crypto)
+ (public_name scilla.crypto)
+ (wrapped true)
  (libraries ctypes ctypes.foreign cryptokit)
  (preprocess
   (pps ppx_compare))

--- a/src/base/dune
+++ b/src/base/dune
@@ -19,9 +19,9 @@
  (name scilla_base)
  (modes byte native)
  (public_name scilla.base)
- (wrapped false)
+ (wrapped true)
  (libraries core num hex stdint angstrom polynomials cryptokit secp256k1
-   bitstring yojson fileutils scilla_cpp_deps menhirLib)
+   bitstring yojson fileutils scilla_crypto menhirLib)
  (preprocess
   (pps ppx_sexp_conv ppx_let ppx_deriving.show ppx_compare bisect_ppx
     --conditional))

--- a/src/checkers/dune
+++ b/src/checkers/dune
@@ -1,6 +1,6 @@
 (library
  (name scilla_checkers)
- (wrapped false)
+ (wrapped true)
  (modes byte native)
  (libraries core angstrom stdint polynomials yojson cryptokit scilla_base)
  (preprocess

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -18,6 +18,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
+open Scilla_base
 open Identifier
 open Type
 open Literal

--- a/src/eval/EvalUtil.ml
+++ b/src/eval/EvalUtil.ml
@@ -18,6 +18,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
+open Scilla_base
 open Identifier
 open Literal
 open Syntax

--- a/src/eval/PatternMatching.ml
+++ b/src/eval/PatternMatching.ml
@@ -18,6 +18,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
+open Scilla_base
 open Datatypes
 open Identifier
 open Literal

--- a/src/eval/Runner.ml
+++ b/src/eval/Runner.ml
@@ -18,6 +18,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
+open Scilla_base
 open Identifier
 open Literal
 open Syntax

--- a/src/eval/RunnerCLI.ml
+++ b/src/eval/RunnerCLI.ml
@@ -18,6 +18,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
+open Scilla_base
 
 type args = {
   input_init : string;

--- a/src/eval/StateIPCClient.ml
+++ b/src/eval/StateIPCClient.ml
@@ -18,6 +18,7 @@
 open Core
 open! Int.Replace_polymorphic_compare
 open Result.Let_syntax
+open Scilla_base
 open MonadUtil
 open Identifier
 open Literal

--- a/src/eval/StateIPCClient.mli
+++ b/src/eval/StateIPCClient.mli
@@ -16,6 +16,7 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
+open Scilla_base
 open ErrorUtils
 
 (* Fetch from a field. "keys" is empty when fetching non-map fields or an entire Map field.

--- a/src/eval/StateService.ml
+++ b/src/eval/StateService.ml
@@ -19,6 +19,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Result.Let_syntax
+open Scilla_base
 open MonadUtil
 open TypeUtil
 open Identifier

--- a/src/eval/StateService.mli
+++ b/src/eval/StateService.mli
@@ -19,6 +19,7 @@
 (* This file describes function that communicate with the blockchain to fetch
  * and update state variables on demand. *)
 
+open Scilla_base
 open Syntax
 open ParsedSyntax
 open ErrorUtils

--- a/src/eval/dune
+++ b/src/eval/dune
@@ -1,6 +1,6 @@
 (library
  (name scilla_eval)
- (wrapped false)
+ (wrapped true)
  (modes byte native)
  (libraries core angstrom stdint yojson cryptokit scilla_base rpclib unix
    rpclib.json rresult ocaml-protoc)

--- a/src/polynomials/dune
+++ b/src/polynomials/dune
@@ -1,7 +1,7 @@
 (library
  (name polynomials)
  (public_name scilla.polynomials)
- (wrapped false)
+ (wrapped true)
  (modes byte native)
  (synopsis "Utility to deal with multivariate polynomials")
  (libraries core))

--- a/src/runners/dune
+++ b/src/runners/dune
@@ -5,7 +5,7 @@
  (package scilla)
  (modules scilla_runner eval_runner type_checker scilla_checker scilla_server)
  (libraries core angstrom yojson cryptokit fileutils scilla_base scilla_eval
-   scilla_server_lib scilla_cpp_deps)
+   scilla_server_lib scilla_crypto)
  (modes byte native)
  (preprocess
   (pps ppx_sexp_conv ppx_let ppx_deriving.show bisect_ppx --conditional)))

--- a/src/runners/eval_runner.ml
+++ b/src/runners/eval_runner.ml
@@ -18,6 +18,8 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
+open Scilla_base
+open Scilla_eval
 open Identifier
 open Syntax
 open FrontEndParser

--- a/src/runners/scilla_checker.ml
+++ b/src/runners/scilla_checker.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core_kernel
+open Scilla_base
 open ErrorUtils
 open DebugMessage
 

--- a/src/runners/type_checker.ml
+++ b/src/runners/type_checker.ml
@@ -19,6 +19,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Printf
+open Scilla_base
 open Identifier
 open Type
 open Syntax

--- a/src/server/api.ml
+++ b/src/server/api.ml
@@ -16,6 +16,7 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
+open Scilla_eval
 open Idl
 open IPCUtil
 

--- a/src/server/client.ml
+++ b/src/server/client.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core
+open Scilla_eval
 open Api
 module U = Unix
 module M = Idl.IdM

--- a/src/server/server.ml
+++ b/src/server/server.ml
@@ -17,6 +17,8 @@
 *)
 
 open Core
+open Scilla_base
+open Scilla_eval
 open DebugMessage
 open ErrorUtils
 open Api

--- a/tests/Testsuite.ml
+++ b/tests/Testsuite.ml
@@ -18,7 +18,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
-open TestUtil
+open Scilla_test.Util
 
 let () =
   run_tests
@@ -29,12 +29,10 @@ let () =
          * these tests will change, resulting in the tests not being run.
          * See the Makefile target "test_extipcserver". *)
       Testcontracts.contract_tests;
-      TestExps.all_tests;
-      TestExpsFail.all_tests;
-      Testtypes.all_tests;
-      TestTypeFail.all_tests;
-      TestPMFail.all_tests;
-      TestChecker.all_tests;
-      (* TestGasExpr.all_tests;
-         TestGasContracts.all_tests; *)
+      Testexps.All.tests;
+      Testtypes.All.tests;
+      Testpm.All.tests;
+      Testchecker.All.tests;
+      (* TestGasExpr.All.tests;
+         TestGasContracts.All.tests; *)
     ]

--- a/tests/base/TestBech32.ml
+++ b/tests/base/TestBech32.ml
@@ -19,6 +19,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open OUnit2
+open Scilla_base
 open Bech32
 open Literal
 open Utils
@@ -116,5 +117,7 @@ let random_tests =
         random_test (i + r)
       done)
 
-let all_tests _ =
-  "bech32_tests" >::: [ test1; test2; test3; test4; test5; random_tests ]
+module All = struct
+  let tests _ =
+    "bech32_tests" >::: [ test1; test2; test3; test4; test5; random_tests ]
+end

--- a/tests/base/TestInteger256.ml
+++ b/tests/base/TestInteger256.ml
@@ -18,6 +18,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
+open Scilla_base
 
 let uint256_max_str =
   "115792089237316195423570985008687907853269984665640564039457584007913129639935"
@@ -528,5 +529,8 @@ let int256_tests_list = List.append [ t1_int; t2_int; t3_int ] list_int256
 let int256_tests = "int256_tests" >::: int256_tests_list
 
 (* The test to be called from Testsuite. *)
-let all_tests _ =
-  "integer256_tests" >::: [ uint256_tests; int256_tests; non_arithmetic_tests ]
+module All = struct
+  let tests _ =
+    "integer256_tests"
+    >::: [ uint256_tests; int256_tests; non_arithmetic_tests ]
+end

--- a/tests/base/TestSafeArith.ml
+++ b/tests/base/TestSafeArith.ml
@@ -2,6 +2,7 @@ open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Stdint
 open OUnit2
+open Scilla_base
 open SafeArith
 
 (* We test by comparing the result of the safe arithmetic operations
@@ -94,4 +95,6 @@ let builtin_arith_8bit_tests =
            ("unsigned 8-bit: isqrt", TestUnsigned.test_all_isqrt U8_safe.isqrt);
          ]
 
-let all_tests _ = "arith_builtin_tests" >::: [ builtin_arith_8bit_tests ]
+module All = struct
+  let tests _ = "arith_builtin_tests" >::: [ builtin_arith_8bit_tests ]
+end

--- a/tests/base/TestSignatures.ml
+++ b/tests/base/TestSignatures.ml
@@ -2,6 +2,8 @@ open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Result
 open OUnit2
+open Scilla_base
+open Scilla_crypto
 
 let t1 =
   test_case (fun _ ->
@@ -91,4 +93,6 @@ let t2' =
 
 let ecdsa_tests = "ecda_tests" >::: [ t1'; t2' ]
 
-let all_tests _ = "signature_tests" >::: [ schnorr_tests; ecdsa_tests ]
+module All = struct
+  let tests _ = "signature_tests" >::: [ schnorr_tests; ecdsa_tests ]
+end

--- a/tests/base/TestSnark.ml
+++ b/tests/base/TestSnark.ml
@@ -21,6 +21,8 @@
 
 open Core_kernel
 open OUnit2
+open Scilla_base
+open Scilla_crypto
 open Snark
 open Integer256
 open Literal
@@ -556,13 +558,15 @@ let test_generate_random_points =
             "0x14789d0d4a730b354403b5fac948113739e276c23e0258d8596ee72f9cd9d3230af18a63153e0ec25ff9f2951dd3fa90ed0197bfef6e2a1a62b5095b9d2b4a27"
         ))
 
-let all_tests _ =
-  "snark_tests"
-  >::: [
-         test_add_zero;
-         test_invalid;
-         test_mul_add;
-         test_pairing;
-         test_pairing_null_input;
-         test_generate_random_points;
-       ]
+module All = struct
+  let tests _ =
+    "snark_tests"
+    >::: [
+           test_add_zero;
+           test_invalid;
+           test_mul_add;
+           test_pairing;
+           test_pairing_null_input;
+           test_generate_random_points;
+         ]
+end

--- a/tests/base/TestSyntax.ml
+++ b/tests/base/TestSyntax.ml
@@ -2,6 +2,7 @@ open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Stdint
 open OUnit2
+open Scilla_base
 open Identifier
 open Type
 open Literal
@@ -135,4 +136,6 @@ let unannotated_syntax_tests =
                 free_vars_in_expr (parse_expr_wrapper expr)) );
          ]
 
-let all_tests _ = "syntax_tests" >::: [ unannotated_syntax_tests ]
+module All = struct
+  let tests _ = "syntax_tests" >::: [ unannotated_syntax_tests ]
+end

--- a/tests/base/Testsuite_base.ml
+++ b/tests/base/Testsuite_base.ml
@@ -18,17 +18,16 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
-open TestUtil
+open Scilla_test.Util
 
 let () =
   run_tests
     [
-      TestBech32.all_tests;
-      TestInteger256.all_tests;
-      TestParser.all_tests;
-      TestSafeArith.all_tests;
-      TestSignatures.all_tests;
-      TestSnark.all_tests;
-      TestSyntax.all_tests;
-      (* TestPolynomial.all_tests; *)
+      TestBech32.All.tests;
+      TestInteger256.All.tests;
+      Testparser.All.tests;
+      TestSafeArith.All.tests;
+      TestSignatures.All.tests;
+      TestSnark.All.tests;
+      TestSyntax.All.tests;
     ]

--- a/tests/base/dune
+++ b/tests/base/dune
@@ -3,4 +3,4 @@
  (name testsuite_base)
  (preprocess
   (pps ppx_sexp_conv ppx_let ppx_deriving.show ppx_compare))
- (libraries core oUnit scilla_base testutil testparser))
+ (libraries core oUnit scilla_base scilla_test testparser))

--- a/tests/base/parser/All.ml
+++ b/tests/base/parser/All.ml
@@ -2,36 +2,24 @@
   This file is part of scilla.
 
   Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
-
+  
   scilla is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software
   Foundation, either version 3 of the License, or (at your option) any later
   version.
-
+ 
   scilla is distributed in the hope that it will be useful, but WITHOUT ANY
   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
   A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
-
+ 
   You should have received a copy of the GNU General Public License along with
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Core
-open Scilla_base
-open Scilla_eval
-open ErrorUtils
-open RunnerCLI
+open Core_kernel
+open! Int.Replace_polymorphic_compare
+open OUnit2
 
-let output_to_string output ~args =
-  if args.pp_json then Yojson.Basic.pretty_to_string output
-  else Yojson.Basic.to_string output
-
-let () =
-  try
-    let output, args = Runner.run None ~exe_name:Sys.argv.(0) in
-    let str = output_to_string output ~args in
-    if String.is_empty args.output then DebugMessage.pout str
-    else
-      Out_channel.with_file args.output ~f:(fun ch ->
-          Out_channel.output_string ch str)
-  with FatalError msg -> exit_with_error msg
+let tests env =
+  "parser_tests"
+  >::: [ Bad.Tests.tests env; Bad.LibTests.tests env; Bad.ExpTests.tests env ]

--- a/tests/base/parser/Parser_dummy.ml
+++ b/tests/base/parser/Parser_dummy.ml
@@ -18,6 +18,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
+open Scilla_base
 open FrontEndParser
 open GlobalConfig
 open ErrorUtils

--- a/tests/base/parser/bad/Bad.ml
+++ b/tests/base/parser/bad/Bad.ml
@@ -21,7 +21,7 @@ open! Int.Replace_polymorphic_compare
 
 (* Add tests in alphabetical order *)
 
-module Tests = TestUtil.DiffBasedTests (struct
+module Tests = Scilla_test.Util.DiffBasedTests (struct
   let gold_path dir f = [ dir; "base"; "parser"; "bad"; "gold"; f ^ ".gold" ]
 
   let test_path f = [ "base"; "parser"; "bad"; f ]
@@ -139,7 +139,7 @@ module Tests = TestUtil.DiffBasedTests (struct
   let exit_code : Unix.process_status = WEXITED 1
 end)
 
-module LibTests = TestUtil.DiffBasedTests (struct
+module LibTests = Scilla_test.Util.DiffBasedTests (struct
   let gold_path dir f = [ dir; "base"; "parser"; "bad"; "gold"; f ^ ".gold" ]
 
   let test_path f = [ "base"; "parser"; "bad"; "lib"; f ]
@@ -184,7 +184,7 @@ module LibTests = TestUtil.DiffBasedTests (struct
   let exit_code : Unix.process_status = WEXITED 1
 end)
 
-module ExpTests = TestUtil.DiffBasedTests (struct
+module ExpTests = Scilla_test.Util.DiffBasedTests (struct
   let gold_path dir f = [ dir; "base"; "parser"; "bad"; "gold"; f ^ ".gold" ]
 
   let test_path f = [ "base"; "parser"; "bad"; "exps"; f ]

--- a/tests/base/parser/bad/dune
+++ b/tests/base/parser/bad/dune
@@ -1,5 +1,0 @@
-(library
- (modes byte native)
- (name testparserfail)
- (wrapped false)
- (libraries core oUnit testutil))

--- a/tests/base/parser/dune
+++ b/tests/base/parser/dune
@@ -1,9 +1,11 @@
+(include_subdirs unqualified)
+
 (library
  (modes byte native)
  (name testparser)
- (modules TestParser)
- (wrapped false)
- (libraries core_kernel oUnit testutil testparserfail))
+ (modules All Bad)
+ (wrapped true)
+ (libraries core_kernel oUnit scilla_test))
 
 (executable
  (modes byte native)

--- a/tests/checker/All.ml
+++ b/tests/checker/All.ml
@@ -2,36 +2,37 @@
   This file is part of scilla.
 
   Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
-
+  
   scilla is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software
   Foundation, either version 3 of the License, or (at your option) any later
   version.
-
+ 
   scilla is distributed in the hope that it will be useful, but WITHOUT ANY
   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
   A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
-
+ 
   You should have received a copy of the GNU General Public License along with
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Core
-open Scilla_base
-open Scilla_eval
-open ErrorUtils
-open RunnerCLI
+open OUnit2
 
-let output_to_string output ~args =
-  if args.pp_json then Yojson.Basic.pretty_to_string output
-  else Yojson.Basic.to_string output
-
-let () =
-  try
-    let output, args = Runner.run None ~exe_name:Sys.argv.(0) in
-    let str = output_to_string output ~args in
-    if String.is_empty args.output then DebugMessage.pout str
-    else
-      Out_channel.with_file args.output ~f:(fun ch ->
-          Out_channel.output_string ch str)
-  with FatalError msg -> exit_with_error msg
+let tests env =
+  "checker"
+  >::: [
+         "good"
+         >::: [
+                Good.Tests.tests env;
+                Good.CheckerTests.tests env;
+                Good.ShogiTests.tests env;
+                Good.TypeInfoTests.tests env;
+                Good.InitArgTests.tests env;
+              ];
+         "bad"
+         >::: [
+                Bad.Tests.tests env;
+                Bad.LibTests.tests env;
+                Bad.InitArgTests.tests env;
+              ];
+       ]

--- a/tests/checker/bad/Bad.ml
+++ b/tests/checker/bad/Bad.ml
@@ -19,7 +19,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 
-module Tests = TestUtil.DiffBasedTests (struct
+module Tests = Scilla_test.Util.DiffBasedTests (struct
   let gold_path dir f = [ dir; "checker"; "bad"; "gold"; f ^ ".gold" ]
 
   let test_path f = [ "checker"; "bad"; f ]
@@ -101,7 +101,7 @@ module Tests = TestUtil.DiffBasedTests (struct
   let exit_code : Unix.process_status = WEXITED 1
 end)
 
-module LibTests = TestUtil.DiffBasedTests (struct
+module LibTests = Scilla_test.Util.DiffBasedTests (struct
   let gold_path dir f = [ dir; "checker"; "bad"; "gold"; f ^ ".gold" ]
 
   let test_path f = [ "checker"; "bad"; f ]
@@ -146,7 +146,7 @@ end)
 
 (* The test here require the `-init` argument. This is required for
  * importing libraries whose addresses are specified in the init JSON *)
-module InitArgTests = TestUtil.DiffBasedTests (struct
+module InitArgTests = Scilla_test.Util.DiffBasedTests (struct
   let gold_path dir f = [ dir; "checker"; "bad"; "gold"; f ^ ".gold" ]
 
   let test_path f = [ "checker"; "bad"; f ]

--- a/tests/checker/bad/dune
+++ b/tests/checker/bad/dune
@@ -1,5 +1,0 @@
-(library
- (modes byte native)
- (name testcheckerfail)
- (wrapped false)
- (libraries core oUnit testutil))

--- a/tests/checker/good/Good.ml
+++ b/tests/checker/good/Good.ml
@@ -19,7 +19,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 
-module Tests = TestUtil.DiffBasedTests (struct
+module Tests = Scilla_test.Util.DiffBasedTests (struct
   let gold_path dir f = [ dir; "checker"; "good"; "gold"; f ^ ".gold" ]
 
   let test_path f = [ "contracts"; f ]
@@ -78,7 +78,7 @@ module Tests = TestUtil.DiffBasedTests (struct
 end)
 
 (* These differ from "Tests" because of an additional libdir argument. *)
-module CheckerTests = TestUtil.DiffBasedTests (struct
+module CheckerTests = Scilla_test.Util.DiffBasedTests (struct
   let gold_path dir f = [ dir; "checker"; "good"; "gold"; f ^ ".gold" ]
 
   let test_path f = [ "checker"; "good"; f ]
@@ -139,7 +139,7 @@ end)
 
 (* The test here require the `-init` argument. This is required for
  * importing libraries whose addresses are specified in the init JSON *)
-module InitArgTests = TestUtil.DiffBasedTests (struct
+module InitArgTests = Scilla_test.Util.DiffBasedTests (struct
   let gold_path dir f = [ dir; "checker"; "good"; "gold"; f ^ ".gold" ]
 
   let test_path f = [ "checker"; "good"; f ]
@@ -163,7 +163,7 @@ module InitArgTests = TestUtil.DiffBasedTests (struct
   let exit_code : Unix.process_status = WEXITED 0
 end)
 
-module ShogiTests = TestUtil.DiffBasedTests (struct
+module ShogiTests = Scilla_test.Util.DiffBasedTests (struct
   let gold_path dir f = [ dir; "checker"; "good"; "gold"; f ^ ".gold" ]
 
   let test_path f = [ "contracts"; f ]
@@ -189,7 +189,7 @@ end)
 
 (* We don't add the "-typeinfo" argument to the main set of "Tests"
  * because that adds a lot of diff noise when things change. *)
-module TypeInfoTests = TestUtil.DiffBasedTests (struct
+module TypeInfoTests = Scilla_test.Util.DiffBasedTests (struct
   let gold_path dir f = [ dir; "checker"; "good"; "gold"; f ^ ".typeinfo.gold" ]
 
   let test_path f = [ "contracts"; f ]

--- a/tests/checker/good/dune
+++ b/tests/checker/good/dune
@@ -1,5 +1,0 @@
-(library
- (modes byte native)
- (name testcheckersuccess)
- (wrapped false)
- (libraries core oUnit testutil))

--- a/tests/dune
+++ b/tests/dune
@@ -3,5 +3,5 @@
  (names testsuite scilla_client)
  (preprocess
   (pps ppx_sexp_conv ppx_let ppx_deriving.show))
- (libraries core oUnit testcontracts testexps testexpsfail testtypes
-   testtypefail testpmfail testgasexpr testgascontracts testchecker))
+ (libraries core oUnit testcontracts testexps testtypes testpm testgasexpr
+   testgascontracts testchecker))

--- a/tests/eval/All.ml
+++ b/tests/eval/All.ml
@@ -18,15 +18,4 @@
 
 open OUnit2
 
-let all_tests env =
-  "checker_tests"
-  >::: [
-         TestCheckerSuccess.Tests.all_tests env;
-         TestCheckerSuccess.CheckerTests.all_tests env;
-         TestCheckerSuccess.ShogiTests.all_tests env;
-         TestCheckerFail.Tests.all_tests env;
-         TestCheckerFail.LibTests.all_tests env;
-         TestCheckerSuccess.TypeInfoTests.all_tests env;
-         TestCheckerSuccess.InitArgTests.all_tests env;
-         TestCheckerFail.InitArgTests.all_tests env;
-       ]
+let tests env = "eval" >::: [ Good.Tests.tests env; Bad.Tests.tests env ]

--- a/tests/eval/bad/Bad.ml
+++ b/tests/eval/bad/Bad.ml
@@ -61,7 +61,7 @@ let explist =
     "substr_err1.scilexp";
   ]
 
-module Tests = TestUtil.DiffBasedTests (struct
+module Tests = Scilla_test.Util.DiffBasedTests (struct
   let gold_path dir f = [ dir; "eval"; "bad"; "gold"; f ^ ".gold" ]
 
   let test_path f = [ "eval"; "bad"; f ]
@@ -85,4 +85,4 @@ module Tests = TestUtil.DiffBasedTests (struct
   let exit_code : Unix.process_status = WEXITED 1
 end)
 
-let all_tests env = "eval_exp_fail_tests" >::: [ Tests.all_tests env ]
+let tests env = "bad" >::: [ Tests.tests env ]

--- a/tests/eval/bad/dune
+++ b/tests/eval/bad/dune
@@ -1,5 +1,0 @@
-(library
- (modes byte native)
- (name testexpsfail)
- (wrapped false)
- (libraries core oUnit testutil))

--- a/tests/eval/dune
+++ b/tests/eval/dune
@@ -2,6 +2,6 @@
 
 (library
  (modes byte native)
- (name testchecker)
+ (name testexps)
  (wrapped true)
  (libraries core oUnit scilla_test))

--- a/tests/eval/good/Good.ml
+++ b/tests/eval/good/Good.ml
@@ -18,6 +18,7 @@
 
 open Core_kernel
 open! Int.Replace_polymorphic_compare
+open OUnit2
 
 let explist =
   [
@@ -135,7 +136,7 @@ let explist =
     "builtin-alt-bn128.scilexp";
   ]
 
-module Tests = TestUtil.DiffBasedTests (struct
+module Tests = Scilla_test.Util.DiffBasedTests (struct
   let gold_path dir f = [ dir; "eval"; "good"; "gold"; f ^ ".gold" ]
 
   let test_path f = [ "eval"; "good"; f ]
@@ -159,4 +160,4 @@ module Tests = TestUtil.DiffBasedTests (struct
   let exit_code : Unix.process_status = WEXITED 0
 end)
 
-let all_tests = Tests.all_tests
+let tests env = "good" >::: [ Tests.tests env ]

--- a/tests/eval/good/dune
+++ b/tests/eval/good/dune
@@ -1,5 +1,0 @@
-(library
- (modes byte native)
- (name testexps)
- (wrapped false)
- (libraries core oUnit testutil))

--- a/tests/gas_use_analysis/contracts/TestGasContracts.ml
+++ b/tests/gas_use_analysis/contracts/TestGasContracts.ml
@@ -29,7 +29,7 @@ let explist =
     "wallet.scilla";
   ]
 
-module Tests = TestUtil.DiffBasedTests (struct
+module Tests = Scilla_test.Util.DiffBasedTests (struct
   let gold_path dir f =
     [ dir; "gas_use_analysis"; "contracts"; "gold"; f ^ ".gold" ]
 
@@ -54,4 +54,4 @@ module Tests = TestUtil.DiffBasedTests (struct
   let exit_code : Unix.process_status = WEXITED 0
 end)
 
-let all_tests = Tests.all_tests
+let tests = Tests.tests

--- a/tests/gas_use_analysis/contracts/dune
+++ b/tests/gas_use_analysis/contracts/dune
@@ -1,5 +1,5 @@
 (library
  (modes byte native)
  (name testgascontracts)
- (wrapped false)
- (libraries core oUnit testutil scilla_base))
+ (wrapped true)
+ (libraries core oUnit scilla_test scilla_base))

--- a/tests/gas_use_analysis/expr/TestGasExpr.ml
+++ b/tests/gas_use_analysis/expr/TestGasExpr.ml
@@ -37,7 +37,7 @@ let explist =
     "list_zip_with.scilexp";
   ]
 
-module Tests = TestUtil.DiffBasedTests (struct
+module Tests = Scilla_test.Util.DiffBasedTests (struct
   let gold_path dir f = [ dir; "gas_use_analysis"; "expr"; "gold"; f ^ ".gold" ]
 
   let test_path f = [ "gas_use_analysis"; "expr"; f ]
@@ -61,4 +61,4 @@ module Tests = TestUtil.DiffBasedTests (struct
   let exit_code : Unix.process_status = WEXITED 0
 end)
 
-let all_tests = Tests.all_tests
+let tests = Tests.tests

--- a/tests/ipc/StateIPCTest.ml
+++ b/tests/ipc/StateIPCTest.ml
@@ -22,8 +22,10 @@
 open OUnit2
 open Core_kernel
 open! Int.Replace_polymorphic_compare
-open Type
 open Yojson
+open Scilla_base
+open Scilla_eval
+open Type
 
 let parse_typ_wrapper t =
   match FrontEndParser.parse_type t with

--- a/tests/ipc/StateIPCTest.mli
+++ b/tests/ipc/StateIPCTest.mli
@@ -16,6 +16,9 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
+open Scilla_base
+open Scilla_eval
+
 (* This file aids Testcontracts.ml in setting up a state server
  * and initializing it with some initial data. *)
 

--- a/tests/ipc/StateIPCTestClient.ml
+++ b/tests/ipc/StateIPCTestClient.ml
@@ -18,6 +18,8 @@
 
 open Core
 open! Int.Replace_polymorphic_compare
+open Scilla_base
+open Scilla_eval
 open TypeUtil
 open StateIPCIdl
 open OUnit2

--- a/tests/ipc/StateIPCTestServer.ml
+++ b/tests/ipc/StateIPCTestServer.ml
@@ -24,6 +24,8 @@
 open Core
 open! Int.Replace_polymorphic_compare
 open Result.Let_syntax
+open Scilla_base
+open Scilla_eval
 open MonadUtil
 open StateIPCIdl
 open IPCUtil

--- a/tests/pm_check/All.ml
+++ b/tests/pm_check/All.ml
@@ -2,36 +2,20 @@
   This file is part of scilla.
 
   Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
-
+  
   scilla is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software
   Foundation, either version 3 of the License, or (at your option) any later
   version.
-
+ 
   scilla is distributed in the hope that it will be useful, but WITHOUT ANY
   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
   A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
-
+ 
   You should have received a copy of the GNU General Public License along with
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Core
-open Scilla_base
-open Scilla_eval
-open ErrorUtils
-open RunnerCLI
+open OUnit2
 
-let output_to_string output ~args =
-  if args.pp_json then Yojson.Basic.pretty_to_string output
-  else Yojson.Basic.to_string output
-
-let () =
-  try
-    let output, args = Runner.run None ~exe_name:Sys.argv.(0) in
-    let str = output_to_string output ~args in
-    if String.is_empty args.output then DebugMessage.pout str
-    else
-      Out_channel.with_file args.output ~f:(fun ch ->
-          Out_channel.output_string ch str)
-  with FatalError msg -> exit_with_error msg
+let tests env = "PM" >::: [ Bad.Tests.tests env ]

--- a/tests/pm_check/bad/Bad.ml
+++ b/tests/pm_check/bad/Bad.ml
@@ -20,7 +20,7 @@ open Core_kernel
 open! Int.Replace_polymorphic_compare
 open OUnit2
 
-module Tests = TestUtil.DiffBasedTests (struct
+module Tests = Scilla_test.Util.DiffBasedTests (struct
   let gold_path dir f = [ dir; "pm_check"; "bad"; "gold"; f ^ ".gold" ]
 
   let test_path f = [ "pm_check"; "bad"; f ]
@@ -56,4 +56,4 @@ module Tests = TestUtil.DiffBasedTests (struct
   let exit_code : Unix.process_status = WEXITED 1
 end)
 
-let all_tests env = "pm_check_fail_tests" >::: [ Tests.all_tests env ]
+let tests env = "bad" >::: [ Tests.tests env ]

--- a/tests/pm_check/bad/dune
+++ b/tests/pm_check/bad/dune
@@ -1,5 +1,0 @@
-(library
- (name testpmfail)
- (modes byte native)
- (wrapped false)
- (libraries core oUnit testutil scilla_base))

--- a/tests/pm_check/dune
+++ b/tests/pm_check/dune
@@ -1,5 +1,7 @@
+(include_subdirs unqualified)
+
 (library
+ (name testpm)
  (modes byte native)
- (name testgasexpr)
  (wrapped true)
  (libraries core oUnit scilla_test scilla_base))

--- a/tests/polynomials/Testsuite_polynomials.ml
+++ b/tests/polynomials/Testsuite_polynomials.ml
@@ -17,7 +17,7 @@
 *)
 
 open OUnit2
-open Polynomial
+open Polynomials.Polynomial
 
 let t1_pn =
   test_case (fun _ ->

--- a/tests/runner/Testcontracts.ml
+++ b/tests/runner/Testcontracts.ml
@@ -19,8 +19,9 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open OUnit2
+open Scilla_base
 open ScillaUtil.FilePathInfix
-open TestUtil
+open Scilla_test.Util
 open OUnitTest
 
 let testsuit_gas_limit = "8000"

--- a/tests/runner/dune
+++ b/tests/runner/dune
@@ -1,7 +1,7 @@
 (library
  (modes byte native)
  (name testcontracts)
- (wrapped false)
- (libraries core oUnit testutil stateIPCTest scilla_server_lib)
+ (wrapped true)
+ (libraries core oUnit scilla_test stateIPCTest scilla_server_lib)
  (preprocess
   (pps ppx_compare)))

--- a/tests/scilla_client.ml
+++ b/tests/scilla_client.ml
@@ -17,6 +17,7 @@
 *)
 
 open Core
+open Scilla_base
 open Scilla_server_lib
 module J = Yojson.Basic
 

--- a/tests/typecheck/All.ml
+++ b/tests/typecheck/All.ml
@@ -16,14 +16,6 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Core_kernel
-open! Int.Replace_polymorphic_compare
 open OUnit2
 
-let all_tests env =
-  "parser_tests"
-  >::: [
-         TestParserFail.Tests.all_tests env;
-         TestParserFail.LibTests.all_tests env;
-         TestParserFail.ExpTests.all_tests env;
-       ]
+let tests env = "typecheck" >::: [ Good.tests env; Bad.tests env ]

--- a/tests/typecheck/bad/Bad.ml
+++ b/tests/typecheck/bad/Bad.ml
@@ -24,6 +24,7 @@ open OUnit2
  * literals is by constructing them ourselves as there are checks
  * in both Scilla source parser and the JSON parser against
  * building bad literals. *)
+open Scilla_base
 open Type
 open Literal
 open PrettyPrinters
@@ -133,7 +134,7 @@ let lit_typ_tests =
   "literal_type_tests" >::: [ t1; t2; t3; t4; t5; t6; t7; t8; t9; t10; t11 ]
 
 (* PART B: Regular tests based on diffing outputs. *)
-module Tests = TestUtil.DiffBasedTests (struct
+module Tests = Scilla_test.Util.DiffBasedTests (struct
   let gold_path dir f = [ dir; "typecheck"; "bad"; "gold"; f ^ ".gold" ]
 
   let test_path f = [ "typecheck"; "bad"; f ]
@@ -193,5 +194,4 @@ module Tests = TestUtil.DiffBasedTests (struct
   let exit_code : Unix.process_status = WEXITED 1
 end)
 
-let all_tests env =
-  "type_check_fail_tests" >::: [ lit_typ_tests; Tests.all_tests env ]
+let tests env = "bad" >::: [ lit_typ_tests; Tests.tests env ]

--- a/tests/typecheck/bad/dune
+++ b/tests/typecheck/bad/dune
@@ -1,5 +1,0 @@
-(library
- (modes byte native)
- (name testtypefail)
- (wrapped false)
- (libraries core oUnit testutil scilla_base))

--- a/tests/typecheck/dune
+++ b/tests/typecheck/dune
@@ -1,0 +1,9 @@
+(include_subdirs unqualified)
+
+(library
+ (modes byte native)
+ (name testtypes)
+ (wrapped true)
+ (libraries core oUnit scilla_test scilla_base)
+ (preprocess
+  (pps ppx_compare)))

--- a/tests/typecheck/good/Good.ml
+++ b/tests/typecheck/good/Good.ml
@@ -19,6 +19,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open OUnit2
+open Scilla_base
 open Type
 open Syntax
 open ErrorUtils
@@ -158,7 +159,7 @@ let ground_type_tests =
 let map_access_type_tests =
   "map_access_type_tests" >::: make_map_access_type_tests map_access_type_tests
 
-module Tests = TestUtil.DiffBasedTests (struct
+module Tests = Scilla_test.Util.DiffBasedTests (struct
   let gold_path dir f = [ dir; "typecheck"; "good"; "gold"; f ^ ".gold" ]
 
   let test_path f = [ "typecheck"; "good"; f ]
@@ -210,11 +211,11 @@ module Tests = TestUtil.DiffBasedTests (struct
   let exit_code : Unix.process_status = WEXITED 0
 end)
 
-let all_tests env =
-  "type_check_success_tests"
+let tests env =
+  "good"
   >::: [
          type_equiv_tests;
-         Tests.all_tests env;
+         Tests.tests env;
          ground_type_tests;
          map_access_type_tests;
        ]

--- a/tests/typecheck/good/dune
+++ b/tests/typecheck/good/dune
@@ -1,7 +1,0 @@
-(library
- (modes byte native)
- (name testtypes)
- (wrapped false)
- (libraries core oUnit testutil scilla_base)
- (preprocess
-  (pps ppx_compare)))

--- a/tests/util/Util.ml
+++ b/tests/util/Util.ml
@@ -19,7 +19,7 @@
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open OUnit2
-open ScillaUtil.FilePathInfix
+open Scilla_base.ScillaUtil.FilePathInfix
 
 (* Helper funcation borrowed from Batteries library *)
 let stream_to_string fl =
@@ -78,7 +78,7 @@ let run_tests tests =
       ext_ipc_server;
     }
   in
-  run_test_tt_main ("all_tests" >::: List.map ~f:(( |> ) env) tests)
+  run_test_tt_main ("tests" >::: List.map ~f:(( |> ) env) tests)
 
 let output_verifier goldoutput_file msg print_diff output =
   (* load all data from file *)
@@ -190,5 +190,5 @@ module DiffBasedTests (Input : TestSuiteInput) = struct
               output_verifier goldoutput_file msg (env.print_diff test_ctxt) out)
           ~exit_code ~use_stderr:true ~chdir:dir ~ctxt:test_ctxt runner args)
 
-  let all_tests env = "exptests" >::: build_exp_tests env tests
+  let tests env = "exptests" >::: build_exp_tests env tests
 end

--- a/tests/util/dune
+++ b/tests/util/dune
@@ -1,5 +1,5 @@
 (library
  (modes byte native)
- (name testutil)
- (wrapped false)
+ (name scilla_test)
+ (wrapped true)
  (libraries core oUnit fileutils scilla_base patdiff.lib))


### PR DESCRIPTION
I changed `wrapped false` to `wrapped true` in the dune files (and removed a bunch of those in tests) as recommended in the docs: https://dune.readthedocs.io/en/stable/dune-files.html#library

> The default is true and it is highly recommended to keep it this way. Because OCaml top-level modules must all be unique when linking an executables, polluting the top-level namespace will make your library unusable with other libraries if there is a module name clash. This option is only intended for libraries that manually prefix all their modules by the library name and to ease porting of existing projects to dune

This lead to the other changes.

The test stats before this change:

```
ulimit -n 1024; dune exec -- tests/polynomials/testsuite_polynomials.exe
Ran: 8 tests in: 0.12 seconds.
OK
ulimit -n 1024; dune exec -- tests/base/testsuite_base.exe -print-diff true
    ocamlopt tests/base/testsuite_base.exe
Ran: 521 tests in: 3.88 seconds.
OK
ulimit -n 1024; dune exec -- tests/testsuite.exe -print-diff true
    ocamlopt tests/testsuite.exe
Ran: 1288 tests in: 27.97 seconds.
OK
```

The test stats on this PR:

```
ulimit -n 1024; dune exec -- tests/polynomials/testsuite_polynomials.exe
Ran: 8 tests in: 0.12 seconds.
OK
ulimit -n 1024; dune exec -- tests/base/testsuite_base.exe -print-diff true
    ocamlopt tests/base/testsuite_base.exe
Ran: 521 tests in: 4.30 seconds.
OK
ulimit -n 1024; dune exec -- tests/testsuite.exe -print-diff true
    ocamlopt tests/testsuite.exe
Ran: 1288 tests in: 27.56 seconds.
OK
```

Upshot: this PR preserves the number of tests. Feel free to suggest better names for libraries, modules, etc.