### PR TITLE
Fixed stack overflow issue in disambiguation tool

### DIFF
--- a/src/eval/Disambiguator.ml
+++ b/src/eval/Disambiguator.ml
@@ -980,21 +980,8 @@ let run_with_args args =
               in
               let _ = OutputStateService.finalize () in
 
-              (* TODO: Make sure the ipc-generated state have the correct form for state output *)
               match OutputStateService.get_full_state () with
-              | Ok state ->
-                  (*
-                  (* _balance is not availabe from IPC server, so use the one from the state file *)
-                  let state_from_file =
-                    parse_json args.input_state this_address
-                  in
-                  let balance =
-                    List.find_exn state_from_file ~f:(fun (fname, _, _) ->
-                        OutputName.equal fname ContractUtil.balance_label)
-                  in
-                  balance :: 
-*)
-                  state
+              | Ok state -> state
               | Error e -> fatal_error e
           in
           (init, state)
@@ -1014,10 +1001,9 @@ let run args ~exe_name =
   let args = parse args ~exe_name in
   let result_init, result_state = run_with_args args in
   let init_str = output_to_string result_init in
-  let state_str = output_to_string result_state in
   Out_channel.with_file args.output_init ~f:(fun ch ->
       Out_channel.output_string ch init_str);
   if not (String.is_empty args.output_state) then
     Out_channel.with_file args.output_state ~f:(fun ch ->
-        Out_channel.output_string ch state_str);
+        Out_channel.output_string ch (output_to_string result_state));
   "\"Disambiguate successful\""


### PR DESCRIPTION
The stack overflow now only occurs if the input state is sufficiently large, and the migrated state is to be written to a state json.