### PR TITLE
Modify scilla docker file to upgrade OS to Ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # escape=\
-ARG BASE_IMAGE=ubuntu:16.04
+ARG BASE_IMAGE=ubuntu:20.04
 
 FROM ${BASE_IMAGE}
 
@@ -11,9 +11,9 @@ WORKDIR /scilla/${MAJOR_VERSION}
 
 RUN apt-get update \
     && apt-get install -y software-properties-common \
-    && add-apt-repository ppa:tah83/secp256k1 -y \
-    && add-apt-repository ppa:avsm/ppa -y \
     && apt-get update && apt-get install -y --no-install-recommends \
+    # git is dependency for opam
+    git \
     curl \
     cmake \
     build-essential \

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,5 +1,5 @@
 # escape=\
-ARG BASE_IMAGE=ubuntu:16.04
+ARG BASE_IMAGE=ubuntu:20.04
 
 FROM ${BASE_IMAGE}
 
@@ -11,9 +11,9 @@ WORKDIR /scilla/${MAJOR_VERSION}
 
 RUN apt-get update \
     && apt-get install -y software-properties-common \
-    && add-apt-repository ppa:tah83/secp256k1 -y \
-    && add-apt-repository ppa:avsm/ppa -y \
     && apt-get update && apt-get install -y --no-install-recommends \
+    # git is dependency for opam
+    git \
     curl \
     cmake \
     build-essential \


### PR DESCRIPTION
The goal of the PR is to upgrade OS running inside docker to Ubuntu `20.04`.This is a part of Zilliqa ecosystem OS upgrade to Ubuntu `20.04` in future releases.At present it's been in discussion to move to `Ubuntu 18.04` to follow more progressive transition.

