### PR TITLE
Fixed elaboration of to_string, strrev and to_ascii for address types

### DIFF
--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -135,6 +135,8 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
           | Int_typ _ | Uint_typ _ | Bystrx_typ _ | Bystr_typ ->
               elab_tfun_with_args_no_gas to_string_type ts
           | _ -> fail0 "Failed to elaborate" )
+      | [], [ t ] when is_address_type t -> 
+          elab_tfun_with_args_no_gas to_string_type [bystrx_typ Type.address_length]
       | _, _ -> fail0 "Failed to elaborate"
 
     let to_ascii_arity = 1
@@ -148,6 +150,8 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
           | Bystrx_typ _ | Bystr_typ ->
               elab_tfun_with_args_no_gas to_ascii_type ts
           | _ -> fail0 "Failed to elaborate" )
+      | [], [ t ] when is_address_type t -> 
+          elab_tfun_with_args_no_gas to_string_type [bystrx_typ Type.address_length]
       | _, _ -> fail0 "Failed to elaborate"
 
     let strrev_arity = 1
@@ -161,6 +165,8 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
           | String_typ | Bystrx_typ _ | Bystr_typ ->
               elab_tfun_with_args_no_gas strrev_type ts
           | _ -> fail0 "Failed to elaborate" )
+      | [], [ t ] when is_address_type t -> 
+          elab_tfun_with_args_no_gas to_string_type [bystrx_typ Type.address_length]
       | _, _ -> fail0 "Failed to elaborate"
   end
 

--- a/tests/checker/good/gold/address_eq_test.scilla.gold
+++ b/tests/checker/good/gold/address_eq_test.scilla.gold
@@ -13,7 +13,10 @@
       { "field": "map_res_5", "tag": "Inconsistent" },
       { "field": "map_res_6", "tag": "NotMoney" },
       { "field": "test_map2", "tag": "(Map NotMoney)" },
-      { "field": "test_map3", "tag": "(Map NotMoney)" }
+      { "field": "test_map3", "tag": "(Map NotMoney)" },
+      { "field": "test_to_string", "tag": "NoInfo" },
+      { "field": "test_to_ascii", "tag": "Inconsistent" },
+      { "field": "test_strrev", "tag": "Inconsistent" }
     ],
     "ADT constructors": []
   },
@@ -66,7 +69,10 @@
         "vname": "test_map3",
         "type": "Map (Uint128) (ByStr20 with contract end)",
         "depth": 1
-      }
+      },
+      { "vname": "test_to_string", "type": "String", "depth": 0 },
+      { "vname": "test_to_ascii", "type": "String", "depth": 0 },
+      { "vname": "test_strrev", "type": "String", "depth": 0 }
     ],
     "transitions": [
       {
@@ -183,6 +189,16 @@
               "ByStr20 with contract field f : Uint32, field g : Int32 end"
           }
         ]
+      },
+      {
+        "vname": "Test11",
+        "params": [
+          {
+            "vname": "param1",
+            "type":
+              "ByStr20 with contract field f : Uint32, field g : Int32 end"
+          }
+        ]
       }
     ],
     "procedures": [],
@@ -232,7 +248,7 @@
       "warning_message": "Consider using in-place Map access",
       "start_location": {
         "file": "contracts/address_eq_test.scilla",
-        "line": 89,
+        "line": 93,
         "column": 10
       },
       "end_location": { "file": "", "line": 0, "column": 0 },
@@ -242,7 +258,7 @@
       "warning_message": "Consider using in-place Map access",
       "start_location": {
         "file": "contracts/address_eq_test.scilla",
-        "line": 85,
+        "line": 89,
         "column": 9
       },
       "end_location": { "file": "", "line": 0, "column": 0 },
@@ -252,7 +268,7 @@
       "warning_message": "Consider using in-place Map access",
       "start_location": {
         "file": "contracts/address_eq_test.scilla",
-        "line": 69,
+        "line": 73,
         "column": 9
       },
       "end_location": { "file": "", "line": 0, "column": 0 },

--- a/tests/contracts/address_eq_test.scilla
+++ b/tests/contracts/address_eq_test.scilla
@@ -18,6 +18,10 @@ field map_res_6 : Uint32 = Uint32 0
 field test_map2 : Map (ByStr20 with contract field f : Uint32 end) Uint128 = Emp (ByStr20 with contract field f : Uint32 end) Uint128
 field test_map3 : Map Uint128 (ByStr20 with contract end) = Emp Uint128 (ByStr20 with contract end)
 
+field test_to_string : String = ""
+field test_to_ascii : String = ""
+field test_strrev : String = ""
+
 transition Test1 (param1 : ByStr20 with contract field f : Uint128, field g : Int32 end,
   param2 : ByStr20 with contract field f : Uint128, field h : Bool end)
   x = builtin eq param1 param2;
@@ -91,3 +95,11 @@ transition Test10 (param1 : ByStr20 with contract field f : Uint32, field g : In
   test_map3 := mp4
 end
 
+transition Test11 (param1 : ByStr20 with contract field f : Uint32, field g : Int32 end)
+  x = builtin to_string param1;
+  test_to_string := x;
+  y = builtin to_ascii param1;
+  test_to_ascii := y;
+  z = builtin strrev param1;
+  test_strrev := z
+end

--- a/tests/runner/Testcontracts.ml
+++ b/tests/runner/Testcontracts.ml
@@ -432,7 +432,7 @@ let contract_tests env =
                      "init_balance_and_nonce" ~is_library:false ~ipc_mode:true;
                 "address_eq_test"
                 >::: build_contract_tests ~pplit:false env "address_eq_test"
-                       succ_code 1 10 [];
+                       succ_code 1 11 [];
                 "address_list_traversal"
                 >::: build_contract_tests ~pplit:false env
                        "address_list_traversal" succ_code 1 3 [];

--- a/tests/runner/address_eq_test/blockchain_11.json
+++ b/tests/runner/address_eq_test/blockchain_11.json
@@ -1,0 +1,1 @@
+[ { "vname": "BLOCKNUMBER", "type": "BNum", "value": "100" } ]

--- a/tests/runner/address_eq_test/message_11.json
+++ b/tests/runner/address_eq_test/message_11.json
@@ -1,0 +1,13 @@
+{
+    "_tag": "Test11",
+    "_amount": "0",
+    "_sender": "0xabfeccdc9012345678901234567890f777564322",
+    "params": [
+        {
+            "vname" : "param1",
+            "type" : "ByStr20",
+            "value" : "0x4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a"
+        }
+    ],
+    "_origin": "0xabfeccdc9012345678901234567890f777564322"
+}

--- a/tests/runner/address_eq_test/output_1.json
+++ b/tests/runner/address_eq_test/output_1.json
@@ -72,7 +72,10 @@
       "vname": "test_map3",
       "type": "Map (Uint128) (ByStr20 with contract end)",
       "value": []
-    }
+    },
+    { "vname": "test_to_string", "type": "String", "value": "" },
+    { "vname": "test_to_ascii", "type": "String", "value": "" },
+    { "vname": "test_strrev", "type": "String", "value": "" }
   ],
   "events": []
 }

--- a/tests/runner/address_eq_test/output_10.json
+++ b/tests/runner/address_eq_test/output_10.json
@@ -76,7 +76,10 @@
         "arguments": []
       }
     },
-    { "vname": "map_res_6", "type": "Uint32", "value": "0" }
+    { "vname": "map_res_6", "type": "Uint32", "value": "0" },
+    { "vname": "test_to_string", "type": "String", "value": "" },
+    { "vname": "test_to_ascii", "type": "String", "value": "" },
+    { "vname": "test_strrev", "type": "String", "value": "" }
   ],
   "events": []
 }

--- a/tests/runner/address_eq_test/output_11.json
+++ b/tests/runner/address_eq_test/output_11.json
@@ -1,14 +1,24 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7945",
+  "gas_remaining": "7935",
   "_accepted": "false",
   "messages": [],
   "states": [
     { "vname": "_balance", "type": "Uint128", "value": "0" },
     {
-      "vname": "to_uint_res",
-      "type": "Uint256",
-      "value": "981919657051257492891310799936320540488183989027"
+      "vname": "test_strrev",
+      "type": "String",
+      "value": "0x4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a"
+    },
+    {
+      "vname": "test_to_ascii",
+      "type": "String",
+      "value": "JJJJJJJJJJJJJJJJJJJJ"
+    },
+    {
+      "vname": "test_to_string",
+      "type": "String",
+      "value": "0x4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a"
     },
     {
       "vname": "eq_test_res",
@@ -16,6 +26,7 @@
       "value": { "constructor": "False", "argtypes": [], "arguments": [] }
     },
     { "vname": "to_bystr_res", "type": "ByStr", "value": "0x12" },
+    { "vname": "to_uint_res", "type": "Uint256", "value": "0" },
     {
       "vname": "concat_res",
       "type": "ByStr40",
@@ -76,10 +87,7 @@
       "vname": "test_map3",
       "type": "Map (Uint128) (ByStr20 with contract end)",
       "value": []
-    },
-    { "vname": "test_to_string", "type": "String", "value": "" },
-    { "vname": "test_to_ascii", "type": "String", "value": "" },
-    { "vname": "test_strrev", "type": "String", "value": "" }
+    }
   ],
   "events": []
 }

--- a/tests/runner/address_eq_test/output_2.json
+++ b/tests/runner/address_eq_test/output_2.json
@@ -72,7 +72,10 @@
       "vname": "test_map3",
       "type": "Map (Uint128) (ByStr20 with contract end)",
       "value": []
-    }
+    },
+    { "vname": "test_to_string", "type": "String", "value": "" },
+    { "vname": "test_to_ascii", "type": "String", "value": "" },
+    { "vname": "test_strrev", "type": "String", "value": "" }
   ],
   "events": []
 }

--- a/tests/runner/address_eq_test/output_3.json
+++ b/tests/runner/address_eq_test/output_3.json
@@ -72,7 +72,10 @@
       "vname": "test_map3",
       "type": "Map (Uint128) (ByStr20 with contract end)",
       "value": []
-    }
+    },
+    { "vname": "test_to_string", "type": "String", "value": "" },
+    { "vname": "test_to_ascii", "type": "String", "value": "" },
+    { "vname": "test_strrev", "type": "String", "value": "" }
   ],
   "events": []
 }

--- a/tests/runner/address_eq_test/output_4.json
+++ b/tests/runner/address_eq_test/output_4.json
@@ -72,7 +72,10 @@
       "vname": "test_map3",
       "type": "Map (Uint128) (ByStr20 with contract end)",
       "value": []
-    }
+    },
+    { "vname": "test_to_string", "type": "String", "value": "" },
+    { "vname": "test_to_ascii", "type": "String", "value": "" },
+    { "vname": "test_strrev", "type": "String", "value": "" }
   ],
   "events": []
 }

--- a/tests/runner/address_eq_test/output_5.json
+++ b/tests/runner/address_eq_test/output_5.json
@@ -72,7 +72,10 @@
       "vname": "test_map3",
       "type": "Map (Uint128) (ByStr20 with contract end)",
       "value": []
-    }
+    },
+    { "vname": "test_to_string", "type": "String", "value": "" },
+    { "vname": "test_to_ascii", "type": "String", "value": "" },
+    { "vname": "test_strrev", "type": "String", "value": "" }
   ],
   "events": []
 }

--- a/tests/runner/address_eq_test/output_6.json
+++ b/tests/runner/address_eq_test/output_6.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7949",
+  "gas_remaining": "7948",
   "_accepted": "false",
   "messages": [],
   "states": [
@@ -76,7 +76,10 @@
       "vname": "test_map3",
       "type": "Map (Uint128) (ByStr20 with contract end)",
       "value": []
-    }
+    },
+    { "vname": "test_to_string", "type": "String", "value": "" },
+    { "vname": "test_to_ascii", "type": "String", "value": "" },
+    { "vname": "test_strrev", "type": "String", "value": "" }
   ],
   "events": []
 }

--- a/tests/runner/address_eq_test/output_8.json
+++ b/tests/runner/address_eq_test/output_8.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7925",
+  "gas_remaining": "7924",
   "_accepted": "false",
   "messages": [],
   "states": [
@@ -72,7 +72,10 @@
       "vname": "test_map3",
       "type": "Map (Uint128) (ByStr20 with contract end)",
       "value": []
-    }
+    },
+    { "vname": "test_to_string", "type": "String", "value": "" },
+    { "vname": "test_to_ascii", "type": "String", "value": "" },
+    { "vname": "test_strrev", "type": "String", "value": "" }
   ],
   "events": []
 }

--- a/tests/runner/address_eq_test/output_9.json
+++ b/tests/runner/address_eq_test/output_9.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7920",
+  "gas_remaining": "7919",
   "_accepted": "false",
   "messages": [],
   "states": [
@@ -96,7 +96,10 @@
       "vname": "test_map3",
       "type": "Map (Uint128) (ByStr20 with contract end)",
       "value": []
-    }
+    },
+    { "vname": "test_to_string", "type": "String", "value": "" },
+    { "vname": "test_to_ascii", "type": "String", "value": "" },
+    { "vname": "test_strrev", "type": "String", "value": "" }
   ],
   "events": []
 }

--- a/tests/runner/address_eq_test/state_1.json
+++ b/tests/runner/address_eq_test/state_1.json
@@ -66,6 +66,21 @@
     "value": []
   },
   {
+    "vname": "test_to_string",
+    "type": "String",
+    "value": ""
+  },
+  {
+    "vname": "test_to_ascii",
+    "type": "String",
+    "value": ""
+  },
+  {
+    "vname": "test_strrev",
+    "type": "String",
+    "value": ""
+  },
+  {
     "vname": "_external",
     "type": "Unit",
     "value": [

--- a/tests/runner/address_eq_test/state_11.json
+++ b/tests/runner/address_eq_test/state_11.json
@@ -85,7 +85,7 @@
     "type": "Unit",
     "value": [
         {
-            "address": "0xabfeccdc9012345678901234567890f777564323",
+            "address": "0x4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a",
             "state": [
                 { "vname": "_nonce", "type": "Uint64", "value": "0" },
                 { "vname": "_balance", "type": "Uint128", "value": "42" },

--- a/tests/runner/address_eq_test/state_2.json
+++ b/tests/runner/address_eq_test/state_2.json
@@ -66,6 +66,21 @@
     "value": []
   },
   {
+    "vname": "test_to_string",
+    "type": "String",
+    "value": ""
+  },
+  {
+    "vname": "test_to_ascii",
+    "type": "String",
+    "value": ""
+  },
+  {
+    "vname": "test_strrev",
+    "type": "String",
+    "value": ""
+  },
+  {
     "vname": "_external",
     "type": "Unit",
     "value": [

--- a/tests/runner/address_eq_test/state_3.json
+++ b/tests/runner/address_eq_test/state_3.json
@@ -66,6 +66,21 @@
     "value": []
   },
   {
+    "vname": "test_to_string",
+    "type": "String",
+    "value": ""
+  },
+  {
+    "vname": "test_to_ascii",
+    "type": "String",
+    "value": ""
+  },
+  {
+    "vname": "test_strrev",
+    "type": "String",
+    "value": ""
+  },
+  {
     "vname": "_external",
     "type": "Unit",
     "value": [

--- a/tests/runner/address_eq_test/state_4.json
+++ b/tests/runner/address_eq_test/state_4.json
@@ -66,6 +66,21 @@
     "value": []
   },
   {
+    "vname": "test_to_string",
+    "type": "String",
+    "value": ""
+  },
+  {
+    "vname": "test_to_ascii",
+    "type": "String",
+    "value": ""
+  },
+  {
+    "vname": "test_strrev",
+    "type": "String",
+    "value": ""
+  },
+  {
     "vname": "_external",
     "type": "Unit",
     "value": [

--- a/tests/runner/address_eq_test/state_5.json
+++ b/tests/runner/address_eq_test/state_5.json
@@ -66,6 +66,21 @@
     "value": []
   },
   {
+    "vname": "test_to_string",
+    "type": "String",
+    "value": ""
+  },
+  {
+    "vname": "test_to_ascii",
+    "type": "String",
+    "value": ""
+  },
+  {
+    "vname": "test_strrev",
+    "type": "String",
+    "value": ""
+  },
+  {
     "vname": "_external",
     "type": "Unit",
     "value": [

--- a/tests/runner/address_eq_test/state_6.json
+++ b/tests/runner/address_eq_test/state_6.json
@@ -66,6 +66,21 @@
     "value": []
   },
   {
+    "vname": "test_to_string",
+    "type": "String",
+    "value": ""
+  },
+  {
+    "vname": "test_to_ascii",
+    "type": "String",
+    "value": ""
+  },
+  {
+    "vname": "test_strrev",
+    "type": "String",
+    "value": ""
+  },
+  {
     "vname": "_external",
     "type": "Unit",
     "value": [

--- a/tests/runner/address_eq_test/state_7.json
+++ b/tests/runner/address_eq_test/state_7.json
@@ -66,6 +66,21 @@
     "value": []
   },
   {
+    "vname": "test_to_string",
+    "type": "String",
+    "value": ""
+  },
+  {
+    "vname": "test_to_ascii",
+    "type": "String",
+    "value": ""
+  },
+  {
+    "vname": "test_strrev",
+    "type": "String",
+    "value": ""
+  },
+  {
     "vname": "_external",
     "type": "Unit",
     "value": [

--- a/tests/runner/address_eq_test/state_8.json
+++ b/tests/runner/address_eq_test/state_8.json
@@ -66,6 +66,21 @@
     "value": []
   },
   {
+    "vname": "test_to_string",
+    "type": "String",
+    "value": ""
+  },
+  {
+    "vname": "test_to_ascii",
+    "type": "String",
+    "value": ""
+  },
+  {
+    "vname": "test_strrev",
+    "type": "String",
+    "value": ""
+  },
+  {
     "vname": "_external",
     "type": "Unit",
     "value": [

--- a/tests/runner/address_eq_test/state_9.json
+++ b/tests/runner/address_eq_test/state_9.json
@@ -66,6 +66,21 @@
     "value": []
   },
   {
+    "vname": "test_to_string",
+    "type": "String",
+    "value": ""
+  },
+  {
+    "vname": "test_to_ascii",
+    "type": "String",
+    "value": ""
+  },
+  {
+    "vname": "test_strrev",
+    "type": "String",
+    "value": ""
+  },
+  {
     "vname": "_external",
     "type": "Unit",
     "value": [


### PR DESCRIPTION
The elaboration of `to_string`, `strrev` and `to_ascii` did not take into account that their arguments may now be addresses. This has now been fixed.