### PR TITLE
Revert opam depext changes to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,15 @@ addons:
     - ocaml
     - curl
     - build-essential
+    - m4
+    - pkg-config
+    - zlib1g-dev
+    - libgmp-dev
+    - libssl-dev
+    - libboost-system-dev
+    - libpcre3-dev
     - aspcud
+    - libsecp256k1-dev
   homebrew:
     brewfile: true
     update: true

--- a/Makefile
+++ b/Makefile
@@ -141,10 +141,6 @@ opamdep:
 opamdep-ci:
 	opam init --disable-sandboxing --compiler=$(OCAML_VERSION) --yes
 	eval $$(opam env)
-	opam install opam-depext --yes
-# The following line adds scilla as a package which lets us use opam depext further
-	opam pin add . --no-action --yes
-	opam depext --noninteractive --yes
 	opam install ./scilla.opam --deps-only --with-test --yes
 	opam install ocamlformat.$(OCAMLFORMAT_VERSION) --yes
 


### PR DESCRIPTION
Because `opam depext`'s behavior results in non-deterministic system-level dependency inference