### PR TITLE
Small tweaks in Accept.ml

### DIFF
--- a/src/base/Accept.ml
+++ b/src/base/Accept.ml
@@ -104,7 +104,7 @@ struct
       let dup_accept_warning (group : loc list) : unit =
         warn2
           ( sprintf
-              "transition %s had a potential code path with duplicate accept \
+              "transition %s has a potential code path with duplicate accept \
                statements:\n"
               (ACIdentifier.as_error_string transition.comp_name)
           ^ String.concat ~sep:""

--- a/src/base/Accept.ml
+++ b/src/base/Accept.ml
@@ -99,9 +99,7 @@ struct
         List.map (find_accept_groups transition.comp_body) ~f:List.rev
       in
 
-      let accept_loc_end (l : loc) =
-        match l with { fname; lnum; cnum } -> { fname; lnum; cnum = cnum + 6 }
-      in
+      let accept_loc_end (l : loc) = { l with cnum = l.cnum + 6 } in
 
       let dup_accept_warning (group : loc list) : unit =
         warn2

--- a/src/base/Accept.ml
+++ b/src/base/Accept.ml
@@ -75,11 +75,11 @@ struct
          we don't know what will happen on each in advance. *)
       List.fold_left stmts ~init:seen
         ~f:(fun (seen2 : loc list list) (stmt : stmt_annot) ->
-          let loc = stmt_loc stmt in
           match fst stmt with
           | AcceptPayment ->
               (* Add this accept statement to the list of accepts
                * already seen on each code path reaching this point. *)
+              let loc = stmt_loc stmt in
               List.map seen2 ~f:(fun accepts -> loc :: accepts)
           | MatchStmt (_ident, branches) ->
               (* For each branch in the match statement we have a

--- a/tests/checker/good/gold/multiple-accepts.scilla.gold
+++ b/tests/checker/good/gold/multiple-accepts.scilla.gold
@@ -70,7 +70,7 @@
   "warnings": [
     {
       "warning_message":
-        "transition donate_variable had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:70:13\n  Accept at checker/good/multiple-accepts.scilla:78:13\n",
+        "transition donate_variable has a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:70:13\n  Accept at checker/good/multiple-accepts.scilla:78:13\n",
       "start_location": {
         "file": "checker/good/multiple-accepts.scilla",
         "line": 70,
@@ -85,7 +85,7 @@
     },
     {
       "warning_message":
-        "transition donate_variable had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:70:13\n  Accept at checker/good/multiple-accepts.scilla:86:13\n",
+        "transition donate_variable has a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:70:13\n  Accept at checker/good/multiple-accepts.scilla:86:13\n",
       "start_location": {
         "file": "checker/good/multiple-accepts.scilla",
         "line": 70,
@@ -100,7 +100,7 @@
     },
     {
       "warning_message":
-        "transition donate_variable had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:78:13\n  Accept at checker/good/multiple-accepts.scilla:86:13\n",
+        "transition donate_variable has a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:78:13\n  Accept at checker/good/multiple-accepts.scilla:86:13\n",
       "start_location": {
         "file": "checker/good/multiple-accepts.scilla",
         "line": 78,
@@ -115,7 +115,7 @@
     },
     {
       "warning_message":
-        "transition donate_variable had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:70:13\n  Accept at checker/good/multiple-accepts.scilla:78:13\n  Accept at checker/good/multiple-accepts.scilla:86:13\n",
+        "transition donate_variable has a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:70:13\n  Accept at checker/good/multiple-accepts.scilla:78:13\n  Accept at checker/good/multiple-accepts.scilla:86:13\n",
       "start_location": {
         "file": "checker/good/multiple-accepts.scilla",
         "line": 70,
@@ -130,7 +130,7 @@
     },
     {
       "warning_message":
-        "transition donate_variable had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:70:13\n  Accept at checker/good/multiple-accepts.scilla:94:13\n",
+        "transition donate_variable has a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:70:13\n  Accept at checker/good/multiple-accepts.scilla:94:13\n",
       "start_location": {
         "file": "checker/good/multiple-accepts.scilla",
         "line": 70,
@@ -145,7 +145,7 @@
     },
     {
       "warning_message":
-        "transition donate_variable had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:78:13\n  Accept at checker/good/multiple-accepts.scilla:94:13\n",
+        "transition donate_variable has a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:78:13\n  Accept at checker/good/multiple-accepts.scilla:94:13\n",
       "start_location": {
         "file": "checker/good/multiple-accepts.scilla",
         "line": 78,
@@ -160,7 +160,7 @@
     },
     {
       "warning_message":
-        "transition donate_variable had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:70:13\n  Accept at checker/good/multiple-accepts.scilla:78:13\n  Accept at checker/good/multiple-accepts.scilla:94:13\n",
+        "transition donate_variable has a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:70:13\n  Accept at checker/good/multiple-accepts.scilla:78:13\n  Accept at checker/good/multiple-accepts.scilla:94:13\n",
       "start_location": {
         "file": "checker/good/multiple-accepts.scilla",
         "line": 70,
@@ -175,7 +175,7 @@
     },
     {
       "warning_message":
-        "transition donate_variable had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:86:13\n  Accept at checker/good/multiple-accepts.scilla:94:13\n",
+        "transition donate_variable has a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:86:13\n  Accept at checker/good/multiple-accepts.scilla:94:13\n",
       "start_location": {
         "file": "checker/good/multiple-accepts.scilla",
         "line": 86,
@@ -190,7 +190,7 @@
     },
     {
       "warning_message":
-        "transition donate_variable had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:70:13\n  Accept at checker/good/multiple-accepts.scilla:86:13\n  Accept at checker/good/multiple-accepts.scilla:94:13\n",
+        "transition donate_variable has a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:70:13\n  Accept at checker/good/multiple-accepts.scilla:86:13\n  Accept at checker/good/multiple-accepts.scilla:94:13\n",
       "start_location": {
         "file": "checker/good/multiple-accepts.scilla",
         "line": 70,
@@ -205,7 +205,7 @@
     },
     {
       "warning_message":
-        "transition donate_variable had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:78:13\n  Accept at checker/good/multiple-accepts.scilla:86:13\n  Accept at checker/good/multiple-accepts.scilla:94:13\n",
+        "transition donate_variable has a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:78:13\n  Accept at checker/good/multiple-accepts.scilla:86:13\n  Accept at checker/good/multiple-accepts.scilla:94:13\n",
       "start_location": {
         "file": "checker/good/multiple-accepts.scilla",
         "line": 78,
@@ -220,7 +220,7 @@
     },
     {
       "warning_message":
-        "transition donate_variable had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:70:13\n  Accept at checker/good/multiple-accepts.scilla:78:13\n  Accept at checker/good/multiple-accepts.scilla:86:13\n  Accept at checker/good/multiple-accepts.scilla:94:13\n",
+        "transition donate_variable has a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:70:13\n  Accept at checker/good/multiple-accepts.scilla:78:13\n  Accept at checker/good/multiple-accepts.scilla:86:13\n  Accept at checker/good/multiple-accepts.scilla:94:13\n",
       "start_location": {
         "file": "checker/good/multiple-accepts.scilla",
         "line": 70,
@@ -235,7 +235,7 @@
     },
     {
       "warning_message":
-        "transition donate_once_non_obvious had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:48:13\n  Accept at checker/good/multiple-accepts.scilla:54:14\n",
+        "transition donate_once_non_obvious has a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:48:13\n  Accept at checker/good/multiple-accepts.scilla:54:14\n",
       "start_location": {
         "file": "checker/good/multiple-accepts.scilla",
         "line": 48,
@@ -250,7 +250,7 @@
     },
     {
       "warning_message":
-        "transition donate_once_or_twice_reversed had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:34:13\n  Accept at checker/good/multiple-accepts.scilla:39:3\n",
+        "transition donate_once_or_twice_reversed has a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:34:13\n  Accept at checker/good/multiple-accepts.scilla:39:3\n",
       "start_location": {
         "file": "checker/good/multiple-accepts.scilla",
         "line": 34,
@@ -265,7 +265,7 @@
     },
     {
       "warning_message":
-        "transition donate_once_or_twice had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:23:3\n  Accept at checker/good/multiple-accepts.scilla:25:13\n",
+        "transition donate_once_or_twice has a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:23:3\n  Accept at checker/good/multiple-accepts.scilla:25:13\n",
       "start_location": {
         "file": "checker/good/multiple-accepts.scilla",
         "line": 23,
@@ -280,7 +280,7 @@
     },
     {
       "warning_message":
-        "transition donate_thrice had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:17:3\n  Accept at checker/good/multiple-accepts.scilla:18:3\n  Accept at checker/good/multiple-accepts.scilla:19:3\n",
+        "transition donate_thrice has a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:17:3\n  Accept at checker/good/multiple-accepts.scilla:18:3\n  Accept at checker/good/multiple-accepts.scilla:19:3\n",
       "start_location": {
         "file": "checker/good/multiple-accepts.scilla",
         "line": 17,
@@ -295,7 +295,7 @@
     },
     {
       "warning_message":
-        "transition donate_twice had a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:12:3\n  Accept at checker/good/multiple-accepts.scilla:13:3\n",
+        "transition donate_twice has a potential code path with duplicate accept statements:\n  Accept at checker/good/multiple-accepts.scilla:12:3\n  Accept at checker/good/multiple-accepts.scilla:13:3\n",
       "start_location": {
         "file": "checker/good/multiple-accepts.scilla",
         "line": 12,


### PR DESCRIPTION
I needed some code for traversing code paths for the TLA+ transpiler, so I read some relevant code in Scilla and made a few tweaks in `Accept.ml` file.