### PR TITLE
ci: OCaml 4.11.0 to 4.11.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
     - os: linux
       dist: xenial
-      env: OCAML_VERSION=4.11.0
+      env: OCAML_VERSION=4.11.1
     - os: linux
       dist: xenial
       env: OCAML_VERSION=4.10.1


### PR DESCRIPTION
OCaml 4.11.0 is known to have a bug in the typechecker.