### PR TITLE
Type args for builtins

### DIFF
--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -142,7 +142,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let strlen_type = tfun_typ "'A" (fun_typ (tvar "'A") uint32_typ)
 
     let strlen_elab _ targs ts =
-      match targs, ts with
+      match (targs, ts) with
       | [], [ PrimType pt ] -> (
           match pt with
           | String_typ | Bystr_typ -> elab_tfun_with_args_no_gas strlen_type ts
@@ -162,7 +162,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let to_string_type = tfun_typ "'A" (fun_typ (tvar "'A") string_typ)
 
     let to_string_elab _ targs ts =
-      match targs, ts with
+      match (targs, ts) with
       | [], [ PrimType pt ] -> (
           match pt with
           | Int_typ _ | Uint_typ _ | Bystrx_typ _ | Bystr_typ ->
@@ -186,7 +186,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let to_ascii_type = tfun_typ "'A" (fun_typ (tvar "'A") string_typ)
 
     let to_ascii_elab _ targs ts =
-      match targs, ts with
+      match (targs, ts) with
       | [], [ PrimType pt ] -> (
           match pt with
           | Bystrx_typ _ | Bystr_typ ->
@@ -209,7 +209,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let strrev_type = tfun_typ "'A" (fun_typ (tvar "'A") (tvar "'A"))
 
     let strrev_elab _ targs ts =
-      match targs, ts with
+      match (targs, ts) with
       | [], [ PrimType pt ] -> (
           match pt with
           | String_typ | Bystrx_typ _ | Bystr_typ ->
@@ -249,7 +249,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       tfun_typ "'A" (fun_typ (tvar "'A") @@ fun_typ (tvar "'A") bool_typ)
 
     let eq_elab t targs ts =
-      match targs, ts with
+      match (targs, ts) with
       | [], [ i1; i2 ] when [%equal: BIType.t] i1 i2 && is_int_type i1 ->
           elab_tfun_with_args_no_gas t [ i1 ]
       | _, _ -> fail0 "Failed to elaborate"
@@ -260,7 +260,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       tfun_typ "'A" (fun_typ (tvar "'A") @@ fun_typ (tvar "'A") (tvar "'A"))
 
     let binop_elab t targs ts =
-      match targs, ts with
+      match (targs, ts) with
       | [], [ i1; i2 ] when [%equal: BIType.t] i1 i2 && is_int_type i1 ->
           elab_tfun_with_args_no_gas t [ i1 ]
       | _, _ -> fail0 "Failed to elaborate"
@@ -366,8 +366,9 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       tfun_typ "'A" (fun_typ (tvar "'A") @@ fun_typ uint32_typ (tvar "'A"))
 
     let pow_elab t targs ts =
-      match targs, ts with
-      | [], [ i1; i2 ] when is_int_type i1 && [%equal: BIType.t] i2 uint32_typ ->
+      match (targs, ts) with
+      | [], [ i1; i2 ] when is_int_type i1 && [%equal: BIType.t] i2 uint32_typ
+        ->
           elab_tfun_with_args_no_gas t [ i1 ]
       | _, _ -> fail0 "Failed to elaborate"
 
@@ -411,7 +412,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       @@ tfun_typ "'B" (fun_typ (tvar "'A") (option_typ (tvar "'B")))
 
     let to_int_elab w sc targs ts =
-      match targs, ts with
+      match (targs, ts) with
       | [], [ (PrimType (Int_typ _) as t) ]
       | [], [ (PrimType (Uint_typ _) as t) ]
       | [], [ (PrimType String_typ as t) ] ->
@@ -452,7 +453,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       tfun_typ "'A" (fun_typ (tvar "'A") @@ fun_typ (tvar "'A") bool_typ)
 
     let eq_elab sc targs ts =
-      match targs, ts with
+      match (targs, ts) with
       | [], [ i1; i2 ] when [%equal: BIType.t] i1 i2 && is_uint_type i1 ->
           elab_tfun_with_args_no_gas sc [ i1 ]
       | _, _ -> fail0 "Failed to elaborate"
@@ -463,7 +464,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       tfun_typ "'A" (fun_typ (tvar "'A") @@ fun_typ (tvar "'A") (tvar "'A"))
 
     let binop_elab sc targs ts =
-      match targs, ts with
+      match (targs, ts) with
       | [], [ i1; i2 ] when [%equal: BIType.t] i1 i2 && is_uint_type i1 ->
           elab_tfun_with_args_no_gas sc [ i1 ]
       | _, _ -> fail0 "Failed to elaborate"
@@ -571,8 +572,9 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       tfun_typ "'A" (fun_typ (tvar "'A") @@ fun_typ uint32_typ (tvar "'A"))
 
     let pow_elab t targs ts =
-      match targs, ts with
-      | [], [ i1; i2 ] when is_uint_type i1 && [%equal: BIType.t] i2 uint32_typ ->
+      match (targs, ts) with
+      | [], [ i1; i2 ] when is_uint_type i1 && [%equal: BIType.t] i2 uint32_typ
+        ->
           elab_tfun_with_args_no_gas t [ i1 ]
       | _, _ -> fail0 "Failed to elaborate"
 
@@ -599,7 +601,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let isqrt_type = tfun_typ "'A" (fun_typ (tvar "'A") (tvar "'A"))
 
     let isqrt_elab t targs ts =
-      match targs, ts with
+      match (targs, ts) with
       | [], [ i ] when is_uint_type i -> elab_tfun_with_args_no_gas t [ i ]
       | _, _ -> fail0 "Failed to elaborate"
 
@@ -639,7 +641,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       @@ tfun_typ "'B" (fun_typ (tvar "'A") (option_typ (tvar "'B")))
 
     let to_uint_elab w sc targs ts =
-      match targs, ts with
+      match (targs, ts) with
       | [], [ (PrimType (Int_typ _) as t) ]
       | [], [ (PrimType (Uint_typ _) as t) ]
       | [], [ (PrimType String_typ as t) ] ->
@@ -692,8 +694,9 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let to_bystrx_elab x sc targs ts =
       let open Type.PrimType in
-      match targs, ts with
-      | [], [ (PrimType (Uint_typ w) as t) ] when int_bit_width_to_int w / 8 = x ->
+      match (targs, ts) with
+      | [], [ (PrimType (Uint_typ w) as t) ] when int_bit_width_to_int w / 8 = x
+        ->
           elab_tfun_with_args_no_gas sc
             [ t; PrimType (Bystrx_typ (int_bit_width_to_int w / 8)) ]
       | _, _ -> fail0 "Failed to elaborate"
@@ -748,7 +751,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     (* Elaborator to run with arbitrary uints *)
     let badd_elab sc targs ts =
-      match targs, ts with
+      match (targs, ts) with
       | [], [ PrimType Bnum_typ; PrimType (Uint_typ _) ] ->
           elab_tfun_with_args_no_gas sc ts
       | _, _ -> fail0 "Failed to elaborate"
@@ -775,7 +778,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     (* Elaborator to run with arbitrary uints *)
     let bsub_elab sc targs ts =
-      match targs, ts with
+      match (targs, ts) with
       | [], [ PrimType Bnum_typ; PrimType Bnum_typ ] ->
           elab_tfun_with_args_no_gas sc ts
       | _, _ -> fail0 "Failed to elaborate"
@@ -861,7 +864,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let eq_arity = 2
 
     let eq_elab sc targs ts =
-      match targs, ts with
+      match (targs, ts) with
       | [], [ bstyp1; bstyp2 ]
         when (* We want both types to be ByStr with equal width. *)
              is_bystrx_type bstyp1 && [%equal: BIType.t] bstyp1 bstyp2 ->
@@ -883,11 +886,12 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let hash_arity = 1
 
     let hash_elab sc targs ts =
-      match targs, ts with
+      match (targs, ts) with
       | [], [ _ ] -> elab_tfun_with_args_no_gas sc ts
       | _, _ -> fail0 "Failed to elaborate"
 
-    let sha256hash _ ls _ = hash_helper sha256_hasher "sha256hash" hash_length ls
+    let sha256hash _ ls _ =
+      hash_helper sha256_hasher "sha256hash" hash_length ls
 
     let keccak256hash _ ls _ =
       hash_helper keccak256_hasher "keccak256hash" hash_length ls
@@ -918,7 +922,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let to_bystr_arity = 1
 
     let to_bystr_elab sc targs ts =
-      match targs, ts with
+      match (targs, ts) with
       | [], [ t ] when is_bystrx_type t -> elab_tfun_with_args_no_gas sc ts
       | _, _ -> fail0 "Failed to elaborate"
 
@@ -948,7 +952,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let to_uint_elab x sc targs ts =
       let open Type.PrimType in
-      match targs, ts with
+      match (targs, ts) with
       | [], [ PrimType (Bystrx_typ w) ] when w <= int_bit_width_to_int x / 8 ->
           elab_tfun_with_args_no_gas sc ts
       | _, _ -> fail0 "Failed to elaborate"
@@ -1019,7 +1023,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let concat_arity = 2
 
     let concat_elab sc targs ts =
-      match targs, ts with
+      match (targs, ts) with
       | [], [ PrimType (Bystrx_typ w1); PrimType (Bystrx_typ w2) ] ->
           elab_tfun_with_args_no_gas sc (ts @ [ bystrx_typ (w1 + w2) ])
       | [], [ PrimType Bystr_typ; PrimType Bystr_typ ] ->
@@ -1283,7 +1287,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       @@ fun_typ (tvar "'K") bool_typ
 
     let contains_elab sc targs ts =
-      match targs, ts with
+      match (targs, ts) with
       | [], [ MapType (kt, vt); u ] when [%equal: BIType.t] kt u ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _, _ -> fail0 "Failed to elaborate"
@@ -1304,7 +1308,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       @@ fun_typ (tvar "'V") (map_typ (tvar "'K") (tvar "'V"))
 
     let put_elab sc targs ts =
-      match targs, ts with
+      match (targs, ts) with
       | [], [ MapType (kt, vt); kt'; vt' ]
         when [%equal: BIType.t] kt kt' && [%equal: BIType.t] vt vt' ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
@@ -1328,7 +1332,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       @@ fun_typ (tvar "'K") (option_typ (tvar "'V"))
 
     let get_elab sc targs ts =
-      match targs, ts with
+      match (targs, ts) with
       | [], [ MapType (kt, vt); kt' ] when [%equal: BIType.t] kt kt' ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _, _ -> fail0 "Failed to elaborate"
@@ -1350,7 +1354,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       @@ fun_typ (tvar "'K") (map_typ (tvar "'K") (tvar "'V"))
 
     let remove_elab sc targs ts =
-      match targs, ts with
+      match (targs, ts) with
       | [], [ MapType (kt, vt); u ] when [%equal: BIType.t] kt u ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _, _ -> fail0 "Failed to elaborate"
@@ -1372,7 +1376,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       @@ list_typ (pair_typ (tvar "'K") (tvar "'V"))
 
     let to_list_elab sc targs ts =
-      match targs, ts with
+      match (targs, ts) with
       | [], [ MapType (kt, vt) ] -> elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _, _ -> fail0 "Failed to elaborate"
 
@@ -1401,7 +1405,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       @@ uint32_typ
 
     let size_elab sc targs ts =
-      match targs, ts with
+      match (targs, ts) with
       | [], [ MapType (kt, vt) ] -> elab_tfun_with_args_no_gas sc [ kt; vt ]
       | _, _ -> fail0 "Failed to elaborate"
 
@@ -1424,16 +1428,22 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
   module BuiltInDictionary = struct
     (* Elaborates the operation type based on the arguments types *)
     type elaborator =
-      BIType.t ->      (* builtin type *)
-      BIType.t list -> (* type arguments *)
-      BIType.t list -> (* types of value arguments *)
+      BIType.t ->
+      (* builtin type *)
+      BIType.t list ->
+      (* type arguments *)
+      BIType.t list ->
+      (* types of value arguments *)
       (BIType.t, scilla_error list) result
 
     (* Takes the expected type as an argument to elaborate the result *)
     type built_in_executor =
-      BIType.t list ->    (* type arguments *)
-      BILiteral.t list -> (* value arguments *)
-      BIType.t ->         (* result type *)
+      BIType.t list ->
+      (* type arguments *)
+      BILiteral.t list ->
+      (* value arguments *)
+      BIType.t ->
+      (* result type *)
       (BILiteral.t, scilla_error list) result
 
     (* A built-in record type:
@@ -1564,7 +1574,8 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
                  "Type error: cannot apply \"%s\" built-in to argument(s) of \
                   type(s) %s%s."
                  (pp_builtin op)
-                 (if List.is_empty targtypes then "" else sprintf "{%s} " (pp_typ_list_error targtypes))
+                 ( if List.is_empty targtypes then ""
+                 else sprintf "{%s} " (pp_typ_list_error targtypes) )
                  (pp_typ_list_error vargtypes))
               (ER.get_loc rep))
       in

--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -107,7 +107,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let eq_type = fun_typ string_typ @@ fun_typ string_typ bool_typ
 
-    let eq ls _ =
+    let eq _ ls _ =
       match ls with
       | [ StringLit x; StringLit y ] -> pure @@ build_bool_lit String.(x = y)
       | _ -> builtin_fail "String.eq" ls
@@ -116,7 +116,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let concat_type = fun_typ string_typ @@ fun_typ string_typ string_typ
 
-    let concat ls _ =
+    let concat _ ls _ =
       match ls with
       | [ StringLit x; StringLit y ] -> pure @@ StringLit (x ^ y)
       | _ -> builtin_fail "String.concat" ls
@@ -126,7 +126,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let substr_type =
       fun_typ string_typ @@ fun_typ uint32_typ @@ fun_typ uint32_typ string_typ
 
-    let substr ls _ =
+    let substr _ ls _ =
       match ls with
       | [ StringLit x; UintLit (Uint32L s); UintLit (Uint32L e) ] -> (
           try
@@ -141,15 +141,15 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let strlen_type = tfun_typ "'A" (fun_typ (tvar "'A") uint32_typ)
 
-    let strlen_elab _ ts =
-      match ts with
-      | [ PrimType pt ] -> (
+    let strlen_elab _ targs ts =
+      match targs, ts with
+      | [], [ PrimType pt ] -> (
           match pt with
           | String_typ | Bystr_typ -> elab_tfun_with_args_no_gas strlen_type ts
           | _ -> fail0 "Failed to elaborate" )
-      | _ -> fail0 "Failed to elaborate"
+      | _, _ -> fail0 "Failed to elaborate"
 
-    let strlen ls _ =
+    let strlen _ ls _ =
       match ls with
       | [ StringLit x ] ->
           pure @@ UintLit (Uint32L (Uint32.of_int (String.length x)))
@@ -161,16 +161,16 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let to_string_type = tfun_typ "'A" (fun_typ (tvar "'A") string_typ)
 
-    let to_string_elab _ ts =
-      match ts with
-      | [ PrimType pt ] -> (
+    let to_string_elab _ targs ts =
+      match targs, ts with
+      | [], [ PrimType pt ] -> (
           match pt with
           | Int_typ _ | Uint_typ _ | Bystrx_typ _ | Bystr_typ ->
               elab_tfun_with_args_no_gas to_string_type ts
           | _ -> fail0 "Failed to elaborate" )
-      | _ -> fail0 "Failed to elaborate"
+      | _, _ -> fail0 "Failed to elaborate"
 
-    let to_string ls _ =
+    let to_string _ ls _ =
       let%bind s =
         match ls with
         | [ IntLit x ] -> pure @@ string_of_int_lit x
@@ -185,16 +185,16 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let to_ascii_type = tfun_typ "'A" (fun_typ (tvar "'A") string_typ)
 
-    let to_ascii_elab _ ts =
-      match ts with
-      | [ PrimType pt ] -> (
+    let to_ascii_elab _ targs ts =
+      match targs, ts with
+      | [], [ PrimType pt ] -> (
           match pt with
           | Bystrx_typ _ | Bystr_typ ->
               elab_tfun_with_args_no_gas to_ascii_type ts
           | _ -> fail0 "Failed to elaborate" )
-      | _ -> fail0 "Failed to elaborate"
+      | _, _ -> fail0 "Failed to elaborate"
 
-    let to_ascii ls _ =
+    let to_ascii _ ls _ =
       let%bind s =
         match ls with
         | [ ByStr x ] -> pure @@ Bystr.to_raw_bytes x
@@ -208,16 +208,16 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let strrev_type = tfun_typ "'A" (fun_typ (tvar "'A") (tvar "'A"))
 
-    let strrev_elab _ ts =
-      match ts with
-      | [ PrimType pt ] -> (
+    let strrev_elab _ targs ts =
+      match targs, ts with
+      | [], [ PrimType pt ] -> (
           match pt with
           | String_typ | Bystrx_typ _ | Bystr_typ ->
               elab_tfun_with_args_no_gas strrev_type ts
           | _ -> fail0 "Failed to elaborate" )
-      | _ -> fail0 "Failed to elaborate"
+      | _, _ -> fail0 "Failed to elaborate"
 
-    let strrev ls _ =
+    let strrev _ ls _ =
       match ls with
       | [ StringLit x ] -> pure @@ StringLit (String.rev x)
       | [ ByStr x ] -> pure @@ ByStr (Bystr.rev x)
@@ -248,29 +248,29 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let eq_type =
       tfun_typ "'A" (fun_typ (tvar "'A") @@ fun_typ (tvar "'A") bool_typ)
 
-    let eq_elab t ts =
-      match ts with
-      | [ i1; i2 ] when [%equal: BIType.t] i1 i2 && is_int_type i1 ->
+    let eq_elab t targs ts =
+      match targs, ts with
+      | [], [ i1; i2 ] when [%equal: BIType.t] i1 i2 && is_int_type i1 ->
           elab_tfun_with_args_no_gas t [ i1 ]
-      | _ -> fail0 "Failed to elaborate"
+      | _, _ -> fail0 "Failed to elaborate"
 
     let binop_arity = 2
 
     let binop_type =
       tfun_typ "'A" (fun_typ (tvar "'A") @@ fun_typ (tvar "'A") (tvar "'A"))
 
-    let binop_elab t ts =
-      match ts with
-      | [ i1; i2 ] when [%equal: BIType.t] i1 i2 && is_int_type i1 ->
+    let binop_elab t targs ts =
+      match targs, ts with
+      | [], [ i1; i2 ] when [%equal: BIType.t] i1 i2 && is_int_type i1 ->
           elab_tfun_with_args_no_gas t [ i1 ]
-      | _ -> fail0 "Failed to elaborate"
+      | _, _ -> fail0 "Failed to elaborate"
 
-    let eq ls _ =
+    let eq _ ls _ =
       match ls with
       | [ IntLit x; IntLit y ] -> pure @@ build_bool_lit ([%equal: int_lit] x y)
       | _ -> builtin_fail "Int.eq: unsupported types" ls
 
-    let add ls _ =
+    let add _ ls _ =
       try
         let%bind l =
           match ls with
@@ -288,7 +288,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       with IntOverflow | IntUnderflow ->
         builtin_fail "Int.add: an overflow/underflow occurred" ls
 
-    let sub ls _ =
+    let sub _ ls _ =
       try
         let%bind l =
           match ls with
@@ -306,7 +306,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       with IntOverflow | IntUnderflow ->
         builtin_fail "Int.sub: an overflow/underflow occurred" ls
 
-    let mul ls _ =
+    let mul _ ls _ =
       try
         let%bind l =
           match ls with
@@ -324,7 +324,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       with IntOverflow | IntUnderflow ->
         builtin_fail "Int.mul: an overflow/underflow occurred" ls
 
-    let div ls _ =
+    let div _ ls _ =
       try
         let%bind l =
           match ls with
@@ -342,7 +342,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       with Division_by_zero | IntOverflow ->
         builtin_fail "Int.div: Division by zero / IntOverflow error occurred" ls
 
-    let rem ls _ =
+    let rem _ ls _ =
       try
         let%bind l =
           match ls with
@@ -365,13 +365,13 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let pow_type =
       tfun_typ "'A" (fun_typ (tvar "'A") @@ fun_typ uint32_typ (tvar "'A"))
 
-    let pow_elab t ts =
-      match ts with
-      | [ i1; i2 ] when is_int_type i1 && [%equal: BIType.t] i2 uint32_typ ->
+    let pow_elab t targs ts =
+      match targs, ts with
+      | [], [ i1; i2 ] when is_int_type i1 && [%equal: BIType.t] i2 uint32_typ ->
           elab_tfun_with_args_no_gas t [ i1 ]
-      | _ -> fail0 "Failed to elaborate"
+      | _, _ -> fail0 "Failed to elaborate"
 
-    let pow ls _ =
+    let pow _ ls _ =
       try
         let%bind l =
           match ls with
@@ -389,7 +389,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       with IntOverflow | IntUnderflow ->
         builtin_fail "Int.pow: an overflow/underflow occurred" ls
 
-    let lt ls _ =
+    let lt _ ls _ =
       try
         match ls with
         | [ IntLit (Int32L x); IntLit (Int32L y) ] ->
@@ -410,14 +410,14 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       tfun_typ "'A"
       @@ tfun_typ "'B" (fun_typ (tvar "'A") (option_typ (tvar "'B")))
 
-    let to_int_elab w sc ts =
-      match ts with
-      | [ (PrimType (Int_typ _) as t) ]
-      | [ (PrimType (Uint_typ _) as t) ]
-      | [ (PrimType String_typ as t) ] ->
+    let to_int_elab w sc targs ts =
+      match targs, ts with
+      | [], [ (PrimType (Int_typ _) as t) ]
+      | [], [ (PrimType (Uint_typ _) as t) ]
+      | [], [ (PrimType String_typ as t) ] ->
           let ityp = PrimType (Int_typ w) in
           elab_tfun_with_args_no_gas sc [ t; ityp ]
-      | _ -> fail0 "Failed to elaborate"
+      | _, _ -> fail0 "Failed to elaborate"
 
     let to_int_helper ls w =
       let open Type.PrimType in
@@ -433,13 +433,13 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       | Some lit -> pure @@ build_some_lit lit (PrimType iptyp)
       | None -> pure @@ build_none_lit (PrimType iptyp)
 
-    let to_int32 ls _ = to_int_helper ls Bits32
+    let to_int32 _ ls _ = to_int_helper ls Bits32
 
-    let to_int64 ls _ = to_int_helper ls Bits64
+    let to_int64 _ ls _ = to_int_helper ls Bits64
 
-    let to_int128 ls _ = to_int_helper ls Bits128
+    let to_int128 _ ls _ = to_int_helper ls Bits128
 
-    let to_int256 ls _ = to_int_helper ls Bits256
+    let to_int256 _ ls _ = to_int_helper ls Bits256
   end
 
   (* Unsigned integer operation *)
@@ -451,30 +451,30 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let eq_type =
       tfun_typ "'A" (fun_typ (tvar "'A") @@ fun_typ (tvar "'A") bool_typ)
 
-    let eq_elab sc ts =
-      match ts with
-      | [ i1; i2 ] when [%equal: BIType.t] i1 i2 && is_uint_type i1 ->
+    let eq_elab sc targs ts =
+      match targs, ts with
+      | [], [ i1; i2 ] when [%equal: BIType.t] i1 i2 && is_uint_type i1 ->
           elab_tfun_with_args_no_gas sc [ i1 ]
-      | _ -> fail0 "Failed to elaborate"
+      | _, _ -> fail0 "Failed to elaborate"
 
     let binop_arity = 2
 
     let binop_type =
       tfun_typ "'A" (fun_typ (tvar "'A") @@ fun_typ (tvar "'A") (tvar "'A"))
 
-    let binop_elab sc ts =
-      match ts with
-      | [ i1; i2 ] when [%equal: BIType.t] i1 i2 && is_uint_type i1 ->
+    let binop_elab sc targs ts =
+      match targs, ts with
+      | [], [ i1; i2 ] when [%equal: BIType.t] i1 i2 && is_uint_type i1 ->
           elab_tfun_with_args_no_gas sc [ i1 ]
-      | _ -> fail0 "Failed to elaborate"
+      | _, _ -> fail0 "Failed to elaborate"
 
-    let eq ls _ =
+    let eq _ ls _ =
       match ls with
       | [ UintLit x; UintLit y ] ->
           pure @@ build_bool_lit ([%equal: uint_lit] x y)
       | _ -> builtin_fail "Uint.eq: unsupported types" ls
 
-    let add ls _ =
+    let add _ ls _ =
       try
         let%bind l =
           match ls with
@@ -492,7 +492,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       with IntOverflow | IntUnderflow ->
         builtin_fail "Uint.add: an overflow/underflow occurred" ls
 
-    let sub ls _ =
+    let sub _ ls _ =
       try
         let%bind l =
           match ls with
@@ -510,7 +510,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       with IntOverflow | IntUnderflow ->
         builtin_fail "Uint.sub: an overflow/underflow occurred" ls
 
-    let mul ls _ =
+    let mul _ ls _ =
       try
         let%bind l =
           match ls with
@@ -528,7 +528,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       with IntOverflow | IntUnderflow ->
         builtin_fail "Uint.mul: an overflow/underflow occurred" ls
 
-    let div ls _ =
+    let div _ ls _ =
       try
         let%bind l =
           match ls with
@@ -547,7 +547,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
         builtin_fail "Uint.div: Division by zero / UintOverflow error occurred"
           ls
 
-    let rem ls _ =
+    let rem _ ls _ =
       try
         let%bind l =
           match ls with
@@ -570,13 +570,13 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let pow_type =
       tfun_typ "'A" (fun_typ (tvar "'A") @@ fun_typ uint32_typ (tvar "'A"))
 
-    let pow_elab t ts =
-      match ts with
-      | [ i1; i2 ] when is_uint_type i1 && [%equal: BIType.t] i2 uint32_typ ->
+    let pow_elab t targs ts =
+      match targs, ts with
+      | [], [ i1; i2 ] when is_uint_type i1 && [%equal: BIType.t] i2 uint32_typ ->
           elab_tfun_with_args_no_gas t [ i1 ]
-      | _ -> fail0 "Failed to elaborate"
+      | _, _ -> fail0 "Failed to elaborate"
 
-    let pow ls _ =
+    let pow _ ls _ =
       try
         let%bind l =
           match ls with
@@ -598,12 +598,12 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let isqrt_type = tfun_typ "'A" (fun_typ (tvar "'A") (tvar "'A"))
 
-    let isqrt_elab t ts =
-      match ts with
-      | [ i ] when is_uint_type i -> elab_tfun_with_args_no_gas t [ i ]
-      | _ -> fail0 "Failed to elaborate"
+    let isqrt_elab t targs ts =
+      match targs, ts with
+      | [], [ i ] when is_uint_type i -> elab_tfun_with_args_no_gas t [ i ]
+      | _, _ -> fail0 "Failed to elaborate"
 
-    let isqrt ls _ =
+    let isqrt _ ls _ =
       try
         let%bind l =
           match ls with
@@ -617,7 +617,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       with IntOverflow | IntUnderflow ->
         builtin_fail "Uint.isqrt: isqrt cannot throw, impossible!" ls
 
-    let lt ls _ =
+    let lt _ ls _ =
       try
         match ls with
         | [ UintLit (Uint32L x); UintLit (Uint32L y) ] ->
@@ -638,14 +638,14 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       tfun_typ "'A"
       @@ tfun_typ "'B" (fun_typ (tvar "'A") (option_typ (tvar "'B")))
 
-    let to_uint_elab w sc ts =
-      match ts with
-      | [ (PrimType (Int_typ _) as t) ]
-      | [ (PrimType (Uint_typ _) as t) ]
-      | [ (PrimType String_typ as t) ] ->
+    let to_uint_elab w sc targs ts =
+      match targs, ts with
+      | [], [ (PrimType (Int_typ _) as t) ]
+      | [], [ (PrimType (Uint_typ _) as t) ]
+      | [], [ (PrimType String_typ as t) ] ->
           let ityp = PrimType (Uint_typ w) in
           elab_tfun_with_args_no_gas sc [ t; ityp ]
-      | _ -> fail0 "Failed to elaborate"
+      | _, _ -> fail0 "Failed to elaborate"
 
     let to_uint_helper ls w =
       let open Type.PrimType in
@@ -662,19 +662,19 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       | Some lit -> pure @@ build_some_lit lit (PrimType iptyp)
       | None -> pure @@ build_none_lit (PrimType iptyp)
 
-    let to_uint32 ls _ = to_uint_helper ls Bits32
+    let to_uint32 _ ls _ = to_uint_helper ls Bits32
 
-    let to_uint64 ls _ = to_uint_helper ls Bits64
+    let to_uint64 _ ls _ = to_uint_helper ls Bits64
 
-    let to_uint128 ls _ = to_uint_helper ls Bits128
+    let to_uint128 _ ls _ = to_uint_helper ls Bits128
 
-    let to_uint256 ls _ = to_uint_helper ls Bits256
+    let to_uint256 _ ls _ = to_uint_helper ls Bits256
 
     let to_nat_arity = 1
 
     let to_nat_type = fun_typ uint32_typ nat_typ
 
-    let to_nat ls _ =
+    let to_nat _ ls _ =
       match ls with
       | [ UintLit (Uint32L n) ] ->
           let rec nat_builder (i : Uint32.t) (acc : BILiteral.t) =
@@ -690,15 +690,15 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let to_bystrx_type =
       tfun_typ "'A" @@ tfun_typ "'B" (fun_typ (tvar "'A") (tvar "'B"))
 
-    let to_bystrx_elab x sc ts =
+    let to_bystrx_elab x sc targs ts =
       let open Type.PrimType in
-      match ts with
-      | [ (PrimType (Uint_typ w) as t) ] when int_bit_width_to_int w / 8 = x ->
+      match targs, ts with
+      | [], [ (PrimType (Uint_typ w) as t) ] when int_bit_width_to_int w / 8 = x ->
           elab_tfun_with_args_no_gas sc
             [ t; PrimType (Bystrx_typ (int_bit_width_to_int w / 8)) ]
-      | _ -> fail0 "Failed to elaborate"
+      | _, _ -> fail0 "Failed to elaborate"
 
-    let to_bystrx ls _ =
+    let to_bystrx _ ls _ =
       match ls with
       | [ UintLit nl ] -> (
           match
@@ -721,7 +721,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let eq_arity = 2
 
-    let eq ls _ =
+    let eq _ ls _ =
       match ls with
       | [ BNum x; BNum y ] -> pure @@ build_bool_lit Core_kernel.String.(x = y)
       | _ -> builtin_fail "BNum.eq" ls
@@ -730,7 +730,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let blt_arity = 2
 
-    let blt ls _ =
+    let blt _ ls _ =
       match ls with
       | [ BNum x; BNum y ] ->
           pure
@@ -747,13 +747,13 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       @@ fun_typ (tvar "'B") bnum_typ
 
     (* Elaborator to run with arbitrary uints *)
-    let badd_elab sc ts =
-      match ts with
-      | [ PrimType Bnum_typ; PrimType (Uint_typ _) ] ->
+    let badd_elab sc targs ts =
+      match targs, ts with
+      | [], [ PrimType Bnum_typ; PrimType (Uint_typ _) ] ->
           elab_tfun_with_args_no_gas sc ts
-      | _ -> fail0 "Failed to elaborate"
+      | _, _ -> fail0 "Failed to elaborate"
 
-    let badd ls _ =
+    let badd _ ls _ =
       match ls with
       | [ BNum x; UintLit y ] ->
           let i1 = big_int_of_string x in
@@ -774,13 +774,13 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       @@ fun_typ (tvar "'B") int256_typ
 
     (* Elaborator to run with arbitrary uints *)
-    let bsub_elab sc ts =
-      match ts with
-      | [ PrimType Bnum_typ; PrimType Bnum_typ ] ->
+    let bsub_elab sc targs ts =
+      match targs, ts with
+      | [], [ PrimType Bnum_typ; PrimType Bnum_typ ] ->
           elab_tfun_with_args_no_gas sc ts
-      | _ -> fail0 "Failed to elaborate"
+      | _, _ -> fail0 "Failed to elaborate"
 
-    let bsub ls _ =
+    let bsub _ ls _ =
       match ls with
       | [ BNum x; BNum y ] -> (
           let i1 = big_int_of_string x in
@@ -860,17 +860,17 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let eq_arity = 2
 
-    let eq_elab sc ts =
-      match ts with
-      | [ bstyp1; bstyp2 ]
+    let eq_elab sc targs ts =
+      match targs, ts with
+      | [], [ bstyp1; bstyp2 ]
         when (* We want both types to be ByStr with equal width. *)
              is_bystrx_type bstyp1 && [%equal: BIType.t] bstyp1 bstyp2 ->
           elab_tfun_with_args_no_gas sc [ bstyp1 ]
-      | [ PrimType Bystr_typ; PrimType Bystr_typ ] ->
+      | [], [ PrimType Bystr_typ; PrimType Bystr_typ ] ->
           elab_tfun_with_args_no_gas sc [ PrimType Bystr_typ ]
-      | _ -> fail0 "Failed to elaborate"
+      | _, _ -> fail0 "Failed to elaborate"
 
-    let eq ls _ =
+    let eq _ ls _ =
       match ls with
       | [ ByStrX bs1; ByStrX bs2 ] ->
           pure @@ build_bool_lit (Bystrx.equal bs1 bs2)
@@ -882,21 +882,21 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let hash_arity = 1
 
-    let hash_elab sc ts =
-      match ts with
-      | [ _ ] -> elab_tfun_with_args_no_gas sc ts
-      | _ -> fail0 "Failed to elaborate"
+    let hash_elab sc targs ts =
+      match targs, ts with
+      | [], [ _ ] -> elab_tfun_with_args_no_gas sc ts
+      | _, _ -> fail0 "Failed to elaborate"
 
-    let sha256hash ls _ = hash_helper sha256_hasher "sha256hash" hash_length ls
+    let sha256hash _ ls _ = hash_helper sha256_hasher "sha256hash" hash_length ls
 
-    let keccak256hash ls _ =
+    let keccak256hash _ ls _ =
       hash_helper keccak256_hasher "keccak256hash" hash_length ls
 
     (* RIPEMD-160 is a 160 bit hash, so define a separate type for it. *)
     let ripemd160hash_type =
       tfun_typ "'A" @@ fun_typ (tvar "'A") (bystrx_typ address_length)
 
-    let ripemd160hash ls _ =
+    let ripemd160hash _ ls _ =
       hash_helper ripemd160_hasher "ripemd160hash" address_length ls
 
     (* ByStr -> Option ByStrX *)
@@ -904,7 +904,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let to_bystrx_arity = 1
 
-    let to_bystrx x ls _ =
+    let to_bystrx x _ ls _ =
       match ls with
       | [ ByStr bs ] -> (
           match Bystrx.of_raw_bytes x (Bystr.to_raw_bytes bs) with
@@ -917,12 +917,12 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let to_bystr_arity = 1
 
-    let to_bystr_elab sc ts =
-      match ts with
-      | [ t ] when is_bystrx_type t -> elab_tfun_with_args_no_gas sc ts
-      | _ -> fail0 "Failed to elaborate"
+    let to_bystr_elab sc targs ts =
+      match targs, ts with
+      | [], [ t ] when is_bystrx_type t -> elab_tfun_with_args_no_gas sc ts
+      | _, _ -> fail0 "Failed to elaborate"
 
-    let to_bystr ls _ =
+    let to_bystr _ ls _ =
       match ls with
       | [ ByStrX bs ] -> pure @@ ByStr (Bystrx.to_bystr bs)
       | _ -> builtin_fail "Crypto.to_bystr" ls
@@ -932,7 +932,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     let substr_type =
       fun_typ bystr_typ @@ fun_typ uint32_typ @@ fun_typ uint32_typ bystr_typ
 
-    let substr ls _ =
+    let substr _ ls _ =
       try
         match ls with
         | [ ByStr x; UintLit (Uint32L s); UintLit (Uint32L e) ] ->
@@ -946,14 +946,14 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let to_uint_arity = 1
 
-    let to_uint_elab x sc ts =
+    let to_uint_elab x sc targs ts =
       let open Type.PrimType in
-      match ts with
-      | [ PrimType (Bystrx_typ w) ] when w <= int_bit_width_to_int x / 8 ->
+      match targs, ts with
+      | [], [ PrimType (Bystrx_typ w) ] when w <= int_bit_width_to_int x / 8 ->
           elab_tfun_with_args_no_gas sc ts
-      | _ -> fail0 "Failed to elaborate"
+      | _, _ -> fail0 "Failed to elaborate"
 
-    let to_uint x ls _ =
+    let to_uint x _ ls _ =
       let open Type.PrimType in
       let width_bytes = int_bit_width_to_int x / 8 in
       match ls with
@@ -978,7 +978,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let bech32_to_bystr20_arity = 2
 
-    let bech32_to_bystr20 ls _ =
+    let bech32_to_bystr20 _ ls _ =
       match ls with
       | [ StringLit prfx; StringLit addr ] -> (
           if Core_kernel.String.(prfx <> "zil" && prfx <> "tzil") then
@@ -998,7 +998,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let bystr20_to_bech32_arity = 2
 
-    let bystr20_to_bech32 ls _ =
+    let bystr20_to_bech32 _ ls _ =
       match ls with
       | [ StringLit prfx; ByStrX addr ] -> (
           if Core_kernel.String.(prfx <> "zil" && prfx <> "tzil") then
@@ -1018,15 +1018,15 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let concat_arity = 2
 
-    let concat_elab sc ts =
-      match ts with
-      | [ PrimType (Bystrx_typ w1); PrimType (Bystrx_typ w2) ] ->
+    let concat_elab sc targs ts =
+      match targs, ts with
+      | [], [ PrimType (Bystrx_typ w1); PrimType (Bystrx_typ w2) ] ->
           elab_tfun_with_args_no_gas sc (ts @ [ bystrx_typ (w1 + w2) ])
-      | [ PrimType Bystr_typ; PrimType Bystr_typ ] ->
+      | [], [ PrimType Bystr_typ; PrimType Bystr_typ ] ->
           elab_tfun_with_args_no_gas sc (ts @ [ bystr_typ ])
-      | _ -> fail0 "Failed to elaborate"
+      | _, _ -> fail0 "Failed to elaborate"
 
-    let concat ls _ =
+    let concat _ ls _ =
       match ls with
       | [ ByStrX bs1; ByStrX bs2 ] -> pure @@ ByStrX (Bystrx.concat bs1 bs2)
       | [ ByStr bs1; ByStr bs2 ] -> pure @@ ByStr (Bystr.concat bs1 bs2)
@@ -1100,7 +1100,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let schnorr_verify_arity = 3
 
-    let schnorr_verify ls _ =
+    let schnorr_verify _ ls _ =
       match ls with
       | [ ByStrX pubkey; ByStr msg; ByStrX signature ]
         when Bystrx.width pubkey = pubkey_len
@@ -1151,7 +1151,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let ecdsa_verify_arity = 3
 
-    let ecdsa_verify ls _ =
+    let ecdsa_verify _ ls _ =
       let open Secp256k1Wrapper in
       match ls with
       | [ ByStrX pubkey; ByStr msg; ByStrX signature ]
@@ -1178,7 +1178,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
         (* public key *)
         (bystrx_typ Secp256k1Wrapper.uncompressed_pubkey_len)
 
-    let ecdsa_recover_pk ls _ =
+    let ecdsa_recover_pk _ ls _ =
       let open Secp256k1Wrapper in
       match ls with
       | [ ByStr msg; ByStrX signature; UintLit (Uint32L recid) ]
@@ -1198,7 +1198,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let schnorr_get_address_arity = 1
 
-    let schnorr_get_address ls _ =
+    let schnorr_get_address _ ls _ =
       match ls with
       | [ ByStrX pubkey ] when Bystrx.width pubkey = pubkey_len -> (
           let pks = Bystrx.to_raw_bytes pubkey in
@@ -1221,7 +1221,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let alt_bn128_G1_add_arity = 2
 
-    let alt_bn128_G1_add ls _ =
+    let alt_bn128_G1_add _ ls _ =
       match ls with
       | [ p1; p2 ] -> (
           let%bind p1' = scilla_g1point_to_ocaml p1 in
@@ -1240,7 +1240,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let alt_bn128_G1_mul_arity = 2
 
-    let alt_bn128_G1_mul ls _ =
+    let alt_bn128_G1_mul _ ls _ =
       match ls with
       | [ p1; s ] -> (
           let%bind p1' = scilla_g1point_to_ocaml p1 in
@@ -1258,7 +1258,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let alt_bn128_pairing_product_arity = 1
 
-    let alt_bn128_pairing_product ls _ =
+    let alt_bn128_pairing_product _ ls _ =
       match ls with
       | [ pairs ] -> (
           let%bind pairs' = scilla_g1g2pairlist_to_ocaml pairs in
@@ -1282,13 +1282,13 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       @@ fun_typ (map_typ (tvar "'K") (tvar "'V"))
       @@ fun_typ (tvar "'K") bool_typ
 
-    let contains_elab sc ts =
-      match ts with
-      | [ MapType (kt, vt); u ] when [%equal: BIType.t] kt u ->
+    let contains_elab sc targs ts =
+      match targs, ts with
+      | [], [ MapType (kt, vt); u ] when [%equal: BIType.t] kt u ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
-      | _ -> fail0 "Failed to elaborate"
+      | _, _ -> fail0 "Failed to elaborate"
 
-    let contains ls _ =
+    let contains _ ls _ =
       match ls with
       | [ Map (_, entries); key ] ->
           let res = Caml.Hashtbl.mem entries key in
@@ -1303,14 +1303,14 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       @@ fun_typ (tvar "'K")
       @@ fun_typ (tvar "'V") (map_typ (tvar "'K") (tvar "'V"))
 
-    let put_elab sc ts =
-      match ts with
-      | [ MapType (kt, vt); kt'; vt' ]
+    let put_elab sc targs ts =
+      match targs, ts with
+      | [], [ MapType (kt, vt); kt'; vt' ]
         when [%equal: BIType.t] kt kt' && [%equal: BIType.t] vt vt' ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
-      | _ -> fail0 "Failed to elaborate"
+      | _, _ -> fail0 "Failed to elaborate"
 
-    let put ls _ =
+    let put _ ls _ =
       match ls with
       | [ Map (tm, entries); key; value ] ->
           (* Scilla semantics is not in-place modification. *)
@@ -1327,14 +1327,14 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       @@ fun_typ (map_typ (tvar "'K") (tvar "'V"))
       @@ fun_typ (tvar "'K") (option_typ (tvar "'V"))
 
-    let get_elab sc ts =
-      match ts with
-      | [ MapType (kt, vt); kt' ] when [%equal: BIType.t] kt kt' ->
+    let get_elab sc targs ts =
+      match targs, ts with
+      | [], [ MapType (kt, vt); kt' ] when [%equal: BIType.t] kt kt' ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
-      | _ -> fail0 "Failed to elaborate"
+      | _, _ -> fail0 "Failed to elaborate"
 
     (* Notice that get passes return type *)
-    let get ls rt =
+    let get _ ls rt =
       match (ls, rt) with
       | [ Map (_, entries); key ], ADT (tname, [ targ ])
         when Datatypes.is_option_adt_name (BIIdentifier.get_id tname) -> (
@@ -1349,13 +1349,13 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       @@ fun_typ (map_typ (tvar "'K") (tvar "'V"))
       @@ fun_typ (tvar "'K") (map_typ (tvar "'K") (tvar "'V"))
 
-    let remove_elab sc ts =
-      match ts with
-      | [ MapType (kt, vt); u ] when [%equal: BIType.t] kt u ->
+    let remove_elab sc targs ts =
+      match targs, ts with
+      | [], [ MapType (kt, vt); u ] when [%equal: BIType.t] kt u ->
           elab_tfun_with_args_no_gas sc [ kt; vt ]
-      | _ -> fail0 "Failed to elaborate"
+      | _, _ -> fail0 "Failed to elaborate"
 
-    let remove ls _ =
+    let remove _ ls _ =
       match ls with
       | [ Map (tm, entries); key ] ->
           (* Scilla semantics is not in-place modification. *)
@@ -1371,12 +1371,12 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       @@ fun_typ (map_typ (tvar "'K") (tvar "'V"))
       @@ list_typ (pair_typ (tvar "'K") (tvar "'V"))
 
-    let to_list_elab sc ts =
-      match ts with
-      | [ MapType (kt, vt) ] -> elab_tfun_with_args_no_gas sc [ kt; vt ]
-      | _ -> fail0 "Failed to elaborate"
+    let to_list_elab sc targs ts =
+      match targs, ts with
+      | [], [ MapType (kt, vt) ] -> elab_tfun_with_args_no_gas sc [ kt; vt ]
+      | _, _ -> fail0 "Failed to elaborate"
 
-    let to_list ls _ =
+    let to_list _ ls _ =
       match ls with
       | [ Map ((kt, vt), entries) ] ->
           (* The type of the output list will be "Pair (kt) (vt)" *)
@@ -1400,12 +1400,12 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       @@ fun_typ (map_typ (tvar "'K") (tvar "'V"))
       @@ uint32_typ
 
-    let size_elab sc ts =
-      match ts with
-      | [ MapType (kt, vt) ] -> elab_tfun_with_args_no_gas sc [ kt; vt ]
-      | _ -> fail0 "Failed to elaborate"
+    let size_elab sc targs ts =
+      match targs, ts with
+      | [], [ MapType (kt, vt) ] -> elab_tfun_with_args_no_gas sc [ kt; vt ]
+      | _, _ -> fail0 "Failed to elaborate"
 
-    let size ls _ =
+    let size _ ls _ =
       match ls with
       | [ Map (_, entries) ] ->
           (* The type of the output will be "Uint32" *)
@@ -1415,7 +1415,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
   end
 
   (* Identity elaborator *)
-  let elab_id t _ = pure t
+  let elab_id t _ _ = pure t
 
   (**********************************************************)
   (*                   Built-in  Dictionary                *)
@@ -1424,11 +1424,17 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
   module BuiltInDictionary = struct
     (* Elaborates the operation type based on the arguments types *)
     type elaborator =
-      BIType.t -> BIType.t list -> (BIType.t, scilla_error list) result
+      BIType.t ->      (* builtin type *)
+      BIType.t list -> (* type arguments *)
+      BIType.t list -> (* types of value arguments *)
+      (BIType.t, scilla_error list) result
 
     (* Takes the expected type as an argument to elaborate the result *)
     type built_in_executor =
-      BILiteral.t list -> BIType.t -> (BILiteral.t, scilla_error list) result
+      BIType.t list ->    (* type arguments *)
+      BILiteral.t list -> (* value arguments *)
+      BIType.t ->         (* result type *)
+      (BILiteral.t, scilla_error list) result
 
     (* A built-in record type:
        * arity
@@ -1537,15 +1543,15 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
     [@@@ocamlformat "enable"]
 
     (* Dictionary lookup based on the operation name and type *)
-    let find_builtin_op (op, rep) argtypes =
+    let find_builtin_op (op, rep) ~targtypes ~vargtypes =
       let finder = function
         | arity, optype, elab, exec ->
-            if arity = List.length argtypes then
+            if arity = List.length vargtypes then
               (* First: elaborate based on argument types *)
-              let%bind type_elab = elab optype argtypes in
+              let%bind type_elab = elab optype targtypes vargtypes in
               (* Second: check applicability *)
               let%bind res_type =
-                fun_type_applies type_elab argtypes ~lc:(ER.get_loc rep)
+                fun_type_applies type_elab vargtypes ~lc:(ER.get_loc rep)
               in
               pure (type_elab, res_type, exec)
             else fail0 @@ "Name or arity don't match"
@@ -1556,9 +1562,10 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
             mk_error1
               (sprintf
                  "Type error: cannot apply \"%s\" built-in to argument(s) of \
-                  type(s) %s."
+                  type(s) %s%s."
                  (pp_builtin op)
-                 (pp_typ_list_error argtypes))
+                 (if List.is_empty targtypes then "" else sprintf "{%s} " (pp_typ_list_error targtypes))
+                 (pp_typ_list_error vargtypes))
               (ER.get_loc rep))
       in
       pure (type_elab, res_type, exec)

--- a/src/base/BuiltIns.mli
+++ b/src/base/BuiltIns.mli
@@ -38,7 +38,10 @@ end
 module ScillaBuiltIns (SR : Rep) (ER : Rep) : sig
   module BuiltInDictionary : sig
     type built_in_executor =
-      BILiteral.t list -> BIType.t -> (BILiteral.t, scilla_error list) result
+      BIType.t list ->    (* type arguments *)
+      BILiteral.t list -> (* value arguments *)
+      BIType.t ->         (* result type *)
+      (BILiteral.t, scilla_error list) result
 
     (* The return result is a triple:
      * The full elaborated type of the operation, e.g., string -> Bool
@@ -47,11 +50,15 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) : sig
      *)
     val find_builtin_op :
       ER.rep builtin_annot ->
-      BIType.t list ->
+      targtypes:BIType.t list -> (* type arguments *)
+      vargtypes:BIType.t list -> (* types of value arguments *)
       (BIType.t * BIType.t * built_in_executor, scilla_error list) result
   end
 
   (* Elaborator for the built-in typ *)
   val elab_id :
-    BIType.t -> BIType.t list -> (BIType.t, scilla_error list) result
+    BIType.t ->      (* builtin type *)
+    BIType.t list -> (* type arguments *)
+    BIType.t list -> (* types of value arguments *)
+    (BIType.t, scilla_error list) result
 end

--- a/src/base/BuiltIns.mli
+++ b/src/base/BuiltIns.mli
@@ -38,9 +38,12 @@ end
 module ScillaBuiltIns (SR : Rep) (ER : Rep) : sig
   module BuiltInDictionary : sig
     type built_in_executor =
-      BIType.t list ->    (* type arguments *)
-      BILiteral.t list -> (* value arguments *)
-      BIType.t ->         (* result type *)
+      BIType.t list ->
+      (* type arguments *)
+      BILiteral.t list ->
+      (* value arguments *)
+      BIType.t ->
+      (* result type *)
       (BILiteral.t, scilla_error list) result
 
     (* The return result is a triple:
@@ -50,15 +53,20 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) : sig
      *)
     val find_builtin_op :
       ER.rep builtin_annot ->
-      targtypes:BIType.t list -> (* type arguments *)
-      vargtypes:BIType.t list -> (* types of value arguments *)
+      targtypes:BIType.t list ->
+      (* type arguments *)
+      vargtypes:BIType.t list ->
+      (* types of value arguments *)
       (BIType.t * BIType.t * built_in_executor, scilla_error list) result
   end
 
   (* Elaborator for the built-in typ *)
   val elab_id :
-    BIType.t ->      (* builtin type *)
-    BIType.t list -> (* type arguments *)
-    BIType.t list -> (* types of value arguments *)
+    BIType.t ->
+    (* builtin type *)
+    BIType.t list ->
+    (* type arguments *)
+    BIType.t list ->
+    (* types of value arguments *)
     (BIType.t, scilla_error list) result
 end

--- a/src/base/Cashflow.ml
+++ b/src/base/Cashflow.ml
@@ -151,9 +151,9 @@ struct
       | App (f, actuals) ->
           CFSyntax.App
             (add_noinfo_to_ident f, List.map ~f:add_noinfo_to_ident actuals)
-      | Builtin (op, actuals) ->
+      | Builtin (op, targs, actuals) ->
           CFSyntax.Builtin
-            (add_noinfo_to_builtin op, List.map ~f:add_noinfo_to_ident actuals)
+            (add_noinfo_to_builtin op, targs, List.map ~f:add_noinfo_to_ident actuals)
       | Let (i, topt, lhs, rhs) ->
           CFSyntax.Let
             ( add_noinfo_to_ident i,
@@ -1300,7 +1300,7 @@ struct
             ctr_tag_map,
             args_changes
             || (not @@ [%equal: ECFR.money_tag] f_tag (get_id_tag f)) )
-      | Builtin (f, args) ->
+      | Builtin (f, targs, args) ->
           let args_tags =
             List.map
               ~f:(fun arg -> lookup_var_tag2 arg local_env param_env)
@@ -1335,7 +1335,7 @@ struct
           let op, (tag, r) = f in
           let new_f = (op, (f_tag, r)) in
 
-          ( Builtin (new_f, final_args),
+          ( Builtin (new_f, targs, final_args),
             res_tag,
             final_param_env,
             final_local_env,

--- a/src/base/Cashflow.ml
+++ b/src/base/Cashflow.ml
@@ -153,7 +153,9 @@ struct
             (add_noinfo_to_ident f, List.map ~f:add_noinfo_to_ident actuals)
       | Builtin (op, targs, actuals) ->
           CFSyntax.Builtin
-            (add_noinfo_to_builtin op, targs, List.map ~f:add_noinfo_to_ident actuals)
+            ( add_noinfo_to_builtin op,
+              targs,
+              List.map ~f:add_noinfo_to_ident actuals )
       | Let (i, topt, lhs, rhs) ->
           CFSyntax.Let
             ( add_noinfo_to_ident i,

--- a/src/base/Disambiguate.ml
+++ b/src/base/Disambiguate.ml
@@ -446,14 +446,15 @@ module ScillaDisambiguation (SR : Rep) (ER : Rep) = struct
                   pure (dis_p, dis_erep'))
             in
             pure @@ PostDisSyntax.MatchExpr (dis_x, dis_pes)
-        | Builtin (b, args) ->
+        | Builtin (b, targs, args) ->
+            let%bind dis_targs = mapM targs ~f:disambiguate_type_helper in
             let%bind dis_args =
               mapM args
                 ~f:
                   (disambiguate_identifier_helper simp_var_dict
                      (ER.get_loc rep))
             in
-            pure @@ PostDisSyntax.Builtin (b, dis_args)
+            pure @@ PostDisSyntax.Builtin (b, dis_targs, dis_args)
         | TFun (tvar, body) ->
             let%bind dis_tvar = name_def_as_simple_global tvar in
             (* tvar is in scope as a type, but won't affect disambiguation,

--- a/src/base/Gas.ml
+++ b/src/base/Gas.ml
@@ -284,9 +284,12 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
   (* op -> arguments -> base cost -> total cost *)
   type coster =
     builtin ->
-    GasType.t list ->   (* type arguments *)
-    ER.rep GI.t list -> (* argument identifiers *)
-    GasType.t list ->   (* types of value arguments *)
+    GasType.t list ->
+    (* type arguments *)
+    ER.rep GI.t list ->
+    (* argument identifiers *)
+    GasType.t list ->
+    (* types of value arguments *)
     (GasGasCharge.gas_charge, scilla_error list) result
 
   (* op, arg types, coster, base cost. *)
@@ -486,7 +489,8 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
       pure (GasGasCharge.ProdOf (base', GasGasCharge.StaticCost 4))
     else fail0 @@ "Gas cost error for integer built-in"
 
-  let bnum_coster _op _targs _args _arg_types = pure (GasGasCharge.StaticCost 32)
+  let bnum_coster _op _targs _args _arg_types =
+    pure (GasGasCharge.StaticCost 32)
 
   let tvar s = TypeVar s
 

--- a/src/base/GasUseAnalysis.ml
+++ b/src/base/GasUseAnalysis.ml
@@ -962,7 +962,7 @@ struct
         let%bind ressize', gup' = resolve_expand genv u v in
         (* TODO: Return value having no arguments implies partial application not supported. *)
         pure ([], ressize', add_pn gup' cc)
-    | Builtin ((b, rep), actuals) ->
+    | Builtin ((b, rep), _, actuals) ->
         (* Handle builtin-s like we handle function application. *)
         let%bind bsig = builtin_cost (b, rep) actuals in
         let genv' = GUAEnv.addS genv (pp_builtin b) bsig in

--- a/src/base/ParserUtil.ml
+++ b/src/base/ParserUtil.ml
@@ -85,7 +85,10 @@ module type Syn = sig
         * SType.t list
         * ParserRep.rep SIdentifier.t list
     | MatchExpr of ParserRep.rep SIdentifier.t * (pattern * expr_annot) list
-    | Builtin of ParserRep.rep builtin_annot * SType.t list * ParserRep.rep SIdentifier.t list
+    | Builtin of
+        ParserRep.rep builtin_annot
+        * SType.t list
+        * ParserRep.rep SIdentifier.t list
     (* Advanced features: to be added in Scilla 0.2 *)
     | TFun of ParserRep.rep SIdentifier.t * expr_annot
     | TApp of ParserRep.rep SIdentifier.t * SType.t list

--- a/src/base/ParserUtil.ml
+++ b/src/base/ParserUtil.ml
@@ -85,7 +85,7 @@ module type Syn = sig
         * SType.t list
         * ParserRep.rep SIdentifier.t list
     | MatchExpr of ParserRep.rep SIdentifier.t * (pattern * expr_annot) list
-    | Builtin of ParserRep.rep builtin_annot * ParserRep.rep SIdentifier.t list
+    | Builtin of ParserRep.rep builtin_annot * SType.t list * ParserRep.rep SIdentifier.t list
     (* Advanced features: to be added in Scilla 0.2 *)
     | TFun of ParserRep.rep SIdentifier.t * expr_annot
     | TApp of ParserRep.rep SIdentifier.t * SType.t list

--- a/src/base/PatternChecker.ml
+++ b/src/base/PatternChecker.ml
@@ -215,7 +215,7 @@ struct
                clauses
            in
            pure @@ (CheckedPatternSyntax.MatchExpr (x, checked_clauses), rep)
-    | Builtin (f, args) -> pure @@ (CheckedPatternSyntax.Builtin (f, args), rep)
+    | Builtin (f, targs, args) -> pure @@ (CheckedPatternSyntax.Builtin (f, targs, args), rep)
     (* Advanced features: to be added in Scilla 0.2 *)
     | TFun (t, body) ->
         let%bind checked_body = pm_check_expr body in

--- a/src/base/PatternChecker.ml
+++ b/src/base/PatternChecker.ml
@@ -215,7 +215,8 @@ struct
                clauses
            in
            pure @@ (CheckedPatternSyntax.MatchExpr (x, checked_clauses), rep)
-    | Builtin (f, targs, args) -> pure @@ (CheckedPatternSyntax.Builtin (f, targs, args), rep)
+    | Builtin (f, targs, args) ->
+        pure @@ (CheckedPatternSyntax.Builtin (f, targs, args), rep)
     (* Advanced features: to be added in Scilla 0.2 *)
     | TFun (t, body) ->
         let%bind checked_body = pm_check_expr body in

--- a/src/base/Recursion.ml
+++ b/src/base/Recursion.ml
@@ -151,7 +151,9 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
                 pes
             in
             pure @@ RecursionSyntax.MatchExpr (x, new_pes)
-        | Builtin (f, args) -> pure @@ RecursionSyntax.Builtin (f, args)
+        | Builtin (f, targs, args) ->
+            let%bind () = forallM ~f:(fun t -> recursion_typ t) targs in
+            pure @@ RecursionSyntax.Builtin (f, targs, args)
         | TFun (s, e) ->
             let%bind new_e = walk e in
             pure @@ RecursionSyntax.TFun (s, new_e)

--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -239,9 +239,9 @@ simple_exp :
 (* Atomic expression *)
 | a = atomic_exp {a}
 (* Built-in call *)
-| BUILTIN; b = ID; xs = builtin_args
+| BUILTIN; b = ID; targs = option(ctargs); xs = builtin_args
   { let bloc = toLoc $startpos(b) in
-    (Builtin ((parse_builtin b bloc, bloc), xs)), toLoc $startpos }
+    (Builtin ((parse_builtin b bloc, bloc), Option.value targs ~default:[], xs)), toLoc $startpos }
 (* Message construction *)
 | LBRACE; es = separated_list(SEMICOLON, msg_entry); RBRACE
   { (Message es, toLoc $startpos) }

--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -271,7 +271,7 @@ module ScillaSyntax (SR : Rep) (ER : Rep) (Literal : ScillaLiteral) = struct
     | App of ER.rep SIdentifier.t * ER.rep SIdentifier.t list
     | Constr of SR.rep SIdentifier.t * SType.t list * ER.rep SIdentifier.t list
     | MatchExpr of ER.rep SIdentifier.t * (pattern * expr_annot) list
-    | Builtin of ER.rep builtin_annot * ER.rep SIdentifier.t list
+    | Builtin of ER.rep builtin_annot * SType.t list * ER.rep SIdentifier.t list
     | TFun of ER.rep SIdentifier.t * expr_annot
     | TApp of ER.rep SIdentifier.t * SType.t list
     (* Fixpoint combinator: used to implement recursion principles *)
@@ -469,7 +469,7 @@ module ScillaSyntax (SR : Rep) (ER : Rep) (Literal : ScillaLiteral) = struct
       | TFun (_, body) -> recurser body bound_vars acc
       | Constr (_, _, es) -> get_free es bound_vars @ acc
       | App (f, args) -> get_free (f :: args) bound_vars @ acc
-      | Builtin (_f, args) -> get_free args bound_vars @ acc
+      | Builtin (_f, _targs, args) -> get_free args bound_vars @ acc
       | Let (i, _, lhs, rhs) ->
           let acc_lhs = recurser lhs bound_vars acc in
           recurser rhs (i :: bound_vars) acc_lhs
@@ -527,7 +527,7 @@ module ScillaSyntax (SR : Rep) (ER : Rep) (Literal : ScillaLiteral) = struct
           sprintf
             "Type error in pattern matching on `%s`%s (or one of its branches):\n"
             (as_error_string x) opt
-      | Builtin ((i, _), _) ->
+      | Builtin ((i, _), _, _) ->
           sprintf "Type error in built-in application of `%s`:\n" (pp_builtin i)
       | TApp (tf, _) ->
           sprintf "Type error in type application of `%s`:\n"

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -312,12 +312,11 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
         let typed_f = add_type_to_ident f (rr_typ fres) in
         pure @@ (TypedSyntax.App (typed_f, typed_actuals), (apptyp, rep))
     | Builtin (b, ts, actuals) ->
-        let%bind _ =
-          mapM ts ~f:(fun t -> fromR_TE @@ TEnv.is_wf_type tenv t)
-        in
+        let%bind _ = mapM ts ~f:(fun t -> fromR_TE @@ TEnv.is_wf_type tenv t) in
         let%bind targs, typed_actuals = type_actuals tenv actuals in
         let%bind _, ret_typ, _ =
-          fromR_TE @@ BuiltInDictionary.find_builtin_op b ~targtypes:ts ~vargtypes:targs
+          fromR_TE
+          @@ BuiltInDictionary.find_builtin_op b ~targtypes:ts ~vargtypes:targs
         in
         let%bind () = fromR_TE @@ TEnv.is_wf_type tenv ret_typ in
         let q_ret_typ = mk_qual_tp ret_typ in

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -311,16 +311,19 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
         in
         let typed_f = add_type_to_ident f (rr_typ fres) in
         pure @@ (TypedSyntax.App (typed_f, typed_actuals), (apptyp, rep))
-    | Builtin (b, actuals) ->
+    | Builtin (b, ts, actuals) ->
+        let%bind _ =
+          mapM ts ~f:(fun t -> fromR_TE @@ TEnv.is_wf_type tenv t)
+        in
         let%bind targs, typed_actuals = type_actuals tenv actuals in
         let%bind _, ret_typ, _ =
-          fromR_TE @@ BuiltInDictionary.find_builtin_op b targs
+          fromR_TE @@ BuiltInDictionary.find_builtin_op b ~targtypes:ts ~vargtypes:targs
         in
         let%bind () = fromR_TE @@ TEnv.is_wf_type tenv ret_typ in
         let q_ret_typ = mk_qual_tp ret_typ in
         let q_ret_tag = ETR.mk_rep rep q_ret_typ in
         pure
-        @@ ( TypedSyntax.Builtin ((fst b, q_ret_tag), typed_actuals),
+        @@ ( TypedSyntax.Builtin ((fst b, q_ret_tag), ts, typed_actuals),
              (q_ret_typ, rep) )
     | Let (i, topt, lhs, rhs) ->
         (* Poor man's error reporting *)

--- a/src/base/TypeInfo.ml
+++ b/src/base/TypeInfo.ml
@@ -92,7 +92,7 @@ struct
               patternsts @ branchts)
         in
         ots :: List.concat clausets
-    | Builtin (_, il) -> List.map il ~f:calc_ident_locs
+    | Builtin (_, _, il) -> List.map il ~f:calc_ident_locs
     | TFun (i, e) -> calc_ident_locs i :: type_info_expr e
     | GasExpr (_, e) -> type_info_expr e
 

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -133,7 +133,9 @@ let eval_gas_charge env g =
 let builtin_cost env f targs tps args_id =
   let open MonadUtil in
   let open Result.Let_syntax in
-  let%bind cost_expr = EvalGas.builtin_cost f ~targ_types:targs ~arg_types:tps args_id in
+  let%bind cost_expr =
+    EvalGas.builtin_cost f ~targ_types:targs ~arg_types:tps args_id
+  in
   let%bind cost = eval_gas_charge env cost_expr in
   pure cost
 
@@ -144,7 +146,9 @@ let builtin_executor env f targs args_id =
   in
   let%bind tps = fromR @@ MonadUtil.mapM arg_lits ~f:literal_type in
   let%bind _, ret_typ, op =
-    fromR @@ EvalBuiltIns.BuiltInDictionary.find_builtin_op f ~targtypes:targs ~vargtypes:tps
+    fromR
+    @@ EvalBuiltIns.BuiltInDictionary.find_builtin_op f ~targtypes:targs
+         ~vargtypes:tps
   in
   let%bind cost = fromR @@ builtin_cost env f targs tps args_id in
   let res () = op targs arg_lits ret_typ in

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -130,24 +130,24 @@ let eval_gas_charge env g =
   in
   SGasCharge.eval resolver g
 
-let builtin_cost env f tps args_id =
+let builtin_cost env f targs tps args_id =
   let open MonadUtil in
   let open Result.Let_syntax in
-  let%bind cost_expr = EvalGas.builtin_cost f tps args_id in
+  let%bind cost_expr = EvalGas.builtin_cost f ~targ_types:targs ~arg_types:tps args_id in
   let%bind cost = eval_gas_charge env cost_expr in
   pure cost
 
 (* Return a builtin_op wrapped in EvalMonad *)
-let builtin_executor env f args_id =
+let builtin_executor env f targs args_id =
   let%bind arg_lits =
     mapM args_id ~f:(fun arg -> fromR @@ Env.lookup env arg)
   in
   let%bind tps = fromR @@ MonadUtil.mapM arg_lits ~f:literal_type in
   let%bind _, ret_typ, op =
-    fromR @@ EvalBuiltIns.BuiltInDictionary.find_builtin_op f tps
+    fromR @@ EvalBuiltIns.BuiltInDictionary.find_builtin_op f ~targtypes:targs ~vargtypes:tps
   in
-  let%bind cost = fromR @@ builtin_cost env f tps args_id in
-  let res () = op arg_lits ret_typ in
+  let%bind cost = fromR @@ builtin_cost env f targs tps args_id in
+  let res () = op targs arg_lits ret_typ in
   checkwrap_opR res (Uint64.of_int cost)
 
 (*******************************************************)
@@ -244,8 +244,8 @@ let rec exp_eval erep env =
             Env.bind z (get_id i) w)
       in
       exp_eval e_branch env'
-  | Builtin (i, actuals) ->
-      let%bind res = builtin_executor env i actuals in
+  | Builtin (i, targs, actuals) ->
+      let%bind res = builtin_executor env i targs actuals in
       pure (res, env)
   | Fixpoint (g, _, body) ->
       let rec fix arg =

--- a/tests/base/parser/bad/gold/cmodule-field-id-colon-cid-eq-hexlit-with.scilla.gold
+++ b/tests/base/parser/bad/gold/cmodule-field-id-colon-cid-eq-hexlit-with.scilla.gold
@@ -1,7 +1,7 @@
 {
   "errors": [
     {
-      "error_message": "Syntax error, state number 289",
+      "error_message": "Syntax error, state number 290",
       "start_location": {
         "file":
           "base/parser/bad/cmodule-field-id-colon-cid-eq-hexlit-with.scilla",

--- a/tests/base/parser/bad/gold/exp_t-match-spid-with-bar-underscore-arrow-hexlit-with.scilexp.gold
+++ b/tests/base/parser/bad/gold/exp_t-match-spid-with-bar-underscore-arrow-hexlit-with.scilexp.gold
@@ -1,7 +1,7 @@
 {
   "errors": [
     {
-      "error_message": "Syntax error, state number 181",
+      "error_message": "Syntax error, state number 182",
       "start_location": {
         "file":
           "base/parser/bad/exps/exp_t-match-spid-with-bar-underscore-arrow-hexlit-with.scilexp",

--- a/tests/base/parser/bad/gold/lmodule-library-cid-let-id-eq-hexlit-with.scillib.gold
+++ b/tests/base/parser/bad/gold/lmodule-library-cid-let-id-eq-hexlit-with.scillib.gold
@@ -1,7 +1,7 @@
 {
   "errors": [
     {
-      "error_message": "Syntax error, state number 189",
+      "error_message": "Syntax error, state number 190",
       "start_location": {
         "file":
           "base/parser/bad/lib/lmodule-library-cid-let-id-eq-hexlit-with.scillib",

--- a/tests/checker/bad/Bad.ml
+++ b/tests/checker/bad/Bad.ml
@@ -95,6 +95,7 @@ module Tests = Scilla_test.Util.DiffBasedTests (struct
       "constraint_type_illegal.scilla";
       "match-in-transition.scilla";
       "listiter-bad.scilla";
+      "builtin_type_args.scilla";
     ]
 
   let exit_code : UnixLabels.process_status = WEXITED 1

--- a/tests/checker/bad/builtin_type_args.scilla
+++ b/tests/checker/bad/builtin_type_args.scilla
@@ -1,0 +1,12 @@
+scilla_version 0
+
+library Lib
+
+let x : Uint128 = Uint128 0
+
+let y : Uint128 = Uint128 1
+
+(* No type argument allowed to add *)
+let foo = builtin add { Uint128 } x y
+
+contract Contr()

--- a/tests/checker/bad/gold/builtin_type_args.scilla.gold
+++ b/tests/checker/bad/gold/builtin_type_args.scilla.gold
@@ -1,0 +1,16 @@
+{
+  "gas_remaining": "8000",
+  "errors": [
+    {
+      "error_message":
+        "Type error: cannot apply \"add\" built-in to argument(s) of type(s) {[Uint128]} [Uint128; Uint128].",
+      "start_location": {
+        "file": "checker/bad/builtin_type_args.scilla",
+        "line": 10,
+        "column": 19
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": []
+}

--- a/tests/checker/good/Good.ml
+++ b/tests/checker/good/Good.ml
@@ -164,6 +164,7 @@ module CheckerTests = Scilla_test.Util.DiffBasedTests (struct
       "event_reordered_fields.scilla";
       "blowup_1.scilla";
       "blowup_2.scilla";
+      "builtin_type_args.scilla";
     ]
 
   let exit_code : UnixLabels.process_status = WEXITED 0

--- a/tests/checker/good/builtin_type_args.scilla
+++ b/tests/checker/good/builtin_type_args.scilla
@@ -1,0 +1,12 @@
+scilla_version 0
+
+library Lib
+
+let x : Uint128 = Uint128 0
+
+let y : Uint128 = Uint128 1
+
+(* Empty type argument allowed to add *)
+let foo = builtin add { } x y
+
+contract Contr()

--- a/tests/checker/good/gold/builtin_type_args.scilla.gold
+++ b/tests/checker/good/gold/builtin_type_args.scilla.gold
@@ -1,0 +1,62 @@
+{
+  "cashflow_tags": { "State variables": [], "ADT constructors": [] },
+  "contract_info": {
+    "scilla_major_version": "0",
+    "vname": "Contr",
+    "params": [],
+    "fields": [],
+    "transitions": [],
+    "procedures": [],
+    "events": [],
+    "ADTs": [
+      {
+        "tname": "Option",
+        "tparams": [ "'A" ],
+        "tmap": [
+          { "cname": "Some", "argtypes": [ "'A" ] },
+          { "cname": "None", "argtypes": [] }
+        ]
+      },
+      {
+        "tname": "Bool",
+        "tparams": [],
+        "tmap": [
+          { "cname": "True", "argtypes": [] },
+          { "cname": "False", "argtypes": [] }
+        ]
+      },
+      {
+        "tname": "Nat",
+        "tparams": [],
+        "tmap": [
+          { "cname": "Zero", "argtypes": [] },
+          { "cname": "Succ", "argtypes": [ "Nat" ] }
+        ]
+      },
+      {
+        "tname": "List",
+        "tparams": [ "'A" ],
+        "tmap": [
+          { "cname": "Cons", "argtypes": [ "'A", "List ('A)" ] },
+          { "cname": "Nil", "argtypes": [] }
+        ]
+      },
+      {
+        "tname": "Pair",
+        "tparams": [ "'A", "'B" ],
+        "tmap": [ { "cname": "Pair", "argtypes": [ "'A", "'B" ] } ]
+      }
+    ]
+  },
+  "warnings": [
+    {
+      "warning_message":
+        "No transition in contract Contr contains an accept statement\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 1
+    }
+  ],
+  "gas_remaining": "7999"
+}
+

--- a/tests/eval/good/Good.ml
+++ b/tests/eval/good/Good.ml
@@ -148,6 +148,7 @@ let explist =
     "polynetwork_extract_bystr2.scilexp";
     "polynetwork_extract_bystr3.scilexp";
     "polynetwork_getBookKeeper.scilexp";
+    "builtin_type_args.scilexp";
   ]
 
 module Tests = Scilla_test.Util.DiffBasedTests (struct

--- a/tests/eval/good/builtin_type_args.scilexp
+++ b/tests/eval/good/builtin_type_args.scilexp
@@ -1,0 +1,5 @@
+let x : Uint128 = Uint128 0
+in
+let y : Uint128 = Uint128 1
+in
+builtin add { } x y

--- a/tests/eval/good/gold/builtin_type_args.scilexp.gold
+++ b/tests/eval/good/gold/builtin_type_args.scilexp.gold
@@ -1,0 +1,4 @@
+(Uint128 1),
+{ [y -> (Uint128 1)],
+  [x -> (Uint128 0)] }
+Gas remaining: 4001227


### PR DESCRIPTION
This is in preparation for `to_addr`, but there is no particular reason to lump this change into the address type PR.