### PR TITLE
Handle migration of contracts with missing state

### DIFF
--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -135,8 +135,9 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
           | Int_typ _ | Uint_typ _ | Bystrx_typ _ | Bystr_typ ->
               elab_tfun_with_args_no_gas to_string_type ts
           | _ -> fail0 "Failed to elaborate" )
-      | [], [ t ] when is_address_type t -> 
-          elab_tfun_with_args_no_gas to_string_type [bystrx_typ Type.address_length]
+      | [], [ t ] when is_address_type t ->
+          elab_tfun_with_args_no_gas to_string_type
+            [ bystrx_typ Type.address_length ]
       | _, _ -> fail0 "Failed to elaborate"
 
     let to_ascii_arity = 1
@@ -150,8 +151,9 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
           | Bystrx_typ _ | Bystr_typ ->
               elab_tfun_with_args_no_gas to_ascii_type ts
           | _ -> fail0 "Failed to elaborate" )
-      | [], [ t ] when is_address_type t -> 
-          elab_tfun_with_args_no_gas to_string_type [bystrx_typ Type.address_length]
+      | [], [ t ] when is_address_type t ->
+          elab_tfun_with_args_no_gas to_string_type
+            [ bystrx_typ Type.address_length ]
       | _, _ -> fail0 "Failed to elaborate"
 
     let strrev_arity = 1
@@ -165,8 +167,9 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
           | String_typ | Bystrx_typ _ | Bystr_typ ->
               elab_tfun_with_args_no_gas strrev_type ts
           | _ -> fail0 "Failed to elaborate" )
-      | [], [ t ] when is_address_type t -> 
-          elab_tfun_with_args_no_gas to_string_type [bystrx_typ Type.address_length]
+      | [], [ t ] when is_address_type t ->
+          elab_tfun_with_args_no_gas to_string_type
+            [ bystrx_typ Type.address_length ]
       | _, _ -> fail0 "Failed to elaborate"
   end
 

--- a/tests/typecheck/good/Good.ml
+++ b/tests/typecheck/good/Good.ml
@@ -95,31 +95,39 @@ let equivalent_types =
       "ByStr20 with contract field x : Uint32, field y : ByStr20 with contract \
        field y1 : Option Int256, field y2 : ByStr20 end end" );
     ( "forall 'A. 'A -> ByStr20 with contract field f : 'A end",
-      "forall 'C. 'C -> ByStr20 with contract field f : 'C end");
-    ( "forall 'A. 'A -> ByStr20 with contract field f : ByStr20 with contract field z : 'A end end",
-      "forall 'C. 'C -> ByStr20 with contract field f : ByStr20 with contract field z : 'C end end");
-    ( "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 with contract field y : Bool end",
-      "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 with contract field y : Bool end");
+      "forall 'C. 'C -> ByStr20 with contract field f : 'C end" );
+    ( "forall 'A. 'A -> ByStr20 with contract field f : ByStr20 with contract \
+       field z : 'A end end",
+      "forall 'C. 'C -> ByStr20 with contract field f : ByStr20 with contract \
+       field z : 'C end end" );
+    ( "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 \
+       with contract field y : Bool end",
+      "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 \
+       with contract field y : Bool end" );
     ( "ByStr20 with end -> ByStr20 with contract field y : Bool end",
-      "ByStr20 with end -> ByStr20 with contract field y : Bool end");
+      "ByStr20 with end -> ByStr20 with contract field y : Bool end" );
     ( "ByStr20 with contract end -> ByStr20 with contract field y : Bool end",
-      "ByStr20 with contract end -> ByStr20 with contract field y : Bool end");
+      "ByStr20 with contract end -> ByStr20 with contract field y : Bool end" );
     ( "ByStr20 -> ByStr20 with contract field y : Bool end",
-      "ByStr20 -> ByStr20 with contract field y : Bool end");
+      "ByStr20 -> ByStr20 with contract field y : Bool end" );
     ( "ByStr20 with contract field y : Bool end -> ByStr20 with end",
-      "ByStr20 with contract field y : Bool end -> ByStr20 with end");
+      "ByStr20 with contract field y : Bool end -> ByStr20 with end" );
     ( "ByStr20 with contract field y : Bool end -> ByStr20 with contract end",
-      "ByStr20 with contract field y : Bool end -> ByStr20 with contract end");
+      "ByStr20 with contract field y : Bool end -> ByStr20 with contract end" );
     ( "ByStr20 with contract field y : Bool end -> ByStr20",
-      "ByStr20 with contract field y : Bool end -> ByStr20");
-    ( "Map (ByStr20 with contract field x : Uint32, field y : ByStr20 with end end) ByStr20",
-      "Map (ByStr20 with contract field x : Uint32, field y : ByStr20 with end end) ByStr20");
-    ( "Map (ByStr20 with contract end) (ByStr20 with contract field x : Uint32 end)",
-      "Map (ByStr20 with contract end) (ByStr20 with contract field x : Uint32 end)");
+      "ByStr20 with contract field y : Bool end -> ByStr20" );
+    ( "Map (ByStr20 with contract field x : Uint32, field y : ByStr20 with end \
+       end) ByStr20",
+      "Map (ByStr20 with contract field x : Uint32, field y : ByStr20 with end \
+       end) ByStr20" );
+    ( "Map (ByStr20 with contract end) (ByStr20 with contract field x : Uint32 \
+       end)",
+      "Map (ByStr20 with contract end) (ByStr20 with contract field x : Uint32 \
+       end)" );
     ( "Map ByStr20 (ByStr20 with contract field x : Uint32 end)",
-      "Map ByStr20 (ByStr20 with contract field x : Uint32 end)");
+      "Map ByStr20 (ByStr20 with contract field x : Uint32 end)" );
   ]
-  
+
 let assignable_but_not_equivalent_types =
   [
     (* Addresses *)
@@ -147,39 +155,59 @@ let assignable_but_not_equivalent_types =
     ( "ByStr20 with contract field x : ByStr20 with end end",
       "ByStr20 with contract field x : ByStr20 with contract end end" );
     ( "forall 'A. 'A -> ByStr20",
-      "forall 'C. 'C -> ByStr20 with contract field f : 'C end");
+      "forall 'C. 'C -> ByStr20 with contract field f : 'C end" );
     ( "forall 'A. 'A -> ByStr20 with end",
-      "forall 'C. 'C -> ByStr20 with contract field f : 'C end");
+      "forall 'C. 'C -> ByStr20 with contract field f : 'C end" );
     ( "forall 'A. 'A -> ByStr20 with contract end",
-      "forall 'C. 'C -> ByStr20 with contract field f : 'C end");
+      "forall 'C. 'C -> ByStr20 with contract field f : 'C end" );
     ( "forall 'A. 'A -> ByStr20 with contract field f : ByStr20 end",
-      "forall 'C. 'C -> ByStr20 with contract field f : ByStr20 with contract field z : 'C end end");
+      "forall 'C. 'C -> ByStr20 with contract field f : ByStr20 with contract \
+       field z : 'C end end" );
     ( "forall 'A. 'A -> ByStr20 with contract field f : ByStr20 with end end",
-      "forall 'C. 'C -> ByStr20 with contract field f : ByStr20 with contract field z : 'C end end");
-    ( "forall 'A. 'A -> ByStr20 with contract field f : ByStr20 with contract end end",
-      "forall 'C. 'C -> ByStr20 with contract field f : ByStr20 with contract field z : 'C end end");
-    ( "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 with contract field y : Bool end",
-      "ByStr20 with contract field x : Uint32 end -> ByStr20 with contract field y : Bool end");
-    ( "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 with contract field y : Bool end",
-      "ByStr20 with contract end -> ByStr20 with contract field y : Bool end");
-    ( "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 with contract field y : Bool end",
-      "ByStr20 with end -> ByStr20 with contract field y : Bool end");
-    ( "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 with contract field y : Bool end",
-      "ByStr20 -> ByStr20 with contract field y : Bool end");
-    ( "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 with contract field y : Bool end",
-      "ByStr20 with end -> ByStr20 with contract field y : Bool, field z : Uint32 end");
-    ( "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 with contract field y : Bool end",
-      "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 with contract field y : Bool, field z : Uint32 end");
-    ( "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 with contract end",
-      "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 with contract field y : Bool, field z : Uint32 end");
-    ( "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 with end",
-      "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 with contract field y : Bool, field z : Uint32 end");
+      "forall 'C. 'C -> ByStr20 with contract field f : ByStr20 with contract \
+       field z : 'C end end" );
+    ( "forall 'A. 'A -> ByStr20 with contract field f : ByStr20 with contract \
+       end end",
+      "forall 'C. 'C -> ByStr20 with contract field f : ByStr20 with contract \
+       field z : 'C end end" );
+    ( "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 \
+       with contract field y : Bool end",
+      "ByStr20 with contract field x : Uint32 end -> ByStr20 with contract \
+       field y : Bool end" );
+    ( "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 \
+       with contract field y : Bool end",
+      "ByStr20 with contract end -> ByStr20 with contract field y : Bool end" );
+    ( "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 \
+       with contract field y : Bool end",
+      "ByStr20 with end -> ByStr20 with contract field y : Bool end" );
+    ( "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 \
+       with contract field y : Bool end",
+      "ByStr20 -> ByStr20 with contract field y : Bool end" );
+    ( "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 \
+       with contract field y : Bool end",
+      "ByStr20 with end -> ByStr20 with contract field y : Bool, field z : \
+       Uint32 end" );
+    ( "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 \
+       with contract field y : Bool end",
+      "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 \
+       with contract field y : Bool, field z : Uint32 end" );
+    ( "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 \
+       with contract end",
+      "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 \
+       with contract field y : Bool, field z : Uint32 end" );
+    ( "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 \
+       with end",
+      "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 \
+       with contract field y : Bool, field z : Uint32 end" );
     ( "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20",
-      "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 with contract field y : Bool, field z : Uint32 end");
+      "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 \
+       with contract field y : Bool, field z : Uint32 end" );
     ( "Map (ByStr20 with end) (ByStr20 with contract field x : Uint32 end)",
-      "Map (ByStr20 with contract end) (ByStr20 with contract field x : Uint32 end)");
+      "Map (ByStr20 with contract end) (ByStr20 with contract field x : Uint32 \
+       end)" );
     ( "Map (ByStr20 with contract end) (ByStr20 with contract end)",
-      "Map (ByStr20 with contract end) (ByStr20 with contract field x : Uint32 end)");
+      "Map (ByStr20 with contract end) (ByStr20 with contract field x : Uint32 \
+       end)" );
   ]
 
 let not_assignable_in_either_direction_types =
@@ -207,25 +235,41 @@ let not_assignable_in_either_direction_types =
       "ByStr20 with contract field x : ByStr20 with contract field y2 : Int32 \
        end end" );
     ( "forall 'A. 'A -> ByStr20 with contract field f : Uint32 end",
-      "forall 'C. 'C -> ByStr20 with contract field f : 'C end");
-    ( "forall 'A. forall 'B. ByStr20 with contract field f : 'A, field g : 'B end",
-      "forall 'C. forall 'D. ByStr20 with contract field f : 'D, field g : 'C end");
-    ( "forall 'A. forall 'B. 'A -> 'B -> ByStr20 with contract field f : 'A, field g : 'B end",
-      "forall 'C. forall 'D. 'D -> 'C -> ByStr20 with contract field f : 'C, field g : 'D end");
-    ( "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 with contract field y : Bool end",
-      "ByStr20 with contract field x : Uint32, field z : Bool end -> ByStr20 with contract field y : Bool end");
-    ( "ByStr20 with contract field x : Uint32 end -> ByStr20 with contract field y : Bool, field z : Bool end",
-      "ByStr20 with contract field x : Uint32 end -> ByStr20 with contract field y : Bool, field w : Bool  end");
+      "forall 'C. 'C -> ByStr20 with contract field f : 'C end" );
+    ( "forall 'A. forall 'B. ByStr20 with contract field f : 'A, field g : 'B \
+       end",
+      "forall 'C. forall 'D. ByStr20 with contract field f : 'D, field g : 'C \
+       end" );
+    ( "forall 'A. forall 'B. 'A -> 'B -> ByStr20 with contract field f : 'A, \
+       field g : 'B end",
+      "forall 'C. forall 'D. 'D -> 'C -> ByStr20 with contract field f : 'C, \
+       field g : 'D end" );
+    ( "ByStr20 with contract field x : Uint32, field y : Bool end -> ByStr20 \
+       with contract field y : Bool end",
+      "ByStr20 with contract field x : Uint32, field z : Bool end -> ByStr20 \
+       with contract field y : Bool end" );
+    ( "ByStr20 with contract field x : Uint32 end -> ByStr20 with contract \
+       field y : Bool, field z : Bool end",
+      "ByStr20 with contract field x : Uint32 end -> ByStr20 with contract \
+       field y : Bool, field w : Bool  end" );
     ( "ByStr20 with contract end -> ByStr20 with contract end",
-      "ByStr20 with contract field x : Uint32 end -> ByStr20 with contract field y : Bool end");
-    ( "ByStr20 with contract field x : Uint32 end -> ByStr20 with contract field y : Bool end",
-      "ByStr20 with contract end -> ByStr20 with contract end");
-    ( "Map (ByStr20 with contract end) (ByStr20 with contract field x : Uint32 end)",
-      "Map (ByStr20 with contract field x : Uint32 end) (ByStr20 with contract end)");
-    ( "Map (ByStr20 with contract end) (ByStr20 with contract field y : Uint32 end)",
-      "Map (ByStr20 with contract end) (ByStr20 with contract field x : Uint32 end)");
-    ( "Map (ByStr20 with contract field y : Uint32 end) (ByStr20 with contract end)",
-      "Map (ByStr20 with contract field x : Uint32 end) (ByStr20 with contract end)");
+      "ByStr20 with contract field x : Uint32 end -> ByStr20 with contract \
+       field y : Bool end" );
+    ( "ByStr20 with contract field x : Uint32 end -> ByStr20 with contract \
+       field y : Bool end",
+      "ByStr20 with contract end -> ByStr20 with contract end" );
+    ( "Map (ByStr20 with contract end) (ByStr20 with contract field x : Uint32 \
+       end)",
+      "Map (ByStr20 with contract field x : Uint32 end) (ByStr20 with contract \
+       end)" );
+    ( "Map (ByStr20 with contract end) (ByStr20 with contract field y : Uint32 \
+       end)",
+      "Map (ByStr20 with contract end) (ByStr20 with contract field x : Uint32 \
+       end)" );
+    ( "Map (ByStr20 with contract field y : Uint32 end) (ByStr20 with contract \
+       end)",
+      "Map (ByStr20 with contract field x : Uint32 end) (ByStr20 with contract \
+       end)" );
   ]
 
 let make_test eq (t1, t2) = (t1, t2, eq)


### PR DESCRIPTION
For non-problematic contracts we fetch the state from the IPC server. The state is then disambiguated, and pushed back to the IPC server in an `update` call.

For contracts where the state doesn't exist in the database we instead build the state from the field initalisers, in the same way we do during deployment (I have removed all the validation checks from this branch of the logic, since the contracts are already deployed). Disambiguating and pushing back the state works as for non-problem contracts.

To determine whether we are dealing with a problem contract we attempt to fetch the value of the first field. If that fetch fails, we are dealing with a problem contract.