### PR TITLE
Move EvalBuiltin to work inside EvalMonad

### DIFF
--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -33,19 +33,6 @@ module BIName = BIIdentifier.Name
 open BIType
 open BILiteral
 
-module UsefulLiterals = struct
-  let some_lit l =
-    let%bind t = literal_type l in
-    pure @@ build_some_lit l t
-
-  let none_lit t = build_none_lit t
-
-  let pair_lit l1 l2 =
-    let%bind t1 = literal_type l1 in
-    let%bind t2 = literal_type l2 in
-    pure @@ build_pair_lit l1 t1 l2 t2
-end
-
 module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
   let print_literal_list ls = PrettyPrinters.pp_literal_list ls
 
@@ -373,7 +360,6 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
   (******************** Crypto Builtins *************************)
   (***********************************************************)
   module CryptoBuiltins = struct
-    open UsefulLiterals
     open Datatypes.DataTypeDictionary
     open Scilla_crypto.Schnorr
 
@@ -470,24 +456,6 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
         (pair_typ (bystrx_typ privkey_len) (bystrx_typ pubkey_len))
 
     let[@warning "-32"] ec_gen_key_pair_arity = 0
-
-    let[@warning "-32"] ec_gen_key_pair ls _ =
-      match ls with
-      | [] -> (
-          match genKeyPair () with
-          | Some (privK, pubK) -> (
-              let privK_lit_o = Bystrx.of_raw_bytes privkey_len privK in
-              let pubK_lit_o = Bystrx.of_raw_bytes pubkey_len pubK in
-              match (privK_lit_o, pubK_lit_o) with
-              | Some privK', Some pubK' ->
-                  pair_lit (ByStrX privK') (ByStrX pubK')
-              | _ ->
-                  builtin_fail
-                    "ec_gen_key_pair: internal error, invalid private/public \
-                     key(s)."
-                    ls )
-          | None -> builtin_fail "ec_gen_key_pair: internal error." ls )
-      | _ -> builtin_fail "ec_gen_key_pair" ls
 
     let[@warning "-32"] schnorr_sign_type =
       fun_typ (bystrx_typ privkey_len)

--- a/src/base/BuiltIns.mli
+++ b/src/base/BuiltIns.mli
@@ -25,22 +25,7 @@ module BIType = BILiteral.LType
 module BIIdentifier = BIType.TIdentifier
 module BIName = BIIdentifier.Name
 
-module UsefulLiterals : sig
-  val some_lit :
-    BILiteral.t -> (BILiteral.t, ErrorUtils.scilla_error list) result
-
-  val none_lit : BIType.t -> BILiteral.t
-
-  val pair_lit :
-    BILiteral.t ->
-    BILiteral.t ->
-    (BILiteral.t, ErrorUtils.scilla_error list) result
-end
-
 module ScillaBuiltIns (SR : Rep) (ER : Rep) : sig
-  val builtin_fail :
-    string -> BILiteral.t list -> ('a, ErrorUtils.scilla_error list) result
-
   val bstring_from_int_lit : BILiteral.int_lit -> string
 
   val bstring_from_uint_lit : BILiteral.uint_lit -> string

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -146,13 +146,12 @@ let builtin_executor env f targs args_id =
   in
   let%bind tps = fromR @@ MonadUtil.mapM arg_lits ~f:literal_type in
   let%bind ret_typ, op =
-    fromR
-    @@ EvalBuiltIns.EvalBuiltInDictionary.find_builtin_op f ~targtypes:targs
-         ~vargtypes:tps
+    EvalBuiltIns.EvalBuiltInDictionary.find_builtin_op f ~targtypes:targs
+      ~vargtypes:tps
   in
   let%bind cost = fromR @@ builtin_cost env f targs tps args_id in
   let res () = op targs arg_lits ret_typ in
-  checkwrap_opR res (Uint64.of_int cost)
+  checkwrap_op res (Uint64.of_int cost) []
 
 (*******************************************************)
 (* A monadic big-step evaluator for Scilla expressions *)

--- a/src/eval/EvalBuiltins.ml
+++ b/src/eval/EvalBuiltins.ml
@@ -36,7 +36,6 @@ module ScillaEvalBuiltIns (SR : Rep) (ER : Rep) = struct
   open BILiteral
   open BIType
 
-  (* TODO *)
   let print_literal_list ls = PrettyPrinters.pp_literal_list ls
 
   let builtin_fail name ls =

--- a/src/eval/EvalBuiltins.mli
+++ b/src/eval/EvalBuiltins.mli
@@ -16,23 +16,23 @@
   scilla.  If not, see <http://www.gnu.org/licenses/>.
 *)
 
-open Core_kernel
 open Scilla_base
 open Syntax
 open ErrorUtils
 open BuiltIns
+open MonadUtil
 
 module ScillaEvalBuiltIns (SR : Rep) (ER : Rep) : sig
   module EvalBuiltInDictionary : sig
     (* Takes the expected type as an argument to elaborate the result *)
-    type built_in_executor =
+    type ('a, 'b) built_in_executor =
       BIType.t list ->
       (* type arguments *)
       BILiteral.t list ->
       (* value arguments *)
       BIType.t ->
       (* result type *)
-      (BILiteral.t, scilla_error list) result
+      (BILiteral.t, scilla_error list, 'a -> 'b) CPSMonad.t
 
     (* Returns a pair:
      * - The result type for given argument types, e.g., Bool
@@ -44,6 +44,9 @@ module ScillaEvalBuiltIns (SR : Rep) (ER : Rep) : sig
       (* type arguments *)
       vargtypes:BIType.t list ->
       (* types of value arguments *)
-      (BIType.t * built_in_executor, scilla_error list) result
+      ( BIType.t * ('a, 'b) built_in_executor,
+        scilla_error list,
+        'a -> 'b )
+      CPSMonad.t
   end
 end

--- a/src/eval/EvalUtil.ml
+++ b/src/eval/EvalUtil.ml
@@ -191,7 +191,7 @@ module Configuration = struct
 
   (* Fetch from a map. If "fetchval" is true, fetch the value, else just query if the key exists. *)
   let map_get st m klist fetchval =
-    let open BuiltIns.UsefulLiterals in
+    let open EvalLiteral in
     if fetchval then
       let%bind vopt = fromR @@ StateService.fetch ~fname:m ~keys:klist in
       match
@@ -204,9 +204,9 @@ module Configuration = struct
           (* Need to wrap the result in a Scilla Option. *)
           match vopt with
           | Some v ->
-              let%bind v_lit = fromR @@ some_lit v in
+              let%bind v_lit = pure @@ build_some_lit v vt in
               pure v_lit
-          | None -> pure (none_lit vt) )
+          | None -> pure (build_none_lit vt) )
       | None ->
           fail1
             (sprintf "Unable to fetch from map field %s" (as_error_string m))


### PR DESCRIPTION
This is needed in order to implement `to_addr`, since it relies on EvalUtil.ml, which operates within EvalMonad.