### PR TITLE
Remote state reads bugfixes

### DIFF
--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -703,6 +703,30 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
       | _, _ -> fail0 "Failed to elaborate"
   end
 
+  (***********************************************************)
+  (*                       Addresses                         *)
+  (***********************************************************)
+  module AddressBuiltins = struct
+    open Datatypes.DataTypeDictionary
+
+    let to_addr_arity = 1
+
+    let to_addr_type =
+      tfun_typ "'K"
+      @@ fun_typ (bystrx_typ Type.address_length)
+      @@ option_typ (tvar "'K")
+
+    let to_addr_elab sc targs ts =
+      match (targs, ts) with
+      | [ Address _ ], [ bstyp ]
+        when type_assignable
+               ~expected:(bystrx_typ Type.address_length)
+               ~actual:bstyp ->
+          (* Instantiate type variable with the given address type *)
+          elab_tfun_with_args_no_gas sc targs
+      | _, _ -> fail0 @@ "Failed to elaborate"
+  end
+
   (* Identity elaborator *)
   let elab_id t _ _ = pure t
 
@@ -814,6 +838,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
           UintBuiltins.to_uint_arity, UintBuiltins.to_uint_type, UintBuiltins.to_uint_elab Bits256
         ]
       | Builtin_to_nat -> [UintBuiltins.to_nat_arity, UintBuiltins.to_nat_type, elab_id]
+      | Builtin_to_addr -> [AddressBuiltins.to_addr_arity, AddressBuiltins.to_addr_type, AddressBuiltins.to_addr_elab]
 
     [@@@ocamlformat "enable"]
 

--- a/src/base/BuiltIns.mli
+++ b/src/base/BuiltIns.mli
@@ -310,6 +310,14 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) : sig
     val size_elab : elaborator
   end
 
+  module AddressBuiltins : sig
+    val to_addr_arity : int
+
+    val to_addr_type : BIType.t
+
+    val to_addr_elab : elaborator
+  end
+
   module BuiltInDictionary : sig
     (* Returns the result type for given argument types, e.g., Bool *)
     val find_builtin_op :

--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -240,7 +240,10 @@ address_type_field:
 | ft = id_with_typ { ft }
 (* Allow _this_address as well *)
 | n = SPID; t = type_annot
-  { ( to_loc_id n (toLoc $startpos(n)), t) }
+    { let loc = toLoc $startpos(n) in
+      if n = "_this_address"
+      then to_loc_id n loc, t
+      else raise (SyntaxError ("Invalid field name " ^ n ^ " in address type", loc)) }
 
 (***********************************************)
 (*                 Expressions                 *)

--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -183,7 +183,6 @@ type_annot:
 id_with_typ :
 | n = ID; t = type_annot { (to_loc_id n (toLoc $startpos(n)), t) }
 
-
 (***********************************************)
 (*                  Types                      *)
 (***********************************************)
@@ -211,7 +210,7 @@ t_map_value :
 | LPAREN; t = t_map_value; RPAREN; { t }
 
 address_typ :
-| d = CID; WITH; fs = separated_list(COMMA, address_field_type); END;
+| d = CID; WITH; fs = separated_list(COMMA, address_type_field); END;
     { if d = "ByStr20"
       then Address fs
       else raise (SyntaxError ("Invalid primitive type", toLoc $startpos(d))) }
@@ -237,9 +236,11 @@ targ:
 | t = address_typ; { t }
 | MAP; k=t_map_key; v = t_map_value; { MapType (k, v) }
 
-address_field_type:
+address_type_field:
 | ft = id_with_typ { ft }
-
+(* Allow _this_address as well *)
+| n = SPID; t = type_annot
+  { ( to_loc_id n (toLoc $startpos(n)), t) }
 
 (***********************************************)
 (*                 Expressions                 *)

--- a/src/base/Syntax.ml
+++ b/src/base/Syntax.ml
@@ -85,6 +85,7 @@ type builtin =
   | Builtin_to_uint128
   | Builtin_to_nat
   | Builtin_schnorr_get_address
+  | Builtin_to_addr
 [@@deriving sexp, equal]
 
 type 'rep builtin_annot = builtin * 'rep [@@deriving sexp]
@@ -138,6 +139,7 @@ let pp_builtin b =
   | Builtin_to_uint64 -> "to_uint64"
   | Builtin_to_uint128 -> "to_uint128"
   | Builtin_to_nat -> "to_nat"
+  | Builtin_to_addr -> "to_addr"
 
 let parse_builtin s loc =
   match s with
@@ -187,6 +189,7 @@ let parse_builtin s loc =
   | "to_uint64" -> Builtin_to_uint64
   | "to_uint128" -> Builtin_to_uint128
   | "to_nat" -> Builtin_to_nat
+  | "to_addr" -> Builtin_to_addr
   | _ -> (
       try
         let size = String.chop_prefix_exn s ~prefix:"to_bystr" in

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -1038,7 +1038,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
           in
           let typed_fs = add_type_to_ident fn ar in
           if is_legal_field_type ft then
-            let _ = TEnv.addT fields_env fn actual in
+            let _ = TEnv.addT fields_env fn (mk_qual_tp ft).tp in
             pure @@ ((typed_fs, ft, typed_expr) :: acc)
           else
             fail

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -35,7 +35,11 @@ open EvalIdentifier
 open EvalType
 open EvalLiteral
 open EvalSyntax
-module CU = ScillaContractUtil (ParserRep) (ParserRep)
+open EvalBuiltins
+module SR = ParserRep
+module ER = ParserRep
+module CU = ScillaContractUtil (SR) (ER)
+module EvalBuiltins = ScillaEvalBuiltIns (SR) (ER)
 
 (***************************************************)
 (*                    Utilities                    *)
@@ -147,7 +151,7 @@ let builtin_executor env f targs args_id =
   let%bind tps = fromR @@ MonadUtil.mapM arg_lits ~f:literal_type in
   let%bind ret_typ, op =
     fromR
-    @@ EvalBuiltIns.EvalBuiltInDictionary.find_builtin_op f ~targtypes:targs
+    @@ EvalBuiltins.EvalBuiltInDictionary.find_builtin_op f ~targtypes:targs
          ~vargtypes:tps
   in
   let%bind cost = fromR @@ builtin_cost env f targs tps args_id in

--- a/src/eval/EvalUtil.ml
+++ b/src/eval/EvalUtil.ml
@@ -423,8 +423,10 @@ module EvalTypecheck = struct
   open EvalType
 
   let typecheck_remote_fields_no_err caddr fts =
+    (* Add _balance to ensure that caddr is in use *)
+    let all_fts = (mk_loc_id balance_label, balance_typ) :: fts in
     (* Catch errors and return a boolean - errors should be thrown by the caller *)
-    List.for_all fts ~f:(fun (f, t) ->
+    List.for_all all_fts ~f:(fun (f, t) ->
         match
           Configuration.remote_field_type caddr f (fun x _y -> x) (fun x -> x)
         with

--- a/tests/base/parser/bad/gold/cmodule-field-id-colon-cid-eq-hexlit-with.scilla.gold
+++ b/tests/base/parser/bad/gold/cmodule-field-id-colon-cid-eq-hexlit-with.scilla.gold
@@ -1,7 +1,7 @@
 {
   "errors": [
     {
-      "error_message": "Syntax error, state number 314",
+      "error_message": "Syntax error, state number 316",
       "start_location": {
         "file":
           "base/parser/bad/cmodule-field-id-colon-cid-eq-hexlit-with.scilla",

--- a/tests/base/parser/bad/gold/cmodule-field-id-colon-tid-eq-with.scilla.gold
+++ b/tests/base/parser/bad/gold/cmodule-field-id-colon-tid-eq-with.scilla.gold
@@ -1,7 +1,7 @@
 {
   "errors": [
     {
-      "error_message": "Syntax error, state number 225",
+      "error_message": "Syntax error, state number 227",
       "start_location": {
         "file": "base/parser/bad/cmodule-field-id-colon-tid-eq-with.scilla",
         "line": 7,

--- a/tests/base/parser/bad/gold/exp_t-match-spid-with-bar-underscore-arrow-hexlit-with.scilexp.gold
+++ b/tests/base/parser/bad/gold/exp_t-match-spid-with-bar-underscore-arrow-hexlit-with.scilexp.gold
@@ -1,7 +1,7 @@
 {
   "errors": [
     {
-      "error_message": "Syntax error, state number 199",
+      "error_message": "Syntax error, state number 201",
       "start_location": {
         "file":
           "base/parser/bad/exps/exp_t-match-spid-with-bar-underscore-arrow-hexlit-with.scilexp",

--- a/tests/base/parser/bad/gold/lmodule-library-cid-let-id-eq-hexlit-with.scillib.gold
+++ b/tests/base/parser/bad/gold/lmodule-library-cid-let-id-eq-hexlit-with.scillib.gold
@@ -1,7 +1,7 @@
 {
   "errors": [
     {
-      "error_message": "Syntax error, state number 207",
+      "error_message": "Syntax error, state number 209",
       "start_location": {
         "file":
           "base/parser/bad/lib/lmodule-library-cid-let-id-eq-hexlit-with.scillib",

--- a/tests/checker/bad/gold/bad_map_key_1.scilla.gold
+++ b/tests/checker/bad/gold/bad_map_key_1.scilla.gold
@@ -2,7 +2,7 @@
   "gas_remaining": "8000",
   "errors": [
     {
-      "error_message": "Syntax error, state number 86",
+      "error_message": "Syntax error, state number 88",
       "start_location": {
         "file": "checker/bad/bad_map_key_1.scilla",
         "line": 7,


### PR DESCRIPTION
A few small bugfixes:

- `_this_address` is now allowed as an address type field. Other names starting with `_` are disallowed, since `_balance` is always implicitly defined, and no other names may legally start with `_`.
- The type environment now uses the declared type of a field rather than the type of the initialiser. This is necessary since the initialiser will almost always be a ByStr20.
- 