### PR TITLE
Catch JSON parse exceptions properly in the fast parser.

### DIFF
--- a/src/base/JSON.ml
+++ b/src/base/JSON.ml
@@ -43,8 +43,11 @@ open JSONLiteral
 (****************************************************************)
 
 let json_exn_wrapper = JSONParser.json_exn_wrapper
+
 let member_exn = JSONParser.member_exn
+
 let to_string_exn = JSONParser.to_string_exn
+
 let constr_pattern_arg_types_exn = JSONParser.constr_pattern_arg_types_exn
 
 let from_file f =
@@ -107,9 +110,7 @@ let rec json_to_adtargs cname tlist ajs =
   (* For each component literal of our ADT, calculate it's type.
    * This is essentially using DataTypes.constr_tmap and substituting safely. *)
   let tmap =
-    constr_pattern_arg_types_exn
-      (ADT (mk_loc_id dt.tname, tlist))
-      cname
+    constr_pattern_arg_types_exn (ADT (mk_loc_id dt.tname, tlist)) cname
   in
   verify_args_exn cname (List.length ajs) (List.length tmap);
   let llist = List.map2_exn tmap ajs ~f:(fun t j -> json_to_lit t j) in
@@ -211,8 +212,7 @@ let jobj_to_statevar json =
   let tstring = member_exn "type" json |> to_string_exn in
   let t = parse_typ_exn tstring in
   let v = member_exn "value" json in
-  if GlobalConfig.validate_json () then
-    (n, json_to_lit t v)
+  if GlobalConfig.validate_json () then (n, json_to_lit t v)
   else (n, JSONParser.parse_json t v)
 
 (****************************************************************)

--- a/src/base/JSONParser.mli
+++ b/src/base/JSONParser.mli
@@ -27,9 +27,14 @@ module JSONLiteral = TypeUtil.TULiteral
 (***** Exception and wrappers ********)
 (*************************************)
 
+val json_exn_wrapper : ?filename:string -> (unit -> 'a) -> 'a
+
 (* member_exn k obj returns the value associated with the key k in the JSON object obj,
    or raises an exception if k is not present in obj. *)
 val member_exn : string -> Basic.t -> Basic.t
+
+(* String JSON value to OCaml string with exceptions translated. *)
+val to_string_exn : Yojson.Basic.t -> string
 
 (* Wrapper for constr_pattern_arg_types. Throws Invalid_json exception instead of using result type *)
 val constr_pattern_arg_types_exn : JSONType.t -> string -> JSONType.t list

--- a/src/base/RunnerUtil.ml
+++ b/src/base/RunnerUtil.ml
@@ -52,9 +52,8 @@ let get_init_extlibs filename =
                 filename)
       else name_addr_pairs
     with Invalid_json s ->
-      (* Inability to fetch extlibs info from init json shouldn't be fatal error. *)
-      plog (scilla_error_to_string s);
-      []
+      fatal_error
+        (s @ mk_error0 (sprintf "Unable to parse JSON file %s. " filename))
 
 (* Find (by looking for in StdlibTracker) and parse library named "id.scillib".
  * If "id.json" exists, parse it's extlibs info and provide that also. *)
@@ -358,6 +357,8 @@ let parse_cli args ~exe_name =
   let r_type_info = ref false in
   let r_cf = ref false in
   let r_cf_token_fields = ref [] in
+  let r_validate_json = ref true in
+
   let speclist =
     [
       ( "-version",
@@ -402,6 +403,9 @@ let parse_cli args ~exe_name =
       ( "-typeinfo",
         Arg.Unit (fun () -> r_type_info := true),
         "Print types of variables with location" );
+      ( "-disable-validate-json",
+        Arg.Unit (fun () -> r_validate_json := false),
+        "Disable validation of input JSONs" );
     ]
   in
 
@@ -433,6 +437,7 @@ let parse_cli args ~exe_name =
   in
   if not @@ List.is_empty !r_cf_token_fields then r_cf := true;
   GlobalConfig.set_use_json_errors !r_json_errors;
+  GlobalConfig.set_validate_json !r_validate_json;
   {
     input_file = !r_input_file;
     stdlib_dirs = !r_stdlib_dir;

--- a/tests/checker/bad/Bad.ml
+++ b/tests/checker/bad/Bad.ml
@@ -165,7 +165,7 @@ module InitArgTests = Scilla_test.Util.DiffBasedTests (struct
 
   let additional_libdirs = [ [ "checker"; "bad"; "lib" ] ]
 
-  let tests = [ "extlib_dup_entry.scilla" ]
+  let tests = [ "extlib_dup_entry.scilla"; "bad_init.scilla" ]
 
   let exit_code : Unix.process_status = WEXITED 1
 end)

--- a/tests/checker/bad/bad_init.json
+++ b/tests/checker/bad/bad_init.json
@@ -1,0 +1,13 @@
+[
+  {
+    "vname": "some_uint",
+    "value": 2,
+    "type": "Uint32"
+  },
+  {
+    "vname": "_scilla_version",
+    "type": "Uint32",
+    "value": "0"
+  }
+]
+

--- a/tests/checker/bad/bad_init.scilla
+++ b/tests/checker/bad/bad_init.scilla
@@ -1,0 +1,7 @@
+scilla_version 0
+
+contract BadInit
+(
+  required_signatures : Uint32
+)
+

--- a/tests/checker/bad/gold/bad_init.scilla.gold
+++ b/tests/checker/bad/gold/bad_init.scilla.gold
@@ -1,0 +1,16 @@
+{
+  "errors": [
+    {
+      "error_message": "Expected string, got int",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Unable to parse JSON file checker/bad/bad_init.json. ",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": []
+}


### PR DESCRIPTION
Provide a command line flag -disable-validate-json for checker.
Similar to scilla-runner, validate json is enabled by default.