### PR TITLE
Address types that compare equal must be structurally equal

### DIFF
--- a/src/base/Disambiguate.ml
+++ b/src/base/Disambiguate.ml
@@ -220,10 +220,12 @@ module ScillaDisambiguation (SR : Rep) (ER : Rep) = struct
       | Address None -> pure @@ PostDisType.Address None
       | Address (Some fts) ->
           let%bind dis_fts =
-            mapM fts ~f:(fun (id, t) ->
+            foldM (IdLoc_Comp.Map.to_alist fts)
+              ~init:PostDisType.IdLoc_Comp.Map.empty ~f:(fun acc (id, t) ->
                 let%bind dis_id = name_def_as_simple_global id in
                 let%bind dis_t = recurse t in
-                pure @@ (dis_id, dis_t))
+                pure
+                @@ PostDisType.IdLoc_Comp.Map.set acc ~key:dis_id ~data:dis_t)
           in
           pure @@ PostDisType.Address (Some dis_fts)
     in

--- a/src/base/Recursion.ml
+++ b/src/base/Recursion.ml
@@ -73,17 +73,8 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
           forallM ~f:walk targs
       | PolyFun (_, t) -> walk t
       | Address None -> pure ()
-      | Address (Some fts) -> (
-          match
-            List.find_a_dup fts ~compare:(fun (f1, _) (f2, _) ->
-                RecIdentifier.compare f1 f2)
-          with
-          | Some (dup_field, _) ->
-              fail1
-                (sprintf "Duplicate field %s in address type."
-                   (as_error_string dup_field))
-                (get_rep dup_field)
-          | None -> forallM fts ~f:(fun (_, t) -> walk t))
+      | Address (Some fts) ->
+          forallM (IdLoc_Comp.Map.to_alist fts) ~f:(fun (_, t) -> walk t)
     in
     walk t
 
@@ -299,7 +290,8 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
           (* Disallow polymorphic definitions for the time being. *)
           fail1 "Type variables not allowed in type definitions" error_loc
       | Address None -> pure ()
-      | Address (Some fts) -> forallM fts ~f:(fun (_, t) -> walk t)
+      | Address (Some fts) ->
+          forallM (IdLoc_Comp.Map.to_alist fts) ~f:(fun (_, t) -> walk t)
     in
     walk t
 

--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -217,7 +217,10 @@ address_typ :
     { if d = "ByStr20"
       then
         (* Add _this_address : ByStr20 to field list. This ensures the type is treated as a contract address *)
-        Address (Some fs)
+        let fs' = List.fold_left (fun acc (id, t) -> 
+          SType.IdLoc_Comp.Map.set acc ~key:id ~data:t) SType.IdLoc_Comp.Map.empty fs
+        in
+        Address (Some fs')
       else raise (SyntaxError ("Invalid type", toLoc $startpos(d))) }
 | (* Adding this production in preparation for contract parameters *)
   d = CID; WITH; CONTRACT; LPAREN; _ps = separated_list(COMMA, param_pair); RPAREN; _fs = separated_list(COMMA, address_type_field); END;

--- a/src/base/Type.ml
+++ b/src/base/Type.ml
@@ -104,15 +104,6 @@ module IdLoc_Comp (TIdentifier : ScillaIdentifier) = struct
   include Comparable.Make (T)
 end
 
-(* module type TIdentifier_Loc = functor (TIdentifier : ScillaIdentifier) ->
-  sig
-    type t = loc TIdentifier.t
-    val compare : t -> t -> int
-    val equal : t -> t -> bool
-    val sexp_of_t : loc TIdentifier.t -> Sexp.t
-    val t_of_sexp : Sexp.t -> loc TIdentifier.t
-  end
- *)
 module type ScillaType = sig
   module TIdentifier : ScillaIdentifier
 

--- a/src/eval/Runner.ml
+++ b/src/eval/Runner.ml
@@ -276,7 +276,8 @@ let perform_dynamic_typechecks checks gas_remaining =
       match t with
       | Address fts -> (
           match
-            EvalUtil.EvalTypecheck.typecheck_remote_field_types ~caddr fts
+            EvalUtil.EvalTypecheck.typecheck_remote_field_types ~caddr
+              (Option.map ~f:IdLoc_Comp.Map.to_alist fts)
           with
           | Ok true -> ()
           | Ok false ->

--- a/tests/checker/good/gold/remote_state_reads.scilla.gold
+++ b/tests/checker/good/gold/remote_state_reads.scilla.gold
@@ -43,7 +43,7 @@
       {
         "vname": "cparam3",
         "type":
-          "ByStr20 with contract field transactionCount : Uint32, field admin : ByStr20 with end, field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)), field other_map : Map (Uint128) (ByStr20 with end) end"
+          "ByStr20 with contract field admin : ByStr20 with end, field other_map : Map (Uint128) (ByStr20 with end), field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)), field transactionCount : Uint32 end"
       }
     ],
     "fields": [
@@ -148,7 +148,7 @@
           {
             "vname": "remote3",
             "type":
-              "ByStr20 with contract field transactionCount : Uint32, field admin : ByStr20 with end, field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)) end"
+              "ByStr20 with contract field admin : ByStr20 with end, field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)), field transactionCount : Uint32 end"
           }
         ]
       },

--- a/tests/ipc/StateIPCTestServer.ml
+++ b/tests/ipc/StateIPCTestServer.ml
@@ -203,9 +203,7 @@ module MakeServer () = struct
 
   let fetch_ext_state_value caddr query =
     let%bind f, v, t = fetch_state_value_helper (Some caddr) query in
-    match t with
-    | Some t' -> pure (f, v, t')
-    | None -> fail RPCError.{ code = 0; message = fetch_message }
+    match t with Some t' -> pure (f, v, t') | None -> pure (false, "", "")
 
   let update_state_value query value = set_value_helper None query value None
 

--- a/tests/runner/remote_state_reads/init_missing_field_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_missing_field_ipc_output.json
@@ -3,7 +3,7 @@
   "errors": [
     {
       "error_message":
-        "StateIPCClient: Error in IPC access: (code:0, message:Fetching state value failed).",
+        "Address 0x1234567890123456789012345678901234567890 does not satisfy type ByStr20 with contract field admin : ByStr20 with end, field other_map : Map (Uint128) (ByStr20 with end), field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)), field transactionCount : Uint32 end\n",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/runner/remote_state_reads/init_no_address_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_no_address_ipc_output.json
@@ -3,7 +3,7 @@
   "errors": [
     {
       "error_message":
-        "StateIPCClient: Error in IPC access: (code:0, message:Fetching state value failed).",
+        "Address 0x1234567890123456789012345678901234567890 not in use.",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/runner/remote_state_reads/init_wrong_address_field_type_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_wrong_address_field_type_ipc_output.json
@@ -3,7 +3,7 @@
   "errors": [
     {
       "error_message":
-        "Address 0x1234567890123456789012345678901234567890 does not satisfy type ByStr20 with contract field transactionCount : Uint32, field admin : ByStr20 with end, field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)), field other_map : Map (Uint128) (ByStr20 with end) end\n",
+        "Address 0x1234567890123456789012345678901234567890 does not satisfy type ByStr20 with contract field admin : ByStr20 with end, field other_map : Map (Uint128) (ByStr20 with end), field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)), field transactionCount : Uint32 end\n",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/runner/remote_state_reads/init_wrong_field_type_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_wrong_field_type_ipc_output.json
@@ -3,7 +3,7 @@
   "errors": [
     {
       "error_message":
-        "Address 0x1234567890123456789012345678901234567890 does not satisfy type ByStr20 with contract field transactionCount : Uint32, field admin : ByStr20 with end, field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)), field other_map : Map (Uint128) (ByStr20 with end) end\n",
+        "Address 0x1234567890123456789012345678901234567890 does not satisfy type ByStr20 with contract field admin : ByStr20 with end, field other_map : Map (Uint128) (ByStr20 with end), field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)), field transactionCount : Uint32 end\n",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/runner/remote_state_reads/init_wrong_map_type_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_wrong_map_type_ipc_output.json
@@ -3,7 +3,7 @@
   "errors": [
     {
       "error_message":
-        "Address 0x1234567890123456789012345678901234567890 does not satisfy type ByStr20 with contract field transactionCount : Uint32, field admin : ByStr20 with end, field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)), field other_map : Map (Uint128) (ByStr20 with end) end\n",
+        "Address 0x1234567890123456789012345678901234567890 does not satisfy type ByStr20 with contract field admin : ByStr20 with end, field other_map : Map (Uint128) (ByStr20 with end), field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)), field transactionCount : Uint32 end\n",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/runner/remote_state_reads/output_102.json
+++ b/tests/runner/remote_state_reads/output_102.json
@@ -3,7 +3,7 @@
   "errors": [
     {
       "error_message":
-        "Address 0xabfeccdc9012345678901234567890f777564325 does not satisfy type ByStr20 with contract field transactionCount : Uint32, field admin : ByStr20 with end, field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)) end\n",
+        "Address 0xabfeccdc9012345678901234567890f777564325 does not satisfy type ByStr20 with contract field admin : ByStr20 with end, field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)), field transactionCount : Uint32 end\n",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/runner/remote_state_reads/output_103.json
+++ b/tests/runner/remote_state_reads/output_103.json
@@ -3,7 +3,7 @@
   "errors": [
     {
       "error_message":
-        "Address 0xabfeccdc9012345678901234567890f777564325 does not satisfy type ByStr20 with contract field transactionCount : Uint32, field admin : ByStr20 with end, field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)) end\n",
+        "Address 0xabfeccdc9012345678901234567890f777564325 does not satisfy type ByStr20 with contract field admin : ByStr20 with end, field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)), field transactionCount : Uint32 end\n",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/runner/remote_state_reads/output_104.json
+++ b/tests/runner/remote_state_reads/output_104.json
@@ -3,7 +3,7 @@
   "errors": [
     {
       "error_message":
-        "Address 0xabfeccdc9012345678901234567890f777564325 does not satisfy type ByStr20 with contract field transactionCount : Uint32, field admin : ByStr20 with end, field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)) end\n",
+        "Address 0xabfeccdc9012345678901234567890f777564325 does not satisfy type ByStr20 with contract field admin : ByStr20 with end, field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)), field transactionCount : Uint32 end\n",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/runner/remote_state_reads/output_105.json
+++ b/tests/runner/remote_state_reads/output_105.json
@@ -3,7 +3,7 @@
   "errors": [
     {
       "error_message":
-        "Address 0xabfeccdc9012345678901234567890f777564325 does not satisfy type ByStr20 with contract field transactionCount : Uint32, field admin : ByStr20 with end, field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)) end\n",
+        "Address 0xabfeccdc9012345678901234567890f777564325 does not satisfy type ByStr20 with contract field admin : ByStr20 with end, field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)), field transactionCount : Uint32 end\n",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/runner/remote_state_reads/output_106.json
+++ b/tests/runner/remote_state_reads/output_106.json
@@ -3,7 +3,7 @@
   "errors": [
     {
       "error_message":
-        "Address 0xabfeccdc9012345678901234567890f777564325 does not satisfy type ByStr20 with contract field transactionCount : Uint32, field admin : ByStr20 with end, field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)) end\n",
+        "Address 0xabfeccdc9012345678901234567890f777564325 does not satisfy type ByStr20 with contract field admin : ByStr20 with end, field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)), field transactionCount : Uint32 end\n",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/runner/remote_state_reads/output_107.json
+++ b/tests/runner/remote_state_reads/output_107.json
@@ -3,7 +3,7 @@
   "errors": [
     {
       "error_message":
-        "Address 0xabfeccdc9012345678901234567890f777564325 does not satisfy type ByStr20 with contract field transactionCount : Uint32, field admin : ByStr20 with end, field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)) end\n",
+        "Address 0xabfeccdc9012345678901234567890f777564325 does not satisfy type ByStr20 with contract field admin : ByStr20 with end, field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)), field transactionCount : Uint32 end\n",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/runner/remote_state_reads/output_108.json
+++ b/tests/runner/remote_state_reads/output_108.json
@@ -3,7 +3,7 @@
   "errors": [
     {
       "error_message":
-        "Address 0xabfeccdc9012345678901234567890f777564325 does not satisfy type ByStr20 with contract field transactionCount : Uint32, field admin : ByStr20 with end, field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)) end\n",
+        "Address 0xabfeccdc9012345678901234567890f777564325 does not satisfy type ByStr20 with contract field admin : ByStr20 with end, field owners : Map (ByStr20 with end) (Bool), field signatures : Map (Uint32) (Map (ByStr20 with end) (Bool)), field transactionCount : Uint32 end\n",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }


### PR DESCRIPTION
This is achieved by representing addresses using Maps rather than lists. Maps bring in an order.

Also update the test IPC server to return false on "not found" as per the latest protocol with the blockchain IPC server. Errors are to be raised only for things such as database error, invalid request etc.