### PR TITLE
Remote state reads practicalities

### DIFF
--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -1288,7 +1288,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let contains_elab sc ts =
       match ts with
-      | [ MapType (kt, vt); u ] when type_assignable kt u ->
+      | [ MapType (kt, vt); u ] when type_assignable ~expected:kt ~actual:u ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -1310,7 +1310,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let put_elab sc ts =
       match ts with
       | [ MapType (kt, vt); kt'; vt' ]
-        when type_assignable kt kt' && type_assignable vt vt' ->
+        when type_assignable ~expected:kt ~actual:kt' && type_assignable ~expected:vt ~actual:vt' ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -1333,7 +1333,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let get_elab sc ts =
       match ts with
-      | [ MapType (kt, vt); kt' ] when type_assignable kt kt' ->
+      | [ MapType (kt, vt); kt' ] when type_assignable ~expected:kt ~actual:kt' ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -1355,7 +1355,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let remove_elab sc ts =
       match ts with
-      | [ MapType (kt, vt); u ] when type_assignable kt u ->
+      | [ MapType (kt, vt); u ] when type_assignable ~expected:kt ~actual:u ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _ -> fail0 "Failed to elaborate"
 

--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -1310,7 +1310,8 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let put_elab sc ts =
       match ts with
       | [ MapType (kt, vt); kt'; vt' ]
-        when type_assignable ~expected:kt ~actual:kt' && type_assignable ~expected:vt ~actual:vt' ->
+        when type_assignable ~expected:kt ~actual:kt'
+             && type_assignable ~expected:vt ~actual:vt' ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _ -> fail0 "Failed to elaborate"
 
@@ -1333,7 +1334,8 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let get_elab sc ts =
       match ts with
-      | [ MapType (kt, vt); kt' ] when type_assignable ~expected:kt ~actual:kt' ->
+      | [ MapType (kt, vt); kt' ] when type_assignable ~expected:kt ~actual:kt'
+        ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _ -> fail0 "Failed to elaborate"
 

--- a/src/base/ContractUtil.ml
+++ b/src/base/ContractUtil.ml
@@ -150,13 +150,13 @@ module ScillaContractUtil (SR : Rep) (ER : Rep) = struct
       ( CUIdentifier.mk_id
           (label_name_of_string MessagePayload.sender_label)
           ER.address_rep,
-        Address [] )
+        address_typ [] )
     in
     let origin =
       ( CUIdentifier.mk_id
           (label_name_of_string MessagePayload.origin_label)
           ER.address_rep,
-        Address [] )
+        address_typ [] )
     in
     let amount =
       ( CUIdentifier.mk_id

--- a/src/base/EventInfo.ml
+++ b/src/base/EventInfo.ml
@@ -100,9 +100,9 @@ struct
               let matcher m_types tlist =
                 List.length m_types = List.length tlist
                 && (* Check that each entry in tlist is equal to the same entry in m_types. *)
-                List.for_all tlist ~f:(fun (n1, t1) ->
-                    List.exists m_types ~f:(fun (n2, t2) ->
-                        String.(n1 = n2) && type_assignable t2 t1))
+                List.for_all tlist ~f:(fun (n1, actual) ->
+                    List.exists m_types ~f:(fun (n2, expected) ->
+                        String.(n1 = n2) && type_assignable ~expected ~actual))
               in
               if not @@ matcher m_types tlist then
                 fail1

--- a/src/base/Gas.ml
+++ b/src/base/Gas.ml
@@ -581,12 +581,12 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
       if
         List.length types = List.length arg_types
         && List.for_all2_exn
-             ~f:(fun t1 t2 ->
+             ~f:(fun expected actual ->
                (* the types should match *)
-               type_assignable t1 t2
+               type_assignable ~expected ~actual
                ||
                (* or the built-in record is generic *)
-               match t1 with TypeVar _ -> true | _ -> false)
+               match expected with TypeVar _ -> true | _ -> false)
              types arg_types
       then fcoster op arg_ids arg_types (* this can fail too *)
       else fail0 @@ "Name or arity doesn't match"

--- a/src/base/JSON.ml
+++ b/src/base/JSON.ml
@@ -173,7 +173,7 @@ and read_adt_json name j tlist_verify =
   let verify_exn name tlist1 adt =
     match adt with
     | ADTValue (_, tlist2, _) ->
-        if type_assignable_list tlist1 tlist2 then ()
+        if type_assignable_list ~to_list:tlist1 ~from_list:tlist2 then ()
         else
           let expected = pp_typ_list_error tlist1 in
           let observed = pp_typ_list_error tlist2 in

--- a/src/base/Type.ml
+++ b/src/base/Type.ml
@@ -173,6 +173,8 @@ module type ScillaType = sig
 
   (* Given a ByStrX, return integer X *)
   val bystrx_width : t -> int option
+
+  val address_typ : (loc TIdentifier.t * t) list -> t
 end
 
 module MkType (I : ScillaIdentifier) = struct
@@ -431,6 +433,8 @@ module MkType (I : ScillaIdentifier) = struct
 
   (* Given a ByStrX string, return integer X *)
   let bystrx_width = function PrimType (Bystrx_typ w) -> Some w | _ -> None
+
+  let address_typ fts = Address fts
 
   let is_prim_type = function PrimType _ -> true | _ -> false
 

--- a/src/base/Type.ml
+++ b/src/base/Type.ml
@@ -117,7 +117,7 @@ module type ScillaType = sig
 
   val type_equivalent : t -> t -> bool
 
-  val type_assignable : t -> t -> bool
+  val type_assignable : expected:t -> actual:t -> bool
 
   val subst_type_in_type : string -> t -> t -> t
 
@@ -361,9 +361,9 @@ module MkType (I : ScillaIdentifier) = struct
     let t2' = canonicalize_tfun t2 in
     equal t1' t2'
 
-  let type_assignable to_typ from_typ =
-    let to_typ' = canonicalize_tfun to_typ in
-    let from_typ' = canonicalize_tfun from_typ in
+  let type_assignable ~expected ~actual =
+    let to_typ' = canonicalize_tfun expected in
+    let from_typ' = canonicalize_tfun actual in
     let rec assignable to_typ from_typ =
       match (to_typ, from_typ) with
       | Address tfts, Address ffts ->

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -341,7 +341,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
           | Some tannot ->
               let%bind () =
                 fromR_TE
-                @@ assert_type_assignable ~lc:(ER.get_loc rep) tannot ityp.tp
+                @@ assert_type_assignable ~lc:(ER.get_loc rep) ~expected:tannot ~actual:ityp.tp
               in
               pure (mk_qual_tp tannot)
           | None -> pure ityp
@@ -419,7 +419,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
           with_extended_env tenv Fn.id [ (f, t) ] [] (type_expr body)
         in
         let%bind () =
-          fromR_TE @@ assert_type_assignable ~lc:(ER.get_loc rep) t bt.tp
+          fromR_TE @@ assert_type_assignable ~lc:(ER.get_loc rep) ~expected:t ~actual:bt.tp
         in
         pure
         @@ ( TypedSyntax.Fixpoint
@@ -467,7 +467,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
               List.Assoc.find CU.msg_mandatory_field_types fld
                 ~equal:String.( = )
             with
-            | Some fld_t when not @@ type_assignable fld_t seen_type ->
+            | Some fld_t when not @@ type_assignable ~expected:fld_t ~actual:seen_type ->
                 fail
                   (mk_type_error1
                      (sprintf
@@ -572,7 +572,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
           in
           let%bind () =
             fromR_TE
-            @@ assert_type_assignable kt (rr_typ k_t).tp
+            @@ assert_type_assignable ~expected:kt ~actual:(rr_typ k_t).tp
                  ~lc:(ER.get_loc (get_rep k))
           in
           let%bind typed_keys, res = helper vt rest in
@@ -680,16 +680,16 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
                   @@ TEnv.resolveT env.fields (get_id f)
                        ~lopt:(Some (get_rep f))
                 in
-                let%bind r =
+                let%bind rr =
                   fromR_TE
                   @@ TEnv.resolveT env.pure (get_id r) ~lopt:(Some (get_rep r))
                 in
                 let%bind () =
                   fromR_TE
-                  @@ assert_type_assignable (rr_typ fr).tp (rr_typ r).tp
+                  @@ assert_type_assignable ~expected:(rr_typ fr).tp ~actual:(rr_typ rr).tp ~lc:(ER.get_loc (get_rep r))
                 in
                 let%bind checked_stmts = type_stmts sts get_loc env in
-                pure @@ (checked_stmts, rr_typ fr, rr_typ r)
+                pure @@ (checked_stmts, rr_typ fr, rr_typ rr)
               in
               let typed_f = add_type_to_ident f f_type in
               let typed_r = add_type_to_ident r r_type in
@@ -725,7 +725,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
                     let typed_v = rr_typ v_resolv in
                     let%bind () =
                       fromR_TE
-                      @@ assert_type_assignable v_type typed_v.tp
+                      @@ assert_type_assignable ~expected:v_type ~actual:typed_v.tp
                            ~lc:(ER.get_loc (get_rep v))
                     in
                     let typed_v' = add_type_to_ident v typed_v in
@@ -839,7 +839,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
             let expected = list_typ msg_typ in
             let%bind () =
               fromR_TE
-              @@ assert_type_assignable expected i_type.tp
+              @@ assert_type_assignable ~expected ~actual:i_type.tp
                    ~lc:(ER.get_loc (get_rep i))
             in
             let typed_i = add_type_to_ident i i_type in
@@ -857,7 +857,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
             let i_type = rr_typ r in
             let%bind () =
               fromR_TE
-              @@ assert_type_assignable event_typ i_type.tp
+              @@ assert_type_assignable ~expected:event_typ ~actual:i_type.tp
                    ~lc:(ER.get_loc (get_rep i))
             in
             let typed_i = add_type_to_ident i i_type in
@@ -898,7 +898,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
                 let%bind () =
                   fromR_TE
                   (* The procedure accepts an element of l. *)
-                  @@ assert_type_assignable (list_typ arg_typ) l_type.tp
+                  @@ assert_type_assignable ~expected:(list_typ arg_typ) ~actual:l_type.tp
                        ~lc:(ER.get_loc (get_rep l))
                 in
                 let%bind checked_stmts = type_stmts sts get_loc env in
@@ -925,7 +925,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
                 let i_type = rr_typ r in
                 let%bind () =
                   fromR_TE
-                  @@ assert_type_assignable exception_typ i_type.tp
+                  @@ assert_type_assignable ~expected:exception_typ ~actual:i_type.tp
                        ~lc:(ER.get_loc (get_rep i))
                 in
                 let typed_i = add_type_to_ident i i_type in
@@ -1016,13 +1016,13 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
                    Dynamic typecheck ensures that the byte string
                    refers to an address with the correct shape. *)
                 assert_type_assignable
-                  (bystrx_typ Type.address_length)
-                  actual
+                  ~expected:(bystrx_typ Type.address_length)
+                  ~actual
                   ~lc:(ER.get_loc (get_rep fn))
             | _ ->
                 (* Non-address field.
                    Initialiser must be assignable to field type. *)
-                assert_type_assignable ft actual ~lc:(ER.get_loc (get_rep fn))
+                assert_type_assignable ~expected:ft ~actual ~lc:(ER.get_loc (get_rep fn))
           in
           let typed_fs = add_type_to_ident fn ar in
           if is_legal_field_type ft then
@@ -1062,7 +1062,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
           let%bind ((_, (ar, _)) as typed_body) = type_expr body env0 in
           let%bind () =
             match topt with
-            | Some tannot -> fromR_TE @@ assert_type_assignable tannot ar.tp
+            | Some tannot -> fromR_TE @@ assert_type_assignable ~expected:tannot ~actual:ar.tp ~lc:(ER.get_loc (snd body))
             | None -> pure ()
           in
           let typed_rn = add_type_to_ident rn ar in
@@ -1138,7 +1138,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
                     match ltopt with
                     | Some tannot -> (
                         match
-                          assert_type_assignable tannot tr.tp
+                          assert_type_assignable ~expected:tannot ~actual:tr.tp
                             ~lc:(ER.get_loc (get_rep ln))
                         with
                         | Ok () -> Ok (thunk ())
@@ -1315,8 +1315,8 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
              type_expr cconstraint tenv0 init_gas_kont remaining_gas
            in
            match
-             assert_type_assignable Datatypes.DataTypeDictionary.bool_typ
-               ityp.tp ~lc:(ER.get_loc rep)
+             assert_type_assignable ~expected:Datatypes.DataTypeDictionary.bool_typ
+               ~actual:ityp.tp ~lc:(ER.get_loc rep)
            with
            | Ok () -> pure (checked_constraint, remaining_gas)
            | Error e -> Error ((TypeError, e), remaining_gas)

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -341,7 +341,8 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
           | Some tannot ->
               let%bind () =
                 fromR_TE
-                @@ assert_type_assignable ~lc:(ER.get_loc rep) ~expected:tannot ~actual:ityp.tp
+                @@ assert_type_assignable ~lc:(ER.get_loc rep) ~expected:tannot
+                     ~actual:ityp.tp
               in
               pure (mk_qual_tp tannot)
           | None -> pure ityp
@@ -419,7 +420,9 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
           with_extended_env tenv Fn.id [ (f, t) ] [] (type_expr body)
         in
         let%bind () =
-          fromR_TE @@ assert_type_assignable ~lc:(ER.get_loc rep) ~expected:t ~actual:bt.tp
+          fromR_TE
+          @@ assert_type_assignable ~lc:(ER.get_loc rep) ~expected:t
+               ~actual:bt.tp
         in
         pure
         @@ ( TypedSyntax.Fixpoint
@@ -467,7 +470,8 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
               List.Assoc.find CU.msg_mandatory_field_types fld
                 ~equal:String.( = )
             with
-            | Some fld_t when not @@ type_assignable ~expected:fld_t ~actual:seen_type ->
+            | Some fld_t
+              when not @@ type_assignable ~expected:fld_t ~actual:seen_type ->
                 fail
                   (mk_type_error1
                      (sprintf
@@ -686,7 +690,9 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
                 in
                 let%bind () =
                   fromR_TE
-                  @@ assert_type_assignable ~expected:(rr_typ fr).tp ~actual:(rr_typ rr).tp ~lc:(ER.get_loc (get_rep r))
+                  @@ assert_type_assignable ~expected:(rr_typ fr).tp
+                       ~actual:(rr_typ rr).tp
+                       ~lc:(ER.get_loc (get_rep r))
                 in
                 let%bind checked_stmts = type_stmts sts get_loc env in
                 pure @@ (checked_stmts, rr_typ fr, rr_typ rr)
@@ -725,7 +731,8 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
                     let typed_v = rr_typ v_resolv in
                     let%bind () =
                       fromR_TE
-                      @@ assert_type_assignable ~expected:v_type ~actual:typed_v.tp
+                      @@ assert_type_assignable ~expected:v_type
+                           ~actual:typed_v.tp
                            ~lc:(ER.get_loc (get_rep v))
                     in
                     let typed_v' = add_type_to_ident v typed_v in
@@ -898,7 +905,8 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
                 let%bind () =
                   fromR_TE
                   (* The procedure accepts an element of l. *)
-                  @@ assert_type_assignable ~expected:(list_typ arg_typ) ~actual:l_type.tp
+                  @@ assert_type_assignable ~expected:(list_typ arg_typ)
+                       ~actual:l_type.tp
                        ~lc:(ER.get_loc (get_rep l))
                 in
                 let%bind checked_stmts = type_stmts sts get_loc env in
@@ -925,7 +933,8 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
                 let i_type = rr_typ r in
                 let%bind () =
                   fromR_TE
-                  @@ assert_type_assignable ~expected:exception_typ ~actual:i_type.tp
+                  @@ assert_type_assignable ~expected:exception_typ
+                       ~actual:i_type.tp
                        ~lc:(ER.get_loc (get_rep i))
                 in
                 let typed_i = add_type_to_ident i i_type in
@@ -1022,7 +1031,8 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
             | _ ->
                 (* Non-address field.
                    Initialiser must be assignable to field type. *)
-                assert_type_assignable ~expected:ft ~actual ~lc:(ER.get_loc (get_rep fn))
+                assert_type_assignable ~expected:ft ~actual
+                  ~lc:(ER.get_loc (get_rep fn))
           in
           let typed_fs = add_type_to_ident fn ar in
           if is_legal_field_type ft then
@@ -1062,7 +1072,10 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
           let%bind ((_, (ar, _)) as typed_body) = type_expr body env0 in
           let%bind () =
             match topt with
-            | Some tannot -> fromR_TE @@ assert_type_assignable ~expected:tannot ~actual:ar.tp ~lc:(ER.get_loc (snd body))
+            | Some tannot ->
+                fromR_TE
+                @@ assert_type_assignable ~expected:tannot ~actual:ar.tp
+                     ~lc:(ER.get_loc (snd body))
             | None -> pure ()
           in
           let typed_rn = add_type_to_ident rn ar in
@@ -1315,8 +1328,9 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
              type_expr cconstraint tenv0 init_gas_kont remaining_gas
            in
            match
-             assert_type_assignable ~expected:Datatypes.DataTypeDictionary.bool_typ
-               ~actual:ityp.tp ~lc:(ER.get_loc rep)
+             assert_type_assignable
+               ~expected:Datatypes.DataTypeDictionary.bool_typ ~actual:ityp.tp
+               ~lc:(ER.get_loc rep)
            with
            | Ok () -> pure (checked_constraint, remaining_gas)
            | Error e -> Error ((TypeError, e), remaining_gas)

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -499,8 +499,9 @@ module TypeUtilities = struct
           lc
 
   let proc_type_applies ~lc formals actuals =
-    map2M formals actuals ~f:(fun expected actual -> assert_type_assignable ~expected ~actual ~lc) ~msg:(fun () ->
-        mk_error1 "Incorrect number of arguments to procedure" lc)
+    map2M formals actuals
+      ~f:(fun expected actual -> assert_type_assignable ~expected ~actual ~lc)
+      ~msg:(fun () -> mk_error1 "Incorrect number of arguments to procedure" lc)
 
   let rec elab_tfun_with_args_no_gas tf args =
     match (tf, args) with
@@ -700,7 +701,9 @@ module TypeUtilities = struct
                 else
                   let%bind kt' = is_wellformed_lit k in
                   let%bind vt' = is_wellformed_lit v in
-                  pure @@ (type_assignable ~expected:kt ~actual:kt' && type_assignable ~expected:vt ~actual:vt'))
+                  pure
+                  @@ ( type_assignable ~expected:kt ~actual:kt'
+                     && type_assignable ~expected:vt ~actual:vt' ))
               kv (pure true)
           in
           if not valid then
@@ -733,7 +736,10 @@ module TypeUtilities = struct
           let res = ADT (mk_loc_id tname, ts) in
           let%bind tmap = constr_pattern_arg_types res cname in
           let%bind arg_typs = mapM ~f:(fun l -> is_wellformed_lit l) args in
-          let args_valid = List.for_all2_exn tmap arg_typs ~f:(fun expected actual -> type_assignable ~expected ~actual) in
+          let args_valid =
+            List.for_all2_exn tmap arg_typs ~f:(fun expected actual ->
+                type_assignable ~expected ~actual)
+          in
           if not args_valid then
             fail0
             @@ sprintf "Malformed ADT %s. Arguments do not match expected types"

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -340,18 +340,18 @@ module TypeUtilities = struct
          (List.exists2_exn tlist1 tlist2 ~f:(fun t1 t2 ->
               not (type_equivalent t1 t2)))
 
-  let type_assignable_list tlist1 tlist2 =
-    List.length tlist1 = List.length tlist2
+  let type_assignable_list ~to_list ~from_list =
+    List.length to_list = List.length from_list
     && not
-         (List.exists2_exn tlist1 tlist2 ~f:(fun t1 t2 ->
-              not (type_assignable t1 t2)))
+         (List.exists2_exn to_list from_list ~f:(fun expected actual ->
+              not (type_assignable ~expected ~actual)))
 
-  let assert_type_assignable ?(lc = dummy_loc) expected given =
-    if type_assignable expected given then pure ()
+  let assert_type_assignable ?(lc = dummy_loc) ~expected ~actual =
+    if type_assignable ~expected ~actual then pure ()
     else
       fail1
         (sprintf "Type unassignable: %s expected, but %s provided."
-           (pp_typ expected) (pp_typ given))
+           (pp_typ expected) (pp_typ actual))
         lc
 
   let rec is_ground_type t =
@@ -483,7 +483,7 @@ module TypeUtilities = struct
   let rec fun_type_applies ?(lc = dummy_loc) ft argtypes =
     match (ft, argtypes) with
     | FunType (argt, rest), a :: ats ->
-        let%bind () = assert_type_assignable argt a ~lc in
+        let%bind () = assert_type_assignable ~expected:argt ~actual:a ~lc in
         fun_type_applies ~lc rest ats
     | FunType (Unit, rest), [] -> pure rest
     | t, [] -> pure t
@@ -499,7 +499,7 @@ module TypeUtilities = struct
           lc
 
   let proc_type_applies ~lc formals actuals =
-    map2M formals actuals ~f:(assert_type_assignable ~lc) ~msg:(fun () ->
+    map2M formals actuals ~f:(fun expected actual -> assert_type_assignable ~expected ~actual ~lc) ~msg:(fun () ->
         mk_error1 "Incorrect number of arguments to procedure" lc)
 
   let rec elab_tfun_with_args_no_gas tf args =
@@ -700,7 +700,7 @@ module TypeUtilities = struct
                 else
                   let%bind kt' = is_wellformed_lit k in
                   let%bind vt' = is_wellformed_lit v in
-                  pure @@ (type_assignable kt kt' && type_assignable vt vt'))
+                  pure @@ (type_assignable ~expected:kt ~actual:kt' && type_assignable ~expected:vt ~actual:vt'))
               kv (pure true)
           in
           if not valid then
@@ -733,7 +733,7 @@ module TypeUtilities = struct
           let res = ADT (mk_loc_id tname, ts) in
           let%bind tmap = constr_pattern_arg_types res cname in
           let%bind arg_typs = mapM ~f:(fun l -> is_wellformed_lit l) args in
-          let args_valid = List.for_all2_exn tmap arg_typs ~f:type_assignable in
+          let args_valid = List.for_all2_exn tmap arg_typs ~f:(fun expected actual -> type_assignable ~expected ~actual) in
           if not args_valid then
             fail0
             @@ sprintf "Malformed ADT %s. Arguments do not match expected types"

--- a/src/base/TypeUtil.mli
+++ b/src/base/TypeUtil.mli
@@ -178,12 +178,12 @@ module TypeUtilities : sig
   val mark_error_as_type_error :
     ('a, 'b) result -> ('a, typeCheckerErrorType * 'b) result
 
-  val type_assignable_list : TUType.t list -> TUType.t list -> bool
+  val type_assignable_list : to_list:TUType.t list -> from_list:TUType.t list -> bool
 
   val assert_type_assignable :
     ?lc:ErrorUtils.loc ->
-    TUType.t ->
-    TUType.t ->
+    expected:TUType.t ->
+    actual:TUType.t ->
     (unit, scilla_error list) result
 
   (* Applying a function type *)

--- a/src/base/TypeUtil.mli
+++ b/src/base/TypeUtil.mli
@@ -178,7 +178,8 @@ module TypeUtilities : sig
   val mark_error_as_type_error :
     ('a, 'b) result -> ('a, typeCheckerErrorType * 'b) result
 
-  val type_assignable_list : to_list:TUType.t list -> from_list:TUType.t list -> bool
+  val type_assignable_list :
+    to_list:TUType.t list -> from_list:TUType.t list -> bool
 
   val assert_type_assignable :
     ?lc:ErrorUtils.loc ->

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -640,7 +640,7 @@ let init_contract clibs elibs cconstraint' cparams' cfields args' init_bal =
               let%bind at = fromR @@ literal_type (snd a) in
               if
                 [%equal: EvalName.t] (get_id ps) (fst a)
-                && type_assignable pt at
+                && type_assignable ~expected:pt ~actual:at
               then pure ()
               else fail0 "")
             cparams ~msg:emsg

--- a/tests/typecheck/good/Good.ml
+++ b/tests/typecheck/good/Good.ml
@@ -49,7 +49,7 @@ let make_type_assignable_equiv_test st1 st2 eq f_name f =
 
 let make_type_assignable_test st1 st2 eq =
   make_type_assignable_equiv_test st1 st2 eq "type_assignable"
-    TestTypeType.type_assignable
+    (fun expected actual -> TestTypeType.type_assignable ~expected ~actual)
 
 let make_all_type_assignable_tests tlist =
   List.map tlist ~f:(fun (st1, st2, eq) -> make_type_assignable_test st1 st2 eq)


### PR DESCRIPTION
`type_assignable`, `assert_type_assignable` and `assignable_list` have been given named parameters, because it's otherwise unclear whether the first or the second type is the to-type, and which is the from-type.

`address_typ` has been added as a convenience measure to construct address type nodes.