### PR TITLE
Typecheck incoming messages

### DIFF
--- a/src/base/ContractUtil.ml
+++ b/src/base/ContractUtil.ml
@@ -35,24 +35,35 @@ module CUName = CUIdentifier.Name
 module MessagePayload = struct
   let tag_label = "_tag"
 
+  let tag_type = CUType.string_typ
+
   let amount_label = "_amount"
+
+  let amount_type = CUType.uint128_typ
 
   let sender_label = "_sender"
 
+  let sender_type = CUType.bystrx_typ address_length
+
   let origin_label = "_origin"
 
+  let origin_type = CUType.bystrx_typ address_length
+
   let recipient_label = "_recipient"
+
+  let recipient_type = CUType.bystrx_typ address_length
 
   let eventname_label = "_eventname"
 
   let exception_label = "_exception"
 
   let get_value_for_entry lab f es =
-    match List.Assoc.find es lab ~equal:String.( = ) with
+    match List.find es ~f:(fun (x, _, _) -> String.(x = lab)) with
     | None ->
         fail0
-        @@ sprintf "No field \"%s\" in message [%s]." lab (pp_literal_map es)
-    | Some p ->
+        @@ sprintf "No field \"%s\" in message [%s]." lab
+             (pp_typ_literal_map es)
+    | Some (_, _, p) ->
         f p
         |> Option.value
              ~default:
@@ -95,12 +106,26 @@ module MessagePayload = struct
       | _ -> None)
 
   let get_other_entries es =
-    List.filter es ~f:(fun (l, _) -> String.(l <> tag_label))
+    List.filter es ~f:(fun (l, _, _) -> String.(l <> tag_label))
 end
+
+(*****************************************************************)
+(*               Blockchain component typing                     *)
+(*****************************************************************)
+
+let blocknum_name = "BLOCKNUMBER"
+
+let blocknum_type = CUType.bnum_typ
+
+(*****************************************************************)
+(*           Init and outputjson component typing                *)
+(*****************************************************************)
 
 let label_name_of_string str = CUName.parse_simple_name str
 
 let balance_label = label_name_of_string "_balance"
+
+let balance_type = CUType.uint128_typ
 
 let creation_block_label = label_name_of_string "_creation_block"
 
@@ -119,8 +144,7 @@ module ScillaContractUtil (SR : Rep) (ER : Rep) = struct
   open ContractUtilSyntax
 
   let balance_field =
-    let open CUType in
-    (CUIdentifier.mk_id balance_label ER.uint128_rep, uint128_typ)
+    (CUIdentifier.mk_id balance_label ER.uint128_rep, balance_type)
 
   let append_implict_contract_params tparams =
     let open CUType in
@@ -143,32 +167,31 @@ module ScillaContractUtil (SR : Rep) (ER : Rep) = struct
         not (List.mem nonevalargs (fst a) ~equal:[%equal: CUName.t]))
 
   let append_implict_comp_params cparams =
-    let open CUType in
     let sender =
       ( CUIdentifier.mk_id
           (label_name_of_string MessagePayload.sender_label)
           ER.address_rep,
-        bystrx_typ address_length )
+        MessagePayload.sender_type )
     in
     let origin =
       ( CUIdentifier.mk_id
           (label_name_of_string MessagePayload.origin_label)
           ER.address_rep,
-        bystrx_typ address_length )
+        MessagePayload.origin_type )
     in
     let amount =
       ( CUIdentifier.mk_id
           (label_name_of_string MessagePayload.amount_label)
           ER.uint128_rep,
-        uint128_typ )
+        MessagePayload.amount_type )
     in
     amount :: origin :: sender :: cparams
 
   let msg_mandatory_field_types =
     [
-      (MessagePayload.tag_label, CUType.string_typ);
-      (MessagePayload.amount_label, CUType.uint128_typ);
-      (MessagePayload.recipient_label, CUType.bystrx_typ address_length);
+      (MessagePayload.tag_label, MessagePayload.tag_type);
+      (MessagePayload.amount_label, MessagePayload.amount_type);
+      (MessagePayload.recipient_label, MessagePayload.recipient_type);
     ]
 
   (* Iterate over all messages in the contract, accumuating result. 

--- a/src/base/Disambiguate.ml
+++ b/src/base/Disambiguate.ml
@@ -288,9 +288,10 @@ module ScillaDisambiguation (SR : Rep) (ER : Rep) = struct
       | Msg msg_entries ->
           (* Msg literals are strictly speaking illegal, but the parser should prevent us from ever getting here. *)
           let%bind res_msg_entries =
-            foldrM msg_entries ~init:[] ~f:(fun acc (label, l) ->
+            foldrM msg_entries ~init:[] ~f:(fun acc (label, t, l) ->
                 let%bind res_l = recurser l in
-                pure @@ ((label, res_l) :: acc))
+                let%bind res_t = disambiguate_type dicts.typ_dict t in
+                pure @@ ((label, res_t, res_l) :: acc))
           in
           pure @@ ResLit.Msg res_msg_entries
       | Map ((kt, vt), mentries) ->

--- a/src/base/Gas.ml
+++ b/src/base/Gas.ml
@@ -66,7 +66,7 @@ module ScillaGas (SR : Rep) (ER : Rep) = struct
     (* Message: an associative array *)
     | Msg m ->
         foldM
-          ~f:(fun acc (s, lit') ->
+          ~f:(fun acc (s, _t, lit') ->
             let%bind cs = literal_cost (StringLit s) in
             let%bind clit' = literal_cost lit' in
             pure (acc + cs + clit'))

--- a/src/base/Literal.ml
+++ b/src/base/Literal.ml
@@ -125,7 +125,7 @@ module type ScillaLiteral = sig
     (* Byte string without a statically known length. *)
     | ByStr of Bystr.t
     (* Message: an associative array *)
-    | Msg of (string * t) list
+    | Msg of (string * LType.t * t) list
     (* A dynamic map of literals *)
     | Map of mtype * (t, t) Hashtbl.t
     (* A constructor in HNF *)
@@ -348,7 +348,7 @@ module MkLiteral (T : ScillaType) = struct
     (* Byte string without a statically known length. *)
     | ByStr of Bystr.t
     (* Message: an associative array *)
-    | Msg of (string * t) list
+    | Msg of (string * LType.t * t) list
     (* A dynamic map of literals *)
     | Map of mtype * (t, t) Hashtbl.t
     (* A constructor in HNF *)

--- a/src/base/PrettyPrinters.ml
+++ b/src/base/PrettyPrinters.ml
@@ -232,7 +232,7 @@ let rec pp_literal_simplified l =
   | Msg m ->
       let items =
         "["
-        ^ List.fold_left m ~init:"" ~f:(fun a (s, l') ->
+        ^ List.fold_left m ~init:"" ~f:(fun a (s, _t, l') ->
               let t = "(" ^ s ^ " : " ^ pp_literal_simplified l' ^ ")" in
               if String.is_empty a then t else a ^ " ; " ^ t)
         ^ "]"
@@ -302,15 +302,25 @@ let pp_literal_map s =
   let cs = String.concat ~sep:",\n " ps in
   sprintf "{%s }" cs
 
+let pp_typ_literal_map s =
+  let ps =
+    List.map s ~f:(fun (k, t, v) ->
+        sprintf " [%s : %s -> %s]" k (PPType.pp_typ t) (pp_literal v))
+  in
+  let cs = String.concat ~sep:",\n " ps in
+  sprintf "{%s }" cs
+
 let pp_literal_list ls =
   let ps = List.map ls ~f:(fun l -> sprintf " %s" (pp_literal l)) in
   let cs = String.concat ~sep:",\n " ps in
   sprintf "[ %s]" cs
 
-let pp_typ_map s =
+let pp_str_typ_map s =
   let ps =
-    List.map s ~f:(fun (k, v) ->
-        sprintf " [%s : %s]" (PPName.as_string k) (PPType.pp_typ v))
+    List.map s ~f:(fun (k, v) -> sprintf " [%s : %s]" k (PPType.pp_typ v))
   in
   let cs = String.concat ~sep:",\n" ps in
   sprintf "{%s }" cs
+
+let pp_typ_map s =
+  List.map s ~f:(fun (k, v) -> (PPName.as_string k, v)) |> pp_str_typ_map

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -106,7 +106,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
   (*               Blockchain component typing                     *)
   (*****************************************************************)
 
-  let bc_types = [ (TypeUtil.blocknum_name, bnum_typ) ]
+  let bc_types = [ (blocknum_name, blocknum_type) ]
 
   let lookup_bc_type x =
     match List.Assoc.find bc_types x ~equal:String.( = ) with
@@ -447,7 +447,12 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
         @@ ( TypedSyntax.TApp (add_type_to_ident tf tf_rr, arg_types),
              (mk_qual_tp res_type, rep) )
     | Message bs ->
-        let%bind msg_typ = fromR_TE @@ get_msgevnt_type bs (ER.get_loc rep) in
+        let%bind msg_typ =
+          fromR_TE
+          @@ get_msgevnt_type
+               (List.map bs ~f:(fun (x, l) -> (x, Unit, l)))
+               (ER.get_loc rep)
+        in
         let payload_type fld pld =
           let check_field_type seen_type =
             match

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -391,11 +391,12 @@ module TypeUtilities = struct
 
   let get_msgevnt_type m lc =
     let open ContractUtil.MessagePayload in
-    if List.Assoc.mem m tag_label ~equal:String.( = ) then pure TUType.msg_typ
-    else if List.Assoc.mem m eventname_label ~equal:String.( = ) then
-      pure TUType.event_typ
-    else if List.Assoc.mem m exception_label ~equal:String.( = ) then
-      pure TUType.exception_typ
+    if List.exists m ~f:(fun (x, _, _) -> String.(tag_label = x)) then
+      pure TUType.msg_typ
+    else if List.exists m ~f:(fun (x, _, _) -> String.(eventname_label = x))
+    then pure TUType.event_typ
+    else if List.exists m ~f:(fun (x, _, _) -> String.(exception_label = x))
+    then pure TUType.exception_typ
     else
       fail1 "Invalid message construct. Not any of send, event or exception." lc
 
@@ -616,9 +617,16 @@ module TypeUtilities = struct
         let%bind msg_typ = get_msgevnt_type m lc in
         let%bind all_storable =
           foldM
-            ~f:(fun acc (_, l) ->
-              let%bind t = is_wellformed_lit l in
-              if acc then pure (is_storable_type t) else pure false)
+            ~f:(fun acc (n, t, l) ->
+              let%bind t' = is_wellformed_lit l in
+              if not @@ [%equal: TUType.t] t t' then
+                fail0
+                @@ sprintf
+                     "Message/Event has inconsistent values and types at field \
+                      %s"
+                     n
+              else if acc then pure (is_storable_type t)
+              else pure false)
             ~init:true m
         in
         if not all_storable then
@@ -680,9 +688,3 @@ module TypeUtilities = struct
     | Clo _ -> fail0 @@ "Cannot type-check runtime closure."
     | TAbs _ -> fail0 @@ "Cannot type-check runtime type function."
 end
-
-(*****************************************************************)
-(*               Blockchain component typing                     *)
-(*****************************************************************)
-
-let blocknum_name = "BLOCKNUMBER"

--- a/src/base/TypeUtil.mli
+++ b/src/base/TypeUtil.mli
@@ -147,7 +147,7 @@ module TypeUtilities : sig
   val is_non_map_ground_type : TUType.t -> bool
 
   val get_msgevnt_type :
-    (string * 'a) list -> loc -> (TUType.t, scilla_error list) result
+    (string * 'a * 'b) list -> loc -> (TUType.t, scilla_error list) result
 
   val map_access_type : TUType.t -> int -> (TUType.t, scilla_error list) result
 
@@ -232,9 +232,3 @@ module TypeUtilities : sig
   val assert_all_same_type :
     lc:ErrorUtils.loc -> TUType.t list -> (unit, scilla_error list) result
 end
-
-(****************************************************************)
-(*                  Built-in typed entities                     *)
-(****************************************************************)
-
-val blocknum_name : string

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -68,7 +68,7 @@ let rec is_pure_literal l =
   match l with
   | Clo _ -> false
   | TAbs _ -> false
-  | Msg es -> List.for_all es ~f:(fun (_, l') -> is_pure_literal l')
+  | Msg es -> List.for_all es ~f:(fun (_, _, l') -> is_pure_literal l')
   | ADTValue (_, _, es) -> List.for_all es ~f:(fun e -> is_pure_literal e)
   (* | Map (_, ht) ->
    *     let es = Caml.Hashtbl.to_alist ht in
@@ -187,7 +187,10 @@ let rec exp_eval erep env =
       in
       let%bind payload_resolved =
         (* Make sure we resolve all the payload *)
-        mapM bs ~f:(fun (s, pld) -> liftPair2 s @@ fromR @@ resolve pld)
+        mapM bs ~f:(fun (s, pld) ->
+            let%bind sanitized_lit = fromR @@ resolve pld in
+            let%bind t = fromR @@ literal_type sanitized_lit in
+            pure (s, t, sanitized_lit))
       in
       pure (Msg payload_resolved, env)
   | Fun (formal, _, body) ->
@@ -481,16 +484,18 @@ and try_apply_as_procedure conf proc proc_rest actuals =
 (*******************************************************)
 
 let check_blockchain_entries entries =
-  let expected = [ (TypeUtil.blocknum_name, BNum "0") ] in
+  let expected = [ (ContractUtil.blocknum_name, ContractUtil.blocknum_type) ] in
   (* every entry must be expected *)
   let c1 =
-    List.for_all entries ~f:(fun (s, _) ->
-        List.Assoc.mem expected s ~equal:String.( = ))
+    List.for_all entries ~f:(fun (s, t, _) ->
+        List.exists expected ~f:(fun (x, xt) ->
+            String.(x = s) && [%equal: EvalType.t] xt t))
   in
   (* everything expected must be entered *)
   let c2 =
-    List.for_all expected ~f:(fun (s, _) ->
-        List.Assoc.mem entries s ~equal:String.( = ))
+    List.for_all expected ~f:(fun (x, xt) ->
+        List.exists entries ~f:(fun (s, t, _) ->
+            String.(x = s) && [%equal: EvalType.t] xt t))
   in
   if c1 && c2 then pure entries
   else
@@ -501,7 +506,8 @@ let check_blockchain_entries entries =
           %s\n\
           provided:\n\
           %s\n"
-         (pp_literal_map expected) (pp_literal_map entries)
+         (pp_str_typ_map expected)
+         (pp_typ_literal_map entries)
 
 (*******************************************************)
 (*              Contract initialization                *)
@@ -589,10 +595,10 @@ let init_libraries clibs elibs =
 (* Initialize fields in a constant environment *)
 let init_fields env fs =
   (* Initialize a field in a constant environment *)
-  let init_field fname _t fexp =
+  let init_field fname t fexp =
     let%bind v, _ = exp_eval_wrapper_no_cps fexp env in
     match v with
-    | l when is_pure_literal l -> pure (fname, l)
+    | l when is_pure_literal l -> pure (fname, t, l)
     | _ ->
         fail0
         @@ sprintf "Closure cannot be stored in a field %s."
@@ -665,7 +671,7 @@ let create_cur_state_fields initcstate curcstate =
      flag it as invalid input state *)
   let%bind () =
     forallM
-      ~f:(fun (s, lc) ->
+      ~f:(fun (s, _t, lc) ->
         let%bind t_lc = fromR @@ literal_type lc in
         let emsg () =
           mk_error0
@@ -675,10 +681,9 @@ let create_cur_state_fields initcstate curcstate =
         in
         let%bind _, ex =
           tryM
-            ~f:(fun (t, li) ->
-              let%bind t1 = fromR @@ literal_type lc in
+            ~f:(fun (t, _tt, li) ->
               let%bind t2 = fromR @@ literal_type li in
-              if [%equal: EvalName.t] s t && [%equal: EvalType.t] t1 t2 then
+              if [%equal: EvalName.t] s t && [%equal: EvalType.t] t_lc t2 then
                 pure ()
               else fail0 "")
             initcstate ~msg:emsg
@@ -689,9 +694,10 @@ let create_cur_state_fields initcstate curcstate =
   (* Each entry name is unique *)
   let%bind () =
     forallM
-      ~f:(fun (e, _) ->
+      ~f:(fun (e, _, _) ->
         if
-          List.count curcstate ~f:(fun (e', _) -> [%equal: EvalName.t] e e') > 1
+          List.count curcstate ~f:(fun (e', _, _) -> [%equal: EvalName.t] e e')
+          > 1
         then
           fail0
             (sprintf "Field %s occurs more than once in input.\n"
@@ -701,8 +707,9 @@ let create_cur_state_fields initcstate curcstate =
   in
   (* Get only those fields from initcstate that are not in curcstate *)
   let filtered_init =
-    List.filter initcstate ~f:(fun (s, _) ->
-        not (List.Assoc.mem curcstate s ~equal:[%equal: EvalName.t]))
+    List.filter initcstate ~f:(fun (s, _, _) ->
+        not
+          (List.exists curcstate ~f:(fun x -> [%equal: EvalName.t] s (fst3 x))))
   in
   (* Combine filtered list and curcstate *)
   pure (filtered_init @ curcstate)
@@ -764,18 +771,20 @@ let check_message_entries cparams_o entries =
   let tparams = CU.append_implict_comp_params cparams_o in
   (* There as an entry for each parameter *)
   let valid_entries =
-    List.for_all tparams ~f:(fun (s, _) ->
-        List.Assoc.mem entries (as_string s) ~equal:String.( = ))
+    List.for_all tparams ~f:(fun (x, xt) ->
+        List.exists entries ~f:(fun (s, t, _) ->
+            String.(as_string x = s) && [%equal: EvalType.t] xt t))
   in
   (* There is a parameter for each entry *)
   let valid_params =
-    List.for_all entries ~f:(fun (s, _) ->
-        List.exists tparams ~f:(fun (i, _) -> String.(s = as_string i)))
+    List.for_all entries ~f:(fun (s, t, _) ->
+        List.exists tparams ~f:(fun (x, xt) ->
+            String.(as_string x = s) && [%equal: EvalType.t] xt t))
   in
   (* Each entry name is unique *)
   let uniq_entries =
     not
-    @@ List.contains_dup entries ~compare:(fun (s, _) (t, _) ->
+    @@ List.contains_dup entries ~compare:(fun (s, _, _) (t, _, _) ->
            String.compare s t)
   in
   if not (valid_entries && uniq_entries && valid_params) then
@@ -784,7 +793,8 @@ let check_message_entries cparams_o entries =
          "Duplicate entries or mismatch b/w message entries:\n\
           %s\n\
           and expected transition parameters%s\n"
-         (pp_literal_map entries) (pp_cparams tparams)
+         (pp_typ_literal_map entries)
+         (pp_cparams tparams)
   else pure entries
 
 (* Get the environment, incoming amount, procedures in scope, and body to execute*)
@@ -828,7 +838,7 @@ let post_process_msgs cstate outs =
 Handle message:
 * contr : Syntax.contract - code of the contract (containing transitions and procedures)
 * cstate : ContractState.t - current contract state
-* bstate : (string * literal) list - blockchain state
+* bstate : (string * type * literal) list - blockchain state
 * m : Syntax.literal - incoming message 
 *)
 let handle_message contr cstate bstate m =
@@ -839,7 +849,7 @@ let handle_message contr cstate bstate m =
   let { env; fields; balance } = cstate in
   (* Add all values to the contract environment *)
   let%bind actual_env =
-    foldM tenv ~init:env ~f:(fun e (n, l) ->
+    foldM tenv ~init:env ~f:(fun e (n, _t, l) ->
         (* TODO, Issue #836: Message fields may contain periods, which shouldn't be allowed. *)
         match String.split n ~on:'.' with
         | [ simple_name ] ->
@@ -855,7 +865,7 @@ let handle_message contr cstate bstate m =
       fields;
       balance;
       accepted = false;
-      blockchain_state = bstate;
+      blockchain_state = List.map bstate ~f:(fun x -> (fst3 x, trd3 x));
       incoming_funds;
       procedures;
       component_stack = [ tname ];

--- a/src/eval/EvalBuiltins.ml
+++ b/src/eval/EvalBuiltins.ml
@@ -562,7 +562,7 @@ module ScillaEvalBuiltIns (SR : Rep) (ER : Rep) = struct
             | ByStrX bs -> Bystrx.to_raw_bytes bs
             | Msg entries ->
                 let raw_entries =
-                  List.map entries ~f:(fun (s, v) -> s ^ raw_bytes v)
+                  List.map entries ~f:(fun (s, _t, v) -> s ^ raw_bytes v)
                 in
                 Core_kernel.String.concat ~sep:"" raw_entries
             | Map (_, tbl) ->

--- a/src/eval/EvalUtil.ml
+++ b/src/eval/EvalUtil.ml
@@ -267,39 +267,24 @@ module Configuration = struct
     in
     finder st.procedures
 
-  (* Check that message is well-formed before adding to the sending pool *)
-  let rec validate_messages ls =
-    let open EvalLiteral in
-    (* Note: We don't need a whole lot of checks as the checker does it. *)
-    let validate_msg_payload pl =
-      let has_tag = List.Assoc.mem pl "tag" ~equal:String.( = ) in
-      if has_tag then pure ()
-      else
-        fail0
-        @@ sprintf "Message contents have no \"tag\" field:\n[%s]"
-             (pp_literal_map pl)
-    in
-    match ls with
-    | Msg pl :: tl ->
-        let%bind () = validate_msg_payload pl in
-        validate_messages tl
-    | [] -> pure ()
-    | m :: _ -> fail0 @@ sprintf "This is not a message:\n%s" (pp_literal m)
-
   let validate_outgoing_message m' =
     let open EvalLiteral in
     let open ContractUtil.MessagePayload in
     match m' with
     | Msg m ->
         (* All outgoing messages must have certain mandatory fields *)
-        let tag_found = List.Assoc.mem m tag_label ~equal:String.( = ) in
-        let amount_found = List.Assoc.mem m amount_label ~equal:String.( = ) in
+        let tag_found =
+          List.exists m ~f:(fun (x, _, _) -> String.(tag_label = x))
+        in
+        let amount_found =
+          List.exists m ~f:(fun (x, _, _) -> String.(amount_label = x))
+        in
         let recipient_found =
-          List.Assoc.mem m recipient_label ~equal:String.( = )
+          List.exists m ~f:(fun (x, _, _) -> String.(recipient_label = x))
         in
         let uniq_entries =
           not
-          @@ List.contains_dup m ~compare:(fun (s, _) (t, _) ->
+          @@ List.contains_dup m ~compare:(fun (s, _, _) (t, _, _) ->
                  String.compare s t)
         in
         if tag_found && amount_found && recipient_found && uniq_entries then
@@ -329,11 +314,11 @@ module Configuration = struct
     | Msg m ->
         (* All events must have certain mandatory fields *)
         let eventname_found =
-          List.Assoc.mem m eventname_label ~equal:String.( = )
+          List.exists m ~f:(fun (x, _, _) -> String.(eventname_label = x))
         in
         let uniq_entries =
           not
-          @@ List.contains_dup m ~compare:(fun (s, _) (t, _) ->
+          @@ List.contains_dup m ~compare:(fun (s, _, _) (t, _, _) ->
                  String.compare s t)
         in
         if eventname_found && uniq_entries then pure m'

--- a/src/eval/StateService.ml
+++ b/src/eval/StateService.ml
@@ -275,13 +275,13 @@ module MakeStateService () = struct
                 fail0
                   (sprintf "StateService: Field %s's value is not known"
                      (SSName.as_error_string f.fname))
-            | Some l -> pure (f.fname, l))
+            | Some l -> pure (f.fname, f.ftyp, l))
     | SS (IPC _, fl) ->
         let%bind sl =
           mapM fl ~f:(fun f ->
               let%bind vopt = fetch ~fname:(mk_loc_id f.fname) ~keys:[] in
               match vopt with
-              | Some v -> pure (f.fname, v)
+              | Some v -> pure (f.fname, f.ftyp, v)
               | None ->
                   fail0
                     (sprintf

--- a/src/runners/disambiguate_state_json.ml
+++ b/src/runners/disambiguate_state_json.ml
@@ -542,13 +542,13 @@ let jobj_to_statevar this_address json =
   let t = parse_typ_exn tstring in
   let dis_t = disambiguate_type t this_address in
   let v = member_exn "value" json in
-  (n, parse_json dis_t this_address v)
+  (n, dis_t, parse_json dis_t this_address v)
 
 (* Inserted from Runner.ml *)
 let map_json_input_strings_to_names map =
-  List.map map ~f:(fun (x, l) ->
+  List.map map ~f:(fun (x, t, l) ->
       match String.split x ~on:'.' with
-      | [ simple_name ] -> (OutputName.parse_simple_name simple_name, l)
+      | [ simple_name ] -> (OutputName.parse_simple_name simple_name, t, l)
       | _ -> raise (mk_invalid_json (sprintf "invalid name %s in json input" x)))
 
 let get_address_literal = JSON.get_address_literal
@@ -886,7 +886,7 @@ let run_with_args args =
                     parse_json args.input_state this_address
                   in
                   let balance =
-                    List.find_exn state_from_file ~f:(fun (fname, _) ->
+                    List.find_exn state_from_file ~f:(fun (fname, _, _) ->
                         OutputName.equal fname ContractUtil.balance_label)
                   in
                   balance :: state

--- a/tests/runner/Testcontracts.ml
+++ b/tests/runner/Testcontracts.ml
@@ -381,6 +381,9 @@ let contract_tests env =
                 "crowdfunding_proc"
                 >: build_contract_init_test env fail_code "crowdfunding_proc"
                      "init_goal_is_zero" false;
+                "shogi"
+                >::: build_contract_tests env "shogi" fail_code 5 7
+                       [ "shogi_lib" ];
               ];
          "misc_tests" >::: build_misc_tests env;
        ]

--- a/tests/runner/helloWorld/output_6.json
+++ b/tests/runner/helloWorld/output_6.json
@@ -3,7 +3,7 @@
   "errors": [
     {
       "error_message":
-        "Duplicate entries or mismatch b/w message entries:\n{ [_amount -> (Uint128 0)],\n  [_origin -> (ByStr20 0xa2345678901234567890123456789012345678ab)],\n  [_sender -> (ByStr20 0xa2345678901234567890123456789012345678ab)],\n  [Unknown -> (Int32 0)] }\nand expected transition parameters[_amount : (PrimType Uint128), _origin : (PrimType ByStr20), _sender : (PrimType ByStr20)]\n",
+        "Duplicate entries or mismatch b/w message entries:\n{ [_amount : Uint128 -> (Uint128 0)],\n  [_origin : ByStr20 -> (ByStr20 0xa2345678901234567890123456789012345678ab)],\n  [_sender : ByStr20 -> (ByStr20 0xa2345678901234567890123456789012345678ab)],\n  [Unknown : Int32 -> (Int32 0)] }\nand expected transition parameters[_amount : (PrimType Uint128), _origin : (PrimType ByStr20), _sender : (PrimType ByStr20)]\n",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/runner/helloWorld/output_8.json
+++ b/tests/runner/helloWorld/output_8.json
@@ -3,7 +3,7 @@
   "errors": [
     {
       "error_message":
-        "Mismatch in input blockchain variables:\nexpected:\n{ [BLOCKNUMBER -> (BNum 0)] }\nprovided:\n{ [Unknown -> (BNum 100)] }\n",
+        "Mismatch in input blockchain variables:\nexpected:\n{ [BLOCKNUMBER : BNum] }\nprovided:\n{ [Unknown : BNum -> (BNum 100)] }\n",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/runner/shogi/blockchain_5.json
+++ b/tests/runner/shogi/blockchain_5.json
@@ -1,0 +1,1 @@
+[ { "vname": "BLOCKNUMBER", "type": "BNum", "value": "100" } ]

--- a/tests/runner/shogi/blockchain_6.json
+++ b/tests/runner/shogi/blockchain_6.json
@@ -1,0 +1,1 @@
+[ { "vname": "BLOCKNUMBER", "type": "BNum", "value": "100" } ]

--- a/tests/runner/shogi/blockchain_7.json
+++ b/tests/runner/shogi/blockchain_7.json
@@ -1,0 +1,1 @@
+[ { "vname": "BLOCKNUMBER", "type": "BNum", "value": "100" } ]

--- a/tests/runner/shogi/message_5.json
+++ b/tests/runner/shogi/message_5.json
@@ -1,0 +1,41 @@
+{
+    "_tag": "MoveAction",
+    "_amount": "0",
+    "_sender": "0x1234567890123456789012345678906784567890",
+    "params": [
+        {
+            "vname": "row",
+            "type": "Uint128",
+            "value": "1"
+        },
+        {
+            "vname": "column",
+            "type": "Uint32",
+            "value": "1"
+        },
+        {
+            "vname": "direction",
+            "type": "ShogiLib.Direction",
+            "value": {
+                "constructor": "ShogiLib.North",
+                "argtypes": [],
+                "arguments": []
+            }
+        },
+        {
+            "vname": "distance",
+            "type": "Uint32",
+            "value": "3"
+        },
+        {
+            "vname": "promote",
+            "type": "Bool",
+            "value": {
+                "constructor": "False",
+                "argtypes": [],
+                "arguments": []
+            }
+        }
+    ],
+    "_origin": "0x1234567890123456789012345678906784567890"
+}

--- a/tests/runner/shogi/message_6.json
+++ b/tests/runner/shogi/message_6.json
@@ -1,0 +1,41 @@
+{
+    "_tag": "MoveAction",
+    "_amount": "0",
+    "_sender": "0x1234567890123456789012345678906784567890",
+    "params": [
+        {
+            "vname": "row",
+            "type": "Uint32",
+            "value": "1"
+        },
+        {
+            "vname": "column",
+            "type": "Uint32",
+            "value": "1"
+        },
+        {
+            "vname": "direction",
+            "type": "ShogiLib.Direction",
+            "value": {
+                "constructor": "ShogiLib.Free",
+                "argtypes": [],
+                "arguments": []
+            }
+        },
+        {
+            "vname": "distance",
+            "type": "Uint32",
+            "value": "3"
+        },
+        {
+            "vname": "promote",
+            "type": "Bool",
+            "value": {
+                "constructor": "False",
+                "argtypes": [],
+                "arguments": []
+            }
+        }
+    ],
+    "_origin": "0x1234567890123456789012345678906784567890"
+}

--- a/tests/runner/shogi/message_7.json
+++ b/tests/runner/shogi/message_7.json
@@ -1,0 +1,41 @@
+{
+    "_tag": "MoveAction",
+    "_amount": "0",
+    "_sender": "0x1234567890123456789012345678906784567890",
+    "params": [
+        {
+            "vname": "row",
+            "type": "Uint32",
+            "value": "1"
+        },
+        {
+            "vname": "column",
+            "type": "Uint32",
+            "value": "1"
+        },
+        {
+            "vname": "direction",
+            "type": "ShogiLib.Direction",
+            "value": {
+                "constructor": "ShogiLib.North",
+                "argtypes": [],
+                "arguments": []
+            }
+        },
+        {
+            "vname": "distance",
+            "type": "Uint32",
+            "value": "3"
+        },
+        {
+            "vname": "promote",
+            "type": "ShogiLib.Direction",
+            "value": {
+                "constructor": "ShogiLib.North",
+                "argtypes": [],
+                "arguments": []
+            }
+        }
+    ],
+    "_origin": "0x1234567890123456789012345678906784567890"
+}

--- a/tests/runner/shogi/output_5.json
+++ b/tests/runner/shogi/output_5.json
@@ -1,0 +1,12 @@
+{
+  "gas_remaining": "7763",
+  "errors": [
+    {
+      "error_message":
+        "Duplicate entries or mismatch b/w message entries:\n{ [_amount : Uint128 -> (Uint128 0)],\n  [_origin : ByStr20 -> (ByStr20 0x1234567890123456789012345678906784567890)],\n  [_sender : ByStr20 -> (ByStr20 0x1234567890123456789012345678906784567890)],\n  [row : Uint128 -> (Uint128 1)],\n  [column : Uint32 -> (Uint32 1)],\n  [direction : ShogiLib.Direction -> (ShogiLib.North)],\n  [distance : Uint32 -> (Uint32 3)],\n  [promote : Bool -> (False)] }\nand expected transition parameters[_amount : (PrimType Uint128), _origin : (PrimType ByStr20), _sender : (PrimType ByStr20), row : (PrimType Uint32), column : (PrimType Uint32), direction : (ADT(Ident((QualifiedGlobal ShogiLib Direction)Direction)((fname tests/contracts/shogi.scilla)(lnum 589)(cnum 15)))()), distance : (PrimType Uint32), promote : (ADT(Ident((SimpleGlobal Bool)Bool)((fname tests/contracts/shogi.scilla)(lnum 591)(cnum 13)))())]\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": []
+}

--- a/tests/runner/shogi/output_6.json
+++ b/tests/runner/shogi/output_6.json
@@ -1,0 +1,18 @@
+{
+  "gas_remaining": "7868",
+  "errors": [
+    {
+      "error_message":
+        "ADT type Direction does not match constructor ShogiLib.Free",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Failed to parse json tests/runner/shogi/message_6.json:\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": []
+}

--- a/tests/runner/shogi/output_7.json
+++ b/tests/runner/shogi/output_7.json
@@ -1,0 +1,12 @@
+{
+  "gas_remaining": "7761",
+  "errors": [
+    {
+      "error_message":
+        "Duplicate entries or mismatch b/w message entries:\n{ [_amount : Uint128 -> (Uint128 0)],\n  [_origin : ByStr20 -> (ByStr20 0x1234567890123456789012345678906784567890)],\n  [_sender : ByStr20 -> (ByStr20 0x1234567890123456789012345678906784567890)],\n  [row : Uint32 -> (Uint32 1)],\n  [column : Uint32 -> (Uint32 1)],\n  [direction : ShogiLib.Direction -> (ShogiLib.North)],\n  [distance : Uint32 -> (Uint32 3)],\n  [promote : ShogiLib.Direction -> (ShogiLib.North)] }\nand expected transition parameters[_amount : (PrimType Uint128), _origin : (PrimType ByStr20), _sender : (PrimType ByStr20), row : (PrimType Uint32), column : (PrimType Uint32), direction : (ADT(Ident((QualifiedGlobal ShogiLib Direction)Direction)((fname tests/contracts/shogi.scilla)(lnum 589)(cnum 15)))()), distance : (PrimType Uint32), promote : (ADT(Ident((SimpleGlobal Bool)Bool)((fname tests/contracts/shogi.scilla)(lnum 591)(cnum 13)))())]\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": []
+}

--- a/tests/runner/shogi/state_5.json
+++ b/tests/runner/shogi/state_5.json
@@ -1,0 +1,128 @@
+[
+    { "vname": "_balance",
+      "type": "Uint128",
+      "value": "0" },
+    {
+      "vname": "board",
+      "type": "Map Uint32 (Map Uint32 ShogiLib.SquareContents)",
+      "value": [
+          {
+              "key": "1",
+              "val": [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "ShogiLib.Occupied",
+                          "argtypes" : [],
+                          "arguments" : [
+                              {
+                                  "constructor" : "ShogiLib.Rook",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              {
+                                  "constructor" : "ShogiLib.NotPromoted",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              "0x1234567890123456789012345678906784567890"
+                          ]
+                      }
+                  }
+              ]
+          },
+          {
+              "key" : "2",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "ShogiLib.Free",
+                          "argtypes" : [],
+                          "arguments" : []
+                      }
+                  }
+              ]
+          },
+          {   
+              "key" : "3",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "ShogiLib.Free",
+                          "argtypes" : [],
+                          "arguments" : []
+                      }
+                  }
+              ]
+          },
+          {
+              "key" : "4",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "ShogiLib.Occupied",
+                          "argtypes" : [],
+                          "arguments" : [
+                              {
+                                  "constructor" : "ShogiLib.Pawn",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              {
+                                  "constructor" : "ShogiLib.NotPromoted",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              "0xabcdeabcde123456786782345678901234567890"
+                          ]
+                      }
+                  }
+              ]
+          }
+      ]
+    },
+    {
+      "vname": "captured_pieces",
+      "type": "Map (ByStr20) (Map (Uint32) (Uint32))",
+      "value": [
+          {   
+              "key" : "0x1234567890123456789012345678906784567890",
+              "val" : [
+                  {
+                      "key" : "6",
+                      "val" : "0"
+                  }
+              ]
+          }
+      ]
+    },
+    { 
+      "vname": "player_in_turn",
+      "type": "Option ByStr20",
+      "value":
+        {
+            "constructor": "Some",
+            "argtypes"   : [ "ByStr20" ],
+            "arguments"  : [
+                "0x1234567890123456789012345678906784567890"
+            ]
+        }
+    },
+    { 
+      "vname": "winner",
+      "type": "Option ByStr20",
+      "value":
+        {
+            "constructor": "None",
+            "argtypes"   : [ "ByStr20" ],
+            "arguments"  : []
+        }
+    }
+]

--- a/tests/runner/shogi/state_6.json
+++ b/tests/runner/shogi/state_6.json
@@ -1,0 +1,128 @@
+[
+    { "vname": "_balance",
+      "type": "Uint128",
+      "value": "0" },
+    {
+      "vname": "board",
+      "type": "Map Uint32 (Map Uint32 ShogiLib.SquareContents)",
+      "value": [
+          {
+              "key": "1",
+              "val": [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "ShogiLib.Occupied",
+                          "argtypes" : [],
+                          "arguments" : [
+                              {
+                                  "constructor" : "ShogiLib.Rook",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              {
+                                  "constructor" : "ShogiLib.NotPromoted",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              "0x1234567890123456789012345678906784567890"
+                          ]
+                      }
+                  }
+              ]
+          },
+          {
+              "key" : "2",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "ShogiLib.Free",
+                          "argtypes" : [],
+                          "arguments" : []
+                      }
+                  }
+              ]
+          },
+          {   
+              "key" : "3",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "ShogiLib.Free",
+                          "argtypes" : [],
+                          "arguments" : []
+                      }
+                  }
+              ]
+          },
+          {
+              "key" : "4",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "ShogiLib.Occupied",
+                          "argtypes" : [],
+                          "arguments" : [
+                              {
+                                  "constructor" : "ShogiLib.Pawn",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              {
+                                  "constructor" : "ShogiLib.NotPromoted",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              "0xabcdeabcde123456786782345678901234567890"
+                          ]
+                      }
+                  }
+              ]
+          }
+      ]
+    },
+    {
+      "vname": "captured_pieces",
+      "type": "Map (ByStr20) (Map (Uint32) (Uint32))",
+      "value": [
+          {   
+              "key" : "0x1234567890123456789012345678906784567890",
+              "val" : [
+                  {
+                      "key" : "6",
+                      "val" : "0"
+                  }
+              ]
+          }
+      ]
+    },
+    { 
+      "vname": "player_in_turn",
+      "type": "Option ByStr20",
+      "value":
+        {
+            "constructor": "Some",
+            "argtypes"   : [ "ByStr20" ],
+            "arguments"  : [
+                "0x1234567890123456789012345678906784567890"
+            ]
+        }
+    },
+    { 
+      "vname": "winner",
+      "type": "Option ByStr20",
+      "value":
+        {
+            "constructor": "None",
+            "argtypes"   : [ "ByStr20" ],
+            "arguments"  : []
+        }
+    }
+]

--- a/tests/runner/shogi/state_7.json
+++ b/tests/runner/shogi/state_7.json
@@ -1,0 +1,128 @@
+[
+    { "vname": "_balance",
+      "type": "Uint128",
+      "value": "0" },
+    {
+      "vname": "board",
+      "type": "Map Uint32 (Map Uint32 ShogiLib.SquareContents)",
+      "value": [
+          {
+              "key": "1",
+              "val": [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "ShogiLib.Occupied",
+                          "argtypes" : [],
+                          "arguments" : [
+                              {
+                                  "constructor" : "ShogiLib.Rook",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              {
+                                  "constructor" : "ShogiLib.NotPromoted",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              "0x1234567890123456789012345678906784567890"
+                          ]
+                      }
+                  }
+              ]
+          },
+          {
+              "key" : "2",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "ShogiLib.Free",
+                          "argtypes" : [],
+                          "arguments" : []
+                      }
+                  }
+              ]
+          },
+          {   
+              "key" : "3",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "ShogiLib.Free",
+                          "argtypes" : [],
+                          "arguments" : []
+                      }
+                  }
+              ]
+          },
+          {
+              "key" : "4",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "ShogiLib.Occupied",
+                          "argtypes" : [],
+                          "arguments" : [
+                              {
+                                  "constructor" : "ShogiLib.Pawn",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              {
+                                  "constructor" : "ShogiLib.NotPromoted",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              "0xabcdeabcde123456786782345678901234567890"
+                          ]
+                      }
+                  }
+              ]
+          }
+      ]
+    },
+    {
+      "vname": "captured_pieces",
+      "type": "Map (ByStr20) (Map (Uint32) (Uint32))",
+      "value": [
+          {   
+              "key" : "0x1234567890123456789012345678906784567890",
+              "val" : [
+                  {
+                      "key" : "6",
+                      "val" : "0"
+                  }
+              ]
+          }
+      ]
+    },
+    { 
+      "vname": "player_in_turn",
+      "type": "Option ByStr20",
+      "value":
+        {
+            "constructor": "Some",
+            "argtypes"   : [ "ByStr20" ],
+            "arguments"  : [
+                "0x1234567890123456789012345678906784567890"
+            ]
+        }
+    },
+    { 
+      "vname": "winner",
+      "type": "Option ByStr20",
+      "value":
+        {
+            "constructor": "None",
+            "argtypes"   : [ "ByStr20" ],
+            "arguments"  : []
+        }
+    }
+]


### PR DESCRIPTION
Type information from message jsons is now retained and matched against the declared type of transition parameters.

Type information from init jsons is still ignored, but will be added once the remote state reads migration is ready to take place.

Type information from state jsons is also still ignored, but they are only used for testing, so that is less critical.