### PR TITLE
feat: Add list_is_subset to ListUtils

### DIFF
--- a/src/stdlib/ListUtils.scillib
+++ b/src/stdlib/ListUtils.scillib
@@ -361,3 +361,14 @@ let list_nth : forall 'A. Uint32 -> List 'A -> Option 'A =
     match search with
     | Pair _ discovery => discovery
     end
+
+(* Is "a" a subset of "b", as compared by f *)                                                                                                                                                                     
+let list_is_subset : forall 'A. ('A -> 'A -> Bool) -> List 'A -> List 'A -> Bool =                                                                                                                                 
+  tfun 'A =>                                                                                                                                                                                                       
+  fun (f : 'A -> 'A -> Bool) =>                                                                                                                                                                                    
+  fun (a : List 'A) =>                                                                                                                                                                                             
+  fun (b : List 'A) =>                                                                                                                                                                                             
+    let list_mem_A = @list_mem 'A in                                                                                                                                                                               
+    let in_b = fun (a : 'A) => list_mem_A f a b in                                                                                                                                                                 
+    let forall_A = @list_forall 'A in                                                                                                                                                                              
+    forall_A in_b a


### PR DESCRIPTION
New ListUtils function to check if List A is a subset of List B. Both List must be of same type.
Courtesy of @vaivaswatha