### PR TITLE
Build and CI tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,3 +68,4 @@ script:
 - make coveralls
 - dune build @fmt
 - shellcheck scripts/*.sh && shellcheck easyrun.sh && shellcheck tests/runner/pingpong.sh
+- opam lint .

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,4 @@ script:
 - make test
 - make test_server
 - make coveralls
-- dune build @fmt
-- shellcheck scripts/*.sh && shellcheck easyrun.sh && shellcheck tests/runner/pingpong.sh
-- opam lint .
+- make lint

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,12 @@ utop: release
 fmt:
 	dune build @fmt --auto-promote
 
+# Lint OCaml and dune source files, all the opam files in the project root, and the shell scripts
+lint:
+	dune build @fmt
+	opam lint .
+	shellcheck scripts/*.sh && shellcheck easyrun.sh && shellcheck tests/runner/pingpong.sh
+
 # Installer, uninstaller and test the installation
 install : release
 	dune install

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ dev:
 	dune build --profile dev @install
 	dune build --profile dev tests/scilla_client.exe
 	@test -L bin || ln -s _build/install/default/bin .
-	ln -sr _build/default/tests/scilla_client.exe _build/install/default/bin/scilla-client
+	ln -s ../../../default/tests/scilla_client.exe _build/install/default/bin/scilla-client
 
 # Launch utop such that it finds the libraroes.
 utop: release

--- a/README.md
+++ b/README.md
@@ -186,6 +186,23 @@ dune exec tests/testsuite.exe -- -only-test all_tests:1:exptests:14:let.scilla -
 The optional `-print-cli true` argument is to produce the command line
 that has been used to run the test.
 
+### Formatting and linting the codebase
+Our CI checks that the source code is formatted properly. Use
+```shell
+make fmt
+```
+to ensure your code adheres to the style guide.
+Note that the command will automatically change ("promote") your source code.
+You will need the `ocamlformat` opam package for the command above to work.
+
+To make sure you are good to go, before sending PR run
+```shell
+make lint
+```
+to check if there are any issues with your contribution.
+In addition to the `ocamlformat` package, `make lint` uses `opam` and
+[`shellcheck`](https://www.shellcheck.net).
+
 #### Debugging
 To debug scilla-checker or scilla-runner, you must build `make debug`, which will generate
 the OCaml bytecode versions of the binaries. These can be debugged using `ocamldebug`.


### PR DESCRIPTION
-  Make symlink creation more portable (`ln -r` does not work on macOS, see issue #830)
- Lint all the opam files in the project root in CI with `opam lint .` command