### PR TITLE
Update after cryptoutils dep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ clean:
 
 # Clean up libff installation
 cleanall: clean
-	rm -rf deps/cryptoutils/{build,install} deps/schnorr/{build,install} deps/cryptoutils/src/deps/libff/{build,install}
+	rm -rf deps/cryptoutils/{build,install} deps/schnorr/{build,install}
 
 # Build a standalone scilla docker
 docker:

--- a/scripts/cryptoutils.sh
+++ b/scripts/cryptoutils.sh
@@ -41,13 +41,9 @@ cd $libCryptoUtilsdir || exit
 mkdir -p build install
 cd src || exit
 
-# Build its dependences
-echo "Building deps of libCryptoUtils"
-./build_libff.sh
-
 echo "Installing libCryptoUtils into ${libCryptoUtilsdir}/install"
 cd ../build || exit
-if ! cmake ../src -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_POSITION_INDEPENDENT_CODE=1 -DCRYPTOUTILS_BUILD_ARCHIVE=1
+if ! cmake ../src -DCMAKE_INSTALL_PREFIX=../install -DWITH_PROCPS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=1 -DCRYPTOUTILS_BUILD_ARCHIVE=1
 then
     echo "libCryptoUtils: CMake configuration failed"
     exit 1

--- a/scripts/cryptoutils.sh
+++ b/scripts/cryptoutils.sh
@@ -43,7 +43,7 @@ cd src || exit
 
 echo "Installing libCryptoUtils into ${libCryptoUtilsdir}/install"
 cd ../build || exit
-if ! cmake ../src -DCMAKE_INSTALL_PREFIX=../install -DWITH_PROCPS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=1 -DCRYPTOUTILS_BUILD_ARCHIVE=1
+if ! cmake ../src -DCMAKE_INSTALL_PREFIX=../install -DCRYPTOUTILS_BUILD_ARCHIVE=1
 then
     echo "libCryptoUtils: CMake configuration failed"
     exit 1

--- a/src/base/cpp/dune
+++ b/src/base/cpp/dune
@@ -18,7 +18,7 @@
     %{project_root}/deps/schnorr/install/include))
  ; foreign_archives does not support %{vars} hence the relative path to deps/
  (foreign_archives ../../../deps/cryptoutils/install/lib/CryptoUtils
-   ../../../deps/cryptoutils/src/deps/libff/install/lib/ff
+   ../../../deps/cryptoutils/install/lib/ff
    ../../../deps/schnorr/install/lib/Schnorr)
  (c_library_flags
   -lstdc++


### PR DESCRIPTION
After https://github.com/Zilliqa/cryptoutils/commit/5467f141ff87b1e90f7d1ef3f62c96694c6cd016, cryptoutils doesn't require a separate build script to build it's `libff` dependence. `libff` builds along with the main CMake build. 

Update Scilla accordingly.