### PR TITLE
Opam and CI tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,15 +28,7 @@ addons:
     - ocaml
     - curl
     - build-essential
-    - m4
-    - pkg-config
-    - zlib1g-dev
-    - libgmp-dev
-    - libssl-dev
-    - libboost-system-dev
-    - libpcre3-dev
     - aspcud
-    - libsecp256k1-dev
   homebrew:
     brewfile: true
     update: true

--- a/Brewfile
+++ b/Brewfile
@@ -11,3 +11,4 @@ brew "boost"
 brew "pcre"
 brew "domt4/crypto/secp256k1", args: ["with-enable-module-recovery"]
 brew "cmake"
+brew "gmp"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -228,6 +228,27 @@ You can remove `--yes` from the above command to manually control that process.
 eval $(opam env)
 ```
 
+#### Check that you have all system-level dependencies
+If one of the following commands asks you to install a plugin respond with "Y".
+```shell
+opam pin add . --no-action --yes
+opam depext
+opam pin remove scilla
+```
+You should see something like
+```shell
+# Detecting depexts using vars: arch=x86_64, os=macos, os-distribution=homebrew, os-family=homebrew
+# The following system packages are needed:
+gcc
+gmp
+libffi
+lzlib
+pcre
+pkg-config
+secp256k1
+# All required OS packages found.
+```
+
 #### Install Scilla dependencies using opam
 ```shell
 cd PROJECT_DIR    # go inside your Scilla project directory
@@ -244,6 +265,9 @@ make opamdep
 <details><summary>Local opam switch to avoid conflicts with already installed global opam switches</summary>
 
 ### If you have opam package manager already installed
+
+First of all, [make sure](#check-that-you-have-all-system-level-dependencies) you have all the system-level dependencies.
+
 You can try installing the Scilla dependencies using the instructions above, but skipping the initialization step.
 If `opam` reports a dependency conflict, one way out might be creating yet another opam switch and
 managing your switches when doing Scilla- and non-Scilla- related hacking.

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,8 @@ opamdep-ci:
 	opam init --disable-sandboxing --compiler=$(OCAML_VERSION) --yes
 	eval $$(opam env)
 	opam install opam-depext --yes
+# The following line adds scilla as a package which lets us use opam depext further
+	opam pin add . --no-action --yes
 	opam depext --noninteractive --yes
 	opam install ./scilla.opam --deps-only --with-test --yes
 	opam install ocamlformat.$(OCAMLFORMAT_VERSION) --yes

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,8 @@ test_extipcserver: dev
 
 # Run tests in server-mode
 test_server: dev
-	dune exec src/runners/scilla_server.exe &
+	dune build src/runners/scilla_server.exe
+	./_build/default/src/runners/scilla_server.exe &
 	dune exec tests/testsuite.exe -- -print-diff true -runner sequential \
   -server true \
 	-only-test "all_tests:0:contract_tests:0:these_tests_must_SUCCEED"

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,8 @@ opamdep:
 opamdep-ci:
 	opam init --disable-sandboxing --compiler=$(OCAML_VERSION) --yes
 	eval $$(opam env)
+	opam install opam-depext --yes
+	opam depext --noninteractive --yes
 	opam install ./scilla.opam --deps-only --with-test --yes
 	opam install ocamlformat.$(OCAMLFORMAT_VERSION) --yes
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,13 @@ OCAMLFORMAT_VERSION=0.14.1
 IPC_SOCK_PATH="/tmp/zilliqa.sock"
 CPPLIB_DIR=${PWD}/_build/default/src/base/cpp
 
+# Dependencies useful for developing Scilla
+OPAM_DEV_DEPS := \
+merlin \
+ocamlformat.$(OCAMLFORMAT_VERSION) \
+ocp-indent \
+utop
+
 .PHONY: default release utop dev clean docker zilliqa-docker
 
 default: release
@@ -122,11 +129,13 @@ zilliqa-docker:
 	fi
 	docker build --build-arg BASE_IMAGE=$(ZILLIQA_IMAGE) .
 
+# Create an opam-based development environment
 .PHONY : opamdep
 opamdep:
 	opam init --compiler=$(OCAML_VERSION_RECOMMENDED) --yes
 	eval $$(opam env)
 	opam install ./scilla.opam --deps-only --with-test --yes
+	opam install --yes $(OPAM_DEV_DEPS)
 
 .PHONY : opamdep-ci
 opamdep-ci:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Invoke `make` to build, `make clean` to clean up, etc.
 
 OCAML_VERSION_RECOMMENDED=4.07.1
+OCAMLFORMAT_VERSION=0.14.1
 IPC_SOCK_PATH="/tmp/zilliqa.sock"
 CPPLIB_DIR=${PWD}/_build/default/src/base/cpp
 
@@ -132,6 +133,7 @@ opamdep-ci:
 	opam init --disable-sandboxing --compiler=$(OCAML_VERSION) --yes
 	eval $$(opam env)
 	opam install ./scilla.opam --deps-only --with-test --yes
+	opam install ocamlformat.$(OCAMLFORMAT_VERSION) --yes
 
 .PHONY : coverage
 coverage :

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ coveralls:
 	BISECT_ENABLE=YES make
 	dune build @install
 	dune exec -- tests/testsuite.exe
-	bisect-ppx-report -ignore-missing-files -I _build/ -coveralls coverage.json -service-name travis-ci -service-job-id ${TRAVIS_JOB_ID} `find . -name 'bisect*.out'`
+	bisect-ppx-report --ignore-missing-files -I _build/ --coveralls coverage.json --service-name travis-ci --service-job-id ${TRAVIS_JOB_ID} `find . -name 'bisect*.out'`
 	curl -L -F json_file=@./coverage.json https://coveralls.io/api/v1/jobs
 	make clean
 	-find . -name 'bisect*.out' | xargs rm

--- a/scilla.opam
+++ b/scilla.opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/Zilliqa/scilla.git"
 license: "GPL-3.0"
 depends: [
   "ocaml" {>= "4.07.1" & < "4.10~"}
-  "dune" {build & >= "2.0" & < "2.3"}
+  "dune" {build & >= "2.0"}
   "menhir"
   "core" {>= "v0.12.4" & < "v0.13~"}
   "bitstring" {>= "3.1.0" & < "3.2~"}

--- a/scilla.opam
+++ b/scilla.opam
@@ -26,7 +26,6 @@ depends: [
   "ppx_deriving_rpc" {>= "6.0.0" & < "8.0~"}
   "secp256k1" {>= "0.4.0" & < "0.5~"}
   "stdint" {>= "0.5.1" & < "0.7~"}
-  "ocamlformat" {>= "0.14" & < "0.15~"}
   "ounit" {with-test & (>= "2.0.8" & < "2.3~")}
   "patdiff" {with-test & (>= "v0.12.1" & < "v0.13~")}
 ]

--- a/scilla.opam
+++ b/scilla.opam
@@ -28,6 +28,18 @@ depends: [
   "stdint" {>= "0.5.1" & < "0.7~"}
   "ounit" {with-test & (>= "2.0.8" & < "2.3~")}
   "patdiff" {with-test & (>= "v0.12.1" & < "v0.13~")}
+  "conf-cmake" {build}
+  "conf-gcc" {build}
+  "conf-g++" {build}
+  "conf-m4" {build}
+  "conf-pkg-config" {build}
+  "conf-boost"
+  "conf-gmp"
+  "conf-libffi"
+  "conf-libpcre"
+  "conf-openssl"
+  "conf-secp256k1"
+  "conf-zlib"
 ]
 build: [
   [ "./scripts/libff.sh" ]

--- a/src/server/api.ml
+++ b/src/server/api.ml
@@ -20,9 +20,9 @@ open Scilla_eval
 open Idl
 open IPCUtil
 
+type args_t = string list [@@deriving rpcty, show]
 (** A type alias representing a list of arguments to
     be provided to the scilla-runner or scilla-checker *)
-type args_t = string list [@@deriving rpcty, show]
 
 module API (R : RPC) = struct
   open R


### PR DESCRIPTION
- Drop upper bound on Dune (related issue #812)
- Move dependency on `ocamlformat` to Makefile (this is to prevent rebuilding of the Scilla package every time `ocamlformat` is upgraded)
- "make opamdep" installs some dev tools now