### PR TITLE
Fix Menhir grammar file

### DIFF
--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -22,10 +22,9 @@
   open Syntax
   open ErrorUtils
 
-  module ParserSyntax = S
-  module ParserIdentifier = ParserSyntax.SIdentifier
+  module ParserIdentifier = S.SIdentifier
   module ParserName = ParserIdentifier.Name
-  open ParserSyntax
+  open S
 
   let to_loc_id s loc = SIdentifier.mk_id (ParserName.parse_simple_name s) loc
 


### PR DESCRIPTION
Menhir since 20200525 introduced some changes how it treats module aliases.
From the manual:
> It is important to note that the header is copied by Menhir only to the .ml file, not to the .mli file. Therefore, it should not contain declarations that affect the meaning of the types that appear in the .mli file.

This fixes issue #856.