### PR TITLE
Fix copyright notice for code files

### DIFF
--- a/misc/emacs-mode/scilla-mode.el
+++ b/misc/emacs-mode/scilla-mode.el
@@ -1,3 +1,19 @@
+;;  This file is part of scilla.
+;;
+;;  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+;;  
+;;  scilla is free software: you can redistribute it and/or modify it under the
+;;  terms of the GNU General Public License as published by the Free Software
+;;  Foundation, either version 3 of the License, or (at your option) any later
+;;  version.
+;; 
+;;  scilla is distributed in the hope that it will be useful, but WITHOUT ANY
+;;  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+;;  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+;; 
+;;  You should have received a copy of the GNU General Public License along with
+;;  scilla.  If not, see <http://www.gnu.org/licenses/>.
+
 ;; This is an Emacs major mode for the Scilla language.
 ;; Include the below lines (with path set properly) in ~/.emacs
 ;;    ;; For enabling flycheck mode for Scilla.

--- a/scripts/build_openssl.sh
+++ b/scripts/build_openssl.sh
@@ -1,5 +1,21 @@
 #!/usr/bin/env sh
 
+##  This file is part of scilla.
+##
+##  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+##  
+##  scilla is free software: you can redistribute it and/or modify it under the
+##  terms of the GNU General Public License as published by the Free Software
+##  Foundation, either version 3 of the License, or (at your option) any later
+##  version.
+## 
+##  scilla is distributed in the hope that it will be useful, but WITHOUT ANY
+##  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+##  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+## 
+##  You should have received a copy of the GNU General Public License along with
+##  scilla.  If not, see <http://www.gnu.org/licenses/>.
+
 if [ -d ~/openssl/install ]
 then
     echo "OpenSSL already installed, exiting"

--- a/scripts/install_opam2_ubuntu.sh
+++ b/scripts/install_opam2_ubuntu.sh
@@ -1,5 +1,21 @@
 #!/usr/bin/env bash
 
+##  This file is part of scilla.
+##
+##  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+##  
+##  scilla is free software: you can redistribute it and/or modify it under the
+##  terms of the GNU General Public License as published by the Free Software
+##  Foundation, either version 3 of the License, or (at your option) any later
+##  version.
+## 
+##  scilla is distributed in the hope that it will be useful, but WITHOUT ANY
+##  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+##  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+## 
+##  You should have received a copy of the GNU General Public License along with
+##  scilla.  If not, see <http://www.gnu.org/licenses/>.
+
 # The -e flag makes sure the script exits as soon as one command returns a non-zero exit code
 # The -v flag makes the shell print all lines in the script before executing them, which helps identify which steps failed
 set -ev

--- a/scripts/install_shellcheck_ubuntu.sh
+++ b/scripts/install_shellcheck_ubuntu.sh
@@ -1,5 +1,21 @@
 #!/usr/bin/env bash
 
+##  This file is part of scilla.
+##
+##  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+##  
+##  scilla is free software: you can redistribute it and/or modify it under the
+##  terms of the GNU General Public License as published by the Free Software
+##  Foundation, either version 3 of the License, or (at your option) any later
+##  version.
+## 
+##  scilla is distributed in the hope that it will be useful, but WITHOUT ANY
+##  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+##  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+## 
+##  You should have received a copy of the GNU General Public License along with
+##  scilla.  If not, see <http://www.gnu.org/licenses/>.
+
 # The -x flag makes sure the script exits as soon as one command returns a non-zero exit code
 # The -v flag makes the shell print all lines in the script before executing them, which helps identify which steps failed
 set -ev

--- a/scripts/libff.sh
+++ b/scripts/libff.sh
@@ -1,5 +1,21 @@
 #!/usr/bin/env bash
 
+##  This file is part of scilla.
+##
+##  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+##  
+##  scilla is free software: you can redistribute it and/or modify it under the
+##  terms of the GNU General Public License as published by the Free Software
+##  Foundation, either version 3 of the License, or (at your option) any later
+##  version.
+## 
+##  scilla is distributed in the hope that it will be useful, but WITHOUT ANY
+##  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+##  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+## 
+##  You should have received a copy of the GNU General Public License along with
+##  scilla.  If not, see <http://www.gnu.org/licenses/>.
+
 # This script is expected to be executed from Scilla root
 # $./scripts/libff.sh
 # The script builds and installs libff in the

--- a/scripts/run_ipc_map_corner_tests.sh
+++ b/scripts/run_ipc_map_corner_tests.sh
@@ -1,5 +1,21 @@
 #!/usr/bin/env bash
 
+##  This file is part of scilla.
+##
+##  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+##  
+##  scilla is free software: you can redistribute it and/or modify it under the
+##  terms of the GNU General Public License as published by the Free Software
+##  Foundation, either version 3 of the License, or (at your option) any later
+##  version.
+## 
+##  scilla is distributed in the hope that it will be useful, but WITHOUT ANY
+##  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+##  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+## 
+##  You should have received a copy of the GNU General Public License along with
+##  scilla.  If not, see <http://www.gnu.org/licenses/>.
+
 # This script assumes that there is an IPC state server running
 # at /tmp/zilliqa.sock and runs the interpreter to deploy
 # and run all transitions of tests/contracts/map_corners_test.scilla.

--- a/src/base/EventInfo.ml
+++ b/src/base/EventInfo.ml
@@ -1,7 +1,7 @@
 (*
   This file is part of scilla.
 
-  Copyright (c) 2020 - present Zilliqa Research Pvt. Ltd.
+  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
   
   scilla is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software

--- a/src/base/Identifier.ml
+++ b/src/base/Identifier.ml
@@ -1,7 +1,7 @@
 (*
   This file is part of scilla.
 
-  Copyright (c) 2020 - present Zilliqa Research Pvt. Ltd.
+  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
   
   scilla is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software

--- a/src/base/Literal.ml
+++ b/src/base/Literal.ml
@@ -1,7 +1,7 @@
 (*
   This file is part of scilla.
 
-  Copyright (c) 2020 - present Zilliqa Research Pvt. Ltd.
+  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
   
   scilla is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software

--- a/src/base/ParserFaults.messages
+++ b/src/base/ParserFaults.messages
@@ -1,3 +1,21 @@
+# 
+# This file is part of scilla.
+# 
+# Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+# 
+# scilla is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+# 
+# scilla is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License along with
+# scilla.  If not, see <http://www.gnu.org/licenses/>.
+#
+
 # The .messages file is a list of sentences that lead to parser
 # error states.
 # The 'WITH' token is not special.

--- a/src/base/ParserUtil.ml
+++ b/src/base/ParserUtil.ml
@@ -1,7 +1,7 @@
 (*
   This file is part of scilla.
 
-  Copyright (c) 2020 - present Zilliqa Research Pvt. Ltd.
+  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
   
   scilla is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software

--- a/src/base/Recursion.ml
+++ b/src/base/Recursion.ml
@@ -1,7 +1,7 @@
 (*
   This file is part of scilla.
 
-  Copyright (c) 2020 - present Zilliqa Research Pvt. Ltd.
+  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
   
   scilla is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software

--- a/src/base/SafeArith.ml
+++ b/src/base/SafeArith.ml
@@ -1,3 +1,20 @@
+(*
+  This file is part of scilla.
+
+  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+  
+  scilla is free software: you can redistribute it and/or modify it under the
+  terms of the GNU General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option) any later
+  version.
+ 
+  scilla is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License along with
+  scilla.  If not, see <http://www.gnu.org/licenses/>.
+*)
 open Base
 
 (* No need to open! Int.Replace_polymorphic_compare

--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -1,7 +1,7 @@
 (*
   This file is part of scilla.
 
-  Copyright (c) 2020 - present Zilliqa Research Pvt. Ltd.
+  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
   
   scilla is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software

--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -1,7 +1,7 @@
 (*
   This file is part of scilla.
 
-  Copyright (c) 2020 - present Zilliqa Research Pvt. Ltd.
+  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
   
   scilla is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software

--- a/src/base/Type.ml
+++ b/src/base/Type.ml
@@ -1,7 +1,7 @@
 (*
   This file is part of scilla.
 
-  Copyright (c) 2020 - present Zilliqa Research Pvt. Ltd.
+  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
   
   scilla is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software

--- a/src/base/cpp/c_schnorr.cpp
+++ b/src/base/cpp/c_schnorr.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2019 Zilliqa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #include <cassert>
 #include <cstring>
 

--- a/src/eval/IPCUtil.ml
+++ b/src/eval/IPCUtil.ml
@@ -1,3 +1,20 @@
+(*
+  This file is part of scilla.
+
+  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+  
+  scilla is free software: you can redistribute it and/or modify it under the
+  terms of the GNU General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option) any later
+  version.
+ 
+  scilla is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License along with
+  scilla.  If not, see <http://www.gnu.org/licenses/>.
+*)
 open Core
 open Idl
 

--- a/src/eval/Ipcmessage_pb.ml
+++ b/src/eval/Ipcmessage_pb.ml
@@ -1,3 +1,20 @@
+(*
+  This file is part of scilla.
+
+  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+  
+  scilla is free software: you can redistribute it and/or modify it under the
+  terms of the GNU General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option) any later
+  version.
+ 
+  scilla is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License along with
+  scilla.  If not, see <http://www.gnu.org/licenses/>.
+*)
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 

--- a/src/eval/Ipcmessage_pb.mli
+++ b/src/eval/Ipcmessage_pb.mli
@@ -1,3 +1,20 @@
+(*
+  This file is part of scilla.
+
+  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+  
+  scilla is free software: you can redistribute it and/or modify it under the
+  terms of the GNU General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option) any later
+  version.
+ 
+  scilla is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License along with
+  scilla.  If not, see <http://www.gnu.org/licenses/>.
+*)
 (** Ipcmessage.proto Binary Encoding *)
 
 (** {2 Protobuf Encoding} *)

--- a/src/eval/Ipcmessage_types.ml
+++ b/src/eval/Ipcmessage_types.ml
@@ -1,3 +1,20 @@
+(*
+  This file is part of scilla.
+
+  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+  
+  scilla is free software: you can redistribute it and/or modify it under the
+  terms of the GNU General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option) any later
+  version.
+ 
+  scilla is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License along with
+  scilla.  If not, see <http://www.gnu.org/licenses/>.
+*)
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 

--- a/src/eval/Ipcmessage_types.mli
+++ b/src/eval/Ipcmessage_types.mli
@@ -1,3 +1,20 @@
+(*
+  This file is part of scilla.
+
+  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+  
+  scilla is free software: you can redistribute it and/or modify it under the
+  terms of the GNU General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option) any later
+  version.
+ 
+  scilla is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License along with
+  scilla.  If not, see <http://www.gnu.org/licenses/>.
+*)
 (** Ipcmessage.proto Types *)
 
 (** {2 Types} *)

--- a/src/eval/StateIPCIdl.ml
+++ b/src/eval/StateIPCIdl.ml
@@ -1,3 +1,20 @@
+(*
+  This file is part of scilla.
+
+  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+  
+  scilla is free software: you can redistribute it and/or modify it under the
+  terms of the GNU General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option) any later
+  version.
+ 
+  scilla is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License along with
+  scilla.  If not, see <http://www.gnu.org/licenses/>.
+*)
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Idl

--- a/src/polynomials/Polynomial.mli
+++ b/src/polynomials/Polynomial.mli
@@ -1,3 +1,20 @@
+(*
+  This file is part of scilla.
+
+  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+  
+  scilla is free software: you can redistribute it and/or modify it under the
+  terms of the GNU General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option) any later
+  version.
+ 
+  scilla is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License along with
+  scilla.  If not, see <http://www.gnu.org/licenses/>.
+*)
 exception Polynomial_error of string
 
 (* Variables in the polynomial are of type 'a.

--- a/src/stdlib/BoolUtils.scillib
+++ b/src/stdlib/BoolUtils.scillib
@@ -1,3 +1,20 @@
+(* ******************************************************************************** *)
+(*   This file is part of scilla.                                                   *)
+(*                                                                                  *)
+(*   Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.                        *)
+(*                                                                                  *)
+(*   scilla is free software: you can redistribute it and/or modify it under the    *)
+(*   terms of the GNU General Public License as published by the Free Software      *)
+(*   Foundation, either version 3 of the License, or (at your option) any later     *)
+(*   version.                                                                       *)
+(*                                                                                  *)
+(*   scilla is distributed in the hope that it will be useful, but WITHOUT ANY      *)
+(*   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR  *)
+(*   A PARTICULAR PURPOSE.  See the GNU General Public License for more details.    *)
+(*                                                                                  *)
+(*   You should have received a copy of the GNU General Public License along with   *)
+(*   scilla.  If not, see <http://www.gnu.org/licenses/>.                           *)
+(* ******************************************************************************** *)
 scilla_version 0
 
 library BoolUtils

--- a/src/stdlib/IntUtils.scillib
+++ b/src/stdlib/IntUtils.scillib
@@ -1,3 +1,20 @@
+(* ******************************************************************************** *)
+(*   This file is part of scilla.                                                   *)
+(*                                                                                  *)
+(*   Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.                        *)
+(*                                                                                  *)
+(*   scilla is free software: you can redistribute it and/or modify it under the    *)
+(*   terms of the GNU General Public License as published by the Free Software      *)
+(*   Foundation, either version 3 of the License, or (at your option) any later     *)
+(*   version.                                                                       *)
+(*                                                                                  *)
+(*   scilla is distributed in the hope that it will be useful, but WITHOUT ANY      *)
+(*   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR  *)
+(*   A PARTICULAR PURPOSE.  See the GNU General Public License for more details.    *)
+(*                                                                                  *)
+(*   You should have received a copy of the GNU General Public License along with   *)
+(*   scilla.  If not, see <http://www.gnu.org/licenses/>.                           *)
+(* ******************************************************************************** *)
 scilla_version 0
 
 library IntUtils

--- a/src/stdlib/ListUtils.scillib
+++ b/src/stdlib/ListUtils.scillib
@@ -1,3 +1,20 @@
+(* ******************************************************************************** *)
+(*   This file is part of scilla.                                                   *)
+(*                                                                                  *)
+(*   Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.                        *)
+(*                                                                                  *)
+(*   scilla is free software: you can redistribute it and/or modify it under the    *)
+(*   terms of the GNU General Public License as published by the Free Software      *)
+(*   Foundation, either version 3 of the License, or (at your option) any later     *)
+(*   version.                                                                       *)
+(*                                                                                  *)
+(*   scilla is distributed in the hope that it will be useful, but WITHOUT ANY      *)
+(*   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR  *)
+(*   A PARTICULAR PURPOSE.  See the GNU General Public License for more details.    *)
+(*                                                                                  *)
+(*   You should have received a copy of the GNU General Public License along with   *)
+(*   scilla.  If not, see <http://www.gnu.org/licenses/>.                           *)
+(* ******************************************************************************** *)
 scilla_version 0
 
 library ListUtils

--- a/src/stdlib/NatUtils.scillib
+++ b/src/stdlib/NatUtils.scillib
@@ -1,3 +1,20 @@
+(* ******************************************************************************** *)
+(*   This file is part of scilla.                                                   *)
+(*                                                                                  *)
+(*   Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.                        *)
+(*                                                                                  *)
+(*   scilla is free software: you can redistribute it and/or modify it under the    *)
+(*   terms of the GNU General Public License as published by the Free Software      *)
+(*   Foundation, either version 3 of the License, or (at your option) any later     *)
+(*   version.                                                                       *)
+(*                                                                                  *)
+(*   scilla is distributed in the hope that it will be useful, but WITHOUT ANY      *)
+(*   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR  *)
+(*   A PARTICULAR PURPOSE.  See the GNU General Public License for more details.    *)
+(*                                                                                  *)
+(*   You should have received a copy of the GNU General Public License along with   *)
+(*   scilla.  If not, see <http://www.gnu.org/licenses/>.                           *)
+(* ******************************************************************************** *)
 scilla_version 0
 
 library NatUtils

--- a/src/stdlib/PairUtils.scillib
+++ b/src/stdlib/PairUtils.scillib
@@ -1,3 +1,20 @@
+(* ******************************************************************************** *)
+(*   This file is part of scilla.                                                   *)
+(*                                                                                  *)
+(*   Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.                        *)
+(*                                                                                  *)
+(*   scilla is free software: you can redistribute it and/or modify it under the    *)
+(*   terms of the GNU General Public License as published by the Free Software      *)
+(*   Foundation, either version 3 of the License, or (at your option) any later     *)
+(*   version.                                                                       *)
+(*                                                                                  *)
+(*   scilla is distributed in the hope that it will be useful, but WITHOUT ANY      *)
+(*   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR  *)
+(*   A PARTICULAR PURPOSE.  See the GNU General Public License for more details.    *)
+(*                                                                                  *)
+(*   You should have received a copy of the GNU General Public License along with   *)
+(*   scilla.  If not, see <http://www.gnu.org/licenses/>.                           *)
+(* ******************************************************************************** *)
 scilla_version 0
 
 library PairUtils

--- a/tests/base/TestSafeArith.ml
+++ b/tests/base/TestSafeArith.ml
@@ -1,3 +1,20 @@
+(*
+  This file is part of scilla.
+
+  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+  
+  scilla is free software: you can redistribute it and/or modify it under the
+  terms of the GNU General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option) any later
+  version.
+ 
+  scilla is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License along with
+  scilla.  If not, see <http://www.gnu.org/licenses/>.
+*)
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Stdint

--- a/tests/base/TestSignatures.ml
+++ b/tests/base/TestSignatures.ml
@@ -1,3 +1,20 @@
+(*
+  This file is part of scilla.
+
+  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+  
+  scilla is free software: you can redistribute it and/or modify it under the
+  terms of the GNU General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option) any later
+  version.
+ 
+  scilla is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License along with
+  scilla.  If not, see <http://www.gnu.org/licenses/>.
+*)
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Result

--- a/tests/base/TestSyntax.ml
+++ b/tests/base/TestSyntax.ml
@@ -1,3 +1,20 @@
+(*
+  This file is part of scilla.
+
+  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+  
+  scilla is free software: you can redistribute it and/or modify it under the
+  terms of the GNU General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option) any later
+  version.
+ 
+  scilla is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License along with
+  scilla.  If not, see <http://www.gnu.org/licenses/>.
+*)
 open Core_kernel
 open! Int.Replace_polymorphic_compare
 open Stdint


### PR DESCRIPTION
Fixes to the copyright years that I messed up in earlier PRs.

It was too much effort to track whether files were created in 2018, 2019 or 2020, so I have taken the liberty of changing the copyright year to 2018 for all the files except Disambiguate.ml, which I have added recently.

I also found a bunch of files that didn't have a copyright notice. Note that I have added a notice to one of the C++ files - I wasn't entirely sure whether it was one we wrote ourselves, but I think we did (@vaivaswatha?).

It was too much effort to add copyright notice to the individual test programs, even though we technically should.