### PR TITLE
Gas charges to use Name.t instead of string

### DIFF
--- a/src/base/Disambiguate.ml
+++ b/src/base/Disambiguate.ml
@@ -129,6 +129,52 @@ module ScillaDisambiguation (SR : Rep) (ER : Rep) = struct
     recurse t
 
   (**************************************************************)
+  (*               Disambiguating explict gas charges           *)
+  (**************************************************************)
+
+  (* No variable bindings in gas charge nodes, so dis_id_helper just wraps
+     a call to disambiguate_identifier using the appropriate dictionaries. *)
+
+  let disambiguate_gas_charge dis_id_helper gc =
+    let rec recurser gc =
+      let open PreDisSyntax.SGasCharge in
+      match gc with
+      | StaticCost i -> pure @@ PostDisSyntax.SGasCharge.StaticCost i
+      | SizeOf v ->
+          let%bind dis_v = dis_id_helper v in
+          pure @@ PostDisSyntax.SGasCharge.SizeOf dis_v
+      | ValueOf v ->
+          let%bind dis_v = dis_id_helper v in
+          pure @@ PostDisSyntax.SGasCharge.ValueOf dis_v
+      | LengthOf v ->
+          let%bind dis_v = dis_id_helper v in
+          pure @@ PostDisSyntax.SGasCharge.LengthOf dis_v
+      | MapSortCost m ->
+          let%bind dis_m = dis_id_helper m in
+          pure @@ PostDisSyntax.SGasCharge.MapSortCost dis_m
+      | SumOf (g1, g2) ->
+          let%bind dis_g1 = recurser g1 in
+          let%bind dis_g2 = recurser g2 in
+          pure @@ PostDisSyntax.SGasCharge.SumOf (dis_g1, dis_g2)
+      | ProdOf (g1, g2) ->
+          let%bind dis_g1 = recurser g1 in
+          let%bind dis_g2 = recurser g2 in
+          pure @@ PostDisSyntax.SGasCharge.ProdOf (dis_g1, dis_g2)
+      | MinOf (g1, g2) ->
+          let%bind dis_g1 = recurser g1 in
+          let%bind dis_g2 = recurser g2 in
+          pure @@ PostDisSyntax.SGasCharge.MinOf (dis_g1, dis_g2)
+      | DivCeil (g1, g2) ->
+          let%bind dis_g1 = recurser g1 in
+          let%bind dis_g2 = recurser g2 in
+          pure @@ PostDisSyntax.SGasCharge.DivCeil (dis_g1, dis_g2)
+      | LogOf v ->
+          let%bind dis_v = dis_id_helper v in
+          pure @@ PostDisSyntax.SGasCharge.LogOf dis_v
+    in
+    recurser gc
+
+  (**************************************************************)
   (*                Disambiguate expressions                    *)
   (**************************************************************)
 
@@ -226,6 +272,9 @@ module ScillaDisambiguation (SR : Rep) (ER : Rep) = struct
     recurser p
 
   let disambiguate_exp (dicts : name_dicts) erep =
+    let disambiguate_name_helper simp_var_dict nm =
+      disambiguate_name dicts.ns_dict simp_var_dict nm
+    in
     let disambiguate_identifier_helper simp_var_dict id =
       disambiguate_identifier dicts.ns_dict simp_var_dict id
     in
@@ -336,8 +385,11 @@ module ScillaDisambiguation (SR : Rep) (ER : Rep) = struct
             let%bind dis_body = recurser body_simp_var_dict body in
             pure @@ PostDisSyntax.Fixpoint (dis_f, dis_t, dis_body)
         | GasExpr (g, e) ->
-            let%bind e' = recurser simp_var_dict e in
-            pure @@ PostDisSyntax.GasExpr (g, e')
+            let%bind dis_g =
+              disambiguate_gas_charge (disambiguate_name_helper simp_var_dict) g
+            in
+            let%bind dis_e = recurser simp_var_dict e in
+            pure @@ PostDisSyntax.GasExpr (dis_g, dis_e)
       in
       pure @@ (new_e, rep)
     in
@@ -348,6 +400,9 @@ module ScillaDisambiguation (SR : Rep) (ER : Rep) = struct
   (**************************************************************)
 
   let rec disambiguate_stmts (dicts : name_dicts) stmts =
+    let disambiguate_name_helper simp_var_dict nm =
+      disambiguate_name dicts.ns_dict simp_var_dict nm
+    in
     let disambiguate_identifier_helper simp_var_dict id =
       disambiguate_identifier dicts.ns_dict simp_var_dict id
     in
@@ -464,7 +519,13 @@ module ScillaDisambiguation (SR : Rep) (ER : Rep) = struct
                 ~f:(disambiguate_identifier_helper simp_var_dict_acc)
             in
             pure @@ (PostDisSyntax.Throw dis_xopt, simp_var_dict_acc)
-        | GasStmt g -> pure @@ (PostDisSyntax.GasStmt g, simp_var_dict_acc)
+        | GasStmt g ->
+            let%bind dis_g =
+              disambiguate_gas_charge
+                (disambiguate_name_helper simp_var_dict_acc)
+                g
+            in
+            pure @@ (PostDisSyntax.GasStmt dis_g, simp_var_dict_acc)
       in
       pure @@ (new_simp_var_dict, (dis_s, rep) :: dis_stmts_acc_rev)
     in

--- a/src/base/Gas.ml
+++ b/src/base/Gas.ml
@@ -42,9 +42,10 @@ let version_mismatch_penalty = 97
 module ScillaGas (SR : Rep) (ER : Rep) = struct
   (* TODO: Change this to CanonicalLiteral = Literals based on canonical names. *)
   module GasLiteral = FlattenedLiteral
-  module GasType = GasLiteral.LType
-  module GI = GasType.TIdentifier
   module GasSyntax = ScillaSyntax (SR) (ER) (GasLiteral)
+  module GasType = GasSyntax.SType
+  module GI = GasSyntax.SIdentifier
+  module GasGasCharge = GasSyntax.SGasCharge
   open GasType
   open GasLiteral
   open GasSyntax
@@ -83,13 +84,15 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
     (* A constructor in HNF *)
     | ADTValue (cn, _, ll) as als ->
         (* Make a special case for Lists, to avoid overflowing recursion. *)
-        if String.(cn = "Cons") then
+        if String.(GI.Name.as_string cn = "Cons") then
           let rec walk elm acc_cost =
             match elm with
-            | ADTValue ("Cons", _, [ l; ll ]) ->
+            | ADTValue (c, _, [ l; ll ])
+              when String.(GI.Name.as_string c = "Cons") ->
                 let%bind lcost = literal_cost l in
                 walk ll (acc_cost + lcost)
-            | ADTValue ("Nil", _, _) -> pure (acc_cost + 1)
+            | ADTValue (c, _, _) when String.(GI.Name.as_string c = "Nil") ->
+                pure (acc_cost + 1)
             | _ -> fail0 "Malformed list while computing literal cost"
           in
           walk als 0
@@ -127,21 +130,22 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
     let%bind e' =
       match ee with
       | Literal _ | Var _ | Message _ | App _ | Constr _ | TApp _ ->
-          pure @@ GasExpr (GasCharge.StaticCost 1, e)
+          pure @@ GasExpr (GasGasCharge.StaticCost 1, e)
       | Fixpoint (f, t, e') ->
           let%bind e'' = expr_static_cost e' in
-          pure @@ GasExpr (GasCharge.StaticCost 1, (Fixpoint (f, t, e''), erep))
+          pure
+          @@ GasExpr (GasGasCharge.StaticCost 1, (Fixpoint (f, t, e''), erep))
       | Fun (f, t, e') ->
           let%bind e'' = expr_static_cost e' in
-          pure @@ GasExpr (GasCharge.StaticCost 1, (Fun (f, t, e''), erep))
+          pure @@ GasExpr (GasGasCharge.StaticCost 1, (Fun (f, t, e''), erep))
       | TFun (f, e') ->
           let%bind e'' = expr_static_cost e' in
-          pure @@ GasExpr (GasCharge.StaticCost 1, (TFun (f, e''), erep))
+          pure @@ GasExpr (GasGasCharge.StaticCost 1, (TFun (f, e''), erep))
       | Let (i, t, lhs, rhs) ->
           let%bind lhs' = expr_static_cost lhs in
           let%bind rhs' = expr_static_cost rhs in
           pure
-          @@ GasExpr (GasCharge.StaticCost 1, (Let (i, t, lhs', rhs'), erep))
+          @@ GasExpr (GasGasCharge.StaticCost 1, (Let (i, t, lhs', rhs'), erep))
       | MatchExpr (o, clauses) ->
           let%bind clauses' =
             mapM clauses ~f:(fun (p, e') ->
@@ -150,7 +154,7 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
           in
           pure
           @@ GasExpr
-               ( GasCharge.StaticCost (List.length clauses),
+               ( GasGasCharge.StaticCost (List.length clauses),
                  (MatchExpr (o, clauses'), erep) )
       | Builtin _ ->
           (* We don't add costs for Builtin because we can't know it statically
@@ -170,43 +174,44 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
           | Load (x, _) ->
               let g =
                 GasStmt
-                  (GasCharge.SumOf
-                     ( GasCharge.SizeOf (GI.get_id x),
-                       GasCharge.MapSortCost (GI.get_id x) ))
+                  (GasGasCharge.SumOf
+                     ( GasGasCharge.SizeOf (GI.get_id x),
+                       GasGasCharge.MapSortCost (GI.get_id x) ))
               in
               (* We charge *after* the load because we can't know the size before. *)
               pure @@ [ (s, srep); (g, srep) ]
           | Store (_, v) | SendMsgs v | CreateEvnt v ->
-              let g = GasStmt (GasCharge.SizeOf (GI.get_id v)) in
+              let g = GasStmt (GasGasCharge.SizeOf (GI.get_id v)) in
               pure @@ [ (g, srep); (s, srep) ]
           | Bind (x, e) ->
-              let g = GasStmt (GasCharge.StaticCost 1) in
+              let g = GasStmt (GasGasCharge.StaticCost 1) in
               let%bind e' = expr_static_cost e in
               let s' = Bind (x, e') in
               pure @@ [ (g, srep); (s', srep) ]
           | ReadFromBC _ | CallProc _ ->
-              let g = GasStmt (GasCharge.StaticCost 1) in
+              let g = GasStmt (GasGasCharge.StaticCost 1) in
               pure @@ [ (g, srep); (s, srep) ]
           | MapUpdate (_, klist, ropt) ->
-              let n = GasCharge.StaticCost (List.length klist) in
+              let n = GasGasCharge.StaticCost (List.length klist) in
               let g =
                 match ropt with
-                | Some r -> GasCharge.SumOf (GasCharge.SizeOf (GI.get_id r), n)
+                | Some r ->
+                    GasGasCharge.SumOf (GasGasCharge.SizeOf (GI.get_id r), n)
                 | None -> n
               in
               pure @@ [ (GasStmt g, srep); (s, srep) ]
           | MapGet (x, _, klist, _) ->
-              let n = GasCharge.StaticCost (List.length klist) in
+              let n = GasGasCharge.StaticCost (List.length klist) in
               let g =
-                GasCharge.SumOf
-                  ( GasCharge.SumOf
-                      ( GasCharge.SizeOf (GI.get_id x),
-                        GasCharge.MapSortCost (GI.get_id x) ),
+                GasGasCharge.SumOf
+                  ( GasGasCharge.SumOf
+                      ( GasGasCharge.SizeOf (GI.get_id x),
+                        GasGasCharge.MapSortCost (GI.get_id x) ),
                     n )
               in
               pure @@ [ (s, srep); (GasStmt g, srep) ]
           | MatchStmt (x, clauses) ->
-              let g = GasCharge.StaticCost (List.length clauses) in
+              let g = GasGasCharge.StaticCost (List.length clauses) in
               let%bind clauses' =
                 mapM clauses ~f:(fun (p, stmts) ->
                     let%bind stmts' = stmts_cost stmts in
@@ -215,16 +220,16 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
               let s' = MatchStmt (x, clauses') in
               pure @@ [ (GasStmt g, srep); (s', srep) ]
           | AcceptPayment ->
-              let g = GasStmt (GasCharge.StaticCost 1) in
+              let g = GasStmt (GasGasCharge.StaticCost 1) in
               pure @@ [ (g, srep); (s, srep) ]
           | Iterate (l, _) ->
-              let g = GasStmt (GasCharge.LengthOf (GI.get_id l)) in
+              let g = GasStmt (GasGasCharge.LengthOf (GI.get_id l)) in
               pure @@ [ (g, srep); (s, srep) ]
           | Throw eopt ->
               let g =
                 match eopt with
-                | Some e -> GasCharge.SizeOf (GI.get_id e)
-                | None -> GasCharge.StaticCost 1
+                | Some e -> GasGasCharge.SizeOf (GI.get_id e)
+                | None -> GasGasCharge.StaticCost 1
               in
               pure @@ [ (GasStmt g, srep); (s, srep) ]
           | GasStmt _ -> fail0 "Unexpected gas charge"
@@ -283,7 +288,7 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
     builtin ->
     ER.rep GI.t list ->
     GasType.t list ->
-    (GasCharge.gas_charge, scilla_error list) result
+    (GasGasCharge.gas_charge, scilla_error list) result
 
   (* op, arg types, coster, base cost. *)
   type builtin_record = builtin * GasType.t list * coster
@@ -292,88 +297,90 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
     match (op, args) with
     | Builtin_eq, [ s1; s2 ] ->
         pure
-        @@ GasCharge.MinOf
-             (GasCharge.SizeOf (GI.get_id s1), GasCharge.SizeOf (GI.get_id s2))
+        @@ GasGasCharge.MinOf
+             ( GasGasCharge.SizeOf (GI.get_id s1),
+               GasGasCharge.SizeOf (GI.get_id s2) )
     | Builtin_concat, [ s1; s2 ] ->
         pure
-        @@ GasCharge.SumOf
-             (GasCharge.SizeOf (GI.get_id s1), GasCharge.SizeOf (GI.get_id s2))
+        @@ GasGasCharge.SumOf
+             ( GasGasCharge.SizeOf (GI.get_id s1),
+               GasGasCharge.SizeOf (GI.get_id s2) )
     | Builtin_substr, [ s; i1; i2 ] ->
         pure
-        @@ GasCharge.MinOf
-             ( GasCharge.SizeOf (GI.get_id s),
-               GasCharge.SumOf
-                 ( GasCharge.ValueOf (GI.get_id i1),
-                   GasCharge.ValueOf (GI.get_id i2) ) )
-    | Builtin_strlen, [ s ] -> pure @@ GasCharge.SizeOf (GI.get_id s)
-    | Builtin_to_string, [ l ] -> pure @@ GasCharge.SizeOf (GI.get_id l)
+        @@ GasGasCharge.MinOf
+             ( GasGasCharge.SizeOf (GI.get_id s),
+               GasGasCharge.SumOf
+                 ( GasGasCharge.ValueOf (GI.get_id i1),
+                   GasGasCharge.ValueOf (GI.get_id i2) ) )
+    | Builtin_strlen, [ s ] -> pure @@ GasGasCharge.SizeOf (GI.get_id s)
+    | Builtin_to_string, [ l ] -> pure @@ GasGasCharge.SizeOf (GI.get_id l)
     | _ -> fail0 @@ "Gas cost error for string built-in"
 
   let crypto_coster op args types =
     match (op, types, args) with
     | Builtin_eq, [ PrimType Bystr_typ; PrimType Bystr_typ ], [ a1; _ ] ->
-        pure @@ GasCharge.SizeOf (GI.get_id a1)
+        pure @@ GasGasCharge.SizeOf (GI.get_id a1)
     | Builtin_eq, [ a1; a2 ], _
       when is_bystrx_type a1 && is_bystrx_type a2
            && Option.(value_exn (bystrx_width a1) = value_exn (bystrx_width a2))
       ->
         let width = Option.value_exn (bystrx_width a1) in
-        pure @@ GasCharge.StaticCost width
+        pure @@ GasGasCharge.StaticCost width
     | Builtin_to_uint256, [ a ], _
       when is_bystrx_type a && Option.value_exn (bystrx_width a) <= 32 ->
-        pure @@ GasCharge.StaticCost 32
+        pure @@ GasGasCharge.StaticCost 32
     | Builtin_sha256hash, _, [ a ] | Builtin_schnorr_get_address, _, [ a ] ->
         (* Block size of sha256hash is 512 *)
-        let s = GasCharge.SizeOf (GI.get_id a) in
-        let n = GasCharge.StaticCost (64 * 15) in
-        pure (GasCharge.DivCeil (s, n))
+        let s = GasGasCharge.SizeOf (GI.get_id a) in
+        let n = GasGasCharge.StaticCost (64 * 15) in
+        pure (GasGasCharge.DivCeil (s, n))
     | Builtin_keccak256hash, _, [ a ] ->
         (* Block size of keccak256hash is 1088 *)
-        let s = GasCharge.SizeOf (GI.get_id a) in
-        let n = GasCharge.StaticCost (136 * 15) in
-        pure (GasCharge.DivCeil (s, n))
+        let s = GasGasCharge.SizeOf (GI.get_id a) in
+        let n = GasGasCharge.StaticCost (136 * 15) in
+        pure (GasGasCharge.DivCeil (s, n))
     | Builtin_ripemd160hash, _, [ a ] ->
         (* Block size of ripemd160hash is 512 *)
-        let s = GasCharge.SizeOf (GI.get_id a) in
-        let n = GasCharge.StaticCost (64 * 10) in
-        pure (GasCharge.DivCeil (s, n))
+        let s = GasGasCharge.SizeOf (GI.get_id a) in
+        let n = GasGasCharge.StaticCost (64 * 10) in
+        pure (GasGasCharge.DivCeil (s, n))
     | Builtin_schnorr_verify, _, [ _; s; _ ]
     | Builtin_ecdsa_verify, _, [ _; s; _ ] ->
         (* x = div_ceil (Bystr.width s + 66) 64 *)
         let x =
-          GasCharge.DivCeil
-            ( GasCharge.SumOf
-                (GasCharge.SizeOf (GI.get_id s), GasCharge.StaticCost 66),
-              GasCharge.StaticCost 64 )
+          GasGasCharge.DivCeil
+            ( GasGasCharge.SumOf
+                (GasGasCharge.SizeOf (GI.get_id s), GasGasCharge.StaticCost 66),
+              GasGasCharge.StaticCost 64 )
         in
         (* (250 + (15 * x)) *)
         pure
-          (GasCharge.SumOf
-             ( GasCharge.StaticCost 250,
-               GasCharge.ProdOf (GasCharge.StaticCost 15, x) ))
+          (GasGasCharge.SumOf
+             ( GasGasCharge.StaticCost 250,
+               GasGasCharge.ProdOf (GasGasCharge.StaticCost 15, x) ))
     | Builtin_to_bystr, [ a ], _ when is_bystrx_type a ->
-        pure (GasCharge.StaticCost (Option.value_exn (bystrx_width a)))
+        pure (GasGasCharge.StaticCost (Option.value_exn (bystrx_width a)))
     | Builtin_bech32_to_bystr20, _, [ prefix; addr ]
     | Builtin_bystr20_to_bech32, _, [ prefix; addr ] ->
         let base = 4 in
         pure
-          (GasCharge.ProdOf
-             ( GasCharge.SumOf
-                 ( GasCharge.SizeOf (GI.get_id prefix),
-                   GasCharge.SizeOf (GI.get_id addr) ),
-               GasCharge.StaticCost base ))
+          (GasGasCharge.ProdOf
+             ( GasGasCharge.SumOf
+                 ( GasGasCharge.SizeOf (GI.get_id prefix),
+                   GasGasCharge.SizeOf (GI.get_id addr) ),
+               GasGasCharge.StaticCost base ))
     | Builtin_concat, [ a1; a2 ], _ when is_bystrx_type a1 && is_bystrx_type a2
       ->
         pure
-          (GasCharge.StaticCost
+          (GasGasCharge.StaticCost
              Option.(value_exn (bystrx_width a1) + value_exn (bystrx_width a2)))
-    | Builtin_alt_bn128_G1_add, _, _ -> pure (GasCharge.StaticCost 20)
+    | Builtin_alt_bn128_G1_add, _, _ -> pure (GasGasCharge.StaticCost 20)
     | Builtin_alt_bn128_G1_mul, _, [ _; s ] ->
-        let multiplier = GasCharge.LogOf (GI.get_id s) in
-        pure @@ GasCharge.ProdOf (GasCharge.StaticCost 20, multiplier)
+        let multiplier = GasGasCharge.LogOf (GI.get_id s) in
+        pure @@ GasGasCharge.ProdOf (GasGasCharge.StaticCost 20, multiplier)
     | Builtin_alt_bn128_pairing_product, _, [ pairs ] ->
-        let list_len = GasCharge.LengthOf (GI.get_id pairs) in
-        pure (GasCharge.ProdOf (GasCharge.StaticCost 40, list_len))
+        let list_len = GasGasCharge.LengthOf (GI.get_id pairs) in
+        pure (GasGasCharge.ProdOf (GasGasCharge.StaticCost 40, list_len))
     | _ -> fail0 @@ "Gas cost error for hash built-in"
 
   let map_coster op args _arg_types =
@@ -382,16 +389,17 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
         (* size, get and contains do not make a copy of the Map, hence constant. *)
         match op with
         | Builtin_size | Builtin_get | Builtin_contains ->
-            pure (GasCharge.StaticCost 1)
+            pure (GasGasCharge.StaticCost 1)
         | _ ->
             pure
-              (GasCharge.SumOf
-                 (GasCharge.StaticCost 1, GasCharge.LengthOf (GI.get_id m))) )
+              (GasGasCharge.SumOf
+                 (GasGasCharge.StaticCost 1, GasGasCharge.LengthOf (GI.get_id m)))
+        )
     | _ -> fail0 @@ "Gas cost error for map built-in"
 
   let to_nat_coster _ args _arg_types =
     match args with
-    | [ a ] -> pure (GasCharge.ValueOf (GI.get_id a))
+    | [ a ] -> pure (GasGasCharge.ValueOf (GI.get_id a))
     | _ -> fail0 @@ "Gas cost error for to_nat built-in"
 
   let int_conversion_coster w _ _args arg_types =
@@ -400,9 +408,9 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
     | [ PrimType (Uint_typ _) ]
     | [ PrimType (Int_typ _) ]
     | [ PrimType String_typ ] ->
-        if w = 32 || w = 64 then pure (GasCharge.StaticCost base)
-        else if w = 128 then pure (GasCharge.StaticCost (base * 2))
-        else if w = 256 then pure (GasCharge.StaticCost (base * 4))
+        if w = 32 || w = 64 then pure (GasGasCharge.StaticCost base)
+        else if w = 128 then pure (GasGasCharge.StaticCost (base * 2))
+        else if w = 256 then pure (GasGasCharge.StaticCost (base * 4))
         else fail0 @@ "Gas cost error for integer conversion"
     | _ -> fail0 @@ "Gas cost due to incorrect arguments for int conversion"
 
@@ -411,23 +419,24 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
     let%bind base' =
       match op with
       | Builtin_mul | Builtin_div | Builtin_rem ->
-          pure (GasCharge.StaticCost (5 * base))
+          pure (GasGasCharge.StaticCost (5 * base))
       | Builtin_pow -> (
           match args with
           | [ _; p ] ->
               pure
-                (GasCharge.ProdOf
-                   ( GasCharge.StaticCost (base * 5),
-                     GasCharge.ValueOf (GI.get_id p) ))
+                (GasGasCharge.ProdOf
+                   ( GasGasCharge.StaticCost (base * 5),
+                     GasGasCharge.ValueOf (GI.get_id p) ))
           | _ -> fail0 @@ "Gas cost error for built-in pow" )
       | Builtin_isqrt -> (
           match args with
           | [ a ] ->
               pure
-                (GasCharge.ProdOf
-                   (GasCharge.StaticCost base, GasCharge.LogOf (GI.get_id a)))
+                (GasGasCharge.ProdOf
+                   ( GasGasCharge.StaticCost base,
+                     GasGasCharge.LogOf (GI.get_id a) ))
           | _ -> fail0 "Invalid argument type to isqrt" )
-      | _ -> pure (GasCharge.StaticCost base)
+      | _ -> pure (GasGasCharge.StaticCost base)
     in
     let%bind w =
       match arg_types with
@@ -438,11 +447,13 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
       | _ -> fail0 @@ "Gas cost error for integer built-in"
     in
     if w = 32 || w = 64 then pure base'
-    else if w = 128 then pure (GasCharge.ProdOf (base', GasCharge.StaticCost 2))
-    else if w = 256 then pure (GasCharge.ProdOf (base', GasCharge.StaticCost 4))
+    else if w = 128 then
+      pure (GasGasCharge.ProdOf (base', GasGasCharge.StaticCost 2))
+    else if w = 256 then
+      pure (GasGasCharge.ProdOf (base', GasGasCharge.StaticCost 4))
     else fail0 @@ "Gas cost error for integer built-in"
 
-  let bnum_coster _op _args _arg_types = pure (GasCharge.StaticCost 32)
+  let bnum_coster _op _args _arg_types = pure (GasGasCharge.StaticCost 32)
 
   let tvar s = TypeVar s
 

--- a/src/base/GasCharge.ml
+++ b/src/base/GasCharge.ml
@@ -2,16 +2,16 @@
   This file is part of scilla.
 
   Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
-  
+
   scilla is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software
   Foundation, either version 3 of the License, or (at your option) any later
   version.
- 
+
   scilla is distributed in the hope that it will be useful, but WITHOUT ANY
   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
   A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
- 
+
   You should have received a copy of the GNU General Public License along with
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
@@ -19,87 +19,122 @@
 open Core_kernel
 open Result.Let_syntax
 open MonadUtil
+open Identifier
 
-type gas_charge =
-  | StaticCost of int
-  (* The size of the literal to which the variable resolves to. *)
-  | SizeOf of string
-  (* The value of the integer to which the variable resolves to. *)
-  | ValueOf of string
-  (* The length of the Scilla list / map to which the varible resolves to. *)
-  | LengthOf of string
-  (* The cost incurred in sorting a map read from the database.
-   * leveldb, our backend database doesn't guarantee order. *)
-  | MapSortCost of string
-  (* Sum of two gas charges. *)
-  | SumOf of gas_charge * gas_charge
-  (* Product of two gas charges. *)
-  | ProdOf of gas_charge * gas_charge
-  (* The minimum of two gas charges. *)
-  | MinOf of gas_charge * gas_charge
-  (* div_ceil x y = if x % y = 0 then x / y else (x / y) + 1 *)
-  | DivCeil of gas_charge * gas_charge
-  (* For a Scilla integer I: log(float(I) + 1.0) *)
-  | LogOf of string
-[@@deriving sexp]
+module type GC = sig
+  module Name : QualifiedName
 
-let rec replace_variable_name ~f = function
-  | StaticCost _ as g -> g
-  | SizeOf v -> SizeOf (f v)
-  | ValueOf v -> ValueOf (f v)
-  | LengthOf v -> LengthOf (f v)
-  | MapSortCost m -> MapSortCost (f m)
-  | SumOf (g1, g2) ->
-      SumOf (replace_variable_name ~f g1, replace_variable_name ~f g2)
-  | ProdOf (g1, g2) ->
-      ProdOf (replace_variable_name ~f g1, replace_variable_name ~f g2)
-  | MinOf (g1, g2) ->
-      MinOf (replace_variable_name ~f g1, replace_variable_name ~f g2)
-  | DivCeil (g1, g2) ->
-      DivCeil (replace_variable_name ~f g1, replace_variable_name ~f g2)
-  | LogOf v -> LogOf (f v)
+  type gas_charge =
+    | StaticCost of int
+    (* The size of the literal to which the variable resolves to. *)
+    | SizeOf of Name.t
+    (* The value of the integer to which the variable resolves to. *)
+    | ValueOf of Name.t
+    (* The length of the Scilla list / map to which the varible resolves to. *)
+    | LengthOf of Name.t
+    (* The cost incurred in sorting a map read from the database.
+     * leveldb, our backend database doesn't guarantee order. *)
+    | MapSortCost of Name.t
+    (* Sum of two gas charges. *)
+    | SumOf of gas_charge * gas_charge
+    (* Product of two gas charges. *)
+    | ProdOf of gas_charge * gas_charge
+    (* The minimum of two gas charges. *)
+    | MinOf of gas_charge * gas_charge
+    (* div_ceil x y = if x % y = 0 then x / y else (x / y) + 1 *)
+    | DivCeil of gas_charge * gas_charge
+    (* For a Scilla integer I: log(float(I) + 1.0) *)
+    | LogOf of Name.t
+  [@@deriving sexp]
+end
 
-(* Assuming that resolver resolves
- *   SizeOf v : To the literal_size of v
- *   ValueOf v : The value of the integer literal
- *   Other special purpose charges (ListLength, LogOf, etc)
- * to an integer compute the total gas charge (an integer) for g.
- *)
-let eval resolver g =
-  let rec recurser g =
-    match g with
-    | StaticCost i -> pure i
-    | SizeOf _ | ValueOf _ | LengthOf _ | LogOf _ | MapSortCost _ -> resolver g
+module ScillaGasCharge (N : QualifiedName) = struct
+  module Name = N
+
+  type gas_charge =
+    | StaticCost of int
+    (* The size of the literal to which the variable resolves to. *)
+    | SizeOf of Name.t
+    (* The value of the integer to which the variable resolves to. *)
+    | ValueOf of Name.t
+    (* The length of the Scilla list / map to which the varible resolves to. *)
+    | LengthOf of Name.t
+    (* The cost incurred in sorting a map read from the database.
+     * leveldb, our backend database doesn't guarantee order. *)
+    | MapSortCost of Name.t
+    (* Sum of two gas charges. *)
+    | SumOf of gas_charge * gas_charge
+    (* Product of two gas charges. *)
+    | ProdOf of gas_charge * gas_charge
+    (* The minimum of two gas charges. *)
+    | MinOf of gas_charge * gas_charge
+    (* div_ceil x y = if x % y = 0 then x / y else (x / y) + 1 *)
+    | DivCeil of gas_charge * gas_charge
+    (* For a Scilla integer I: log(float(I) + 1.0) *)
+    | LogOf of Name.t
+  [@@deriving sexp]
+
+  let rec replace_variable_name ~f = function
+    | StaticCost _ as g -> g
+    | SizeOf v -> SizeOf (f v)
+    | ValueOf v -> ValueOf (f v)
+    | LengthOf v -> LengthOf (f v)
+    | MapSortCost m -> MapSortCost (f m)
     | SumOf (g1, g2) ->
-        let%bind i1 = recurser g1 in
-        let%bind i2 = recurser g2 in
-        pure (i1 + i2)
+        SumOf (replace_variable_name ~f g1, replace_variable_name ~f g2)
     | ProdOf (g1, g2) ->
-        let%bind i1 = recurser g1 in
-        let%bind i2 = recurser g2 in
-        pure (i1 * i2)
+        ProdOf (replace_variable_name ~f g1, replace_variable_name ~f g2)
     | MinOf (g1, g2) ->
-        let%bind i1 = recurser g1 in
-        let%bind i2 = recurser g2 in
-        pure (Int.min i1 i2)
+        MinOf (replace_variable_name ~f g1, replace_variable_name ~f g2)
     | DivCeil (g1, g2) ->
-        let div_ceil x y = if x % y = 0 then x / y else (x / y) + 1 in
-        let%bind g1_i = recurser g1 in
-        let%bind g2_i = recurser g2 in
-        pure (div_ceil g1_i g2_i)
-  in
-  recurser g
+        DivCeil (replace_variable_name ~f g1, replace_variable_name ~f g2)
+    | LogOf v -> LogOf (f v)
 
-let rec pp_gas_charge = function
-  | StaticCost i -> Int.to_string i
-  | SizeOf v -> sprintf "sizeof (%s)" v
-  | ValueOf v -> sprintf "valueof (%s)" v
-  | LengthOf v -> sprintf "lengthof (%s)" v
-  | MapSortCost m -> sprintf "mapsortcost (%s)" m
-  | SumOf (g1, g2) -> sprintf "(%s + %s)" (pp_gas_charge g1) (pp_gas_charge g2)
-  | ProdOf (g1, g2) -> sprintf "(%s * %s)" (pp_gas_charge g1) (pp_gas_charge g2)
-  | MinOf (g1, g2) ->
-      sprintf "min(%s, %s)" (pp_gas_charge g1) (pp_gas_charge g2)
-  | DivCeil (g1, g2) ->
-      sprintf "divceil(%s, %s)" (pp_gas_charge g1) (pp_gas_charge g2)
-  | LogOf v -> sprintf "log (%s)" v
+  (* Assuming that resolver resolves
+   *   SizeOf v : To the literal_size of v
+   *   ValueOf v : The value of the integer literal
+   *   Other special purpose charges (ListLength, LogOf, etc)
+   * to an integer compute the total gas charge (an integer) for g.
+   *)
+  let eval resolver g =
+    let rec recurser g =
+      match g with
+      | StaticCost i -> pure i
+      | SizeOf _ | ValueOf _ | LengthOf _ | LogOf _ | MapSortCost _ ->
+          resolver g
+      | SumOf (g1, g2) ->
+          let%bind i1 = recurser g1 in
+          let%bind i2 = recurser g2 in
+          pure (i1 + i2)
+      | ProdOf (g1, g2) ->
+          let%bind i1 = recurser g1 in
+          let%bind i2 = recurser g2 in
+          pure (i1 * i2)
+      | MinOf (g1, g2) ->
+          let%bind i1 = recurser g1 in
+          let%bind i2 = recurser g2 in
+          pure (Int.min i1 i2)
+      | DivCeil (g1, g2) ->
+          let div_ceil x y = if x % y = 0 then x / y else (x / y) + 1 in
+          let%bind g1_i = recurser g1 in
+          let%bind g2_i = recurser g2 in
+          pure (div_ceil g1_i g2_i)
+    in
+    recurser g
+
+  let rec pp_gas_charge = function
+    | StaticCost i -> Int.to_string i
+    | SizeOf v -> sprintf "sizeof (%s)" (Name.as_string v)
+    | ValueOf v -> sprintf "valueof (%s)" (Name.as_string v)
+    | LengthOf v -> sprintf "lengthof (%s)" (Name.as_string v)
+    | MapSortCost m -> sprintf "mapsortcost (%s)" (Name.as_string m)
+    | SumOf (g1, g2) ->
+        sprintf "(%s + %s)" (pp_gas_charge g1) (pp_gas_charge g2)
+    | ProdOf (g1, g2) ->
+        sprintf "(%s * %s)" (pp_gas_charge g1) (pp_gas_charge g2)
+    | MinOf (g1, g2) ->
+        sprintf "min(%s, %s)" (pp_gas_charge g1) (pp_gas_charge g2)
+    | DivCeil (g1, g2) ->
+        sprintf "divceil(%s, %s)" (pp_gas_charge g1) (pp_gas_charge g2)
+    | LogOf v -> sprintf "log (%s)" (Name.as_string v)
+end

--- a/src/base/ParserUtil.ml
+++ b/src/base/ParserUtil.ml
@@ -57,6 +57,8 @@ module type Syn = sig
   module SType = SLiteral.LType
   module SIdentifier = SType.TIdentifier
 
+  module SGasCharge : GC
+
   (*******************************************************)
   (*                   Expressions                       *)
   (*******************************************************)
@@ -89,7 +91,7 @@ module type Syn = sig
     | TApp of ParserRep.rep SIdentifier.t * SType.t list
     (* Fixpoint combinator: used to implement recursion principles *)
     | Fixpoint of ParserRep.rep SIdentifier.t * SType.t * expr_annot
-    | GasExpr of gas_charge * expr_annot
+    | GasExpr of SGasCharge.gas_charge * expr_annot
 
   (*******************************************************)
   (*                   Statements                        *)
@@ -124,7 +126,7 @@ module type Syn = sig
     | CreateEvnt of ParserRep.rep SIdentifier.t
     | CallProc of ParserRep.rep SIdentifier.t * ParserRep.rep SIdentifier.t list
     | Throw of ParserRep.rep SIdentifier.t option
-    | GasStmt of gas_charge
+    | GasStmt of SGasCharge.gas_charge
 
   (*******************************************************)
   (*                    Contracts                        *)

--- a/src/base/PatternChecker.ml
+++ b/src/base/PatternChecker.ml
@@ -50,6 +50,36 @@ struct
 
   let wrap_pmcheck_serr s ?(opt = "") = wrap_serr s "patternmatch checking" ~opt
 
+  (**************************************************************)
+  (*               Typing explict gas charges                   *)
+  (**************************************************************)
+
+  (* No actual checking required - we just need to translate
+     gas_charge constructors to the new syntax *)
+
+  let rec pm_check_gas_charge gc =
+    let open UncheckedPatternSyntax.SGasCharge in
+    match gc with
+    | StaticCost i -> CheckedPatternSyntax.SGasCharge.StaticCost i
+    | SizeOf v -> CheckedPatternSyntax.SGasCharge.SizeOf v
+    | ValueOf v -> CheckedPatternSyntax.SGasCharge.ValueOf v
+    | LengthOf v -> CheckedPatternSyntax.SGasCharge.LengthOf v
+    | MapSortCost m -> CheckedPatternSyntax.SGasCharge.MapSortCost m
+    | SumOf (g1, g2) ->
+        CheckedPatternSyntax.SGasCharge.SumOf
+          (pm_check_gas_charge g1, pm_check_gas_charge g2)
+    | ProdOf (g1, g2) ->
+        CheckedPatternSyntax.SGasCharge.ProdOf
+          (pm_check_gas_charge g1, pm_check_gas_charge g2)
+    | MinOf (g1, g2) ->
+        CheckedPatternSyntax.SGasCharge.MinOf
+          (pm_check_gas_charge g1, pm_check_gas_charge g2)
+    | DivCeil (g1, g2) ->
+        CheckedPatternSyntax.SGasCharge.DivCeil
+          (pm_check_gas_charge g1, pm_check_gas_charge g2)
+    | LogOf v -> CheckedPatternSyntax.SGasCharge.LogOf v
+    [@@deriving sexp]
+
   let pm_check_clauses t clauses =
     let reachable = Array.create ~len:(List.length clauses) false in
     let static_match c_name span dsc =
@@ -200,7 +230,7 @@ struct
            pure @@ (CheckedPatternSyntax.Fixpoint (i, t, checked_body), rep)
     | GasExpr (g, e) ->
         let%bind e' = pm_check_expr e in
-        pure (CheckedPatternSyntax.GasExpr (g, e'), rep)
+        pure (CheckedPatternSyntax.GasExpr (pm_check_gas_charge g, e'), rep)
 
   let rec pm_check_stmts stmts =
     match stmts with
@@ -240,7 +270,8 @@ struct
           | CallProc (p, args) ->
               pure @@ (CheckedPatternSyntax.CallProc (p, args), rep)
           | Throw i -> pure @@ (CheckedPatternSyntax.Throw i, rep)
-          | GasStmt g -> pure (CheckedPatternSyntax.GasStmt g, rep)
+          | GasStmt g ->
+              pure (CheckedPatternSyntax.GasStmt (pm_check_gas_charge g), rep)
         in
         let%bind checked_stmts = pm_check_stmts sts in
         pure @@ (checked_s :: checked_stmts)

--- a/src/base/Recursion.ml
+++ b/src/base/Recursion.ml
@@ -62,6 +62,28 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
     in
     walk t
 
+  let rec recursion_gas_charge gc =
+    let open PreRecursionSyntax.SGasCharge in
+    match gc with
+    | StaticCost i -> RecursionSyntax.SGasCharge.StaticCost i
+    | SizeOf v -> RecursionSyntax.SGasCharge.SizeOf v
+    | ValueOf v -> RecursionSyntax.SGasCharge.ValueOf v
+    | LengthOf v -> RecursionSyntax.SGasCharge.LengthOf v
+    | MapSortCost m -> RecursionSyntax.SGasCharge.MapSortCost m
+    | SumOf (g1, g2) ->
+        RecursionSyntax.SGasCharge.SumOf
+          (recursion_gas_charge g1, recursion_gas_charge g2)
+    | ProdOf (g1, g2) ->
+        RecursionSyntax.SGasCharge.ProdOf
+          (recursion_gas_charge g1, recursion_gas_charge g2)
+    | MinOf (g1, g2) ->
+        RecursionSyntax.SGasCharge.MinOf
+          (recursion_gas_charge g1, recursion_gas_charge g2)
+    | DivCeil (g1, g2) ->
+        RecursionSyntax.SGasCharge.DivCeil
+          (recursion_gas_charge g1, recursion_gas_charge g2)
+    | LogOf v -> RecursionSyntax.SGasCharge.LogOf v
+
   let recursion_payload p =
     match p with
     | MLit l -> RecursionSyntax.MLit l
@@ -135,7 +157,7 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
             pure @@ RecursionSyntax.Fixpoint (x, t, new_e)
         | GasExpr (g, sube) ->
             let%bind sube' = walk sube in
-            pure (RecursionSyntax.GasExpr (g, sube'))
+            pure (RecursionSyntax.GasExpr (recursion_gas_charge g, sube'))
       in
       pure (new_e, rep)
     in
@@ -179,7 +201,7 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
                 (sprintf "Procedure %s is not in scope." (get_id p))
                 (SR.get_loc rep)
         | Throw ex -> pure @@ RecursionSyntax.Throw ex
-        | GasStmt g -> pure @@ RecursionSyntax.GasStmt g
+        | GasStmt g -> pure @@ RecursionSyntax.GasStmt (recursion_gas_charge g)
       in
       pure (new_s, rep)
     in

--- a/src/base/RunnerUtil.ml
+++ b/src/base/RunnerUtil.ml
@@ -202,7 +202,7 @@ let eliminate_namespaces lib_tree ns_tree =
                 (Fixpoint (i, t, exp'), eloc)
             | GasExpr (g, e) ->
                 let g' =
-                  GasCharge.replace_variable_name g
+                  RUSyntax.SGasCharge.replace_variable_name g
                     ~f:(check_and_prefix_id_string env)
                 in
                 (GasExpr (g', rename_in_expr e env), eloc)

--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -229,6 +229,7 @@ module ScillaSyntax (SR : Rep) (ER : Rep) (Literal : ScillaLiteral) = struct
   module SLiteral = Literal
   module SType = SLiteral.LType
   module SIdentifier = SType.TIdentifier
+  module SGasCharge = ScillaGasCharge (SIdentifier.Name)
 
   (*******************************************************)
   (*                   Expressions                       *)
@@ -259,7 +260,7 @@ module ScillaSyntax (SR : Rep) (ER : Rep) (Literal : ScillaLiteral) = struct
     | TApp of ER.rep SIdentifier.t * SType.t list
     (* Fixpoint combinator: used to implement recursion principles *)
     | Fixpoint of ER.rep SIdentifier.t * SType.t * expr_annot
-    | GasExpr of gas_charge * expr_annot
+    | GasExpr of SGasCharge.gas_charge * expr_annot
   [@@deriving sexp]
 
   let expr_rep erep = snd erep
@@ -305,7 +306,7 @@ module ScillaSyntax (SR : Rep) (ER : Rep) (Literal : ScillaLiteral) = struct
     | CreateEvnt of ER.rep SIdentifier.t
     | CallProc of SR.rep SIdentifier.t * ER.rep SIdentifier.t list
     | Throw of ER.rep SIdentifier.t option
-    | GasStmt of gas_charge
+    | GasStmt of SGasCharge.gas_charge
   [@@deriving sexp]
 
   let stmt_rep srep = snd srep

--- a/src/eval/EvalUtil.ml
+++ b/src/eval/EvalUtil.ml
@@ -19,8 +19,6 @@
 open Core_kernel
 open Scilla_base
 open ParserUtil
-open Literal
-open Syntax
 open MonadUtil
 open EvalMonad
 open EvalMonad.Let_syntax
@@ -33,14 +31,14 @@ open Gas
 module SR = ParserRep
 module ER = ParserRep
 
-(* TODO: Change this to CanonicalLiteral = Literals based on canonical names. *)
-module EvalLiteral = FlattenedLiteral
-module EvalType = EvalLiteral.LType
-module EvalIdentifier = EvalType.TIdentifier
-module EvalSyntax = ScillaSyntax (SR) (ER) (EvalLiteral)
+(* EvalLiteral is FlattenedLiteral, but need to pull it from EvalGas *)
+module EvalGas = ScillaGas (SR) (ER)
+module EvalSyntax = EvalGas.GasSyntax
+module EvalLiteral = EvalSyntax.SLiteral
 module EvalTypeUtilities = TypeUtilities
 module EvalBuiltIns = ScillaBuiltIns (SR) (ER)
-module EvalGas = ScillaGas (SR) (ER)
+module EvalType = EvalSyntax.SType
+module EvalIdentifier = EvalSyntax.SIdentifier
 open EvalIdentifier
 open EvalSyntax
 


### PR DESCRIPTION
Gas charge AST nodes refer to program variables, so they need to use Name.t (for an appropriate Name struct) instead of string. This means that they need to be disambiguated.

Most of the code in this PR is entirely brain-dead boilerplate, except for the small change in EvalUtil.ml. The use of gas charge nodes introduces an extra dependency between Gas.ml and Syntax.ml, which makes it impossible to use different syntax structs in EvalUtil.ml and Gas.ml. I have solved this by setting `EvalSyntax = Gas.GasSyntax`, which I think makes sense since we would expect to charge gas based on the syntax being evaluated.

I worry that this will stop working on my current disambiguation branch, but I'll find out when I merge master to that branch.