### PR TITLE
Moved prim_typ to separate module

### DIFF
--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -369,6 +369,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       | _ -> fail0 "Failed to elaborate"
 
     let to_int_helper ls w =
+      let open Type.PrimType in
       let%bind xs =
         match ls with
         | [ IntLit x ] -> pure @@ string_of_int_lit x
@@ -596,6 +597,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       | _ -> fail0 "Failed to elaborate"
 
     let to_uint_helper ls w =
+      let open Type.PrimType in
       let%bind xs =
         match ls with
         | [ IntLit x ] -> pure @@ string_of_int_lit x

--- a/src/base/Literal.ml
+++ b/src/base/Literal.ml
@@ -149,10 +149,10 @@ module type ScillaLiteral = sig
   (*            PrimType Literal utilities                        *)
   (****************************************************************)
 
-  val build_prim_literal : LType.prim_typ -> string -> t option
+  val build_prim_literal : PrimType.t -> string -> t option
 
   (* Is string representation of integer valid for integer typ. *)
-  val validate_int_string : LType.prim_typ -> string -> bool
+  val validate_int_string : PrimType.t -> string -> bool
 
   (* Get bit-width if int_lit. *)
   val int_lit_width : int_lit -> int
@@ -375,6 +375,7 @@ module MkLiteral (T : ScillaType) = struct
 
   (* Is string representation of integer valid for integer typ. *)
   let validate_int_string pt x =
+    let open PrimType in
     let open String in
     try
       match pt with
@@ -451,6 +452,7 @@ module MkLiteral (T : ScillaType) = struct
           else false)
 
   let build_prim_literal pt v =
+    let open PrimType in
     match pt with
     | Int_typ _ | Uint_typ _ -> build_int pt v
     | String_typ -> Option.some_if (validate_string_literal v) (StringLit v)

--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -30,7 +30,7 @@
   let to_loc_id s loc = SIdentifier.mk_id (ParserName.parse_simple_name s) loc
 
   let to_prim_type_exn d loc =
-    let open SType in
+    let open Type.PrimType in
     match d with
     | "Int32" -> Int_typ Bits32
     | "Int64" -> Int_typ Bits64
@@ -70,7 +70,7 @@
   let build_prim_literal_exn t v loc =
     match SLiteral.build_prim_literal t v with
     | Some l -> l
-    | None -> raise (SyntaxError (("Invalid " ^ (SType.pp_prim_typ t) ^ " literal " ^ v), loc))
+    | None -> raise (SyntaxError (("Invalid " ^ (Type.PrimType.pp_prim_typ t) ^ " literal " ^ v), loc))
 
   let build_bool_literal v loc =
     (Literal (SLiteral.build_bool_lit v), loc)

--- a/src/base/Type.ml
+++ b/src/base/Type.ml
@@ -23,11 +23,10 @@ open ErrorUtils
 open Identifier
 
 module PrimType = struct
-
   type int_bit_width = Bits32 | Bits64 | Bits128 | Bits256
   [@@deriving sexp, equal]
 
-  type t = 
+  type t =
     | Int_typ of int_bit_width
     | Uint_typ of int_bit_width
     | String_typ
@@ -74,12 +73,11 @@ module PrimType = struct
     | Exception_typ -> "Exception"
     | Bystr_typ -> "ByStr"
     | Bystrx_typ b -> "ByStr" ^ Int.to_string b
-
 end
 
 module type ScillaType = sig
   module TIdentifier : ScillaIdentifier
- 
+
   type t =
     | PrimType of PrimType.t
     | MapType of t * t

--- a/src/base/Type.ml
+++ b/src/base/Type.ml
@@ -24,7 +24,7 @@ open Identifier
 
 module PrimType = struct
   type int_bit_width = Bits32 | Bits64 | Bits128 | Bits256
-  [@@deriving sexp, equal]
+  [@@deriving sexp, equal, compare]
 
   type t =
     | Int_typ of int_bit_width
@@ -36,7 +36,7 @@ module PrimType = struct
     | Exception_typ
     | Bystr_typ
     | Bystrx_typ of int
-  [@@deriving equal, sexp]
+  [@@deriving equal, sexp, compare]
 
   let sexp_of_t = function
     | Int_typ Bits32 -> Sexp.Atom "Int32"

--- a/src/base/Type.ml
+++ b/src/base/Type.ml
@@ -22,14 +22,12 @@ open Sexplib.Std
 open ErrorUtils
 open Identifier
 
-module type ScillaType = sig
-  module TIdentifier : ScillaIdentifier
+module PrimType = struct
 
   type int_bit_width = Bits32 | Bits64 | Bits128 | Bits256
+  [@@deriving sexp, equal]
 
-  val int_bit_width_to_string : int_bit_width -> string
-
-  type prim_typ =
+  type t = 
     | Int_typ of int_bit_width
     | Uint_typ of int_bit_width
     | String_typ
@@ -41,10 +39,49 @@ module type ScillaType = sig
     | Bystrx_typ of int
   [@@deriving equal, sexp]
 
-  val pp_prim_typ : prim_typ -> string
+  let sexp_of_t = function
+    | Int_typ Bits32 -> Sexp.Atom "Int32"
+    | Int_typ Bits64 -> Sexp.Atom "Int64"
+    | Int_typ Bits128 -> Sexp.Atom "Int128"
+    | Int_typ Bits256 -> Sexp.Atom "Int256"
+    | Uint_typ Bits32 -> Sexp.Atom "Uint32"
+    | Uint_typ Bits64 -> Sexp.Atom "Uint64"
+    | Uint_typ Bits128 -> Sexp.Atom "Uint128"
+    | Uint_typ Bits256 -> Sexp.Atom "Uint256"
+    | String_typ -> Sexp.Atom "String"
+    | Bnum_typ -> Sexp.Atom "BNum"
+    | Msg_typ -> Sexp.Atom "Message"
+    | Event_typ -> Sexp.Atom "Event"
+    | Exception_typ -> Sexp.Atom "Exception"
+    | Bystr_typ -> Sexp.Atom "ByStr"
+    | Bystrx_typ b -> Sexp.Atom ("ByStr" ^ Int.to_string b)
 
+  let t_of_sexp _ = failwith "prim_typ_of_sexp is not implemented"
+
+  let int_bit_width_to_string = function
+    | Bits32 -> "32"
+    | Bits64 -> "64"
+    | Bits128 -> "128"
+    | Bits256 -> "256"
+
+  let pp_prim_typ = function
+    | Int_typ bw -> "Int" ^ int_bit_width_to_string bw
+    | Uint_typ bw -> "Uint" ^ int_bit_width_to_string bw
+    | String_typ -> "String"
+    | Bnum_typ -> "BNum"
+    | Msg_typ -> "Message"
+    | Event_typ -> "Event"
+    | Exception_typ -> "Exception"
+    | Bystr_typ -> "ByStr"
+    | Bystrx_typ b -> "ByStr" ^ Int.to_string b
+
+end
+
+module type ScillaType = sig
+  module TIdentifier : ScillaIdentifier
+ 
   type t =
-    | PrimType of prim_typ
+    | PrimType of PrimType.t
     | MapType of t * t
     | FunType of t * t
     | ADT of loc TIdentifier.t * t list
@@ -130,42 +167,8 @@ module MkType (I : ScillaIdentifier) = struct
   (*                         Types                       *)
   (*******************************************************)
 
-  type int_bit_width = Bits32 | Bits64 | Bits128 | Bits256
-  [@@deriving sexp, equal]
-
-  type prim_typ =
-    | Int_typ of int_bit_width
-    | Uint_typ of int_bit_width
-    | String_typ
-    | Bnum_typ
-    | Msg_typ
-    | Event_typ
-    | Exception_typ
-    | Bystr_typ
-    | Bystrx_typ of int
-  [@@deriving equal]
-
-  let sexp_of_prim_typ = function
-    | Int_typ Bits32 -> Sexp.Atom "Int32"
-    | Int_typ Bits64 -> Sexp.Atom "Int64"
-    | Int_typ Bits128 -> Sexp.Atom "Int128"
-    | Int_typ Bits256 -> Sexp.Atom "Int256"
-    | Uint_typ Bits32 -> Sexp.Atom "Uint32"
-    | Uint_typ Bits64 -> Sexp.Atom "Uint64"
-    | Uint_typ Bits128 -> Sexp.Atom "Uint128"
-    | Uint_typ Bits256 -> Sexp.Atom "Uint256"
-    | String_typ -> Sexp.Atom "String"
-    | Bnum_typ -> Sexp.Atom "BNum"
-    | Msg_typ -> Sexp.Atom "Message"
-    | Event_typ -> Sexp.Atom "Event"
-    | Exception_typ -> Sexp.Atom "Exception"
-    | Bystr_typ -> Sexp.Atom "ByStr"
-    | Bystrx_typ b -> Sexp.Atom ("ByStr" ^ Int.to_string b)
-
-  let prim_typ_of_sexp _ = failwith "prim_typ_of_sexp is not implemented"
-
   type t =
-    | PrimType of prim_typ
+    | PrimType of PrimType.t
     | MapType of t * t
     | FunType of t * t
     | ADT of loc TIdentifier.t * t list
@@ -174,25 +177,8 @@ module MkType (I : ScillaIdentifier) = struct
     | Unit
   [@@deriving sexp]
 
-  let int_bit_width_to_string = function
-    | Bits32 -> "32"
-    | Bits64 -> "64"
-    | Bits128 -> "128"
-    | Bits256 -> "256"
-
-  let pp_prim_typ = function
-    | Int_typ bw -> "Int" ^ int_bit_width_to_string bw
-    | Uint_typ bw -> "Uint" ^ int_bit_width_to_string bw
-    | String_typ -> "String"
-    | Bnum_typ -> "BNum"
-    | Msg_typ -> "Message"
-    | Event_typ -> "Event"
-    | Exception_typ -> "Exception"
-    | Bystr_typ -> "ByStr"
-    | Bystrx_typ b -> "ByStr" ^ Int.to_string b
-
   let rec pp_typ = function
-    | PrimType t -> pp_prim_typ t
+    | PrimType t -> PrimType.pp_prim_typ t
     | MapType (kt, vt) -> sprintf "Map (%s) (%s)" (pp_typ kt) (pp_typ vt)
     | ADT (name, targs) ->
         let elems =
@@ -299,7 +285,7 @@ module MkType (I : ScillaIdentifier) = struct
     let t2' = canonicalize_tfun t2 in
     let rec equiv t1 t2 =
       match (t1, t2) with
-      | PrimType p1, PrimType p2 -> [%equal: prim_typ] p1 p2
+      | PrimType p1, PrimType p2 -> [%equal: PrimType.t] p1 p2
       | TypeVar v1, TypeVar v2 -> String.equal v1 v2
       | Unit, Unit -> true
       | ADT (tname1, tl1), ADT (tname2, tl2) ->


### PR DESCRIPTION
One more small refactoring.

As predicted by @anton-trunov it's slightly less painful to have `prim_typ` located in a separate module.