### PR TITLE
Added positive tests for exponential gas charges

### DIFF
--- a/tests/checker/good/Good.ml
+++ b/tests/checker/good/Good.ml
@@ -162,6 +162,8 @@ module CheckerTests = Scilla_test.Util.DiffBasedTests (struct
       "lib_typing2.scilla";
       "constraint_scope.scilla";
       "event_reordered_fields.scilla";
+      "blowup_1.scilla";
+      "blowup_2.scilla";
     ]
 
   let exit_code : UnixLabels.process_status = WEXITED 0

--- a/tests/checker/good/blowup_1.scilla
+++ b/tests/checker/good/blowup_1.scilla
@@ -1,0 +1,24 @@
+scilla_version 0
+
+library Blowup
+
+let not_owner_code = Int32 1
+let foo = tfun 'A => fun (f : 'A -> 'A) => fun (x : 'A) => f x
+let bar0 = tfun 'A => @foo ('A -> 'A)
+let bar1 = tfun 'A => @bar0 ('A -> 'A)
+let bar1 = tfun 'A => @bar0 ('A -> 'A)
+let bar2 = tfun 'A => @bar1 ('A -> 'A)
+let bar3 = tfun 'A => @bar2 ('A -> 'A)
+let bar4 = tfun 'A => @bar3 ('A -> 'A)
+let bar5 = tfun 'A => @bar4 ('A -> 'A)
+let bar6 = tfun 'A => @bar5 ('A -> 'A)
+let bar7 = tfun 'A => @bar6 ('A -> 'A)
+let bar8 = tfun 'A => @bar7 ('A -> 'A)
+let bar9 = tfun 'A => @bar8 ('A -> 'A)
+
+contract Blowup (owner: ByStr20)
+
+transition setHello (msg : String)
+  e = {_eventname : "setHello()"; code : not_owner_code};
+  event e
+end

--- a/tests/checker/good/blowup_2.scilla
+++ b/tests/checker/good/blowup_2.scilla
@@ -1,0 +1,25 @@
+scilla_version 0
+
+library Blowup
+
+let not_owner_code = Int32 1
+let foo = tfun 'A => fun (f : 'A -> 'A) => fun (x : 'A) => f x
+let bar0 = tfun 'A => @foo ('A -> 'A)
+let bar1 = tfun 'A => @bar0 ('A -> 'A)
+let bar1 = tfun 'A => @bar0 ('A -> 'A)
+let bar2 = tfun 'A => @bar1 ('A -> 'A)
+let bar3 = tfun 'A => @bar2 ('A -> 'A)
+let bar4 = tfun 'A => @bar3 ('A -> 'A)
+let bar5 = tfun 'A => @bar4 ('A -> 'A)
+let bar6 = tfun 'A => @bar5 ('A -> 'A)
+let bar7 = tfun 'A => @bar6 ('A -> 'A)
+let bar8 = tfun 'A => @bar7 ('A -> 'A)
+let bar9 = tfun 'A => @bar8 ('A -> 'A)
+let bar10 = tfun 'A => @bar9 ('A -> 'A)
+
+contract Blowup (owner: ByStr20)
+
+transition setHello (msg : String)
+  e = {_eventname : "setHello()"; code : not_owner_code};
+  event e
+end

--- a/tests/checker/good/gold/blowup_1.scilla.gold
+++ b/tests/checker/good/gold/blowup_1.scilla.gold
@@ -1,0 +1,75 @@
+{
+  "cashflow_tags": {
+    "State variables": [ { "field": "owner", "tag": "NoInfo" } ],
+    "ADT constructors": []
+  },
+  "contract_info": {
+    "scilla_major_version": "0",
+    "vname": "Blowup",
+    "params": [ { "vname": "owner", "type": "ByStr20" } ],
+    "fields": [],
+    "transitions": [
+      {
+        "vname": "setHello",
+        "params": [ { "vname": "msg", "type": "String" } ]
+      }
+    ],
+    "procedures": [],
+    "events": [
+      {
+        "vname": "setHello()",
+        "params": [ { "vname": "code", "type": "Int32" } ]
+      }
+    ],
+    "ADTs": [
+      {
+        "tname": "Option",
+        "tparams": [ "'A" ],
+        "tmap": [
+          { "cname": "Some", "argtypes": [ "'A" ] },
+          { "cname": "None", "argtypes": [] }
+        ]
+      },
+      {
+        "tname": "Bool",
+        "tparams": [],
+        "tmap": [
+          { "cname": "True", "argtypes": [] },
+          { "cname": "False", "argtypes": [] }
+        ]
+      },
+      {
+        "tname": "Nat",
+        "tparams": [],
+        "tmap": [
+          { "cname": "Zero", "argtypes": [] },
+          { "cname": "Succ", "argtypes": [ "Nat" ] }
+        ]
+      },
+      {
+        "tname": "List",
+        "tparams": [ "'A" ],
+        "tmap": [
+          { "cname": "Cons", "argtypes": [ "'A", "List ('A)" ] },
+          { "cname": "Nil", "argtypes": [] }
+        ]
+      },
+      {
+        "tname": "Pair",
+        "tparams": [ "'A", "'B" ],
+        "tmap": [ { "cname": "Pair", "argtypes": [ "'A", "'B" ] } ]
+      }
+    ]
+  },
+  "warnings": [
+    {
+      "warning_message":
+        "No transition in contract Blowup contains an accept statement\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 1
+    }
+  ],
+  "gas_remaining": "5951"
+}
+

--- a/tests/checker/good/gold/blowup_2.scilla.gold
+++ b/tests/checker/good/gold/blowup_2.scilla.gold
@@ -1,0 +1,75 @@
+{
+  "cashflow_tags": {
+    "State variables": [ { "field": "owner", "tag": "NoInfo" } ],
+    "ADT constructors": []
+  },
+  "contract_info": {
+    "scilla_major_version": "0",
+    "vname": "Blowup",
+    "params": [ { "vname": "owner", "type": "ByStr20" } ],
+    "fields": [],
+    "transitions": [
+      {
+        "vname": "setHello",
+        "params": [ { "vname": "msg", "type": "String" } ]
+      }
+    ],
+    "procedures": [],
+    "events": [
+      {
+        "vname": "setHello()",
+        "params": [ { "vname": "code", "type": "Int32" } ]
+      }
+    ],
+    "ADTs": [
+      {
+        "tname": "Option",
+        "tparams": [ "'A" ],
+        "tmap": [
+          { "cname": "Some", "argtypes": [ "'A" ] },
+          { "cname": "None", "argtypes": [] }
+        ]
+      },
+      {
+        "tname": "Bool",
+        "tparams": [],
+        "tmap": [
+          { "cname": "True", "argtypes": [] },
+          { "cname": "False", "argtypes": [] }
+        ]
+      },
+      {
+        "tname": "Nat",
+        "tparams": [],
+        "tmap": [
+          { "cname": "Zero", "argtypes": [] },
+          { "cname": "Succ", "argtypes": [ "Nat" ] }
+        ]
+      },
+      {
+        "tname": "List",
+        "tparams": [ "'A" ],
+        "tmap": [
+          { "cname": "Cons", "argtypes": [ "'A", "List ('A)" ] },
+          { "cname": "Nil", "argtypes": [] }
+        ]
+      },
+      {
+        "tname": "Pair",
+        "tparams": [ "'A", "'B" ],
+        "tmap": [ { "cname": "Pair", "argtypes": [ "'A", "'B" ] } ]
+      }
+    ]
+  },
+  "warnings": [
+    {
+      "warning_message":
+        "No transition in contract Blowup contains an accept statement\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 1
+    }
+  ],
+  "gas_remaining": "3903"
+}
+


### PR DESCRIPTION
I noticed that our only testcase for the exponential gas charges for type blowups was a negative one that runs out of gas, so I have added two positive testcases that succeed, but charge significant amounts of gas.

The two tests differ only by one line, but the gas charge differs by 2000 units, so we should be able to use them to discover any changes in the exponential charge.