### PR TITLE
Allow opam depext to fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ dev-deps:
 opamdep-ci:
 	opam init --disable-sandboxing --compiler=$(OCAML_VERSION) --yes
 	eval $$(opam env)
-	opam install ./scilla.opam --deps-only --with-test --yes
+	opam install ./scilla.opam --deps-only --with-test --no-depexts --yes
 	opam install ocamlformat.$(OCAMLFORMAT_VERSION) --yes
 
 .PHONY : coverage


### PR DESCRIPTION
Looks like Ubuntu change libboost-devel package to something else.
That is why opam fails on conf-boost package.