### PR TITLE
Fix compare function for identifiers and names.

### DIFF
--- a/src/base/Identifier.ml
+++ b/src/base/Identifier.ml
@@ -90,6 +90,8 @@ module GlobalName = struct
      will be different from the error string where the name is used *)
   let equal ((an, _) : t) ((bn, _) : t) : bool = [%equal: t_name] an bn
 
+  let compare ((an, _) : t) ((bn, _) : t) : int = [%compare : t_name] an bn
+  
   let as_string = function
     | SimpleGlobal n, _ -> n
     | QualifiedGlobal (ns, n), _ -> flatten_name ns n

--- a/src/base/Recursion.ml
+++ b/src/base/Recursion.ml
@@ -75,9 +75,7 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
       | Address fts -> (
           match
             List.find_a_dup fts ~compare:(fun (f1, _) (f2, _) ->
-                Bytes.compare
-                  (Bytes.of_string (as_string f1))
-                  (Bytes.of_string (as_string f2)))
+                RecIdentifier.compare f1 f2)
           with
           | Some (dup_field, _) ->
               fail1

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -247,9 +247,7 @@ functor
           | Address fts ->
               match List.find_a_dup fts
                       ~compare:(fun (f1, _) (f2, _) ->
-                          Bytes.compare
-                            (Bytes.of_string (as_string f1))
-                            (Bytes.of_string (as_string f2))) with
+                          TIdentifier.compare f1 f2) with
               | Some (dup_f, _) ->
                   (* No duplicate fields allowed *)
                   fail1


### PR DESCRIPTION
The old compare function for names would compare error strings as well as actual names, and the old compare function for identifiers would compare locations as well as actual identifiers.

It won't make a huge difference, but this is the correct behaviour.