### PR TITLE
Make scilla server a public library

### DIFF
--- a/src/server/dune
+++ b/src/server/dune
@@ -1,10 +1,13 @@
 (library
  (name scilla_server_lib)
+ (public_name scilla.server_lib)
+ (wrapped true)
  (libraries core threads unix rresult rpclib rpclib.json rpclib.cmdliner
    scilla_base scilla_eval)
  (modes byte native)
  (preprocess
-  (pps ppx_sexp_conv ppx_deriving_rpc ppx_deriving.show)))
+  (pps ppx_sexp_conv ppx_deriving_rpc ppx_deriving.show))
+ (synopsis "Scilla workbench implementation."))
 
 (env
  (dev


### PR DESCRIPTION
This enables the compiler to be accessed via scilla-server too.