### PR TITLE
Filter function input to Tests to filter test output and gold files

### DIFF
--- a/tests/base/parser/bad/Bad.ml
+++ b/tests/base/parser/bad/Bad.ml
@@ -39,6 +39,8 @@ module Tests = Scilla_test.Util.DiffBasedTests (struct
 
   let provide_init_arg = false
 
+  let diff_filter s = s
+
   let tests =
     [
       "bad_map_key_2.scilla";
@@ -159,6 +161,8 @@ module LibTests = Scilla_test.Util.DiffBasedTests (struct
 
   let provide_init_arg = false
 
+  let diff_filter s = s
+
   let tests =
     [
       "lmodule-import-contract.scillib";
@@ -203,6 +207,8 @@ module ExpTests = Scilla_test.Util.DiffBasedTests (struct
   let additional_libdirs = []
 
   let provide_init_arg = false
+
+  let diff_filter s = s
 
   let tests =
     [

--- a/tests/checker/bad/Bad.ml
+++ b/tests/checker/bad/Bad.ml
@@ -37,6 +37,8 @@ module Tests = Scilla_test.Util.DiffBasedTests (struct
 
   let provide_init_arg = false
 
+  let diff_filter s = s
+
   let tests =
     [
       "bad_fields1.scilla";
@@ -131,6 +133,8 @@ module LibTests = Scilla_test.Util.DiffBasedTests (struct
 
   let provide_init_arg = false
 
+  let diff_filter s = s
+
   let tests =
     [
       "bad_adt_lib_1.scilla";
@@ -176,6 +180,8 @@ module InitArgTests = Scilla_test.Util.DiffBasedTests (struct
   let custom_args = []
 
   let provide_init_arg = true
+
+  let diff_filter s = s
 
   let additional_libdirs = [ [ "checker"; "bad"; "lib" ] ]
 

--- a/tests/checker/good/Good.ml
+++ b/tests/checker/good/Good.ml
@@ -37,6 +37,8 @@ module Tests = Scilla_test.Util.DiffBasedTests (struct
 
   let provide_init_arg = false
 
+  let diff_filter s = s
+
   let tests =
     [
       "auction.scilla";
@@ -107,6 +109,8 @@ module TestsWithInit = Scilla_test.Util.DiffBasedTests (struct
 
   let provide_init_arg = true
 
+  let diff_filter s = s
+
   let tests =
     [
       "import-test-lib.scilla";
@@ -136,6 +140,8 @@ module CheckerTests = Scilla_test.Util.DiffBasedTests (struct
   let additional_libdirs = [ [ "checker"; "good"; "lib" ] ]
 
   let provide_init_arg = false
+
+  let diff_filter s = s
 
   let tests =
     [
@@ -199,6 +205,8 @@ module InitArgTests = Scilla_test.Util.DiffBasedTests (struct
 
   let provide_init_arg = true
 
+  let diff_filter s = s
+
   let additional_libdirs = [ [ "checker"; "good"; "lib" ] ]
 
   let tests = [ "blockchain_import.scilla" ]
@@ -225,6 +233,8 @@ module ShogiTests = Scilla_test.Util.DiffBasedTests (struct
 
   let provide_init_arg = false
 
+  let diff_filter s = s
+
   let tests = [ "shogi.scilla"; "shogi_proc.scilla" ]
 
   let exit_code : UnixLabels.process_status = WEXITED 0
@@ -250,6 +260,8 @@ module TypeInfoTests = Scilla_test.Util.DiffBasedTests (struct
   let additional_libdirs = []
 
   let provide_init_arg = false
+
+  let diff_filter s = s
 
   let tests = [ "map_corners_test.scilla"; "auction.scilla" ]
 

--- a/tests/eval/bad/Bad.ml
+++ b/tests/eval/bad/Bad.ml
@@ -80,6 +80,8 @@ module Tests = Scilla_test.Util.DiffBasedTests (struct
 
   let provide_init_arg = false
 
+  let diff_filter s = s
+
   let tests = explist
 
   let exit_code : UnixLabels.process_status = WEXITED 1

--- a/tests/eval/good/Good.ml
+++ b/tests/eval/good/Good.ml
@@ -177,6 +177,8 @@ module Tests = Scilla_test.Util.DiffBasedTests (struct
 
   let provide_init_arg = false
 
+  let diff_filter s = s
+
   let tests = explist
 
   let exit_code : UnixLabels.process_status = WEXITED 0

--- a/tests/gas_use_analysis/contracts/TestGasContracts.ml
+++ b/tests/gas_use_analysis/contracts/TestGasContracts.ml
@@ -47,6 +47,8 @@ module Tests = Scilla_test.Util.DiffBasedTests (struct
 
   let provide_init_arg = false
 
+  let diff_filter s = s
+
   let json_errors = true
 
   let tests = explist

--- a/tests/gas_use_analysis/expr/TestGasExpr.ml
+++ b/tests/gas_use_analysis/expr/TestGasExpr.ml
@@ -56,6 +56,8 @@ module Tests = Scilla_test.Util.DiffBasedTests (struct
 
   let provide_init_arg = false
 
+  let diff_filter s = s
+
   let tests = explist
 
   let exit_code : UnixLabels.process_status = WEXITED 0

--- a/tests/pm_check/bad/Bad.ml
+++ b/tests/pm_check/bad/Bad.ml
@@ -38,6 +38,8 @@ module Tests = Scilla_test.Util.DiffBasedTests (struct
 
   let provide_init_arg = false
 
+  let diff_filter s = s
+
   let tests =
     [
       "pm1.scilla";

--- a/tests/runner/Testcontracts.ml
+++ b/tests/runner/Testcontracts.ml
@@ -58,7 +58,9 @@ let output_test_result env test_ctxt test_name ipc_mode goldoutput_file msg out
     =
   if env.update_gold test_ctxt && not (ipc_mode || env.server test_ctxt) then
     output_updater goldoutput_file test_name out
-  else output_verifier goldoutput_file msg (env.print_diff test_ctxt) out
+  else
+    output_verifier goldoutput_file msg (env.print_diff test_ctxt) out (fun s ->
+        s)
 
 let foutput env test_ctxt test_name ipc_mode ipc_addr_thread exit_code
     output_file goldoutput_file msg s =

--- a/tests/typecheck/bad/Bad.ml
+++ b/tests/typecheck/bad/Bad.ml
@@ -191,6 +191,8 @@ module Tests = Scilla_test.Util.DiffBasedTests (struct
 
   let provide_init_arg = false
 
+  let diff_filter s = s
+
   let tests =
     [
       "adt-error1.scilexp";

--- a/tests/typecheck/good/Good.ml
+++ b/tests/typecheck/good/Good.ml
@@ -408,6 +408,8 @@ module Tests = Scilla_test.Util.DiffBasedTests (struct
 
   let provide_init_arg = false
 
+  let diff_filter s = s
+
   let tests =
     [
       "ackermann.scilexp";


### PR DESCRIPTION
Created to allow for scilla-compiler test output to filter out what machine LLVM is produced from.