### PR TITLE
Eval minor refactoring

### DIFF
--- a/src/base/MonadUtil.ml
+++ b/src/base/MonadUtil.ml
@@ -94,8 +94,7 @@ let rec foldrM ~f ~init ls =
 let rec mapM ~f ls =
   match ls with
   | x :: ls' ->
-      let%map z = f x
-      and     zs = mapM ~f ls' in
+      let%map z = f x and zs = mapM ~f ls' in
       z :: zs
   | [] -> pure []
 
@@ -103,8 +102,7 @@ let rec mapM ~f ls =
 let rec map2M ~f ls ms ~msg =
   match (ls, ms) with
   | x :: ls', y :: ms' ->
-      let%map z = f x y
-      and     zs = map2M ~f ls' ms' ~msg in
+      let%map z = f x y and zs = map2M ~f ls' ms' ~msg in
       z :: zs
   | [], [] -> pure []
   | _ -> fail @@ msg ()
@@ -118,11 +116,11 @@ let liftPair2 x m =
   (x, z)
 
 let fstM m =
-  let%map (x, _y) = m in
+  let%map x, _y = m in
   x
 
 let sndM m =
-  let%map (_x, y) = m in
+  let%map _x, y = m in
   y
 
 (* Return the first error applying f to elements of ls.
@@ -166,9 +164,7 @@ let partition_mapM ~f l =
      * any errors to be flagged in-order. *)
     foldM ~init:([], []) l ~f:(fun (fst, snd) i ->
         let%map fi = f i in
-        match fi with
-        | `Fst i' -> (i' :: fst, snd)
-        | `Snd i' -> (fst, i' :: snd))
+        match fi with `Fst i' -> (i' :: fst, snd) | `Snd i' -> (fst, i' :: snd))
   in
   (List.rev fst_rev, List.rev snd_rev)
 
@@ -238,8 +234,7 @@ module EvalMonad = struct
   let rec mapM ~f ls =
     match ls with
     | x :: ls' ->
-        let%map z = f x
-        and     zs = mapM ~f ls' in
+        let%map z = f x and zs = mapM ~f ls' in
         z :: zs
     | [] -> pure []
 
@@ -247,8 +242,7 @@ module EvalMonad = struct
   let rec map2M ~f ls ms ~msg =
     match (ls, ms) with
     | x :: ls', y :: ms' ->
-        let%map z = f x y
-        and     zs = map2M ~f ls' ms' ~msg in
+        let%map z = f x y and zs = map2M ~f ls' ms' ~msg in
         z :: zs
     | [], [] -> pure []
     | _ -> fail @@ msg ()
@@ -262,11 +256,11 @@ module EvalMonad = struct
     (x, z)
 
   let fstM m =
-    let%map (x, _y) = m in
+    let%map x, _y = m in
     x
 
   let sndM m =
-    let%map (_x, y) = m in
+    let%map _x, y = m in
     y
 
   (* Return the first error applying f to elements of ls.

--- a/src/base/MonadUtil.ml
+++ b/src/base/MonadUtil.ml
@@ -117,6 +117,14 @@ let liftPair2 x m =
   let%bind z = m in
   pure (x, z)
 
+let fstM m =
+  let%map (x, _y) = m in
+  x
+
+let sndM m =
+  let%map (_x, y) = m in
+  y
+
 (* Return the first error applying f to elements of ls.
  * Returns () if all elements satisfy f. *)
 let rec forallM ~f ls =
@@ -252,6 +260,14 @@ module EvalMonad = struct
   let liftPair2 x m =
     let%bind z = m in
     pure (x, z)
+
+  let fstM m =
+    let%map (x, _y) = m in
+    x
+
+  let sndM m =
+    let%map (_x, y) = m in
+    y
 
   (* Return the first error applying f to elements of ls.
    * Returns () if all elements satisfy f. *)

--- a/src/base/MonadUtil.ml
+++ b/src/base/MonadUtil.ml
@@ -94,28 +94,28 @@ let rec foldrM ~f ~init ls =
 let rec mapM ~f ls =
   match ls with
   | x :: ls' ->
-      let%bind z = f x in
-      let%bind zs = mapM ~f ls' in
-      pure (z :: zs)
+      let%map z = f x
+      and     zs = mapM ~f ls' in
+      z :: zs
   | [] -> pure []
 
 (* Monadic map2 *)
 let rec map2M ~f ls ms ~msg =
   match (ls, ms) with
   | x :: ls', y :: ms' ->
-      let%bind z = f x y in
-      let%bind zs = map2M ~f ls' ms' ~msg in
-      pure (z :: zs)
+      let%map z = f x y
+      and     zs = map2M ~f ls' ms' ~msg in
+      z :: zs
   | [], [] -> pure []
   | _ -> fail @@ msg ()
 
 let liftPair1 m x =
-  let%bind z = m in
-  pure (z, x)
+  let%map z = m in
+  (z, x)
 
 let liftPair2 x m =
-  let%bind z = m in
-  pure (x, z)
+  let%map z = m in
+  (x, z)
 
 let fstM m =
   let%map (x, _y) = m in
@@ -146,31 +146,31 @@ let option_mapM ~f opt_val =
   match opt_val with
   | None -> pure None
   | Some v ->
-      let%bind z = f v in
-      pure @@ Some z
+      let%map z = f v in
+      Some z
 
 (* Monadic version of List.fold_map *)
 let fold_mapM ~f ~init l =
-  let%bind acc, l'_rev =
+  let%map acc, l'_rev =
     foldM ~init:(init, [])
       ~f:(fun (accacc, lrevacc) lel ->
-        let%bind accacc', lel' = f accacc lel in
-        pure (accacc', lel' :: lrevacc))
+        let%map accacc', lel' = f accacc lel in
+        (accacc', lel' :: lrevacc))
       l
   in
-  pure (acc, List.rev l'_rev)
+  (acc, List.rev l'_rev)
 
 let partition_mapM ~f l =
-  let%bind fst_rev, snd_rev =
+  let%map fst_rev, snd_rev =
     (* We don't use foldrM and avoid List.rev because we want
      * any errors to be flagged in-order. *)
     foldM ~init:([], []) l ~f:(fun (fst, snd) i ->
-        let%bind fi = f i in
+        let%map fi = f i in
         match fi with
-        | `Fst i' -> pure (i' :: fst, snd)
-        | `Snd i' -> pure (fst, i' :: snd))
+        | `Fst i' -> (i' :: fst, snd)
+        | `Snd i' -> (fst, i' :: snd))
   in
-  pure (List.rev fst_rev, List.rev snd_rev)
+  (List.rev fst_rev, List.rev snd_rev)
 
 (* Monadic wrapper around any container's fold (Set, Map etc). *)
 (* folder : 'a t -> init:'accum -> f:('accum -> 'a -> 'accum) -> 'accum *)
@@ -238,28 +238,28 @@ module EvalMonad = struct
   let rec mapM ~f ls =
     match ls with
     | x :: ls' ->
-        let%bind z = f x in
-        let%bind zs = mapM ~f ls' in
-        pure (z :: zs)
+        let%map z = f x
+        and     zs = mapM ~f ls' in
+        z :: zs
     | [] -> pure []
 
   (* Monadic map2 *)
   let rec map2M ~f ls ms ~msg =
     match (ls, ms) with
     | x :: ls', y :: ms' ->
-        let%bind z = f x y in
-        let%bind zs = map2M ~f ls' ms' ~msg in
-        pure (z :: zs)
+        let%map z = f x y
+        and     zs = map2M ~f ls' ms' ~msg in
+        z :: zs
     | [], [] -> pure []
     | _ -> fail @@ msg ()
 
   let liftPair1 m x =
-    let%bind z = m in
-    pure (z, x)
+    let%map z = m in
+    (z, x)
 
   let liftPair2 x m =
-    let%bind z = m in
-    pure (x, z)
+    let%map z = m in
+    (x, z)
 
   let fstM m =
     let%map (x, _y) = m in

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -744,8 +744,7 @@ let handle_message contr cstate bstate m =
   let open ContractState in
   let { env; fields; balance } = cstate in
   (* Add all values to the contract environment *)
-  let actual_env = Env.bind_all env tenv
-  in
+  let actual_env = Env.bind_all env tenv in
   let open Configuration in
   (* Create configuration *)
   let conf =


### PR DESCRIPTION
- Added monadic projections `fstM` and `sndM`
- In `MonadUtils`
  ```ocaml
  let%bind foo = bar in
  pure foo
  ```
  refactored into
  ```ocaml
  let%map foo = bar in foo
  ```
  This is especially useful when there are several **independent** `let%bind` expressions in a row because `let%map` also reflects that.
- Minor refactoring in `Eval`, this is mostly about using `Env.bind_all` because it's much easier to read compared to `List.fold_left ...`.