### PR TITLE
Fix contract parameter validation check

### DIFF
--- a/src/base/EventInfo.ml
+++ b/src/base/EventInfo.ml
@@ -71,16 +71,7 @@ struct
               ~f:(fun (fname, pl) ->
                 let%bind t =
                   match pl with
-                  | MLit l ->
-                      let%bind t, dyn_checks = literal_type l ~lc:bloc in
-                      if not @@ List.is_empty dyn_checks then
-                        fail1
-                          (Printf.sprintf
-                             "Event type %s requires dynamic typecheck, which \
-                              shouldn't happen\n"
-                             eventname)
-                          bloc
-                      else pure t
+                  | MLit l -> literal_type l ~lc:bloc
                   | MVar v ->
                       let t' = ER.get_type (get_rep v) in
                       pure t'.tp

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -1321,7 +1321,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
          | None -> pure ((None, emsgs), remaining_gas)
        in
 
-       (* Step 3: Adding typed contract parameters (incl. implicit ones) *)
+(*       (* Step 3: Adding typed contract parameters (incl. implicit ones) *)
        let emsgs =
          List.fold_left cparams ~init:emsgs ~f:(fun acc_err (pname, ptype) ->
              if not @@ is_legal_contract_parameter_type ptype then
@@ -1333,7 +1333,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
                in
                acc_err @ e
              else acc_err)
-       in
+         in *)
        let params = CU.append_implicit_contract_params cparams in
        let _ = TEnv.addTs tenv0 params in
 

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -299,16 +299,10 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
     let e, rep = erep in
     match e with
     | Literal l ->
-        let%bind lt, dyn_checks =
+        let%bind lt =
           fromR_TE @@ literal_type l ~lc:(ER.get_loc rep)
         in
-        if not @@ List.is_empty dyn_checks then
-          fail
-            (mk_type_error1
-               (sprintf "Unable to typecheck literal %s."
-                  (PrettyPrinters.pp_literal l))
-               (ER.get_loc rep))
-        else pure @@ (TypedSyntax.Literal l, (mk_qual_tp lt, rep))
+        pure @@ (TypedSyntax.Literal l, (mk_qual_tp lt, rep))
     | Var i ->
         let%bind r =
           fromR_TE @@ TEnv.resolveT tenv (get_id i) ~lopt:(Some (get_rep i))
@@ -1321,7 +1315,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
          | None -> pure ((None, emsgs), remaining_gas)
        in
 
-(*       (* Step 3: Adding typed contract parameters (incl. implicit ones) *)
+       (* Step 3: Adding typed contract parameters (incl. implicit ones) *)
        let emsgs =
          List.fold_left cparams ~init:emsgs ~f:(fun acc_err (pname, ptype) ->
              if not @@ is_legal_contract_parameter_type ptype then
@@ -1333,7 +1327,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
                in
                acc_err @ e
              else acc_err)
-         in *)
+       in
        let params = CU.append_implicit_contract_params cparams in
        let _ = TEnv.addTs tenv0 params in
 

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -299,9 +299,7 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
     let e, rep = erep in
     match e with
     | Literal l ->
-        let%bind lt =
-          fromR_TE @@ literal_type l ~lc:(ER.get_loc rep)
-        in
+        let%bind lt = fromR_TE @@ literal_type l ~lc:(ER.get_loc rep) in
         pure @@ (TypedSyntax.Literal l, (mk_qual_tp lt, rep))
     | Var i ->
         let%bind r =

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -674,8 +674,8 @@ module TypeUtilities = struct
     let rec fun_typ_recurser fun_typ args dyn_checks_acc =
       match (fun_typ, args) with
       | FunType (t, res_t), arg :: rest ->
-          let%bind new_dyn_checks_acc = recurser t arg dyn_checks_acc in
-          fun_typ_recurser res_t rest new_dyn_checks_acc
+          let%bind dyn_checks_acc' = recurser t arg dyn_checks_acc in
+          fun_typ_recurser res_t rest dyn_checks_acc'
       | ADT (_, _), [] -> pure @@ dyn_checks_acc
       | _, _ -> fail1 (sprintf "Malformed ADT literal %s\n" (pp_literal l)) lc
     and recurser expected l dyn_check_acc =

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -424,8 +424,8 @@ module TypeUtilities = struct
     is_serializable_storable_helper false true true t []
 
   and is_legal_contract_parameter_type t =
-    (* Like transition parameters. Maps are not allowed. Address values should be checked for storable field types. *)
-    is_serializable_storable_helper false false true t []
+    (* Like fields. Maps are allowed. Address values should be checked for storable field types. *)
+    is_serializable_storable_helper true false true t []
 
   and is_legal_field_type t =
     (* Maps are allowed. Address values should be checked for storable field types. *)
@@ -641,76 +641,85 @@ module TypeUtilities = struct
   (*                     Typing literals                          *)
   (****************************************************************)
 
-  let literal_type ?(lc = dummy_loc) ?(expected = None) l =
+  (* Use when the type of l can be determined without dynamic typechecks or additional information.
+     For example, the value of an IPC fetch of a field can be trusted, since that the value was constructed in a typesafe way.
+     Conversely, the value in a message or an init file cannot be trusted, since that value may have been constructed from outside of Scilla. *)
+  let literal_type ?(lc = dummy_loc) l =
     let open TULiteral in
-    let simple_literal_type l' =
-      match l' with
-      | IntLit (Int32L _) -> pure int32_typ
-      | IntLit (Int64L _) -> pure int64_typ
-      | IntLit (Int128L _) -> pure int128_typ
-      | IntLit (Int256L _) -> pure int256_typ
-      | UintLit (Uint32L _) -> pure uint32_typ
-      | UintLit (Uint64L _) -> pure uint64_typ
-      | UintLit (Uint128L _) -> pure uint128_typ
-      | UintLit (Uint256L _) -> pure uint256_typ
-      | StringLit _ -> pure string_typ
-      | BNum _ -> pure bnum_typ
-      | ByStr _ -> pure bystr_typ
-      | ByStrX bs -> pure (bystrx_typ (Bystrx.width bs))
-      (* Check that messages and events have storable parameters. *)
-      | Msg bs -> get_msgevnt_type bs lc
-      | Map ((kt, vt), _) -> pure (MapType (kt, vt))
-      | ADTValue (cname, ts, _) ->
-          let%bind adt, _ = DataTypeDictionary.lookup_constructor cname in
-          pure @@ ADT (mk_loc_id adt.tname, ts)
-      | Clo _ -> fail0 @@ "Cannot type runtime closure."
-      | TAbs _ -> fail0 @@ "Cannot type runtime type function"
-    in
+    match l with
+    | IntLit (Int32L _) -> pure int32_typ
+    | IntLit (Int64L _) -> pure int64_typ
+    | IntLit (Int128L _) -> pure int128_typ
+    | IntLit (Int256L _) -> pure int256_typ
+    | UintLit (Uint32L _) -> pure uint32_typ
+    | UintLit (Uint64L _) -> pure uint64_typ
+    | UintLit (Uint128L _) -> pure uint128_typ
+    | UintLit (Uint256L _) -> pure uint256_typ
+    | StringLit _ -> pure string_typ
+    | BNum _ -> pure bnum_typ
+    | ByStr _ -> pure bystr_typ
+    | ByStrX bs -> pure (bystrx_typ (Bystrx.width bs))
+    (* Check that messages and events have storable parameters. *)
+    | Msg bs -> get_msgevnt_type bs lc
+    | Map ((kt, vt), _) -> pure (MapType (kt, vt))
+    | ADTValue (cname, ts, _) ->
+        let%bind adt, _ = DataTypeDictionary.lookup_constructor cname in
+        pure @@ ADT (mk_loc_id adt.tname, ts)
+    | Clo _ -> fail0 @@ "Cannot type runtime closure."
+    | TAbs _ -> fail0 @@ "Cannot type runtime type function"
+
+  (* Use when the type of l must be verified using dynamic typechecks or otherwise. *)
+  let assert_literal_type ?(lc = dummy_loc) ~expected l =
+    let open TULiteral in
     let rec fun_typ_recurser fun_typ args dyn_checks_acc =
       match (fun_typ, args) with
       | FunType (t, res_t), arg :: rest ->
-          let%bind _, new_dyn_checks_acc = recurser t arg dyn_checks_acc in
+          let%bind new_dyn_checks_acc = recurser t arg dyn_checks_acc in
           fun_typ_recurser res_t rest new_dyn_checks_acc
-      | ADT (_, _), [] -> pure @@ (fun_typ, dyn_checks_acc)
+      | ADT (_, _), [] -> pure @@ dyn_checks_acc
       | _, _ -> fail1 (sprintf "Malformed ADT literal %s\n" (pp_literal l)) lc
     and recurser expected l dyn_check_acc =
-      match (expected, l) with
-      | ADT (tname, targs), ADTValue (cname, ctargs, cargs) ->
-          let%bind adt, _ = DataTypeDictionary.lookup_constructor cname in
-          (* Constructor must belong to ADT *)
-          if not @@ [%equal: TUName.t] (get_id tname) adt.tname then
-            fail0
-            @@ sprintf "Literal constructor %s does not belong to type %s"
-                 (TUName.as_error_string cname)
-                 (TUIdentifier.as_error_string tname)
-          else
-            (* Constructor type arguments must be assignable to ADT type arguments *)
-            let msg () = mk_error0 "Constructor type arguments unassignable" in
-            let%bind () =
-              forall2M targs ctargs
-                ~f:(fun targ carg ->
+    match (expected, l) with
+    | ADT (tname, targs), ADTValue (cname, ctargs, cargs) ->
+        let%bind adt, _ = DataTypeDictionary.lookup_constructor cname in
+        (* Constructor must belong to ADT *)
+        if not @@ [%equal: TUName.t] (get_id tname) adt.tname then
+          fail0
+          @@ sprintf "Literal constructor %s does not belong to type %s"
+            (TUName.as_error_string cname)
+            (TUIdentifier.as_error_string tname)
+        else
+          (* Constructor type arguments must be assignable to ADT type arguments *)
+          let msg () = mk_error0 "Constructor type arguments unassignable" in
+          let%bind () =
+            forall2M targs ctargs
+              ~f:(fun targ carg ->
                   assert_type_assignable ~expected:targ ~actual:carg ~lc)
-                ~msg
-            in
-            (* Elaborate constructor using expected type arguments (due to assignability) *)
-            let%bind c_fun_typ = elab_constr_type ~lc cname targs in
-            (* Traverse constructor function type and check assignability of value arguments *)
-            fun_typ_recurser c_fun_typ cargs dyn_check_acc
+              ~msg
+          in
+          (* Elaborate constructor using expected type arguments (due to assignability) *)
+          let%bind c_fun_typ = elab_constr_type ~lc cname targs in
+          (* Traverse constructor function type and check assignability of value arguments *)
+          fun_typ_recurser c_fun_typ cargs dyn_check_acc
       | (Address _ as res_t), ByStrX bs
         when Bystrx.width bs = Type.address_length ->
-          (* ByStr20 literal found, address expected. Trust the dynamic typecheck to validate, and expect the address type *)
-          pure @@ (res_t, (res_t, bs) :: dyn_check_acc)
+          (* ByStr20 literal found, address expected. Must be typechecked dynamically. *)
+          pure @@ (res_t, bs) :: dyn_check_acc
+      | MapType (kt, vt), Map ((lkt, lvt), tbl) ->
+          (* Key types and value types must be assignable. *)
+          let%bind () = assert_type_assignable ~expected:kt ~actual:lkt ~lc in
+          let%bind () = assert_type_assignable ~expected:vt ~actual:lvt ~lc in
+          (* key/value pairs must be assignable to the stated types in the literal *)
+          let ks, vs = Caml.Hashtbl.fold (fun k v (k_acc, v_acc) -> (k :: k_acc, v :: v_acc)) tbl ([], []) in
+          let%bind dyn_check_acc' = foldM ks ~init:dyn_check_acc ~f:(fun acc k -> recurser lkt k acc) in
+          foldM vs ~init:dyn_check_acc' ~f:(fun acc v -> recurser lvt v acc)
       | t, l ->
           (* Simple case - type literal, and check assignability *)
-          let%bind lit_t = simple_literal_type l in
+          let%bind lit_t = literal_type ~lc l in
           let%bind () = assert_type_assignable ~expected:t ~actual:lit_t ~lc in
-          pure (t, dyn_check_acc)
+          pure dyn_check_acc
     in
-    match expected with
-    | Some t -> recurser t l []
-    | None ->
-        let%bind res_t = simple_literal_type l in
-        pure @@ (res_t, [])
+    recurser expected l []
 
   (* Verifies a literal to be wellformed and returns it's type. *)
   let rec is_wellformed_lit ?(lc = dummy_loc) l =

--- a/src/base/TypeUtil.mli
+++ b/src/base/TypeUtil.mli
@@ -118,16 +118,14 @@ module TypeUtilities : sig
   module MakeTEnv : MakeTEnvFunctor
 
   val literal_type :
-    ?lc:ErrorUtils.loc ->
-    TULiteral.t ->
-    (TUType.t, scilla_error list) result
+    ?lc:ErrorUtils.loc -> TULiteral.t -> (TUType.t, scilla_error list) result
 
   val assert_literal_type :
     ?lc:ErrorUtils.loc ->
     expected:TUType.t ->
     TULiteral.t ->
     ((TUType.t * TULiteral.Bystrx.t) list, scilla_error list) result
-  
+
   val is_wellformed_lit :
     ?lc:ErrorUtils.loc -> TULiteral.t -> (TUType.t, scilla_error list) result
 

--- a/src/base/TypeUtil.mli
+++ b/src/base/TypeUtil.mli
@@ -119,10 +119,15 @@ module TypeUtilities : sig
 
   val literal_type :
     ?lc:ErrorUtils.loc ->
-    ?expected:TUType.t option ->
     TULiteral.t ->
-    (TUType.t * (TUType.t * TULiteral.Bystrx.t) list, scilla_error list) result
+    (TUType.t, scilla_error list) result
 
+  val assert_literal_type :
+    ?lc:ErrorUtils.loc ->
+    expected:TUType.t ->
+    TULiteral.t ->
+    ((TUType.t * TULiteral.Bystrx.t) list, scilla_error list) result
+  
   val is_wellformed_lit :
     ?lc:ErrorUtils.loc -> TULiteral.t -> (TUType.t, scilla_error list) result
 

--- a/src/eval/Disambiguator.ml
+++ b/src/eval/Disambiguator.ml
@@ -836,9 +836,10 @@ let run_with_args args =
           let init =
             let untyped_state = parse_json args.input_init this_address in
             List.map untyped_state ~f:(fun x ->
+                (* We've been ignoring the type info in the init files, so just trust literal_type *)
                 match TypeUtil.TypeUtilities.literal_type (trd3 x) with
-                | Ok (t, []) -> (fst3 x, t, trd3 x)
-                | Ok _ | Error _ ->
+                | Ok t -> (fst3 x, t, trd3 x)
+                | Error _ ->
                     fatal_error
                       (mk_error0
                          (sprintf "Unable to determine type of literal %s"
@@ -847,15 +848,8 @@ let run_with_args args =
           let state =
             if String.is_empty args.ipc_address then
               (* Use the provided state json. *)
-              let untyped_state = parse_json args.input_state this_address in
-              List.map untyped_state ~f:(fun x ->
-                  match TypeUtil.TypeUtilities.literal_type (trd3 x) with
-                  | Ok (t, []) -> (fst3 x, t, trd3 x)
-                  | Ok _ | Error _ ->
-                      fatal_error
-                        (mk_error0
-                           (sprintf "Unable to determine type of literal %s"
-                              (pp_literal (trd3 x)))))
+              (* We control the state files, so we can assume the type info is correct *)
+              parse_json args.input_state this_address
             else
               (* Use IPC *)
               (* Fetch state from IPC server *)

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -652,7 +652,9 @@ let init_contract clibs elibs cconstraint' cparams' cfields initargs' init_bal =
                 pure None
               else
                 (* Typecheck the literal against the parameter type *)
-                let%bind dyn_checks = fromR @@ assert_literal_type ~expected:xt l in
+                let%bind dyn_checks =
+                  fromR @@ assert_literal_type ~expected:xt l
+                in
                 pure (Some dyn_checks))
         in
         match arg_dyn_checks with
@@ -711,7 +713,9 @@ let create_cur_state_fields initcstate curcstate =
                      (pp_typ t) (pp_typ xt))
               else
                 (* Check that the literal matches the stated type *)
-                let%bind _dyn_checks = fromR @@ assert_literal_type ~expected:t l in
+                let%bind _dyn_checks =
+                  fromR @@ assert_literal_type ~expected:t l
+                in
                 (* Ignore dynamic typechecks - if it's in the current state, then it's already been checked *)
                 pure true)
         in
@@ -805,7 +809,9 @@ let check_message_entries cparams_o entries =
                 pure None
               else
                 (* We ignore the type from the message entry, since that was used to parse the literal, and hence is known to be valid *)
-                let%bind dyn_checks = fromR @@ assert_literal_type ~expected:xt l in
+                let%bind dyn_checks =
+                  fromR @@ assert_literal_type ~expected:xt l
+                in
                 if
                   String.(
                     s = ContractUtil.MessagePayload.sender_label

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -79,8 +79,8 @@ let rec is_pure_literal l =
 let sanitize_literal l =
   let open MonadUtil in
   let open Result.Let_syntax in
-  let%bind t, dyn_checks = literal_type l in
-  if List.is_empty dyn_checks && is_legal_message_field_type t then pure l
+  let%bind t = literal_type l in
+  if is_legal_message_field_type t then pure l
   else fail0 @@ sprintf "Cannot serialize literal %s" (pp_literal l)
 
 let eval_gas_charge env g =
@@ -144,13 +144,8 @@ let builtin_executor env f targs args_id =
   let%bind arg_lits =
     mapM args_id ~f:(fun arg -> fromR @@ Env.lookup env arg)
   in
-  let%bind tps =
-    mapM arg_lits ~f:(fun l ->
-        let%bind t, dyn_checks = fromR @@ literal_type l in
-        if not @@ List.is_empty dyn_checks then
-          fail0 "Dynamic typecheck required for application of builtin"
-        else pure t)
-  in
+  (* Builtin elaborators need to know the literal type of arguments *)
+  let%bind tps = mapM arg_lits ~f:(fun l -> fromR @@ literal_type l) in
   let%bind ret_typ, op =
     EvalBuiltIns.EvalBuiltInDictionary.find_builtin_op f ~targtypes:targs
       ~vargtypes:tps
@@ -195,8 +190,8 @@ let rec exp_eval erep env =
         (* Make sure we resolve all the payload *)
         mapM bs ~f:(fun (s, pld) ->
             let%bind sanitized_lit = fromR @@ resolve pld in
-            let%bind t, _dyn_checks = fromR @@ literal_type sanitized_lit in
-            (* Dynamic typechecks are statically known to be empty *)
+            (* Messages should contain simplified types, so use literal_type *)
+            let%bind t = fromR @@ literal_type sanitized_lit in
             pure (s, t, sanitized_lit))
       in
       pure (Msg payload_resolved, env)
@@ -657,9 +652,7 @@ let init_contract clibs elibs cconstraint' cparams' cfields initargs' init_bal =
                 pure None
               else
                 (* Typecheck the literal against the parameter type *)
-                let%bind _ltyp, dyn_checks =
-                  fromR @@ literal_type ~expected:(Some xt) l
-                in
+                let%bind dyn_checks = fromR @@ assert_literal_type ~expected:xt l in
                 pure (Some dyn_checks))
         in
         match arg_dyn_checks with
@@ -718,10 +711,8 @@ let create_cur_state_fields initcstate curcstate =
                      (pp_typ t) (pp_typ xt))
               else
                 (* Check that the literal matches the stated type *)
-                let%bind _, _dyn_checks =
-                  fromR @@ literal_type ~expected:(Some t) l
-                in
-                (* Allow dynamic typechecks - if it's in the current state, then it's already been checked *)
+                let%bind _dyn_checks = fromR @@ assert_literal_type ~expected:t l in
+                (* Ignore dynamic typechecks - if it's in the current state, then it's already been checked *)
                 pure true)
         in
         if not ex then
@@ -814,9 +805,7 @@ let check_message_entries cparams_o entries =
                 pure None
               else
                 (* We ignore the type from the message entry, since that was used to parse the literal, and hence is known to be valid *)
-                let%bind _entry_typ, dyn_checks =
-                  fromR @@ literal_type ~expected:(Some xt) l
-                in
+                let%bind dyn_checks = fromR @@ assert_literal_type ~expected:xt l in
                 if
                   String.(
                     s = ContractUtil.MessagePayload.sender_label

--- a/tests/checker/good/Good.ml
+++ b/tests/checker/good/Good.ml
@@ -77,6 +77,7 @@ module Tests = Scilla_test.Util.DiffBasedTests (struct
       "address_eq_test.scilla";
       "address_list_traversal.scilla";
       "polymorphic_address.scilla";
+      "map_as_cparam.scilla";
     ]
 
   let exit_code : UnixLabels.process_status = WEXITED 0

--- a/tests/checker/good/gold/map_as_cparam.scilla.gold
+++ b/tests/checker/good/gold/map_as_cparam.scilla.gold
@@ -1,0 +1,81 @@
+{
+  "cashflow_tags": {
+    "State variables": [
+      { "field": "x", "tag": "NoInfo" },
+      { "field": "f", "tag": "NoInfo" }
+    ],
+    "ADT constructors": []
+  },
+  "contract_info": {
+    "scilla_major_version": "0",
+    "vname": "T",
+    "params": [
+      {
+        "vname": "x",
+        "type":
+          "Map (ByStr20 with contract field f : Uint128 end) (ByStr20 with contract field g : Bool end)"
+      }
+    ],
+    "fields": [
+      {
+        "vname": "f",
+        "type":
+          "Map (ByStr20 with contract field f : Uint128 end) (ByStr20 with contract field g : Bool end)",
+        "depth": 1
+      }
+    ],
+    "transitions": [],
+    "procedures": [],
+    "events": [],
+    "ADTs": [
+      {
+        "tname": "Option",
+        "tparams": [ "'A" ],
+        "tmap": [
+          { "cname": "Some", "argtypes": [ "'A" ] },
+          { "cname": "None", "argtypes": [] }
+        ]
+      },
+      {
+        "tname": "Bool",
+        "tparams": [],
+        "tmap": [
+          { "cname": "True", "argtypes": [] },
+          { "cname": "False", "argtypes": [] }
+        ]
+      },
+      {
+        "tname": "Nat",
+        "tparams": [],
+        "tmap": [
+          { "cname": "Zero", "argtypes": [] },
+          { "cname": "Succ", "argtypes": [ "Nat" ] }
+        ]
+      },
+      {
+        "tname": "List",
+        "tparams": [ "'A" ],
+        "tmap": [
+          { "cname": "Cons", "argtypes": [ "'A", "List ('A)" ] },
+          { "cname": "Nil", "argtypes": [] }
+        ]
+      },
+      {
+        "tname": "Pair",
+        "tparams": [ "'A", "'B" ],
+        "tmap": [ { "cname": "Pair", "argtypes": [ "'A", "'B" ] } ]
+      }
+    ]
+  },
+  "warnings": [
+    {
+      "warning_message":
+        "No transition in contract T contains an accept statement\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 1
+    }
+  ],
+  "gas_remaining": "7999"
+}
+

--- a/tests/contracts/map_as_cparam.scilla
+++ b/tests/contracts/map_as_cparam.scilla
@@ -1,0 +1,7 @@
+scilla_version 0
+
+contract T (x : Map (ByStr20 with contract field f : Uint128 end)
+                    (ByStr20 with contract field g : Bool end))
+
+field f : Map (ByStr20 with contract field f : Uint128 end)
+              (ByStr20 with contract field g : Bool end) = x

--- a/tests/runner/Testcontracts.ml
+++ b/tests/runner/Testcontracts.ml
@@ -435,8 +435,8 @@ let contract_tests env =
                 >::: build_contract_tests ~pplit:false env
                        "address_list_traversal" succ_code 1 2 [];
                 "map_as_cparam"
-                >: build_contract_init_test env succ_code "map_as_cparam"
-                     "init" ~is_library:false ~ipc_mode:true;
+                >: build_contract_init_test env succ_code "map_as_cparam" "init"
+                     ~is_library:false ~ipc_mode:true;
               ];
          "these_tests_must_FAIL"
          >::: [

--- a/tests/runner/Testcontracts.ml
+++ b/tests/runner/Testcontracts.ml
@@ -434,6 +434,9 @@ let contract_tests env =
                 "polymorphic_address"
                 >::: build_contract_tests ~pplit:false env
                        "address_list_traversal" succ_code 1 2 [];
+                "map_as_cparam"
+                >: build_contract_init_test env succ_code "map_as_cparam"
+                     "init" ~is_library:false ~ipc_mode:true;
               ];
          "these_tests_must_FAIL"
          >::: [
@@ -494,6 +497,18 @@ let contract_tests env =
                 "remote_state_reads"
                 >::: build_contract_tests env "remote_state_reads" fail_code 101
                        128 [];
+                "map_as_cparam"
+                >: build_contract_init_test env fail_code "map_as_cparam"
+                     "init_unassignable" ~is_library:false ~ipc_mode:true;
+                "map_as_cparam"
+                >: build_contract_init_test env fail_code "map_as_cparam"
+                     "init_unassignable_2" ~is_library:false ~ipc_mode:true;
+                "map_as_cparam"
+                >: build_contract_init_test env fail_code "map_as_cparam"
+                     "init_illegal_key" ~is_library:false ~ipc_mode:true;
+                "map_as_cparam"
+                >: build_contract_init_test env fail_code "map_as_cparam"
+                     "init_illegal_value" ~is_library:false ~ipc_mode:true;
               ];
          "misc_tests" >::: build_misc_tests env;
        ]

--- a/tests/runner/map_as_cparam/blockchain_1.json
+++ b/tests/runner/map_as_cparam/blockchain_1.json
@@ -1,0 +1,1 @@
+[ { "vname": "BLOCKNUMBER", "type": "BNum", "value": "100" } ]

--- a/tests/runner/map_as_cparam/init.json
+++ b/tests/runner/map_as_cparam/init.json
@@ -1,0 +1,31 @@
+[
+    { 
+        "vname" : "_scilla_version",
+        "type" : "Uint32",
+        "value" : "0"
+    },
+    {
+        "vname" : "_this_address",
+        "type" : "ByStr20",
+        "value" : "0x3620c286757a29985cee194eb90064270fb65414"
+    },
+    {
+        "vname" : "_creation_block",
+        "type" : "BNum",
+        "value" : "1"
+    },
+    {
+        "vname" : "x",
+        "type" : "Map (ByStr20 with contract field f : Uint128 end) (ByStr20 with contract field g : Bool end)", 
+        "value" : [
+            {
+                "key" : "0x1234567890123456789012345678901234567890",
+                "val" : "0x1234567890123456789012345678901234567891"
+            },
+            {
+                "key" : "0x1234567890123456789012345678901234567892",
+                "val" : "0x1234567890123456789012345678901234567893"
+            }
+        ]
+    }
+]

--- a/tests/runner/map_as_cparam/init_illegal_key.json
+++ b/tests/runner/map_as_cparam/init_illegal_key.json
@@ -1,0 +1,31 @@
+[
+    { 
+        "vname" : "_scilla_version",
+        "type" : "Uint32",
+        "value" : "0"
+    },
+    {
+        "vname" : "_this_address",
+        "type" : "ByStr20",
+        "value" : "0x3620c286757a29985cee194eb90064270fb65414"
+    },
+    {
+        "vname" : "_creation_block",
+        "type" : "BNum",
+        "value" : "1"
+    },
+    {
+        "vname" : "x",
+        "type" : "Map (ByStr20 with contract field f : Uint128, field f2 : Uint32 end) (ByStr20 with contract field g : Bool end)", 
+        "value" : [
+            {
+                "key" : "0x1234567890123456789012345678901234567890",
+                "val" : "0x1234567890123456789012345678901234567891"
+            },
+            {
+                "key" : "0x1234567890123456789012345678901234567892",
+                "val" : "0x1234567890123456789012345678901234567893"
+            }
+        ]
+    }
+]

--- a/tests/runner/map_as_cparam/init_illegal_key_ipc_output.json
+++ b/tests/runner/map_as_cparam/init_illegal_key_ipc_output.json
@@ -1,0 +1,12 @@
+{
+  "gas_remaining": "7856",
+  "errors": [
+    {
+      "error_message":
+        "Address 0x1234567890123456789012345678901234567890 does not satisfy type ByStr20 with contract field f : Uint128, field f2 : Uint32 end\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": []
+}

--- a/tests/runner/map_as_cparam/init_illegal_key_state.json
+++ b/tests/runner/map_as_cparam/init_illegal_key_state.json
@@ -1,0 +1,47 @@
+[
+    { "vname": "_balance", "type": "Uint128", "value": "0" },
+    {
+        "vname": "_external",
+        "type": "Unit",
+        "value": [
+            {
+                "address": "0x1234567890123456789012345678901234567890",
+                "state": [
+                    { "vname": "_nonce", "type": "Uint64", "value": "42" },
+                    { "vname": "_balance", "type": "Uint128", "value": "42" },
+                    { "vname": "_this_address", "type": "ByStr20", "value": "0x1234567890123456789012345678901234567890" },
+                    { "vname": "f", "type": "Uint128", "value": "42" },
+                    { "vname": "f2", "type": "Uint128", "value": "6" }
+                ]
+            },
+            {
+                "address": "0x1234567890123456789012345678901234567891",
+                "state": [
+                    { "vname": "_nonce", "type": "Uint64", "value": "42" },
+                    { "vname": "_balance", "type": "Uint128", "value": "42" },
+                    { "vname": "_this_address", "type": "ByStr20", "value": "0x1234567890123456789012345678901234567890" },
+                    { "vname": "g", "type": "Bool", "value": { "constructor": "True", "argtypes": [], "arguments": [] } }
+                ]
+            },
+            {
+                "address": "0x1234567890123456789012345678901234567892",
+                "state": [
+                    { "vname": "_nonce", "type": "Uint64", "value": "42" },
+                    { "vname": "_balance", "type": "Uint128", "value": "42" },
+                    { "vname": "_this_address", "type": "ByStr20", "value": "0x1234567890123456789012345678901234567890" },
+                    { "vname": "f", "type": "Uint128", "value": "6" },
+                    { "vname": "f2", "type": "Uint32", "value": "6" }
+                ]
+            },
+            {
+                "address": "0x1234567890123456789012345678901234567893",
+                "state": [
+                    { "vname": "_nonce", "type": "Uint64", "value": "42" },
+                    { "vname": "_balance", "type": "Uint128", "value": "42" },
+                    { "vname": "_this_address", "type": "ByStr20", "value": "0x1234567890123456789012345678901234567890" },
+                    { "vname": "g", "type": "Bool", "value": { "constructor": "False", "argtypes": [], "arguments": [] } }
+                ]
+            }
+        ]
+    }
+]

--- a/tests/runner/map_as_cparam/init_illegal_value.json
+++ b/tests/runner/map_as_cparam/init_illegal_value.json
@@ -1,0 +1,31 @@
+[
+    { 
+        "vname" : "_scilla_version",
+        "type" : "Uint32",
+        "value" : "0"
+    },
+    {
+        "vname" : "_this_address",
+        "type" : "ByStr20",
+        "value" : "0x3620c286757a29985cee194eb90064270fb65414"
+    },
+    {
+        "vname" : "_creation_block",
+        "type" : "BNum",
+        "value" : "1"
+    },
+    {
+        "vname" : "x",
+        "type" : "Map (ByStr20 with contract field f : Uint128 end) (ByStr20 with contract field g : Bool, field g2 : Uint32 end)", 
+        "value" : [
+            {
+                "key" : "0x1234567890123456789012345678901234567890",
+                "val" : "0x1234567890123456789012345678901234567891"
+            },
+            {
+                "key" : "0x1234567890123456789012345678901234567892",
+                "val" : "0x1234567890123456789012345678901234567893"
+            }
+        ]
+    }
+]

--- a/tests/runner/map_as_cparam/init_illegal_value_ipc_output.json
+++ b/tests/runner/map_as_cparam/init_illegal_value_ipc_output.json
@@ -1,0 +1,12 @@
+{
+  "gas_remaining": "7856",
+  "errors": [
+    {
+      "error_message":
+        "Address 0x1234567890123456789012345678901234567893 does not satisfy type ByStr20 with contract field g : Bool, field g2 : Uint32 end\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": []
+}

--- a/tests/runner/map_as_cparam/init_illegal_value_state.json
+++ b/tests/runner/map_as_cparam/init_illegal_value_state.json
@@ -1,0 +1,47 @@
+[
+    { "vname": "_balance", "type": "Uint128", "value": "0" },
+    {
+        "vname": "_external",
+        "type": "Unit",
+        "value": [
+            {
+                "address": "0x1234567890123456789012345678901234567890",
+                "state": [
+                    { "vname": "_nonce", "type": "Uint64", "value": "42" },
+                    { "vname": "_balance", "type": "Uint128", "value": "42" },
+                    { "vname": "_this_address", "type": "ByStr20", "value": "0x1234567890123456789012345678901234567890" },
+                    { "vname": "f", "type": "Uint128", "value": "42" }
+                ]
+            },
+            {
+                "address": "0x1234567890123456789012345678901234567891",
+                "state": [
+                    { "vname": "_nonce", "type": "Uint64", "value": "42" },
+                    { "vname": "_balance", "type": "Uint128", "value": "42" },
+                    { "vname": "_this_address", "type": "ByStr20", "value": "0x1234567890123456789012345678901234567890" },
+                    { "vname": "g", "type": "Bool", "value": { "constructor": "True", "argtypes": [], "arguments": [] } },
+                    { "vname": "g2", "type": "Uint32", "value": "5" }
+                ]
+            },
+            {
+                "address": "0x1234567890123456789012345678901234567892",
+                "state": [
+                    { "vname": "_nonce", "type": "Uint64", "value": "42" },
+                    { "vname": "_balance", "type": "Uint128", "value": "42" },
+                    { "vname": "_this_address", "type": "ByStr20", "value": "0x1234567890123456789012345678901234567890" },
+                    { "vname": "f", "type": "Uint128", "value": "6" }
+                ]
+            },
+            {
+                "address": "0x1234567890123456789012345678901234567893",
+                "state": [
+                    { "vname": "_nonce", "type": "Uint64", "value": "42" },
+                    { "vname": "_balance", "type": "Uint128", "value": "42" },
+                    { "vname": "_this_address", "type": "ByStr20", "value": "0x1234567890123456789012345678901234567890" },
+                    { "vname": "g", "type": "Bool", "value": { "constructor": "False", "argtypes": [], "arguments": [] } },
+                    { "vname": "g2", "type": "Uint", "value": "1" }
+                ]
+            }
+        ]
+    }
+]

--- a/tests/runner/map_as_cparam/init_ipc_output.json
+++ b/tests/runner/map_as_cparam/init_ipc_output.json
@@ -1,0 +1,8 @@
+{
+  "scilla_major_version": "0",
+  "gas_remaining": "62864",
+  "_accepted": "false",
+  "messages": null,
+  "states": [ { "vname": "_balance", "type": "Uint128", "value": "0" } ],
+  "events": []
+}

--- a/tests/runner/map_as_cparam/init_state.json
+++ b/tests/runner/map_as_cparam/init_state.json
@@ -1,0 +1,45 @@
+[
+    { "vname": "_balance", "type": "Uint128", "value": "0" },
+    {
+        "vname": "_external",
+        "type": "Unit",
+        "value": [
+            {
+                "address": "0x1234567890123456789012345678901234567890",
+                "state": [
+                    { "vname": "_nonce", "type": "Uint64", "value": "42" },
+                    { "vname": "_balance", "type": "Uint128", "value": "42" },
+                    { "vname": "_this_address", "type": "ByStr20", "value": "0x1234567890123456789012345678901234567890" },
+                    { "vname": "f", "type": "Uint128", "value": "42" }
+                ]
+            },
+            {
+                "address": "0x1234567890123456789012345678901234567891",
+                "state": [
+                    { "vname": "_nonce", "type": "Uint64", "value": "42" },
+                    { "vname": "_balance", "type": "Uint128", "value": "42" },
+                    { "vname": "_this_address", "type": "ByStr20", "value": "0x1234567890123456789012345678901234567890" },
+                    { "vname": "g", "type": "Bool", "value": { "constructor": "True", "argtypes": [], "arguments": [] } }
+                ]
+            },
+            {
+                "address": "0x1234567890123456789012345678901234567892",
+                "state": [
+                    { "vname": "_nonce", "type": "Uint64", "value": "42" },
+                    { "vname": "_balance", "type": "Uint128", "value": "42" },
+                    { "vname": "_this_address", "type": "ByStr20", "value": "0x1234567890123456789012345678901234567890" },
+                    { "vname": "f", "type": "Uint128", "value": "6" }
+                ]
+            },
+            {
+                "address": "0x1234567890123456789012345678901234567893",
+                "state": [
+                    { "vname": "_nonce", "type": "Uint64", "value": "42" },
+                    { "vname": "_balance", "type": "Uint128", "value": "42" },
+                    { "vname": "_this_address", "type": "ByStr20", "value": "0x1234567890123456789012345678901234567890" },
+                    { "vname": "g", "type": "Bool", "value": { "constructor": "False", "argtypes": [], "arguments": [] } }
+                ]
+            }
+        ]
+    }
+]

--- a/tests/runner/map_as_cparam/init_unassignable.json
+++ b/tests/runner/map_as_cparam/init_unassignable.json
@@ -1,0 +1,31 @@
+[
+    { 
+        "vname" : "_scilla_version",
+        "type" : "Uint32",
+        "value" : "0"
+    },
+    {
+        "vname" : "_this_address",
+        "type" : "ByStr20",
+        "value" : "0x3620c286757a29985cee194eb90064270fb65414"
+    },
+    {
+        "vname" : "_creation_block",
+        "type" : "BNum",
+        "value" : "1"
+    },
+    {
+        "vname" : "x",
+        "type" : "Map (ByStr20 with contract end) (ByStr20 with contract field g : Bool end)", 
+        "value" : [
+            {
+                "key" : "0x1234567890123456789012345678901234567890",
+                "val" : "0x1234567890123456789012345678901234567891"
+            },
+            {
+                "key" : "0x1234567890123456789012345678901234567892",
+                "val" : "0x1234567890123456789012345678901234567893"
+            }
+        ]
+    }
+]

--- a/tests/runner/map_as_cparam/init_unassignable_2.json
+++ b/tests/runner/map_as_cparam/init_unassignable_2.json
@@ -1,0 +1,31 @@
+[
+    { 
+        "vname" : "_scilla_version",
+        "type" : "Uint32",
+        "value" : "0"
+    },
+    {
+        "vname" : "_this_address",
+        "type" : "ByStr20",
+        "value" : "0x3620c286757a29985cee194eb90064270fb65414"
+    },
+    {
+        "vname" : "_creation_block",
+        "type" : "BNum",
+        "value" : "1"
+    },
+    {
+        "vname" : "x",
+        "type" : "Map (ByStr20 with contract field f : Uint128 end) (ByStr20 with contract end)", 
+        "value" : [
+            {
+                "key" : "0x1234567890123456789012345678901234567890",
+                "val" : "0x1234567890123456789012345678901234567891"
+            },
+            {
+                "key" : "0x1234567890123456789012345678901234567892",
+                "val" : "0x1234567890123456789012345678901234567893"
+            }
+        ]
+    }
+]

--- a/tests/runner/map_as_cparam/init_unassignable_2_ipc_output.json
+++ b/tests/runner/map_as_cparam/init_unassignable_2_ipc_output.json
@@ -1,0 +1,12 @@
+{
+  "gas_remaining": "7860",
+  "errors": [
+    {
+      "error_message":
+        "Type unassignable: ByStr20 with contract field g : Bool end expected, but ByStr20 with contract end provided.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": []
+}

--- a/tests/runner/map_as_cparam/init_unassignable_2_state.json
+++ b/tests/runner/map_as_cparam/init_unassignable_2_state.json
@@ -1,0 +1,45 @@
+[
+    { "vname": "_balance", "type": "Uint128", "value": "0" },
+    {
+        "vname": "_external",
+        "type": "Unit",
+        "value": [
+            {
+                "address": "0x1234567890123456789012345678901234567890",
+                "state": [
+                    { "vname": "_nonce", "type": "Uint64", "value": "42" },
+                    { "vname": "_balance", "type": "Uint128", "value": "42" },
+                    { "vname": "_this_address", "type": "ByStr20", "value": "0x1234567890123456789012345678901234567890" },
+                    { "vname": "f", "type": "Uint128", "value": "42" }
+                ]
+            },
+            {
+                "address": "0x1234567890123456789012345678901234567891",
+                "state": [
+                    { "vname": "_nonce", "type": "Uint64", "value": "42" },
+                    { "vname": "_balance", "type": "Uint128", "value": "42" },
+                    { "vname": "_this_address", "type": "ByStr20", "value": "0x1234567890123456789012345678901234567890" },
+                    { "vname": "g", "type": "Bool", "value": { "constructor": "True", "argtypes": [], "arguments": [] } }
+                ]
+            },
+            {
+                "address": "0x1234567890123456789012345678901234567892",
+                "state": [
+                    { "vname": "_nonce", "type": "Uint64", "value": "42" },
+                    { "vname": "_balance", "type": "Uint128", "value": "42" },
+                    { "vname": "_this_address", "type": "ByStr20", "value": "0x1234567890123456789012345678901234567890" },
+                    { "vname": "f", "type": "Uint128", "value": "6" }
+                ]
+            },
+            {
+                "address": "0x1234567890123456789012345678901234567893",
+                "state": [
+                    { "vname": "_nonce", "type": "Uint64", "value": "42" },
+                    { "vname": "_balance", "type": "Uint128", "value": "42" },
+                    { "vname": "_this_address", "type": "ByStr20", "value": "0x1234567890123456789012345678901234567890" },
+                    { "vname": "g", "type": "Bool", "value": { "constructor": "False", "argtypes": [], "arguments": [] } }
+                ]
+            }
+        ]
+    }
+]

--- a/tests/runner/map_as_cparam/init_unassignable_ipc_output.json
+++ b/tests/runner/map_as_cparam/init_unassignable_ipc_output.json
@@ -1,0 +1,12 @@
+{
+  "gas_remaining": "7860",
+  "errors": [
+    {
+      "error_message":
+        "Type unassignable: ByStr20 with contract field f : Uint128 end expected, but ByStr20 with contract end provided.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": []
+}

--- a/tests/runner/map_as_cparam/init_unassignable_state.json
+++ b/tests/runner/map_as_cparam/init_unassignable_state.json
@@ -1,0 +1,45 @@
+[
+    { "vname": "_balance", "type": "Uint128", "value": "0" },
+    {
+        "vname": "_external",
+        "type": "Unit",
+        "value": [
+            {
+                "address": "0x1234567890123456789012345678901234567890",
+                "state": [
+                    { "vname": "_nonce", "type": "Uint64", "value": "42" },
+                    { "vname": "_balance", "type": "Uint128", "value": "42" },
+                    { "vname": "_this_address", "type": "ByStr20", "value": "0x1234567890123456789012345678901234567890" },
+                    { "vname": "f", "type": "Uint128", "value": "42" }
+                ]
+            },
+            {
+                "address": "0x1234567890123456789012345678901234567891",
+                "state": [
+                    { "vname": "_nonce", "type": "Uint64", "value": "42" },
+                    { "vname": "_balance", "type": "Uint128", "value": "42" },
+                    { "vname": "_this_address", "type": "ByStr20", "value": "0x1234567890123456789012345678901234567890" },
+                    { "vname": "g", "type": "Bool", "value": { "constructor": "True", "argtypes": [], "arguments": [] } }
+                ]
+            },
+            {
+                "address": "0x1234567890123456789012345678901234567892",
+                "state": [
+                    { "vname": "_nonce", "type": "Uint64", "value": "42" },
+                    { "vname": "_balance", "type": "Uint128", "value": "42" },
+                    { "vname": "_this_address", "type": "ByStr20", "value": "0x1234567890123456789012345678901234567890" },
+                    { "vname": "f", "type": "Uint128", "value": "6" }
+                ]
+            },
+            {
+                "address": "0x1234567890123456789012345678901234567893",
+                "state": [
+                    { "vname": "_nonce", "type": "Uint64", "value": "42" },
+                    { "vname": "_balance", "type": "Uint128", "value": "42" },
+                    { "vname": "_this_address", "type": "ByStr20", "value": "0x1234567890123456789012345678901234567890" },
+                    { "vname": "g", "type": "Bool", "value": { "constructor": "False", "argtypes": [], "arguments": [] } }
+                ]
+            }
+        ]
+    }
+]


### PR DESCRIPTION
The original contract parameter validation check did not allow maps as contract parameters. This turns out to break existing contracts, so I have changed the check to allow maps.

This also means that a dynamic typecheck must potentially be performed on all key/value pairs of a map. If the map has an address as either the key or the value type, then all map entries must be confirmed to conform to the address type in question.

Once I get to documenting address types I'll add a warning that maps are potentially expensive to use as contract parameters.