### PR TITLE
Remote state reads bugfixes

### DIFF
--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -240,7 +240,10 @@ address_type_field:
 | ft = id_with_typ { ft }
 (* Allow _this_address as well *)
 | n = SPID; t = type_annot
-  { ( to_loc_id n (toLoc $startpos(n)), t) }
+    { let loc = toLoc $startpos(n) in
+      if n = "_this_address"
+      then to_loc_id n loc, t
+      else raise (SyntaxError ("Invalid field name " ^ n ^ " in address type", loc)) }
 
 (***********************************************)
 (*                 Expressions                 *)

--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -183,7 +183,6 @@ type_annot:
 id_with_typ :
 | n = ID; t = type_annot { (to_loc_id n (toLoc $startpos(n)), t) }
 
-
 (***********************************************)
 (*                  Types                      *)
 (***********************************************)
@@ -211,7 +210,7 @@ t_map_value :
 | LPAREN; t = t_map_value; RPAREN; { t }
 
 address_typ :
-| d = CID; WITH; fs = separated_list(COMMA, address_field_type); END;
+| d = CID; WITH; fs = separated_list(COMMA, address_type_field); END;
     { if d = "ByStr20"
       then Address fs
       else raise (SyntaxError ("Invalid primitive type", toLoc $startpos(d))) }
@@ -237,9 +236,11 @@ targ:
 | t = address_typ; { t }
 | MAP; k=t_map_key; v = t_map_value; { MapType (k, v) }
 
-address_field_type:
+address_type_field:
 | ft = id_with_typ { ft }
-
+(* Allow _this_address as well *)
+| n = SPID; t = type_annot
+  { ( to_loc_id n (toLoc $startpos(n)), t) }
 
 (***********************************************)
 (*                 Expressions                 *)

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -1038,7 +1038,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
           in
           let typed_fs = add_type_to_ident fn ar in
           if is_legal_field_type ft then
-            let _ = TEnv.addT fields_env fn actual in
+            let _ = TEnv.addT fields_env fn (mk_qual_tp ft).tp in
             pure @@ ((typed_fs, ft, typed_expr) :: acc)
           else
             fail

--- a/tests/base/parser/bad/gold/cmodule-field-id-colon-cid-eq-hexlit-with.scilla.gold
+++ b/tests/base/parser/bad/gold/cmodule-field-id-colon-cid-eq-hexlit-with.scilla.gold
@@ -1,7 +1,7 @@
 {
   "errors": [
     {
-      "error_message": "Syntax error, state number 314",
+      "error_message": "Syntax error, state number 316",
       "start_location": {
         "file":
           "base/parser/bad/cmodule-field-id-colon-cid-eq-hexlit-with.scilla",

--- a/tests/base/parser/bad/gold/cmodule-field-id-colon-tid-eq-with.scilla.gold
+++ b/tests/base/parser/bad/gold/cmodule-field-id-colon-tid-eq-with.scilla.gold
@@ -1,7 +1,7 @@
 {
   "errors": [
     {
-      "error_message": "Syntax error, state number 225",
+      "error_message": "Syntax error, state number 227",
       "start_location": {
         "file": "base/parser/bad/cmodule-field-id-colon-tid-eq-with.scilla",
         "line": 7,

--- a/tests/base/parser/bad/gold/exp_t-match-spid-with-bar-underscore-arrow-hexlit-with.scilexp.gold
+++ b/tests/base/parser/bad/gold/exp_t-match-spid-with-bar-underscore-arrow-hexlit-with.scilexp.gold
@@ -1,7 +1,7 @@
 {
   "errors": [
     {
-      "error_message": "Syntax error, state number 199",
+      "error_message": "Syntax error, state number 201",
       "start_location": {
         "file":
           "base/parser/bad/exps/exp_t-match-spid-with-bar-underscore-arrow-hexlit-with.scilexp",

--- a/tests/base/parser/bad/gold/lmodule-library-cid-let-id-eq-hexlit-with.scillib.gold
+++ b/tests/base/parser/bad/gold/lmodule-library-cid-let-id-eq-hexlit-with.scillib.gold
@@ -1,7 +1,7 @@
 {
   "errors": [
     {
-      "error_message": "Syntax error, state number 207",
+      "error_message": "Syntax error, state number 209",
       "start_location": {
         "file":
           "base/parser/bad/lib/lmodule-library-cid-let-id-eq-hexlit-with.scillib",

--- a/tests/checker/bad/gold/bad_map_key_1.scilla.gold
+++ b/tests/checker/bad/gold/bad_map_key_1.scilla.gold
@@ -2,7 +2,7 @@
   "gas_remaining": "8000",
   "errors": [
     {
-      "error_message": "Syntax error, state number 86",
+      "error_message": "Syntax error, state number 88",
       "start_location": {
         "file": "checker/bad/bad_map_key_1.scilla",
         "line": 7,


### PR DESCRIPTION
A few small bugfixes:

- `_this_address` is now allowed as an address type field. Other names starting with `_` are disallowed, since `_balance` is always implicitly defined, and no other names may legally start with `_`.
- The type environment now uses the declared type of a field rather than the type of the initialiser. This is necessary since the initialiser will almost always be a ByStr20.
