### PR TITLE
Remove support for tzil bech32 address

### DIFF
--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -981,8 +981,8 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let bech32_to_bystr20 ls _ =
       match ls with
       | [ StringLit prfx; StringLit addr ] -> (
-          if Core_kernel.String.(prfx <> "zil" && prfx <> "tzil") then
-            fail0 "Only zil and tzil bech32 addresses are supported"
+          if Core_kernel.String.(prfx <> "zil") then
+            fail0 "Only zil bech32 addresses are supported"
           else
             match Bech32.decode_bech32_addr ~prfx ~addr with
             | Some bys20 -> (

--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -1001,8 +1001,8 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let bystr20_to_bech32 ls _ =
       match ls with
       | [ StringLit prfx; ByStrX addr ] -> (
-          if Core_kernel.String.(prfx <> "zil" && prfx <> "tzil") then
-            fail0 "Only zil and tzil bech32 addresses are supported"
+          if Core_kernel.String.(prfx <> "zil") then
+            fail0 "Only zil bech32 addresses are supported"
           else
             match
               Bech32.encode_bech32_addr ~prfx ~addr:(Bystrx.to_raw_bytes addr)

--- a/tests/eval/bad/gold/builtin-bech32-1.scilexp.gold
+++ b/tests/eval/bad/gold/builtin-bech32-1.scilexp.gold
@@ -2,7 +2,7 @@
   "gas_remaining": "4000987",
   "errors": [
     {
-      "error_message": "Only zil and tzil bech32 addresses are supported",
+      "error_message": "Only zil bech32 addresses are supported",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/eval/bad/gold/builtin-bech32-2.scilexp.gold
+++ b/tests/eval/bad/gold/builtin-bech32-2.scilexp.gold
@@ -2,7 +2,7 @@
   "gas_remaining": "4001075",
   "errors": [
     {
-      "error_message": "Only zil and tzil bech32 addresses are supported",
+      "error_message": "Only zil bech32 addresses are supported",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }


### PR DESCRIPTION
The spec has been updated to use `zil` prefix for testnet addresses too. So allow only that.

https://github.com/Zilliqa/Zilliqa/wiki/Address-Standard#specification