### PR TITLE
Unexpected map keys not printed when using IPC test server

### DIFF
--- a/tests/ipc/StateIPCTest.ml
+++ b/tests/ipc/StateIPCTest.ml
@@ -118,13 +118,28 @@ let state_to_json s =
 let sort_mapkeys goldj outj =
   let goldstates = json_to_list @@ json_member "states" goldj in
   let outstates = json_to_list @@ json_member "states" outj in
+  let rec map_dumper outmap t =
+    let open IPCTestType in
+    match t with
+    | MapType (_, vt) ->
+        let outlist = json_to_list outmap in
+        let outlist_complete =
+          List.map outlist ~f:(fun out ->
+              let outkey = json_member "key" out in
+              let outval = json_member "val" out in
+              let outval' = map_dumper outval vt in
+              `Assoc [ ("key", outkey); ("val", outval') ])
+        in
+        `List outlist_complete
+    | _ -> outmap
+  in
   let rec map_sorter goldmap outmap t =
     let open IPCTestType in
     match t with
     | MapType (_, vt) ->
         let goldlist = json_to_list goldmap in
         let outlist = json_to_list outmap in
-        let outlist' =
+        let outlist_goldkeys =
           List.fold_right goldlist
             ~f:(fun gold outacc ->
               let goldkey = json_member "key" gold |> json_to_string in
@@ -144,7 +159,27 @@ let sort_mapkeys goldj outj =
               | None -> outacc)
             ~init:[]
         in
-        `List outlist'
+        let outlist_complete =
+          List.fold_left outlist ~init:outlist_goldkeys ~f:(fun outacc out ->
+              let outkey = json_member "key" out in
+              match
+                List.find outlist_goldkeys ~f:(fun other_out ->
+                    let other_outkey =
+                      json_member "key" other_out |> json_to_string
+                    in
+                    String.(json_to_string outkey = other_outkey))
+              with
+              | Some _ ->
+                  (* Ignore - already sorted *)
+                  outacc
+              | None ->
+                  (* New key not present in the gold file *)
+                  let outval = json_member "val" out in
+                  let outval' = map_dumper outval vt in
+                  let outj = `Assoc [ ("key", outkey); ("val", outval') ] in
+                  outj :: outacc)
+        in
+        `List outlist_complete
     | _ -> outmap
   in
   let outstates' =

--- a/tests/ipc/StateIPCTestServer.ml
+++ b/tests/ipc/StateIPCTestServer.ml
@@ -143,10 +143,14 @@ module MakeServer () = struct
       | head :: tail -> (
           let vopt = Hashtbl.find_opt map head in
           match vopt with
-          | None ->
-              let m = Hashtbl.create 8 in
-              let () = Hashtbl.replace map head (MapVal m) in
-              recurser_update ~new_val m tail
+          | None -> (
+              (* Index does not exist. If we are deleting a value, then we can ignore this and all remaining indices *)
+              match new_val with
+              | None -> pure ()
+              | Some _ ->
+                  let m = Hashtbl.create 8 in
+                  let () = Hashtbl.replace map head (MapVal m) in
+                  recurser_update ~new_val m tail )
           | Some v -> (
               match v with
               | NonMapVal _ ->


### PR DESCRIPTION
When using the test IPC server, only keys that already exist in the gold files are printed. This is clearly not what we want, and it affects the simple-dex contract on the disambiguation branch, because the map keys in the order book are sha256 hashes, so a change in the name of the key type constructors means that the key values change.

This PR fixes this problem, but this seems to reveal another bug, which show itself in the transition `test6` in inplace-map.scilla:
```
transition test6()
  a = "Hi";
  b = Int32 1;
  c = Int64 2;
  delete gmap3[a][b][c]
end
```
Tests 9 and 10 of inplace-map.scilla invoke this transition, starting from a contract state in which the key `"Hi"` does not exist in the outermost map of `gmap3`. The expected result is that the state does not change. However, the actual result is that the empty map is inserted at `gmap3["Hi"][1]`, i.e., the equivalent of the following code:

```
transition test6()
  a = "Hi";
  b = Int32 1;
  c = Emp Int64 String;
  gmap3[a][b] := c
end
```

I am going to need some help figuring out how to diagnose this. Presumably the problem is somewhere in tests/ipc or tests/runner/Testcontracts.ml, because running the tests without using ipc works just fine, so I doubt the bug affects production code.