### PR TITLE
Builtin size on maps takes constant time. Adjust gas

### DIFF
--- a/src/base/Gas.ml
+++ b/src/base/Gas.ml
@@ -246,9 +246,9 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
   let map_coster op args base =
     match args with
     | Map (_, m) :: _ -> (
-        (* get and contains do not make a copy of the Map, hence constant. *)
+        (* size, get and contains do not make a copy of the Map, hence constant. *)
         match op with
-        | Builtin_get | Builtin_contains -> pure base
+        | Builtin_size | Builtin_get | Builtin_contains -> pure base
         | _ -> pure (base + (base * Caml.Hashtbl.length m)) )
     | _ -> fail0 @@ "Gas cost error for map built-in"
 

--- a/tests/runner/map_corners_test/output_14.json
+++ b/tests/runner/map_corners_test/output_14.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7806",
+  "gas_remaining": "7807",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_15.json
+++ b/tests/runner/map_corners_test/output_15.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7487",
+  "gas_remaining": "7489",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet/output_1.json
+++ b/tests/runner/wallet/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7241",
+  "gas_remaining": "7244",
   "_accepted": "true",
   "messages": [],
   "states": [

--- a/tests/runner/wallet/output_11.json
+++ b/tests/runner/wallet/output_11.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7078",
+  "gas_remaining": "7084",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet/output_5.json
+++ b/tests/runner/wallet/output_5.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6848",
+  "gas_remaining": "6850",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/wallet/output_9.json
+++ b/tests/runner/wallet/output_9.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6913",
+  "gas_remaining": "6916",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_1.json
+++ b/tests/runner/wallet_2/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7187",
+  "gas_remaining": "7190",
   "_accepted": "true",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_11.json
+++ b/tests/runner/wallet_2/output_11.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6977",
+  "gas_remaining": "6980",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_12.json
+++ b/tests/runner/wallet_2/output_12.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6977",
+  "gas_remaining": "6980",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_14.json
+++ b/tests/runner/wallet_2/output_14.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6973",
+  "gas_remaining": "6976",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_15.json
+++ b/tests/runner/wallet_2/output_15.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6973",
+  "gas_remaining": "6976",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_16.json
+++ b/tests/runner/wallet_2/output_16.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6973",
+  "gas_remaining": "6976",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_17.json
+++ b/tests/runner/wallet_2/output_17.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6912",
+  "gas_remaining": "6915",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_18.json
+++ b/tests/runner/wallet_2/output_18.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6909",
+  "gas_remaining": "6912",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_19.json
+++ b/tests/runner/wallet_2/output_19.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6909",
+  "gas_remaining": "6912",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_2.json
+++ b/tests/runner/wallet_2/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7187",
+  "gas_remaining": "7190",
   "_accepted": "true",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_20.json
+++ b/tests/runner/wallet_2/output_20.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6909",
+  "gas_remaining": "6912",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_21.json
+++ b/tests/runner/wallet_2/output_21.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6974",
+  "gas_remaining": "6977",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_22.json
+++ b/tests/runner/wallet_2/output_22.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6974",
+  "gas_remaining": "6977",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_23.json
+++ b/tests/runner/wallet_2/output_23.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6974",
+  "gas_remaining": "6977",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_24.json
+++ b/tests/runner/wallet_2/output_24.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6888",
+  "gas_remaining": "6891",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_25.json
+++ b/tests/runner/wallet_2/output_25.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6861",
+  "gas_remaining": "6864",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_26.json
+++ b/tests/runner/wallet_2/output_26.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6857",
+  "gas_remaining": "6860",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_27.json
+++ b/tests/runner/wallet_2/output_27.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6847",
+  "gas_remaining": "6850",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_28.json
+++ b/tests/runner/wallet_2/output_28.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6610",
+  "gas_remaining": "6613",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/wallet_2/output_29.json
+++ b/tests/runner/wallet_2/output_29.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6610",
+  "gas_remaining": "6613",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/wallet_2/output_3.json
+++ b/tests/runner/wallet_2/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6725",
+  "gas_remaining": "6728",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_30.json
+++ b/tests/runner/wallet_2/output_30.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6610",
+  "gas_remaining": "6613",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/wallet_2/output_31.json
+++ b/tests/runner/wallet_2/output_31.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6610",
+  "gas_remaining": "6613",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/wallet_2/output_32.json
+++ b/tests/runner/wallet_2/output_32.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6610",
+  "gas_remaining": "6613",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/wallet_2/output_33.json
+++ b/tests/runner/wallet_2/output_33.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6976",
+  "gas_remaining": "6979",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_34.json
+++ b/tests/runner/wallet_2/output_34.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6976",
+  "gas_remaining": "6979",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_35.json
+++ b/tests/runner/wallet_2/output_35.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6976",
+  "gas_remaining": "6979",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_36.json
+++ b/tests/runner/wallet_2/output_36.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6976",
+  "gas_remaining": "6979",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_37.json
+++ b/tests/runner/wallet_2/output_37.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6976",
+  "gas_remaining": "6979",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_38.json
+++ b/tests/runner/wallet_2/output_38.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6967",
+  "gas_remaining": "6970",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_39.json
+++ b/tests/runner/wallet_2/output_39.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6967",
+  "gas_remaining": "6970",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_4.json
+++ b/tests/runner/wallet_2/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6453",
+  "gas_remaining": "6456",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_40.json
+++ b/tests/runner/wallet_2/output_40.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6967",
+  "gas_remaining": "6970",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_42.json
+++ b/tests/runner/wallet_2/output_42.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6610",
+  "gas_remaining": "6613",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/wallet_2/output_5.json
+++ b/tests/runner/wallet_2/output_5.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6453",
+  "gas_remaining": "6456",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_6.json
+++ b/tests/runner/wallet_2/output_6.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6725",
+  "gas_remaining": "6728",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_7.json
+++ b/tests/runner/wallet_2/output_7.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6445",
+  "gas_remaining": "6448",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_8.json
+++ b/tests/runner/wallet_2/output_8.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "6709",
+  "gas_remaining": "6712",
   "_accepted": "false",
   "messages": [],
   "states": [


### PR DESCRIPTION
When gas costs for map operations was fixed in https://github.com/Zilliqa/scilla/commit/b81e10f471b7949ef90cf009f5c533dd008cf685, `builtin size` was missed out as a constant time operation. So fixing that now.