### PR TITLE
Remove redundant cmodule field "cname"

### DIFF
--- a/src/base/Cashflow.ml
+++ b/src/base/Cashflow.ml
@@ -260,13 +260,12 @@ struct
     { CFSyntax.lname; CFSyntax.lentries = List.map ~f:init_tag_entry lentries }
 
   let cf_init_tag_module cmod token_fields =
-    let { smver; cname; libs; elibs; contr } = cmod in
+    let { smver; libs; elibs; contr } = cmod in
     let res_libs =
       match libs with None -> None | Some l -> Some (cf_init_tag_library l)
     in
     {
       CFSyntax.smver;
-      CFSyntax.cname;
       CFSyntax.libs = res_libs;
       CFSyntax.elibs;
       CFSyntax.contr = cf_init_tag_contract contr token_fields;
@@ -2006,9 +2005,9 @@ struct
       final_ctr_tag_map )
 
   let cf_tag_module m =
-    let { smver; cname; libs; elibs; contr } = m in
+    let { smver; libs; elibs; contr } = m in
     let new_contr, ctr_tag_map = cf_tag_contract contr in
-    ({ smver; cname; libs; elibs; contr = new_contr }, ctr_tag_map)
+    ({ smver; libs; elibs; contr = new_contr }, ctr_tag_map)
 
   (*******************************************************)
   (*                Main entry function                  *)

--- a/src/base/ParserUtil.ml
+++ b/src/base/ParserUtil.ml
@@ -160,12 +160,11 @@ module type Syn = sig
   type cmodule = {
     smver : int;
     (* Scilla major version of the contract. *)
-    cname : ParserRep.rep SIdentifier.t;
     libs : library option;
     (* lib functions defined in the module *)
-    (* List of imports / external libs with an optional namespace. *)
     elibs :
       (ParserRep.rep SIdentifier.t * ParserRep.rep SIdentifier.t option) list;
+    (* List of imports / external libs with an optional namespace. *)
     contr : contract;
   }
 

--- a/src/base/PatternChecker.ml
+++ b/src/base/PatternChecker.ml
@@ -345,10 +345,7 @@ struct
         checked_elibs )
 
   let pm_check_module md rlibs elibs =
-    let { smver = mod_smver; cname = mod_cname; libs; elibs = mod_elibs; contr }
-        =
-      md
-    in
+    let { smver = mod_smver; libs; elibs = mod_elibs; contr } = md in
     let { cname = ctr_cname; cparams; cconstraint; cfields; ccomps } = contr in
     let init_msg =
       sprintf "Type error(s) in contract %s:\n"
@@ -395,7 +392,6 @@ struct
          pure
            ( {
                CheckedPatternSyntax.smver = mod_smver;
-               CheckedPatternSyntax.cname = mod_cname;
                CheckedPatternSyntax.libs = checked_lib;
                CheckedPatternSyntax.elibs = mod_elibs;
                CheckedPatternSyntax.contr =

--- a/src/base/Recursion.ml
+++ b/src/base/Recursion.ml
@@ -504,7 +504,7 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
         * RecursionSyntax.libtree list,
         scilla_error list )
       result =
-    let { smver; cname; libs; elibs; contr } = md in
+    let { smver; libs; elibs; contr } = md in
     wrap_with_info
       ( sprintf "Type error(s) in contract %s:\n" (get_id contr.cname),
         SR.get_loc (get_rep contr.cname) )
@@ -533,7 +533,7 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
          | Error el ->
              Ok
                ( {
-                   cname;
+                   cname = contr.cname;
                    cparams = [];
                    cconstraint =
                      ( RecursionSyntax.Literal RecLiteral.false_lit,
@@ -548,7 +548,6 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
          pure
          @@ ( {
                 RecursionSyntax.smver;
-                RecursionSyntax.cname;
                 RecursionSyntax.libs = recursion_md_libs;
                 RecursionSyntax.elibs;
                 RecursionSyntax.contr = recursion_contr;

--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -460,7 +460,6 @@ imports :
 cmodule:
 | SCILLA_VERSION; cver = NUMLIT; els = imports; ls = option(library); c = contract; EOF
   { { smver = Big_int.int_of_big_int cver;
-      cname = c.cname;
       libs = ls;
       elibs = els;
       contr = c } }

--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -368,7 +368,6 @@ module ScillaSyntax (SR : Rep) (ER : Rep) (Literal : ScillaLiteral) = struct
   type cmodule = {
     smver : int;
     (* Scilla major version of the contract. *)
-    cname : SR.rep SIdentifier.t;
     libs : library option;
     (* lib functions defined in the module *)
     (* List of imports / external libs with an optional namespace. *)

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -1251,10 +1251,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
         * Stdint.uint64,
         scilla_error list * Stdint.uint64 )
       result =
-    let { smver = mod_smver; cname = mod_cname; libs; elibs = mod_elibs; contr }
-        =
-      md
-    in
+    let { smver = mod_smver; libs; elibs = mod_elibs; contr } = md in
     let { cname = ctr_cname; cparams; cconstraint; cfields; ccomps } = contr in
     let msg = sprintf "Type error(s) in contract %s:\n" (get_id ctr_cname) in
     strip_error_type
@@ -1357,7 +1354,6 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
          pure
            ( ( {
                  TypedSyntax.smver = mod_smver;
-                 TypedSyntax.cname = mod_cname;
                  TypedSyntax.libs = typed_clibs;
                  TypedSyntax.elibs = mod_elibs;
                  TypedSyntax.contr =


### PR DESCRIPTION
`cmodule.cname` is the same as `cmodule.contr.cname`, but if you would prefer to keep `cmodule.cname` then we should document its purpose.