### PR TITLE
Fixed traversal of dag of imported libraries

### DIFF
--- a/src/base/Recursion.ml
+++ b/src/base/Recursion.ml
@@ -369,6 +369,8 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
       let deps, checked, emsgs =
         List.fold_left libl ~init:([], already_checked, [])
           ~f:(fun (rec_lib_acc_rev, already_checked_acc, emsgs_acc) ext_lib ->
+            (* Only check each library once. Use file names rather than the library names because that's how we identify libraries.
+                TODO, issue #867: We ought to be able to rely on l.lname and ext_lib.libn.lname instead *)
             let ext_lib_fname =
               (SR.get_loc (get_rep ext_lib.libn.lname)).fname
             in

--- a/src/base/Recursion.ml
+++ b/src/base/Recursion.ml
@@ -365,48 +365,54 @@ module ScillaRecursion (SR : Rep) (ER : Rep) = struct
          }
 
   let recursion_rprins_elibs recursion_principles ext_libs libs =
-    let rec recurser libl filenames_already_checked =
-      List.fold_left libl ~init:([], filenames_already_checked, [])
-        ~f:(fun (rec_elibs_acc, files_checked_acc, emsgs_acc) ext_lib ->
-          let ext_lib_fname = (SR.get_loc (get_rep ext_lib.libn.lname)).fname in
-          let rec_lib_opt, dep_libs, all_checked_files, all_emsgs =
-            (* Only check each library once. Use file names rather than the library names because that's how we identify libraries.
-               TODO, issue #867: We ought to be able to rely on l.lname and ext_lib.libn.lname instead *)
+    let rec recurser libl already_checked =
+      let deps, checked, emsgs =
+        List.fold_left libl ~init:([], already_checked, [])
+          ~f:(fun (rec_lib_acc_rev, already_checked_acc, emsgs_acc) ext_lib ->
+            let ext_lib_fname =
+              (SR.get_loc (get_rep ext_lib.libn.lname)).fname
+            in
             match
-              List.find files_checked_acc ~f:(fun fname ->
-                  String.(fname = ext_lib_fname))
+              List.Assoc.find already_checked_acc ext_lib_fname
+                ~equal:String.( = )
             with
-            | Some _ ->
-                (* ext_lib already checked *)
-                (None, [], files_checked_acc, emsgs_acc)
+            | Some (Some lt_opt) ->
+                (* ext_lib already checked successfully *)
+                (lt_opt :: rec_lib_acc_rev, already_checked_acc, emsgs_acc)
+            | Some None ->
+                (* ext_lib already checked, and contains errors *)
+                (rec_lib_acc_rev, already_checked_acc, emsgs_acc)
             | None -> (
                 (* ext_lib not checked yet *)
                 (* Check dependencies *)
-                let rec_dep_libs, dep_files, dep_emsgs =
-                  recurser ext_lib.deps files_checked_acc
-                in
-                let all_files =
-                  ext_lib_fname :: dep_files @ files_checked_acc
+                let rec_dep_libs, already_checked_dep, dep_emsgs =
+                  recurser ext_lib.deps already_checked_acc
                 in
                 match recursion_library ext_lib.libn with
                 | Ok lib ->
-                    (Some lib, rec_dep_libs, all_files, emsgs_acc @ dep_emsgs)
+                    let (new_lt : RecursionSyntax.libtree) =
+                      { libn = lib; deps = rec_dep_libs }
+                    in
+                    let new_already_checked =
+                      List.Assoc.add already_checked_dep ext_lib_fname
+                        (Some new_lt) ~equal:String.( = )
+                    in
+                    ( new_lt :: rec_lib_acc_rev,
+                      new_already_checked,
+                      emsgs_acc @ dep_emsgs )
                 | Error e ->
-                    (None, rec_dep_libs, all_files, emsgs_acc @ dep_emsgs @ e))
-          in
-          match rec_lib_opt with
-          | Some lib ->
-              let (libn' : RecursionSyntax.libtree) =
-                { libn = lib; deps = dep_libs }
-              in
-              (rec_elibs_acc @ [ libn' ], all_checked_files, all_emsgs)
-          | None ->
-              (* An error has occurred *)
-              (rec_elibs_acc, all_checked_files, all_emsgs))
+                    let new_already_checked =
+                      List.Assoc.add already_checked_dep ext_lib_fname None
+                        ~equal:String.( = )
+                    in
+                    ( rec_lib_acc_rev,
+                      new_already_checked,
+                      emsgs_acc @ dep_emsgs @ e )))
+      in
+      (List.rev deps, checked, emsgs)
     in
 
     let recursion_elibs, _, emsgs = recurser ext_libs [] in
-
     let%bind recursion_md_libs, emsgs =
       Option.value_map libs
         ~default:(Ok (None, emsgs))

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -1181,6 +1181,8 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
                (tc_lib_acc_rev, already_checked_acc, emsgs_acc, remaining_gas)
                elib
              ->
+            (* Only check each library once. Use file names rather than the library names because that's how we identify libraries.
+               TODO, issue #867: We ought to be able to rely on l.lname and ext_lib.libn.lname instead *)
             let elib_fname = (SR.get_loc (get_rep elib.libn.lname)).fname in
             match
               List.Assoc.find already_checked_acc elib_fname ~equal:String.( = )

--- a/src/base/TypeChecker.ml
+++ b/src/base/TypeChecker.ml
@@ -1174,68 +1174,69 @@ module ScillaTypechecker (SR : Rep) (ER : Rep) = struct
   (* Type a list of libtrees, with tenv0 as the base environment, updating
    * it in-place, to include entries in elibs (but not their deps). *)
   let type_libraries elibs tenv0 remaining_gas =
-    let%bind typed_elibs, _, emsgs, remaining_gas =
-      let rec recurser libl files_already_checked remaining_gas =
-        foldM libl ~init:([], files_already_checked, [], remaining_gas)
-          ~f:(fun (lib_acc, files_checked_acc, emsgs_acc, remaining_gas) elib ->
+    let rec recurser libl already_checked remaining_gas =
+      let%bind deps, checked, emsgs, remaining_gas =
+        foldM libl ~init:([], already_checked, [], remaining_gas)
+          ~f:(fun
+               (tc_lib_acc_rev, already_checked_acc, emsgs_acc, remaining_gas)
+               elib
+             ->
             let elib_fname = (SR.get_loc (get_rep elib.libn.lname)).fname in
-            let%bind ( tc_lib_opt,
-                       dep_libs,
-                       all_checked_files,
-                       all_emsgs,
-                       remaining_gas ) =
-              (* Only check each library once. Use file names rather than the library names because that's how we identify libraries.
-                 TODO, issue #867: We ought to be able to rely on l.lname and ext_lib.libn.lname instead *)
-              match
-                List.find files_checked_acc ~f:(fun fname ->
-                    String.(fname = elib_fname))
-              with
-              | Some _ ->
-                  (* ext_lib already checked *)
-                  pure (None, [], files_checked_acc, emsgs_acc, remaining_gas)
-              | None -> (
-                  (* ext_lib not checked yet *)
-                  (* Check dependencies *)
-                  let%bind tc_dep_libs, dep_files, dep_emsgs, dep_remaining_gas
-                      =
-                    recurser elib.deps files_checked_acc remaining_gas
-                  in
-                  let all_files = elib_fname :: dep_files @ files_checked_acc in
-                  match type_library tenv0 elib.libn dep_remaining_gas with
-                  | Ok (t_lib, remaining_gas) ->
-                      pure
-                        ( Some t_lib,
-                          tc_dep_libs,
-                          all_files,
-                          emsgs_acc @ dep_emsgs,
-                          remaining_gas )
-                  | Error ((TypeError, el), remaining_gas) ->
-                      (* Collect error, and continue typechecking. *)
-                      pure
-                        ( None,
-                          tc_dep_libs,
-                          all_files,
-                          emsgs_acc @ dep_emsgs @ el,
-                          remaining_gas )
-                  | Error ((GasError, el), remaining_gas) ->
-                      (* Gas error - bail out *)
-                      Error ((GasError, el), remaining_gas))
-            in
-            match tc_lib_opt with
-            | Some t_lib ->
-                let (elib' : TypedSyntax.libtree) =
-                  { libn = t_lib; deps = dep_libs }
-                in
-                (* No reason to remove library entries. Their names are globally unique, and the disambiguator ensures that they are only accessed if they are in scope. *)
+            match
+              List.Assoc.find already_checked_acc elib_fname ~equal:String.( = )
+            with
+            | Some (Some lt_opt) ->
+                (* ext_lib already checked successfully *)
                 pure
-                  ( lib_acc @ [ elib' ],
-                    all_checked_files,
-                    all_emsgs,
+                  ( lt_opt :: tc_lib_acc_rev,
+                    already_checked_acc,
+                    emsgs_acc,
                     remaining_gas )
-            | None ->
-                (* An error has occurred *)
-                Error ((TypeError, all_emsgs), remaining_gas))
+            | Some None ->
+                (* ext_lib already checked, and contains errors *)
+                pure
+                  (tc_lib_acc_rev, already_checked_acc, emsgs_acc, remaining_gas)
+            | None -> (
+                (* ext_lib not checked yet *)
+                (* Check dependencies *)
+                let%bind ( tc_dep_libs,
+                           already_checked_dep,
+                           dep_emsgs,
+                           remaining_gas ) =
+                  recurser elib.deps already_checked_acc remaining_gas
+                in
+                match type_library tenv0 elib.libn remaining_gas with
+                | Ok (t_lib, remaining_gas) ->
+                    let (new_lt : TypedSyntax.libtree) =
+                      { libn = t_lib; deps = tc_dep_libs }
+                    in
+                    let new_already_checked =
+                      List.Assoc.add already_checked_dep elib_fname
+                        (Some new_lt) ~equal:String.( = )
+                    in
+                    pure
+                      ( new_lt :: tc_lib_acc_rev,
+                        new_already_checked,
+                        emsgs_acc @ dep_emsgs,
+                        remaining_gas )
+                | Error ((TypeError, el), remaining_gas) ->
+                    (* Collect error, and continue typechecking. *)
+                    let new_already_checked =
+                      List.Assoc.add already_checked_dep elib_fname None
+                        ~equal:String.( = )
+                    in
+                    pure
+                      ( tc_lib_acc_rev,
+                        new_already_checked,
+                        emsgs_acc @ dep_emsgs @ el,
+                        remaining_gas )
+                | Error ((GasError, el), remaining_gas) ->
+                    (* Gas error - bail out *)
+                    Error ((GasError, el), remaining_gas)))
       in
+      pure (List.rev deps, checked, emsgs, remaining_gas)
+    in
+    let%bind typed_elibs, _, emsgs, remaining_gas =
       recurser elibs [] remaining_gas
     in
     if List.is_empty emsgs then pure (typed_elibs, remaining_gas)


### PR DESCRIPTION
The traversal of imported libraries in Recursion.ml and TypeChecker.ml threw away libtrees in cases where the same library was imported in several branches. Among other things this caused the sanitychecker to sometimes only be told about some of the external libraries that were imported.

The traversal has now been fixed by simplifying the traversal.

No test case has been added because there is no way to trigger the bug. All imported entities are prefixed by their address/filename in Disambiguate.ml, so the environment used by TypeChecker.ml is essentially flat. This means that it doesn't matter which order the external libraries are traversed when building the environment, as long as all imported libraries are traversed exactly once. (Disambiguate.ml has already ensured that imported entities are in scope whenever they are used.)