### PR TITLE
Add merging command for parser error messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,15 @@ dev:
 	@test -L bin || ln -s _build/install/default/bin .
 	ln -s ../../../default/tests/scilla_client.exe _build/install/default/bin/scilla-client
 
+# Update src/base/ParserFaults.messages
+parser-messages:
+	menhir --list-errors src/base/ScillaParser.mly >src/base/NewParserFaultsStubs.messages
+	menhir --merge-errors src/base/ParserFaults.messages \
+		   --merge-errors src/base/NewParserFaultsStubs.messages \
+		   src/base/ScillaParser.mly  >src/base/NewParserFaults.messages
+	mv src/base/NewParserFaults.messages src/base/ParserFaults.messages
+	rm src/base/NewParserFaultsStubs.messages
+
 # Launch utop such that it finds the libraroes.
 utop: release
 	OCAMLPATH=_build/install/default/lib:$(OCAMLPATH) utop

--- a/src/base/ParserFaults.messages
+++ b/src/base/ParserFaults.messages
@@ -1,3 +1,6 @@
+#@ WARNING:
+#@ The following comment has been copied from "src/base/ParserFaults.messages".
+#@ It may need to be proofread, updated, moved, or removed.
 # 
 # This file is part of scilla.
 # 
@@ -27,7 +30,7 @@
 
 type_term: CID LPAREN TID WITH
 ##
-## Ends in an error in state: 69.
+## Ends in an error in state: 68.
 ##
 ## targ -> LPAREN typ . RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ## typ -> typ . TARROW typ [ TARROW RPAREN ]
@@ -41,7 +44,7 @@ This is an invalid type term, likely the ADT argument brackets are not closed pr
 
 type_term: CID LPAREN WITH
 ##
-## Ends in an error in state: 68.
+## Ends in an error in state: 67.
 ##
 ## targ -> LPAREN . typ RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
@@ -67,7 +70,7 @@ This is an invalid type term, the ADT constructor has invalid type arguments. Th
 
 type_term: CID PERIOD WITH
 ##
-## Ends in an error in state: 26.
+## Ends in an error in state: 51.
 ##
 ## scid -> CID PERIOD . CID [ UNDERSCORE TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN ID HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
@@ -80,7 +83,7 @@ This is an invalid type term, the ADT constructor is incorrect. Following the pe
 
 type_term: CID TID WITH
 ##
-## Ends in an error in state: 72.
+## Ends in an error in state: 71.
 ##
 ## list(targ) -> targ . list(targ) [ TARROW RPAREN RBRACE EQ EOF END COMMA ]
 ##
@@ -93,7 +96,7 @@ This is an invalid type term, the ADT constructor arguments are incorrect.
 
 type_term: FORALL TID PERIOD TID WITH
 ##
-## Ends in an error in state: 64.
+## Ends in an error in state: 63.
 ##
 ## typ -> typ . TARROW typ [ TARROW RPAREN EQ EOF END COMMA ]
 ## typ -> FORALL TID PERIOD typ . [ TARROW RPAREN EQ EOF END COMMA ]
@@ -107,7 +110,7 @@ This is an invalid forall type, the type term is finished after the last type id
 
 type_term: FORALL TID PERIOD WITH
 ##
-## Ends in an error in state: 63.
+## Ends in an error in state: 62.
 ##
 ## typ -> FORALL TID PERIOD . typ [ TARROW RPAREN EQ EOF END COMMA ]
 ##
@@ -120,7 +123,7 @@ This is an invalid forall type, after the period (following forall and a type id
 
 type_term: FORALL TID WITH
 ##
-## Ends in an error in state: 62.
+## Ends in an error in state: 61.
 ##
 ## typ -> FORALL TID . PERIOD typ [ TARROW RPAREN EQ EOF END COMMA ]
 ##
@@ -133,7 +136,7 @@ This is an invalid forall type, after the type id (following forall) the parser 
 
 type_term: FORALL WITH
 ##
-## Ends in an error in state: 61.
+## Ends in an error in state: 60.
 ##
 ## typ -> FORALL . TID PERIOD typ [ TARROW RPAREN EQ EOF END COMMA ]
 ##
@@ -160,7 +163,7 @@ This is an invalid type term because the brackets are not closed after the type 
 
 type_term: LPAREN WITH
 ##
-## Ends in an error in state: 60.
+## Ends in an error in state: 59.
 ##
 ## typ -> LPAREN . typ RPAREN [ TARROW RPAREN EQ EOF END COMMA ]
 ##
@@ -173,10 +176,9 @@ This is an invalid type term, please put a valid type term in the brackets.
 
 type_term: MAP CID CID LPAREN WITH
 ##
-## Ends in an error in state: 48.
+## Ends in an error in state: 47.
 ##
 ## t_map_value_args -> LPAREN . t_map_value RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
-## t_map_value_args -> LPAREN . address_typ RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -187,7 +189,7 @@ This is an invalid map type, the map value type is likely incorrect. In the brac
 
 type_term: MAP CID CID MAP WITH
 ##
-## Ends in an error in state: 43.
+## Ends in an error in state: 41.
 ##
 ## t_map_value_args -> MAP . t_map_key t_map_value [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
@@ -200,7 +202,7 @@ This is an invalid map type, the map value type is incorrect. It is likely there
 
 type_term: MAP CID LPAREN CID CID TYPE
 ##
-## Ends in an error in state: 40.
+## Ends in an error in state: 38.
 ##
 ## t_map_value -> LPAREN t_map_value . RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
@@ -211,11 +213,11 @@ type_term: MAP CID LPAREN CID CID TYPE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 30, spurious reduction of production scid -> CID 
-## In state 54, spurious reduction of production t_map_value_args -> scid 
-## In state 53, spurious reduction of production list(t_map_value_args) -> 
-## In state 55, spurious reduction of production list(t_map_value_args) -> t_map_value_args list(t_map_value_args) 
-## In state 57, spurious reduction of production t_map_value -> scid list(t_map_value_args) 
+## In state 50, spurious reduction of production scid -> CID
+## In state 54, spurious reduction of production t_map_value_args -> scid
+## In state 53, spurious reduction of production list(t_map_value_args) ->
+## In state 55, spurious reduction of production list(t_map_value_args) -> t_map_value_args list(t_map_value_args)
+## In state 56, spurious reduction of production t_map_value -> scid list(t_map_value_args)
 ##
 # see tests/parser/bad/type_t-map-cid-lparen-cid-cid-type.scilla
 
@@ -223,7 +225,7 @@ This is an invalid map type, the map value is likely incorrect. The map value ex
 
 type_term: MAP CID LPAREN MAP WITH
 ##
-## Ends in an error in state: 37.
+## Ends in an error in state: 35.
 ##
 ## t_map_value -> MAP . t_map_key t_map_value [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
@@ -236,7 +238,7 @@ This map type is invalid as the map value is likely incorrect. The map value bei
 
 type_term: MAP CID LPAREN WITH
 ##
-## Ends in an error in state: 39.
+## Ends in an error in state: 37.
 ##
 ## t_map_value -> LPAREN . t_map_value RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
@@ -249,9 +251,11 @@ In this map type, the map value is likely incorrect. In the brackets only an ADT
 
 type_term: MAP CID UNDERSCORE
 ##
-## Ends in an error in state: 30.
+## Ends in an error in state: 25.
 ##
-## address_typ -> CID . WITH loption(separated_nonempty_list(COMMA,address_field_type)) END [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+## address_typ -> CID . WITH END [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+## address_typ -> CID . WITH CONTRACT loption(separated_nonempty_list(COMMA,address_type_field)) END [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+## address_typ -> CID . WITH CONTRACT LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN loption(separated_nonempty_list(COMMA,address_type_field)) END [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ## scid -> CID . [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ## scid -> CID . PERIOD CID [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
@@ -267,6 +271,7 @@ type_term: MAP LPAREN WITH
 ## Ends in an error in state: 21.
 ##
 ## t_map_key -> LPAREN . scid RPAREN [ MAP LPAREN HEXLIT CID ]
+## t_map_key -> LPAREN . address_typ RPAREN [ MAP LPAREN HEXLIT CID ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -277,7 +282,7 @@ This map type has an invalid key type. In the brackets we expect a separated cap
 
 type_term: MAP WITH
 ##
-## Ends in an error in state: 35.
+## Ends in an error in state: 33.
 ##
 ## typ -> MAP . t_map_key t_map_value [ TARROW RPAREN EQ EOF END COMMA ]
 ##
@@ -290,7 +295,7 @@ This is an invalid type term, the map key type is incorrect.
 
 type_term: TID TARROW TID WITH
 ##
-## Ends in an error in state: 66.
+## Ends in an error in state: 65.
 ##
 ## typ -> typ . TARROW typ [ TARROW RPAREN EQ EOF END COMMA ]
 ## typ -> typ TARROW typ . [ TARROW RPAREN EQ EOF END COMMA ]
@@ -304,7 +309,7 @@ This function is not terminated early enough or malformed. A possible alteration
 
 type_term: TID TARROW WITH
 ##
-## Ends in an error in state: 65.
+## Ends in an error in state: 64.
 ##
 ## typ -> typ TARROW . typ [ TARROW RPAREN EQ EOF END COMMA ]
 ##
@@ -317,9 +322,11 @@ This function type lacks a result type.
 
 type_term: CID WITH EOF
 ##
-## Ends in an error in state: 31.
+## Ends in an error in state: 26.
 ##
-## address_typ -> CID WITH . loption(separated_nonempty_list(COMMA,address_field_type)) END [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+## address_typ -> CID WITH . END [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+## address_typ -> CID WITH . CONTRACT loption(separated_nonempty_list(COMMA,address_type_field)) END [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+## address_typ -> CID WITH . CONTRACT LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN loption(separated_nonempty_list(COMMA,address_type_field)) END [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## CID WITH
@@ -330,7 +337,7 @@ Invalid or incomplete type.
 
 type_term: TID WITH
 ##
-## Ends in an error in state: 335.
+## Ends in an error in state: 355.
 ##
 ## typ -> typ . TARROW typ [ TARROW EOF ]
 ## type_term -> typ . EOF [ # ]
@@ -344,7 +351,7 @@ This is an invalid type term, the ADT constructor arguments are likely incorrect
 
 type_term: WITH
 ##
-## Ends in an error in state: 333.
+## Ends in an error in state: 353.
 ##
 ## type_term' -> . type_term [ # ]
 ##
@@ -357,7 +364,7 @@ This is an invalid type term.
 
 stmts_term: ACCEPT WITH
 ##
-## Ends in an error in state: 286.
+## Ends in an error in state: 305.
 ##
 ## separated_nonempty_list(SEMICOLON,stmt) -> stmt . [ EOF END BAR ]
 ## separated_nonempty_list(SEMICOLON,stmt) -> stmt . SEMICOLON separated_nonempty_list(SEMICOLON,stmt) [ EOF END BAR ]
@@ -372,7 +379,7 @@ This is likely an improperly terminated statement (lacking the semicolon).
 
 stmts_term: CID WITH
 ##
-## Ends in an error in state: 289.
+## Ends in an error in state: 309.
 ##
 ## stmt -> component_id . list(sident) [ SEMICOLON EOF END BAR ]
 ##
@@ -385,7 +392,7 @@ This is an invalid statements term.
 
 stmts_term: DELETE ID WITH
 ##
-## Ends in an error in state: 283.
+## Ends in an error in state: 302.
 ##
 ## stmt -> DELETE ID . nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ##
@@ -398,7 +405,7 @@ This is an invalid delete statement, it lacks the keys to delete.
 
 stmts_term: DELETE WITH
 ##
-## Ends in an error in state: 282.
+## Ends in an error in state: 301.
 ##
 ## stmt -> DELETE . ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ##
@@ -411,7 +418,7 @@ This is an invalid delete statement, it lacks a map to delete from.
 
 stmts_term: EVENT WITH
 ##
-## Ends in an error in state: 280.
+## Ends in an error in state: 299.
 ##
 ## stmt -> EVENT . sid [ SEMICOLON EOF END BAR ]
 ##
@@ -424,7 +431,7 @@ This is an invalid event statement, it lacks a separated identifier for the even
 
 stmts_term: ID ASSIGN WITH
 ##
-## Ends in an error in state: 272.
+## Ends in an error in state: 291.
 ##
 ## stmt -> ID ASSIGN . sid [ SEMICOLON EOF END BAR ]
 ##
@@ -437,8 +444,14 @@ This is an invalid assign statement, it lacks a separated identifier.
 
 stmts_term: ID FETCH AND WITH
 ##
-## Ends in an error in state: 267.
+## Ends in an error in state: 266.
 ##
+## remote_fetch_stmt -> ID FETCH AND . ID PERIOD sident [ SEMICOLON EOF END BAR ]
+## remote_fetch_stmt -> ID FETCH AND . SPID PERIOD SPID [ SEMICOLON EOF END BAR ]
+## remote_fetch_stmt -> ID FETCH AND . ID PERIOD LPAREN sident RPAREN [ SEMICOLON EOF END BAR ]
+## remote_fetch_stmt -> ID FETCH AND . ID PERIOD ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
+## remote_fetch_stmt -> ID FETCH AND . EXISTS ID PERIOD ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
+## remote_fetch_stmt -> ID FETCH AND . sident AS address_typ [ SEMICOLON EOF END BAR ]
 ## stmt -> ID FETCH AND . CID [ SEMICOLON EOF END BAR ]
 ##
 ## The known suffix of the stack is as follows:
@@ -450,7 +463,7 @@ This is an invalid bind and statement. The parser expects a capital identifier a
 
 stmts_term: ID FETCH EXISTS ID WITH
 ##
-## Ends in an error in state: 265.
+## Ends in an error in state: 264.
 ##
 ## stmt -> ID FETCH EXISTS ID . nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ##
@@ -463,7 +476,7 @@ This is an invalid existence bind statement. It lacks a non-empty list of access
 
 stmts_term: ID FETCH EXISTS WITH
 ##
-## Ends in an error in state: 264.
+## Ends in an error in state: 263.
 ##
 ## stmt -> ID FETCH EXISTS . ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ##
@@ -476,7 +489,7 @@ This is an invalid existence bind statement. It lacks a map to check existence o
 
 stmts_term: ID FETCH ID WITH
 ##
-## Ends in an error in state: 262.
+## Ends in an error in state: 259.
 ##
 ## sid -> ID . [ SEMICOLON EOF END BAR ]
 ## stmt -> ID FETCH ID . nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
@@ -490,8 +503,14 @@ This is an invalid bind statement, it is lacking a non empty list of map accesse
 
 stmts_term: ID FETCH WITH
 ##
-## Ends in an error in state: 261.
+## Ends in an error in state: 258.
 ##
+## remote_fetch_stmt -> ID FETCH . AND ID PERIOD sident [ SEMICOLON EOF END BAR ]
+## remote_fetch_stmt -> ID FETCH . AND SPID PERIOD SPID [ SEMICOLON EOF END BAR ]
+## remote_fetch_stmt -> ID FETCH . AND ID PERIOD LPAREN sident RPAREN [ SEMICOLON EOF END BAR ]
+## remote_fetch_stmt -> ID FETCH . AND ID PERIOD ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
+## remote_fetch_stmt -> ID FETCH . AND EXISTS ID PERIOD ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
+## remote_fetch_stmt -> ID FETCH . AND sident AS address_typ [ SEMICOLON EOF END BAR ]
 ## stmt -> ID FETCH . sid [ SEMICOLON EOF END BAR ]
 ## stmt -> ID FETCH . AND CID [ SEMICOLON EOF END BAR ]
 ## stmt -> ID FETCH . ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
@@ -506,7 +525,7 @@ This is an invalid bind statement, the bind can be followed by '&', 'exists' or 
 
 stmts_term: ID EQ WITH
 ##
-## Ends in an error in state: 270.
+## Ends in an error in state: 289.
 ##
 ## stmt -> ID EQ . exp [ SEMICOLON EOF END BAR ]
 ##
@@ -519,7 +538,7 @@ This is an invalid equal statement, it is lacking a valid expression on the righ
 
 stmts_term: ID LSQB SPID RSQB ASSIGN WITH
 ##
-## Ends in an error in state: 275.
+## Ends in an error in state: 294.
 ##
 ## stmt -> ID nonempty_list(map_access) ASSIGN . sid [ SEMICOLON EOF END BAR ]
 ##
@@ -532,7 +551,7 @@ The map key must be assigned to some separated identifier.
 
 stmts_term: ID LSQB SPID RSQB SEMICOLON
 ##
-## Ends in an error in state: 274.
+## Ends in an error in state: 293.
 ##
 ## stmt -> ID nonempty_list(map_access) . ASSIGN sid [ SEMICOLON EOF END BAR ]
 ##
@@ -543,7 +562,7 @@ stmts_term: ID LSQB SPID RSQB SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 253, spurious reduction of production nonempty_list(map_access) -> map_access 
+## In state 261, spurious reduction of production nonempty_list(map_access) -> map_access
 ##
 # see tests/parser/bad/stmts_t-id-lsqb-spid-rsqb-semicolon.scilla
 
@@ -551,7 +570,7 @@ This is likely an invalid map assign statement, it lacks the assign.
 
 stmts_term: ID LSQB SPID RSQB WITH
 ##
-## Ends in an error in state: 253.
+## Ends in an error in state: 261.
 ##
 ## nonempty_list(map_access) -> map_access . [ SEMICOLON EOF END BAR ASSIGN ]
 ## nonempty_list(map_access) -> map_access . nonempty_list(map_access) [ SEMICOLON EOF END BAR ASSIGN ]
@@ -565,7 +584,7 @@ This is an invalid statements term. A possible continuation may be assigning a m
 
 stmts_term: ID LSQB SPID WITH
 ##
-## Ends in an error in state: 250.
+## Ends in an error in state: 256.
 ##
 ## map_access -> LSQB sident . RSQB [ SEMICOLON LSQB EOF END BAR ASSIGN ]
 ##
@@ -578,7 +597,7 @@ This is an invalid statements term. A possible continuation may be accessing a k
 
 stmts_term: ID LSQB WITH
 ##
-## Ends in an error in state: 249.
+## Ends in an error in state: 255.
 ##
 ## map_access -> LSQB . sident RSQB [ SEMICOLON LSQB EOF END BAR ASSIGN ]
 ##
@@ -591,7 +610,7 @@ This is an invalid statements term. The map access list is malformed.
 
 stmts_term: ID SPID WITH
 ##
-## Ends in an error in state: 177.
+## Ends in an error in state: 193.
 ##
 ## list(sident) -> sident . list(sident) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -604,18 +623,21 @@ This is an invalid statements term, likely a bad procedure call with faulty argu
 
 stmts_term: ID WITH
 ##
-## Ends in an error in state: 244.
+## Ends in an error in state: 254.
 ##
 ## component_id -> ID . [ SPID SEMICOLON ID EOF END CID BAR ]
+## remote_fetch_stmt -> ID . FETCH AND ID PERIOD sident [ SEMICOLON EOF END BAR ]
+## remote_fetch_stmt -> ID . FETCH AND SPID PERIOD SPID [ SEMICOLON EOF END BAR ]
+## remote_fetch_stmt -> ID . FETCH AND ID PERIOD LPAREN sident RPAREN [ SEMICOLON EOF END BAR ]
+## remote_fetch_stmt -> ID . FETCH AND ID PERIOD ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
+## remote_fetch_stmt -> ID . FETCH AND EXISTS ID PERIOD ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
+## remote_fetch_stmt -> ID . FETCH AND sident AS address_typ [ SEMICOLON EOF END BAR ]
 ## stmt -> ID . FETCH sid [ SEMICOLON EOF END BAR ]
-## stmt -> ID . REMOTEFETCH ID PERIOD sid [ SEMICOLON EOF END BAR ]
 ## stmt -> ID . ASSIGN sid [ SEMICOLON EOF END BAR ]
 ## stmt -> ID . EQ exp [ SEMICOLON EOF END BAR ]
 ## stmt -> ID . FETCH AND CID [ SEMICOLON EOF END BAR ]
 ## stmt -> ID . FETCH ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
-## stmt -> ID . REMOTEFETCH ID PERIOD ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ## stmt -> ID . FETCH EXISTS ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
-## stmt -> ID . REMOTEFETCH EXISTS ID PERIOD ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ## stmt -> ID . nonempty_list(map_access) ASSIGN sid [ SEMICOLON EOF END BAR ]
 ##
 ## The known suffix of the stack is as follows:
@@ -627,7 +649,7 @@ This is an invalid statements term. Scilla expects to do something with the iden
 
 stmts_term: MATCH SPID UNDERSCORE
 ##
-## Ends in an error in state: 239.
+## Ends in an error in state: 249.
 ##
 ## stmt -> MATCH sid . WITH list(stmt_pm_clause) END [ SEMICOLON EOF END BAR ]
 ##
@@ -640,7 +662,7 @@ This is an invalid match statement, 'with' is expected after what is specified t
 
 stmts_term: MATCH SPID WITH BAR UNDERSCORE ARROW ACCEPT EOF
 ##
-## Ends in an error in state: 293.
+## Ends in an error in state: 313.
 ##
 ## list(stmt_pm_clause) -> stmt_pm_clause . list(stmt_pm_clause) [ END ]
 ##
@@ -651,9 +673,9 @@ stmts_term: MATCH SPID WITH BAR UNDERSCORE ARROW ACCEPT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 286, spurious reduction of production separated_nonempty_list(SEMICOLON,stmt) -> stmt 
-## In state 291, spurious reduction of production loption(separated_nonempty_list(SEMICOLON,stmt)) -> separated_nonempty_list(SEMICOLON,stmt) 
-## In state 292, spurious reduction of production stmt_pm_clause -> BAR pattern ARROW loption(separated_nonempty_list(SEMICOLON,stmt)) 
+## In state 305, spurious reduction of production separated_nonempty_list(SEMICOLON,stmt) -> stmt
+## In state 311, spurious reduction of production loption(separated_nonempty_list(SEMICOLON,stmt)) -> separated_nonempty_list(SEMICOLON,stmt)
+## In state 312, spurious reduction of production stmt_pm_clause -> BAR pattern ARROW loption(separated_nonempty_list(SEMICOLON,stmt))
 ##
 # see tests/parser/bad/stmts_t-match-spid-with-bar-underscore-arrow-accept-eof.scilla
 
@@ -661,7 +683,7 @@ When the match statement is finished, the parser expects 'end'.
 
 stmts_term: MATCH SPID WITH BAR UNDERSCORE ARROW WITH
 ##
-## Ends in an error in state: 243.
+## Ends in an error in state: 253.
 ##
 ## stmt_pm_clause -> BAR pattern ARROW . loption(separated_nonempty_list(SEMICOLON,stmt)) [ END BAR ]
 ##
@@ -674,7 +696,7 @@ This is an invalid statements term. In the match expression, after an arrow the 
 
 stmts_term: MATCH SPID WITH BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 242.
+## Ends in an error in state: 252.
 ##
 ## stmt_pm_clause -> BAR pattern . ARROW loption(separated_nonempty_list(SEMICOLON,stmt)) [ END BAR ]
 ##
@@ -687,7 +709,7 @@ This is an invalid statements term. In the match expression, after a pattern is 
 
 stmts_term: MATCH SPID WITH BAR WITH
 ##
-## Ends in an error in state: 241.
+## Ends in an error in state: 251.
 ##
 ## stmt_pm_clause -> BAR . pattern ARROW loption(separated_nonempty_list(SEMICOLON,stmt)) [ END BAR ]
 ##
@@ -700,7 +722,7 @@ In the match statement there is a malformed pattern.
 
 stmts_term: MATCH SPID WITH WITH
 ##
-## Ends in an error in state: 240.
+## Ends in an error in state: 250.
 ##
 ## stmt -> MATCH sid WITH . list(stmt_pm_clause) END [ SEMICOLON EOF END BAR ]
 ##
@@ -713,7 +735,7 @@ There is a malformed pattern matching clause, the bar is likely missing.
 
 stmts_term: MATCH WITH
 ##
-## Ends in an error in state: 238.
+## Ends in an error in state: 248.
 ##
 ## stmt -> MATCH . sid WITH list(stmt_pm_clause) END [ SEMICOLON EOF END BAR ]
 ##
@@ -726,7 +748,7 @@ In a match statement, the parser expects a separated identifier to match with.
 
 stmts_term: SEND CID PERIOD WITH
 ##
-## Ends in an error in state: 106.
+## Ends in an error in state: 120.
 ##
 ## sid -> CID PERIOD . ID [ WITH TID SEMICOLON RBRACE MAP LPAREN HEXLIT EOF END COLON CID BAR ]
 ##
@@ -739,7 +761,7 @@ This is an invalid send statement, the identifier is incorrect. After the period
 
 stmts_term: SEND CID WITH
 ##
-## Ends in an error in state: 105.
+## Ends in an error in state: 119.
 ##
 ## sid -> CID . PERIOD ID [ WITH TID SEMICOLON MAP LPAREN HEXLIT EOF END COLON CID BAR ]
 ##
@@ -752,7 +774,7 @@ This send statement is either unfinished or not properly terminated.
 
 stmts_term: SEND WITH
 ##
-## Ends in an error in state: 236.
+## Ends in an error in state: 246.
 ##
 ## stmt -> SEND . sid [ SEMICOLON EOF END BAR ]
 ##
@@ -765,7 +787,7 @@ It is expected to send to a separated identifier.
 
 stmts_term: THROW END
 ##
-## Ends in an error in state: 331.
+## Ends in an error in state: 351.
 ##
 ## stmts_term -> stmts . EOF [ # ]
 ##
@@ -776,11 +798,11 @@ stmts_term: THROW END
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 233, spurious reduction of production option(sid) -> 
-## In state 235, spurious reduction of production stmt -> THROW option(sid) 
-## In state 286, spurious reduction of production separated_nonempty_list(SEMICOLON,stmt) -> stmt 
-## In state 291, spurious reduction of production loption(separated_nonempty_list(SEMICOLON,stmt)) -> separated_nonempty_list(SEMICOLON,stmt) 
-## In state 299, spurious reduction of production stmts -> loption(separated_nonempty_list(SEMICOLON,stmt)) 
+## In state 243, spurious reduction of production option(sid) ->
+## In state 245, spurious reduction of production stmt -> THROW option(sid)
+## In state 305, spurious reduction of production separated_nonempty_list(SEMICOLON,stmt) -> stmt
+## In state 311, spurious reduction of production loption(separated_nonempty_list(SEMICOLON,stmt)) -> separated_nonempty_list(SEMICOLON,stmt)
+## In state 319, spurious reduction of production stmts -> loption(separated_nonempty_list(SEMICOLON,stmt))
 ##
 # special case, only via stmts_term entry point should never happen
 # throw itself is a valid statement term and a procedure or transition
@@ -790,7 +812,7 @@ This is an invalid statements term, bad throw.
 
 stmts_term: THROW SEMICOLON WITH
 ##
-## Ends in an error in state: 287.
+## Ends in an error in state: 306.
 ##
 ## separated_nonempty_list(SEMICOLON,stmt) -> stmt SEMICOLON . separated_nonempty_list(SEMICOLON,stmt) [ EOF END BAR ]
 ##
@@ -805,7 +827,7 @@ What follows the statement was unexpected, for example possibly a statement or t
 
 stmts_term: THROW WITH
 ##
-## Ends in an error in state: 233.
+## Ends in an error in state: 243.
 ##
 ## stmt -> THROW . option(sid) [ SEMICOLON EOF END BAR ]
 ##
@@ -818,7 +840,7 @@ This throw does not throw a valid exception or is not properly terminated.
 
 stmts_term: WITH
 ##
-## Ends in an error in state: 329.
+## Ends in an error in state: 349.
 ##
 ## stmts_term' -> . stmts_term [ # ]
 ##
@@ -871,7 +893,7 @@ To import another library mention the new library name directly after the previo
 
 lmodule: SCILLA_VERSION NUMLIT IMPORT CONTRACT
 ##
-## Ends in an error in state: 325.
+## Ends in an error in state: 345.
 ##
 ## lmodule -> SCILLA_VERSION NUMLIT imports . library EOF [ # ]
 ##
@@ -882,8 +904,8 @@ lmodule: SCILLA_VERSION NUMLIT IMPORT CONTRACT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 3, spurious reduction of production list(importname) -> 
-## In state 7, spurious reduction of production imports -> IMPORT list(importname) 
+## In state 3, spurious reduction of production list(importname) ->
+## In state 7, spurious reduction of production imports -> IMPORT list(importname)
 ##
 # see tests/parser/bad/lib/lmodule-import-contract.scillib
 
@@ -904,7 +926,7 @@ If import is mentioned there must be one or more imported libraries with capital
 
 lmodule: SCILLA_VERSION NUMLIT LIBRARY CID CONTRACT
 ##
-## Ends in an error in state: 326.
+## Ends in an error in state: 346.
 ##
 ## lmodule -> SCILLA_VERSION NUMLIT imports library . EOF [ # ]
 ##
@@ -915,8 +937,8 @@ lmodule: SCILLA_VERSION NUMLIT LIBRARY CID CONTRACT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 12, spurious reduction of production list(libentry) -> 
-## In state 202, spurious reduction of production library -> LIBRARY CID list(libentry) 
+## In state 12, spurious reduction of production list(libentry) ->
+## In state 217, spurious reduction of production library -> LIBRARY CID list(libentry)
 ##
 # see tests/parser/bad/lib/lmodule-library-cid-contract.scillib
 
@@ -924,7 +946,7 @@ When writing solely Scilla libraries, there is no need for a contract.
 
 lmodule: SCILLA_VERSION NUMLIT LIBRARY CID LET ID COLON TID EQ WITH
 ##
-## Ends in an error in state: 200.
+## Ends in an error in state: 215.
 ##
 ## libentry -> LET ID type_annot EQ . exp [ TYPE LET EOF CONTRACT ]
 ##
@@ -937,7 +959,7 @@ This (type-annotated) let expression is missing an expression to assign to an id
 
 lmodule: SCILLA_VERSION NUMLIT LIBRARY CID LET ID EQ HEXLIT WITH
 ##
-## Ends in an error in state: 145.
+## Ends in an error in state: 159.
 ##
 ## lit -> HEXLIT . [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ## scid -> HEXLIT . PERIOD CID [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET LBRACE IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
@@ -951,7 +973,7 @@ Invalid module. A module entry (a type or variable definition for libraries, a f
 
 lmodule: SCILLA_VERSION NUMLIT LIBRARY CID LET ID EQ WITH
 ##
-## Ends in an error in state: 97.
+## Ends in an error in state: 111.
 ##
 ## libentry -> LET ID EQ . exp [ TYPE LET EOF CONTRACT ]
 ##
@@ -964,7 +986,7 @@ This library let expression is missing a valid expression to assign to the ident
 
 lmodule: SCILLA_VERSION NUMLIT LIBRARY CID LET ID WITH
 ##
-## Ends in an error in state: 96.
+## Ends in an error in state: 110.
 ##
 ## libentry -> LET ID . EQ exp [ TYPE LET EOF CONTRACT ]
 ## libentry -> LET ID . type_annot EQ exp [ TYPE LET EOF CONTRACT ]
@@ -978,7 +1000,7 @@ This library let expression is missing an equals, '='.
 
 lmodule: SCILLA_VERSION NUMLIT LIBRARY CID LET WITH
 ##
-## Ends in an error in state: 95.
+## Ends in an error in state: 109.
 ##
 ## libentry -> LET . ID EQ exp [ TYPE LET EOF CONTRACT ]
 ## libentry -> LET . ID type_annot EQ exp [ TYPE LET EOF CONTRACT ]
@@ -992,7 +1014,7 @@ The let expression is missing an identifier to assign an expression to.
 
 lmodule: SCILLA_VERSION NUMLIT LIBRARY CID TYPE CID EQ BAR CID OF CID TRANSITION
 ##
-## Ends in an error in state: 92.
+## Ends in an error in state: 106.
 ##
 ## nonempty_list(tconstr) -> tconstr . [ TYPE LET EOF CONTRACT ]
 ## nonempty_list(tconstr) -> tconstr . nonempty_list(tconstr) [ TYPE LET EOF CONTRACT ]
@@ -1004,10 +1026,10 @@ lmodule: SCILLA_VERSION NUMLIT LIBRARY CID TYPE CID EQ BAR CID OF CID TRANSITION
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 25, spurious reduction of production scid -> CID 
-## In state 73, spurious reduction of production targ -> scid 
-## In state 89, spurious reduction of production nonempty_list(targ) -> targ 
-## In state 91, spurious reduction of production tconstr -> BAR CID OF nonempty_list(targ) 
+## In state 25, spurious reduction of production scid -> CID
+## In state 72, spurious reduction of production targ -> scid
+## In state 103, spurious reduction of production nonempty_list(targ) -> targ
+## In state 105, spurious reduction of production tconstr -> BAR CID OF nonempty_list(targ)
 ##
 # see tests/parser/bad/lib/lmodule-library-cid-type-cid-eq-bar-cid-of-cid-transition.scillib
 
@@ -1123,7 +1145,7 @@ This is an invalid library module because it lacks a capital identifier for a na
 
 lmodule: SCILLA_VERSION NUMLIT WITH
 ##
-## Ends in an error in state: 324.
+## Ends in an error in state: 344.
 ##
 ## lmodule -> SCILLA_VERSION NUMLIT . imports library EOF [ # ]
 ##
@@ -1136,7 +1158,7 @@ This is an invalid library module, Scilla version must be followed by 'library' 
 
 lmodule: WITH
 ##
-## Ends in an error in state: 322.
+## Ends in an error in state: 342.
 ##
 ## lmodule' -> . lmodule [ # ]
 ##
@@ -1149,7 +1171,7 @@ Scilla version number unspecified.
 
 exp_term: AT SPID TID WITH
 ##
-## Ends in an error in state: 89.
+## Ends in an error in state: 103.
 ##
 ## nonempty_list(targ) -> targ . [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ## nonempty_list(targ) -> targ . nonempty_list(targ) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
@@ -1163,7 +1185,7 @@ The type application is wrong. The list of types is problematic.
 
 exp_term: AT SPID WITH
 ##
-## Ends in an error in state: 167.
+## Ends in an error in state: 186.
 ##
 ## simple_exp -> AT sid . nonempty_list(targ) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1176,7 +1198,7 @@ The type application is wrong. The parser expects a non-empty list of type argum
 
 exp_term: AT WITH
 ##
-## Ends in an error in state: 166.
+## Ends in an error in state: 185.
 ##
 ## simple_exp -> AT . sid nonempty_list(targ) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1189,7 +1211,7 @@ This type application is wrong. A separated identifier is expected to apply type
 
 exp_term: BUILTIN ID LPAREN WITH
 ##
-## Ends in an error in state: 156.
+## Ends in an error in state: 174.
 ##
 ## builtin_args -> LPAREN . RPAREN [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1202,9 +1224,9 @@ Builtin functions only take a pair of brackets when of unit input type (e.g. "()
 
 exp_term: BUILTIN ID WITH
 ##
-## Ends in an error in state: 154.
+## Ends in an error in state: 168.
 ##
-## simple_exp -> BUILTIN ID . builtin_args [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
+## simple_exp -> BUILTIN ID . option(ctargs) builtin_args [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## BUILTIN ID
@@ -1215,9 +1237,9 @@ The usage of the builtin function is incorrect.
 
 exp_term: BUILTIN WITH
 ##
-## Ends in an error in state: 153.
+## Ends in an error in state: 167.
 ##
-## simple_exp -> BUILTIN . ID builtin_args [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
+## simple_exp -> BUILTIN . ID option(ctargs) builtin_args [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## BUILTIN
@@ -1228,9 +1250,9 @@ This expression is incorrect because it does not specify a specific builtin func
 
 exp_term: CID LBRACE TID EQ
 ##
-## Ends in an error in state: 174.
+## Ends in an error in state: 170.
 ##
-## ctargs -> LBRACE list(targ) . RBRACE [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
+## ctargs -> LBRACE list(targ) . RBRACE [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LPAREN LET IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LBRACE list(targ)
@@ -1239,8 +1261,8 @@ exp_term: CID LBRACE TID EQ
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 72, spurious reduction of production list(targ) -> 
-## In state 74, spurious reduction of production list(targ) -> targ list(targ) 
+## In state 71, spurious reduction of production list(targ) ->
+## In state 73, spurious reduction of production list(targ) -> targ list(targ)
 ##
 # see tests/parser/bad/exps/exp_t-cid-lbrace-tid-eq.scilexp
 
@@ -1248,9 +1270,9 @@ The data constructor, list of type arguments is incorrect. The parser expects an
 
 exp_term: CID LBRACE WITH
 ##
-## Ends in an error in state: 173.
+## Ends in an error in state: 169.
 ##
-## ctargs -> LBRACE . list(targ) RBRACE [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
+## ctargs -> LBRACE . list(targ) RBRACE [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LPAREN LET IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LBRACE
@@ -1261,7 +1283,7 @@ The data constructor, list of type arguments is incorrect. The parser expects a 
 
 exp_term: CID PERIOD CID WITH
 ##
-## Ends in an error in state: 172.
+## Ends in an error in state: 191.
 ##
 ## simple_exp -> scid . option(ctargs) list(sident) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1274,7 +1296,7 @@ This is an invalid expression, most likely the data constructor is missing argum
 
 exp_term: CID PERIOD WITH
 ##
-## Ends in an error in state: 152.
+## Ends in an error in state: 166.
 ##
 ## scid -> CID PERIOD . CID [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET LBRACE IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
 ## sid -> CID PERIOD . ID [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
@@ -1288,7 +1310,7 @@ This is an invalid expression, most likely the data constructor name is unfinish
 
 exp_term: CID WITH
 ##
-## Ends in an error in state: 151.
+## Ends in an error in state: 165.
 ##
 ## lit -> CID . NUMLIT [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ## scid -> CID . [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET LBRACE IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
@@ -1304,7 +1326,7 @@ This is a malformed expression, it may be an incorrect data constructor usage.
 
 exp_term: EMP WITH
 ##
-## Ends in an error in state: 132.
+## Ends in an error in state: 146.
 ##
 ## lit -> EMP . t_map_key t_map_value [ TYPE TRANSITION SEMICOLON RBRACE PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1317,7 +1339,7 @@ The empty map has invalid key type (capitalised identifier).
 
 exp_term: FUN LPAREN ID COLON TID RPAREN ARROW WITH
 ##
-## Ends in an error in state: 150.
+## Ends in an error in state: 164.
 ##
 ## simple_exp -> FUN LPAREN id_with_typ RPAREN ARROW . exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1330,7 +1352,7 @@ This function is lacking a valid result expression.
 
 exp_term: FUN LPAREN ID COLON TID RPAREN WITH
 ##
-## Ends in an error in state: 149.
+## Ends in an error in state: 163.
 ##
 ## simple_exp -> FUN LPAREN id_with_typ RPAREN . ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1357,7 +1379,7 @@ This type annotation is not closed properly, or has a missing or misplaced '='.
 
 exp_term: FUN LPAREN ID COLON WITH
 ##
-## Ends in an error in state: 33.
+## Ends in an error in state: 31.
 ##
 ## type_annot -> COLON . typ [ RPAREN EQ END COMMA ]
 ##
@@ -1370,7 +1392,7 @@ Missing or invalid type in type annotation.
 
 exp_term: FUN LPAREN ID WITH
 ##
-## Ends in an error in state: 32.
+## Ends in an error in state: 30.
 ##
 ## id_with_typ -> ID . type_annot [ RPAREN EQ END COMMA ]
 ##
@@ -1383,7 +1405,7 @@ Missing type annotation (a colon followed by a legal type).
 
 exp_term: FUN LPAREN WITH
 ##
-## Ends in an error in state: 147.
+## Ends in an error in state: 161.
 ##
 ## simple_exp -> FUN LPAREN . id_with_typ RPAREN ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1396,7 +1418,7 @@ This function is missing a valid argument identifier, beginning with a lower cas
 
 exp_term: FUN WITH
 ##
-## Ends in an error in state: 146.
+## Ends in an error in state: 160.
 ##
 ## simple_exp -> FUN . LPAREN id_with_typ RPAREN ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1409,7 +1431,7 @@ This function needs brackets for the argument.
 
 exp_term: LBRACE SPID COLON CID WITH
 ##
-## Ends in an error in state: 135.
+## Ends in an error in state: 149.
 ##
 ## lit -> CID . NUMLIT [ SEMICOLON RBRACE ]
 ## sid -> CID . PERIOD ID [ SEMICOLON RBRACE ]
@@ -1423,7 +1445,7 @@ This is an invalid message construction. The parser expects another message entr
 
 exp_term: LBRACE SPID COLON HEXLIT SEMICOLON WITH
 ##
-## Ends in an error in state: 141.
+## Ends in an error in state: 155.
 ##
 ## separated_nonempty_list(SEMICOLON,msg_entry) -> msg_entry SEMICOLON . separated_nonempty_list(SEMICOLON,msg_entry) [ RBRACE ]
 ##
@@ -1436,7 +1458,7 @@ This is an invalid message construction. The parser after a semicolon expects an
 
 exp_term: LBRACE SPID COLON HEXLIT WITH
 ##
-## Ends in an error in state: 140.
+## Ends in an error in state: 154.
 ##
 ## separated_nonempty_list(SEMICOLON,msg_entry) -> msg_entry . [ RBRACE ]
 ## separated_nonempty_list(SEMICOLON,msg_entry) -> msg_entry . SEMICOLON separated_nonempty_list(SEMICOLON,msg_entry) [ RBRACE ]
@@ -1450,7 +1472,7 @@ This is likely an invalid message construction. The parser expects another messa
 
 exp_term: LBRACE SPID COLON WITH
 ##
-## Ends in an error in state: 130.
+## Ends in an error in state: 144.
 ##
 ## msg_entry -> sid COLON . lit [ SEMICOLON RBRACE ]
 ## msg_entry -> sid COLON . sid [ SEMICOLON RBRACE ]
@@ -1464,7 +1486,7 @@ This is an invalid message construction. Following the colon, a literal or separ
 
 exp_term: LBRACE SPID WITH
 ##
-## Ends in an error in state: 129.
+## Ends in an error in state: 143.
 ##
 ## msg_entry -> sid . COLON lit [ SEMICOLON RBRACE ]
 ## msg_entry -> sid . COLON sid [ SEMICOLON RBRACE ]
@@ -1478,7 +1500,7 @@ This is an invalid message construction. With a message entry, the parser expect
 
 exp_term: LBRACE WITH
 ##
-## Ends in an error in state: 128.
+## Ends in an error in state: 142.
 ##
 ## simple_exp -> LBRACE . loption(separated_nonempty_list(SEMICOLON,msg_entry)) RBRACE [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1492,7 +1514,7 @@ This is an invalid message construction. The parser expects a semi-colon separat
 
 exp_term: LET ID COLON TID EQ STRING IN WITH
 ##
-## Ends in an error in state: 190.
+## Ends in an error in state: 205.
 ##
 ## simple_exp -> LET ID type_annot EQ simple_exp IN . exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1505,7 +1527,7 @@ This let expression (type-annotated) is likely missing an expression to substitu
 
 exp_term: LET ID EQ STRING IN WITH
 ##
-## Ends in an error in state: 185.
+## Ends in an error in state: 200.
 ##
 ## simple_exp -> LET ID EQ simple_exp IN . exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1518,7 +1540,7 @@ This let expression likely does not substitute a variable into a valid expressio
 
 exp_term: LET ID EQ STRING WITH
 ##
-## Ends in an error in state: 184.
+## Ends in an error in state: 199.
 ##
 ## simple_exp -> LET ID EQ simple_exp . IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1531,7 +1553,7 @@ This let expression is likely missing an 'in'.
 
 exp_term: LET ID EQ WITH
 ##
-## Ends in an error in state: 127.
+## Ends in an error in state: 141.
 ##
 ## simple_exp -> LET ID EQ . simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1544,7 +1566,7 @@ This let expression is missing an expression to substitute a variable in.
 
 exp_term: LET ID WITH
 ##
-## Ends in an error in state: 126.
+## Ends in an error in state: 140.
 ##
 ## simple_exp -> LET ID . EQ simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ## simple_exp -> LET ID . type_annot EQ simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
@@ -1558,7 +1580,7 @@ This let expression is missing an equals ('=') or type annotation, directly afte
 
 exp_term: LET WITH
 ##
-## Ends in an error in state: 125.
+## Ends in an error in state: 139.
 ##
 ## simple_exp -> LET . ID EQ simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ## simple_exp -> LET . ID type_annot EQ simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
@@ -1573,7 +1595,7 @@ This let expression is missing an identifier for the variable.
 
 exp_term: MATCH SPID UNDERSCORE
 ##
-## Ends in an error in state: 108.
+## Ends in an error in state: 122.
 ##
 ## simple_exp -> MATCH sid . WITH list(exp_pm_clause) END [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1586,7 +1608,7 @@ This match expression is missing 'with'.
 
 exp_term: MATCH SPID WITH BAR CID LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 116.
+## Ends in an error in state: 130.
 ##
 ## arg_pattern -> LPAREN pattern . RPAREN [ UNDERSCORE RPAREN LPAREN ID HEXLIT CID ARROW ]
 ##
@@ -1599,7 +1621,7 @@ This is an invalid match expression, possibly unterminated brackets for pattern 
 
 exp_term: MATCH SPID WITH BAR CID LPAREN WITH
 ##
-## Ends in an error in state: 115.
+## Ends in an error in state: 129.
 ##
 ## arg_pattern -> LPAREN . pattern RPAREN [ UNDERSCORE RPAREN LPAREN ID HEXLIT CID ARROW ]
 ##
@@ -1610,10 +1632,9 @@ exp_term: MATCH SPID WITH BAR CID LPAREN WITH
 
 This match expression has invalid pattern arguments, in the brackets we expect a pattern.
 
-
 exp_term: MATCH SPID WITH BAR CID TYPE
 ##
-## Ends in an error in state: 113.
+## Ends in an error in state: 127.
 ##
 ## pattern -> scid . list(arg_pattern) [ RPAREN ARROW ]
 ##
@@ -1624,7 +1645,7 @@ exp_term: MATCH SPID WITH BAR CID TYPE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 25, spurious reduction of production scid -> CID 
+## In state 50, spurious reduction of production scid -> CID
 ##
 # see tests/parser/bad/exps/exp_t-match-spid-with-bar-cid-type.scilexp
 
@@ -1632,7 +1653,7 @@ In this match expression, the parser expects either a list of pattern arguments 
 
 exp_term: MATCH SPID WITH BAR CID UNDERSCORE WITH
 ##
-## Ends in an error in state: 121.
+## Ends in an error in state: 135.
 ##
 ## list(arg_pattern) -> arg_pattern . list(arg_pattern) [ RPAREN ARROW ]
 ##
@@ -1645,7 +1666,7 @@ In this match expression, following the pattern the parser expects an arrow (e.g
 
 exp_term: MATCH SPID WITH BAR UNDERSCORE ARROW WITH
 ##
-## Ends in an error in state: 124.
+## Ends in an error in state: 138.
 ##
 ## exp_pm_clause -> BAR pattern ARROW . exp [ END BAR ]
 ##
@@ -1658,7 +1679,7 @@ This is an invalid match expression. Following an arrow we expect a valid expres
 
 exp_term: MATCH SPID WITH BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 123.
+## Ends in an error in state: 137.
 ##
 ## exp_pm_clause -> BAR pattern . ARROW exp [ END BAR ]
 ##
@@ -1671,7 +1692,7 @@ This is in an invalid match expression. Following a pattern, we expect an arrow 
 
 exp_term: MATCH SPID WITH BAR WITH
 ##
-## Ends in an error in state: 110.
+## Ends in an error in state: 124.
 ##
 ## exp_pm_clause -> BAR . pattern ARROW exp [ END BAR ]
 ##
@@ -1684,7 +1705,7 @@ This is an invalid match expression. In a pattern matching clause following the 
 
 exp_term: MATCH SPID WITH WITH
 ##
-## Ends in an error in state: 109.
+## Ends in an error in state: 123.
 ##
 ## simple_exp -> MATCH sid WITH . list(exp_pm_clause) END [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1697,7 +1718,7 @@ This is an invalid match expression, a pattern matching clause is necessary (pos
 
 exp_term: MATCH WITH
 ##
-## Ends in an error in state: 103.
+## Ends in an error in state: 117.
 ##
 ## simple_exp -> MATCH . sid WITH list(exp_pm_clause) END [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1710,9 +1731,9 @@ This is an invalid match expression, it is lacking a valid identifier to match w
 
 exp_term: SPID CID PERIOD WITH
 ##
-## Ends in an error in state: 160.
+## Ends in an error in state: 178.
 ##
-## sident -> CID PERIOD . ID [ TYPE TRANSITION SPID SEMICOLON RSQB PROCEDURE LET IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
+## sident -> CID PERIOD . ID [ TYPE TRANSITION SPID SEMICOLON RSQB RPAREN PROCEDURE LET IN ID FIELD EOF END CONTRACT CID BAR AS ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## CID PERIOD
@@ -1723,9 +1744,9 @@ This is an invalid expression, the identifier is incomplete or erroneous.
 
 exp_term: SPID CID WITH
 ##
-## Ends in an error in state: 159.
+## Ends in an error in state: 177.
 ##
-## sident -> CID . PERIOD ID [ TYPE TRANSITION SPID SEMICOLON RSQB PROCEDURE LET IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
+## sident -> CID . PERIOD ID [ TYPE TRANSITION SPID SEMICOLON RSQB RPAREN PROCEDURE LET IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## CID
@@ -1736,7 +1757,7 @@ This may be a type application missing '@' or an incorrect function application 
 
 exp_term: SPID SPID WITH
 ##
-## Ends in an error in state: 162.
+## Ends in an error in state: 180.
 ##
 ## nonempty_list(sident) -> sident . [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ## nonempty_list(sident) -> sident . nonempty_list(sident) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
@@ -1752,7 +1773,7 @@ If this is an application of a function, it is necessary to supply a list of val
 
 exp_term: SPID WITH
 ##
-## Ends in an error in state: 170.
+## Ends in an error in state: 189.
 ##
 ## atomic_exp -> sid . [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ## simple_exp -> sid . nonempty_list(sident) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
@@ -1766,7 +1787,7 @@ This is an invalid expression. If it is an application of a function, it is nece
 
 exp_term: STRING WITH
 ##
-## Ends in an error in state: 320.
+## Ends in an error in state: 340.
 ##
 ## exp_term -> exp . EOF [ # ]
 ##
@@ -1779,7 +1800,7 @@ This is not a valid expression, possible bad literal.
 
 exp_term: TFUN TID ARROW WITH
 ##
-## Ends in an error in state: 100.
+## Ends in an error in state: 114.
 ##
 ## simple_exp -> TFUN TID ARROW . exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1792,7 +1813,7 @@ Type functions expect a valid expression after the arrow.
 
 exp_term: TFUN TID WITH
 ##
-## Ends in an error in state: 99.
+## Ends in an error in state: 113.
 ##
 ## simple_exp -> TFUN TID . ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1805,7 +1826,7 @@ Type functions following the type id expect an arrow (e.g. '=>').
 
 exp_term: TFUN WITH
 ##
-## Ends in an error in state: 98.
+## Ends in an error in state: 112.
 ##
 ## simple_exp -> TFUN . TID ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1818,7 +1839,7 @@ Type functions expect a type id (e.g. 'A).
 
 exp_term: WITH
 ##
-## Ends in an error in state: 318.
+## Ends in an error in state: 338.
 ##
 ## exp_term' -> . exp_term [ # ]
 ##
@@ -1831,7 +1852,7 @@ This is an invalid expression term, possibly avoid unnecessary brackets.
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN ID COLON CID COMMA WITH
 ##
-## Ends in an error in state: 211.
+## Ends in an error in state: 82.
 ##
 ## separated_nonempty_list(COMMA,param_pair) -> param_pair COMMA . separated_nonempty_list(COMMA,param_pair) [ RPAREN ]
 ##
@@ -1845,7 +1866,7 @@ Following a comma in the list of immutable fields, the parser expects another im
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD WITH
 ##
-## Ends in an error in state: 219.
+## Ends in an error in state: 229.
 ##
 ## field -> FIELD . id_with_typ EQ exp [ TRANSITION PROCEDURE FIELD EOF ]
 ##
@@ -1859,7 +1880,7 @@ For a mutable field declaration, the parser expects a valid lower case beginning
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN PROCEDURE ID LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 303.
+## Ends in an error in state: 323.
 ##
 ## procedure -> PROCEDURE component_id component_params . component_body [ TRANSITION PROCEDURE EOF ]
 ##
@@ -1872,7 +1893,7 @@ In the transition body the parser expects a list of semi-colon separated stateme
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN PROCEDURE ID WITH
 ##
-## Ends in an error in state: 302.
+## Ends in an error in state: 322.
 ##
 ## procedure -> PROCEDURE component_id . component_params component_body [ TRANSITION PROCEDURE EOF ]
 ##
@@ -1886,7 +1907,7 @@ be a left parenthesis.
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN PROCEDURE WITH
 ##
-## Ends in an error in state: 301.
+## Ends in an error in state: 321.
 ##
 ## procedure -> PROCEDURE . component_id component_params component_body [ TRANSITION PROCEDURE EOF ]
 ##
@@ -1899,7 +1920,7 @@ A procedure requires a valid name.
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN TRANSITION ID LPAREN RPAREN END WITH
 ##
-## Ends in an error in state: 308.
+## Ends in an error in state: 328.
 ##
 ## list(component) -> component . list(component) [ EOF ]
 ##
@@ -1912,7 +1933,7 @@ Following a transition definition, the parser expects a transition or a procedur
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN TRANSITION ID LPAREN RPAREN THROW BAR
 ##
-## Ends in an error in state: 297.
+## Ends in an error in state: 317.
 ##
 ## component_body -> stmts . END [ TRANSITION PROCEDURE EOF ]
 ##
@@ -1923,11 +1944,11 @@ cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN TRANSITION ID LPAREN R
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 233, spurious reduction of production option(sid) -> 
-## In state 235, spurious reduction of production stmt -> THROW option(sid) 
-## In state 286, spurious reduction of production separated_nonempty_list(SEMICOLON,stmt) -> stmt 
-## In state 291, spurious reduction of production loption(separated_nonempty_list(SEMICOLON,stmt)) -> separated_nonempty_list(SEMICOLON,stmt) 
-## In state 299, spurious reduction of production stmts -> loption(separated_nonempty_list(SEMICOLON,stmt)) 
+## In state 243, spurious reduction of production option(sid) ->
+## In state 245, spurious reduction of production stmt -> THROW option(sid)
+## In state 305, spurious reduction of production separated_nonempty_list(SEMICOLON,stmt) -> stmt
+## In state 311, spurious reduction of production loption(separated_nonempty_list(SEMICOLON,stmt)) -> separated_nonempty_list(SEMICOLON,stmt)
+## In state 319, spurious reduction of production stmts -> loption(separated_nonempty_list(SEMICOLON,stmt))
 ##
 # see tests/parser/cmodule-transition-id-lparen-rparen-throw-bar.scilla
 
@@ -1935,7 +1956,7 @@ Possible typo.
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN TRANSITION ID LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 232.
+## Ends in an error in state: 242.
 ##
 ## transition -> TRANSITION component_id component_params . component_body [ TRANSITION PROCEDURE EOF ]
 ##
@@ -1948,7 +1969,7 @@ After a transition has the parameters defined, we expect a semi-colon separated 
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN TRANSITION ID LPAREN WITH
 ##
-## Ends in an error in state: 229.
+## Ends in an error in state: 239.
 ##
 ## component_params -> LPAREN . loption(separated_nonempty_list(COMMA,param_pair)) RPAREN [ THROW SEND MATCH ID FORALL EVENT END DELETE CID ACCEPT ]
 ##
@@ -1962,7 +1983,7 @@ The transition parameter name is invalid. This should start with a lower case le
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN TRANSITION ID WITH
 ##
-## Ends in an error in state: 228.
+## Ends in an error in state: 238.
 ##
 ## transition -> TRANSITION component_id . component_params component_body [ TRANSITION PROCEDURE EOF ]
 ##
@@ -1975,7 +1996,7 @@ After a transition has been named, the parameters must be specified in brackets.
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN TRANSITION WITH
 ##
-## Ends in an error in state: 225.
+## Ends in an error in state: 235.
 ##
 ## transition -> TRANSITION . component_id component_params component_body [ TRANSITION PROCEDURE EOF ]
 ##
@@ -1988,7 +2009,7 @@ Transitions must begin with a valid name, this can be a lower case or capital le
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN UNDERSCORE
 ##
-## Ends in an error in state: 215.
+## Ends in an error in state: 225.
 ##
 ## contract -> CONTRACT CID LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN . list(field) list(component) [ EOF ]
 ## contract -> CONTRACT CID LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN . with_constraint list(field) list(component) [ EOF ]
@@ -2002,7 +2023,7 @@ After the definition of the immutable fields, either a contract constraint, the 
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN WITH
 ##
-## Ends in an error in state: 208.
+## Ends in an error in state: 223.
 ##
 ## contract -> CONTRACT CID LPAREN . loption(separated_nonempty_list(COMMA,param_pair)) RPAREN list(field) list(component) [ EOF ]
 ## contract -> CONTRACT CID LPAREN . loption(separated_nonempty_list(COMMA,param_pair)) RPAREN with_constraint list(field) list(component) [ EOF ]
@@ -2017,7 +2038,7 @@ The name of an immutable field should begin with a lower case letter ('a' - 'z')
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID WITH
 ##
-## Ends in an error in state: 207.
+## Ends in an error in state: 222.
 ##
 ## contract -> CONTRACT CID . LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN list(field) list(component) [ EOF ]
 ## contract -> CONTRACT CID . LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN with_constraint list(field) list(component) [ EOF ]
@@ -2031,7 +2052,7 @@ The declaration of zero or more immutable fields in brackets is expected.
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT WITH
 ##
-## Ends in an error in state: 206.
+## Ends in an error in state: 221.
 ##
 ## contract -> CONTRACT . CID LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN list(field) list(component) [ EOF ]
 ## contract -> CONTRACT . CID LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN with_constraint list(field) list(component) [ EOF ]
@@ -2045,7 +2066,7 @@ When a contract is being defined a valid identifier is expected.
 
 cmodule: SCILLA_VERSION NUMLIT LIBRARY CID EOF
 ##
-## Ends in an error in state: 205.
+## Ends in an error in state: 220.
 ##
 ## cmodule -> SCILLA_VERSION NUMLIT imports option(library) . contract EOF [ # ]
 ##
@@ -2056,9 +2077,9 @@ cmodule: SCILLA_VERSION NUMLIT LIBRARY CID EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 12, spurious reduction of production list(libentry) -> 
-## In state 202, spurious reduction of production library -> LIBRARY CID list(libentry) 
-## In state 316, spurious reduction of production option(library) -> library 
+## In state 12, spurious reduction of production list(libentry) ->
+## In state 217, spurious reduction of production library -> LIBRARY CID list(libentry)
+## In state 336, spurious reduction of production option(library) -> library
 ##
 # see tests/parser/bad/cmodule-version-number-library-name
 
@@ -2105,7 +2126,7 @@ Scilla version number unspecified.
 
 exp_term: CID LBRACE RBRACE AT
 ##
-## Ends in an error in state: 176.
+## Ends in an error in state: 192.
 ##
 ## simple_exp -> scid option(ctargs) . list(sident) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -2118,7 +2139,7 @@ In a data constructor application, the parser expects valid separated uncapitali
 
 exp_term: LET ID COLON TID EQ STRING WITH
 ##
-## Ends in an error in state: 189.
+## Ends in an error in state: 204.
 ##
 ## simple_exp -> LET ID type_annot EQ simple_exp . IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -2131,7 +2152,7 @@ This typed let expression does not have a well placed 'in'.
 
 exp_term: LET ID COLON TID EQ WITH
 ##
-## Ends in an error in state: 188.
+## Ends in an error in state: 203.
 ##
 ## simple_exp -> LET ID type_annot EQ . simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -2141,3 +2162,739 @@ exp_term: LET ID COLON TID EQ WITH
 # see tests/parser/bad/exp_t-let-id-colon-tid-eq-with.scilexp
 
 This typed let expression does not have a valid expression to use for the substitute variable.
+
+type_term: CID MAP CID TYPE
+##
+## Ends in an error in state: 101.
+##
+## targ -> MAP t_map_key . t_map_value [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+##
+## The known suffix of the stack is as follows:
+## MAP t_map_key
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production scid -> CID
+## In state 45, spurious reduction of production t_map_key -> scid
+##
+
+Ends in an error in state: 101.
+
+type_term: CID TYPE
+##
+## Ends in an error in state: 66.
+##
+## typ -> scid . list(targ) [ TARROW RPAREN EQ EOF END COMMA ]
+##
+## The known suffix of the stack is as follows:
+## scid
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production scid -> CID
+##
+
+Ends in an error in state: 66.
+
+type_term: CID WITH CONTRACT FIELD ID COLON TID COMMA WITH
+##
+## Ends in an error in state: 93.
+##
+## separated_nonempty_list(COMMA,address_type_field) -> address_type_field COMMA . separated_nonempty_list(COMMA,address_type_field) [ END ]
+##
+## The known suffix of the stack is as follows:
+## address_type_field COMMA
+##
+
+Ends in an error in state: 93.
+
+type_term: CID WITH CONTRACT FIELD ID COLON TID RPAREN
+##
+## Ends in an error in state: 92.
+##
+## separated_nonempty_list(COMMA,address_type_field) -> address_type_field . [ END ]
+## separated_nonempty_list(COMMA,address_type_field) -> address_type_field . COMMA separated_nonempty_list(COMMA,address_type_field) [ END ]
+##
+## The known suffix of the stack is as follows:
+## address_type_field
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 78, spurious reduction of production type_annot -> COLON typ
+## In state 79, spurious reduction of production id_with_typ -> ID type_annot
+## In state 88, spurious reduction of production address_type_field -> FIELD id_with_typ
+##
+
+Ends in an error in state: 92.
+
+type_term: CID WITH CONTRACT FIELD WITH
+##
+## Ends in an error in state: 87.
+##
+## address_type_field -> FIELD . id_with_typ [ END COMMA ]
+##
+## The known suffix of the stack is as follows:
+## FIELD
+##
+
+Contract fields are not allowed to start with underscore.
+
+type_term: CID WITH CONTRACT LPAREN ID COLON TID EQ
+##
+## Ends in an error in state: 81.
+##
+## separated_nonempty_list(COMMA,param_pair) -> param_pair . [ RPAREN ]
+## separated_nonempty_list(COMMA,param_pair) -> param_pair . COMMA separated_nonempty_list(COMMA,param_pair) [ RPAREN ]
+##
+## The known suffix of the stack is as follows:
+## param_pair
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 78, spurious reduction of production type_annot -> COLON typ
+## In state 79, spurious reduction of production id_with_typ -> ID type_annot
+## In state 84, spurious reduction of production param_pair -> id_with_typ
+##
+
+Ends in an error in state: 81.
+
+type_term: CID WITH CONTRACT LPAREN RPAREN WITH
+##
+## Ends in an error in state: 86.
+##
+## address_typ -> CID WITH CONTRACT LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN . loption(separated_nonempty_list(COMMA,address_type_field)) END [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+##
+## The known suffix of the stack is as follows:
+## CID WITH CONTRACT LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN
+##
+
+Ends in an error in state: 86.
+
+type_term: CID WITH CONTRACT LPAREN WITH
+##
+## Ends in an error in state: 29.
+##
+## address_typ -> CID WITH CONTRACT LPAREN . loption(separated_nonempty_list(COMMA,param_pair)) RPAREN loption(separated_nonempty_list(COMMA,address_type_field)) END [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+##
+## The known suffix of the stack is as follows:
+## CID WITH CONTRACT LPAREN
+##
+
+Ends in an error in state: 29.
+
+type_term: CID WITH CONTRACT WITH
+##
+## Ends in an error in state: 28.
+##
+## address_typ -> CID WITH CONTRACT . loption(separated_nonempty_list(COMMA,address_type_field)) END [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+## address_typ -> CID WITH CONTRACT . LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN loption(separated_nonempty_list(COMMA,address_type_field)) END [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+##
+## The known suffix of the stack is as follows:
+## CID WITH CONTRACT
+##
+
+Ends in an error in state: 28.
+
+type_term: HEXLIT WITH
+##
+## Ends in an error in state: 22.
+##
+## scid -> HEXLIT . PERIOD CID [ UNDERSCORE TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN ID HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+##
+## The known suffix of the stack is as follows:
+## HEXLIT
+##
+
+Ends in an error in state: 22.
+
+type_term: MAP CID CID CID UNDERSCORE
+##
+## Ends in an error in state: 53.
+##
+## list(t_map_value_args) -> t_map_value_args . list(t_map_value_args) [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+##
+## The known suffix of the stack is as follows:
+## t_map_value_args
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 50, spurious reduction of production scid -> CID
+## In state 54, spurious reduction of production t_map_value_args -> scid
+##
+
+Extra parameters or missing parentheses in type signature.
+
+type_term: MAP CID CID CID WITH
+##
+## Ends in an error in state: 50.
+##
+## scid -> CID . [ UNDERSCORE TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN ID HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+## scid -> CID . PERIOD CID [ UNDERSCORE TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN ID HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+##
+## The known suffix of the stack is as follows:
+## CID
+##
+
+Ends in an error in state: 50.
+
+type_term: MAP CID CID LPAREN CID TYPE
+##
+## Ends in an error in state: 48.
+##
+## t_map_value_args -> LPAREN t_map_value . RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN t_map_value
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production scid -> CID
+## In state 40, spurious reduction of production list(t_map_value_args) ->
+## In state 56, spurious reduction of production t_map_value -> scid list(t_map_value_args)
+##
+
+Ends in an error in state: 48.
+
+type_term: MAP CID CID MAP CID TYPE
+##
+## Ends in an error in state: 42.
+##
+## t_map_value_args -> MAP t_map_key . t_map_value [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+##
+## The known suffix of the stack is as follows:
+## MAP t_map_key
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production scid -> CID
+## In state 45, spurious reduction of production t_map_key -> scid
+##
+
+Ends in an error in state: 42.
+
+type_term: MAP CID HEXLIT PERIOD CID AND
+##
+## Ends in an error in state: 40.
+##
+## t_map_value -> scid . list(t_map_value_args) [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+##
+## The known suffix of the stack is as follows:
+## scid
+##
+
+Ends in an error in state: 40.
+
+type_term: MAP CID MAP CID TYPE
+##
+## Ends in an error in state: 36.
+##
+## t_map_value -> MAP t_map_key . t_map_value [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+##
+## The known suffix of the stack is as follows:
+## MAP t_map_key
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production scid -> CID
+## In state 45, spurious reduction of production t_map_key -> scid
+##
+
+Ends in an error in state: 36.
+
+type_term: MAP CID TYPE
+##
+## Ends in an error in state: 34.
+##
+## typ -> MAP t_map_key . t_map_value [ TARROW RPAREN EQ EOF END COMMA ]
+##
+## The known suffix of the stack is as follows:
+## MAP t_map_key
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production scid -> CID
+## In state 45, spurious reduction of production t_map_key -> scid
+##
+
+Ends in an error in state: 34.
+
+type_term: MAP LPAREN CID TYPE
+##
+## Ends in an error in state: 97.
+##
+## t_map_key -> LPAREN scid . RPAREN [ MAP LPAREN HEXLIT CID ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN scid
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production scid -> CID
+##
+
+Ends in an error in state: 97.
+
+type_term: MAP LPAREN CID WITH END WITH
+##
+## Ends in an error in state: 99.
+##
+## t_map_key -> LPAREN address_typ . RPAREN [ MAP LPAREN HEXLIT CID ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN address_typ
+##
+
+Ends in an error in state: 99.
+
+stmts_term: FORALL SPID WITH
+##
+## Ends in an error in state: 297.
+##
+## stmt -> FORALL sident . component_id [ SEMICOLON EOF END BAR ]
+##
+## The known suffix of the stack is as follows:
+## FORALL sident
+##
+
+Ends in an error in state: 297.
+
+stmts_term: FORALL WITH
+##
+## Ends in an error in state: 296.
+##
+## stmt -> FORALL . sident component_id [ SEMICOLON EOF END BAR ]
+##
+## The known suffix of the stack is as follows:
+## FORALL
+##
+
+Ends in an error in state: 296.
+
+stmts_term: ID FETCH AND CID PERIOD ID WITH
+##
+## Ends in an error in state: 284.
+##
+## remote_fetch_stmt -> ID FETCH AND sident . AS address_typ [ SEMICOLON EOF END BAR ]
+##
+## The known suffix of the stack is as follows:
+## ID FETCH AND sident
+##
+
+Remote reads are not allowed to use namespaces.
+
+stmts_term: ID FETCH AND CID WITH
+##
+## Ends in an error in state: 283.
+##
+## sident -> CID . PERIOD ID [ AS ]
+## stmt -> ID FETCH AND CID . [ SEMICOLON EOF END BAR ]
+##
+## The known suffix of the stack is as follows:
+## ID FETCH AND CID
+##
+
+Ends in an error in state: 283.
+
+stmts_term: ID FETCH AND EXISTS ID PERIOD ID WITH
+##
+## Ends in an error in state: 281.
+##
+## remote_fetch_stmt -> ID FETCH AND EXISTS ID PERIOD ID . nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
+##
+## The known suffix of the stack is as follows:
+## ID FETCH AND EXISTS ID PERIOD ID
+##
+
+Ends in an error in state: 281.
+
+stmts_term: ID FETCH AND EXISTS ID PERIOD WITH
+##
+## Ends in an error in state: 280.
+##
+## remote_fetch_stmt -> ID FETCH AND EXISTS ID PERIOD . ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
+##
+## The known suffix of the stack is as follows:
+## ID FETCH AND EXISTS ID PERIOD
+##
+
+Ends in an error in state: 280.
+
+stmts_term: ID FETCH AND EXISTS ID WITH
+##
+## Ends in an error in state: 279.
+##
+## remote_fetch_stmt -> ID FETCH AND EXISTS ID . PERIOD ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
+##
+## The known suffix of the stack is as follows:
+## ID FETCH AND EXISTS ID
+##
+
+Ends in an error in state: 279.
+
+stmts_term: ID FETCH AND EXISTS WITH
+##
+## Ends in an error in state: 278.
+##
+## remote_fetch_stmt -> ID FETCH AND EXISTS . ID PERIOD ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
+##
+## The known suffix of the stack is as follows:
+## ID FETCH AND EXISTS
+##
+
+Ends in an error in state: 278.
+
+stmts_term: ID FETCH AND ID PERIOD ID WITH
+##
+## Ends in an error in state: 275.
+##
+## remote_fetch_stmt -> ID FETCH AND ID PERIOD ID . nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
+## sident -> ID . [ SEMICOLON EOF END BAR ]
+##
+## The known suffix of the stack is as follows:
+## ID FETCH AND ID PERIOD ID
+##
+
+Ends in an error in state: 275.
+
+stmts_term: ID FETCH AND ID PERIOD LPAREN SPID WITH
+##
+## Ends in an error in state: 273.
+##
+## remote_fetch_stmt -> ID FETCH AND ID PERIOD LPAREN sident . RPAREN [ SEMICOLON EOF END BAR ]
+##
+## The known suffix of the stack is as follows:
+## ID FETCH AND ID PERIOD LPAREN sident
+##
+
+Ends in an error in state: 273.
+
+stmts_term: ID FETCH AND ID PERIOD LPAREN WITH
+##
+## Ends in an error in state: 272.
+##
+## remote_fetch_stmt -> ID FETCH AND ID PERIOD LPAREN . sident RPAREN [ SEMICOLON EOF END BAR ]
+##
+## The known suffix of the stack is as follows:
+## ID FETCH AND ID PERIOD LPAREN
+##
+
+Ends in an error in state: 272.
+
+stmts_term: ID FETCH AND ID PERIOD WITH
+##
+## Ends in an error in state: 271.
+##
+## remote_fetch_stmt -> ID FETCH AND ID PERIOD . sident [ SEMICOLON EOF END BAR ]
+## remote_fetch_stmt -> ID FETCH AND ID PERIOD . LPAREN sident RPAREN [ SEMICOLON EOF END BAR ]
+## remote_fetch_stmt -> ID FETCH AND ID PERIOD . ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
+##
+## The known suffix of the stack is as follows:
+## ID FETCH AND ID PERIOD
+##
+
+Ends in an error in state: 271.
+
+stmts_term: ID FETCH AND ID WITH
+##
+## Ends in an error in state: 270.
+##
+## remote_fetch_stmt -> ID FETCH AND ID . PERIOD sident [ SEMICOLON EOF END BAR ]
+## remote_fetch_stmt -> ID FETCH AND ID . PERIOD LPAREN sident RPAREN [ SEMICOLON EOF END BAR ]
+## remote_fetch_stmt -> ID FETCH AND ID . PERIOD ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
+## sident -> ID . [ AS ]
+##
+## The known suffix of the stack is as follows:
+## ID FETCH AND ID
+##
+
+Either blockchain state variable or remote field read expected.
+
+stmts_term: ID FETCH AND SPID AS CID UNDERSCORE
+##
+## Ends in an error in state: 286.
+##
+## address_typ -> CID . WITH END [ SEMICOLON EOF END BAR ]
+## address_typ -> CID . WITH CONTRACT loption(separated_nonempty_list(COMMA,address_type_field)) END [ SEMICOLON EOF END BAR ]
+## address_typ -> CID . WITH CONTRACT LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN loption(separated_nonempty_list(COMMA,address_type_field)) END [ SEMICOLON EOF END BAR ]
+##
+## The known suffix of the stack is as follows:
+## CID
+##
+
+Ends in an error in state: 286.
+
+stmts_term: ID FETCH AND SPID AS WITH
+##
+## Ends in an error in state: 285.
+##
+## remote_fetch_stmt -> ID FETCH AND sident AS . address_typ [ SEMICOLON EOF END BAR ]
+##
+## The known suffix of the stack is as follows:
+## ID FETCH AND sident AS
+##
+
+Ends in an error in state: 285.
+
+stmts_term: ID FETCH AND SPID PERIOD WITH
+##
+## Ends in an error in state: 268.
+##
+## remote_fetch_stmt -> ID FETCH AND SPID PERIOD . SPID [ SEMICOLON EOF END BAR ]
+##
+## The known suffix of the stack is as follows:
+## ID FETCH AND SPID PERIOD
+##
+
+Ends in an error in state: 268.
+
+stmts_term: ID FETCH AND SPID WITH
+##
+## Ends in an error in state: 267.
+##
+## remote_fetch_stmt -> ID FETCH AND SPID . PERIOD SPID [ SEMICOLON EOF END BAR ]
+## sident -> SPID . [ AS ]
+##
+## The known suffix of the stack is as follows:
+## ID FETCH AND SPID
+##
+
+Ends in an error in state: 267.
+
+lmodule: SCILLA_VERSION WITH
+##
+## Ends in an error in state: 343.
+##
+## lmodule -> SCILLA_VERSION . NUMLIT imports library EOF [ # ]
+##
+## The known suffix of the stack is as follows:
+## SCILLA_VERSION
+##
+
+Ends in an error in state: 343.
+
+exp_term: BUILTIN ID LBRACE RBRACE CATCH
+##
+## Ends in an error in state: 172.
+##
+## simple_exp -> BUILTIN ID option(ctargs) . builtin_args [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
+##
+## The known suffix of the stack is as follows:
+## BUILTIN ID option(ctargs)
+##
+
+Ends in an error in state: 172.
+
+exp_term: EMP CID TYPE
+##
+## Ends in an error in state: 147.
+##
+## lit -> EMP t_map_key . t_map_value [ TYPE TRANSITION SEMICOLON RBRACE PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
+##
+## The known suffix of the stack is as follows:
+## EMP t_map_key
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production scid -> CID
+## In state 45, spurious reduction of production t_map_key -> scid
+##
+
+Ends in an error in state: 147.
+
+exp_term: FUN LPAREN ID COLON TID EQ
+##
+## Ends in an error in state: 162.
+##
+## simple_exp -> FUN LPAREN id_with_typ . RPAREN ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
+##
+## The known suffix of the stack is as follows:
+## FUN LPAREN id_with_typ
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 78, spurious reduction of production type_annot -> COLON typ
+## In state 79, spurious reduction of production id_with_typ -> ID type_annot
+##
+
+Ends in an error in state: 162.
+
+exp_term: HEXLIT PERIOD WITH
+##
+## Ends in an error in state: 23.
+##
+## scid -> HEXLIT PERIOD . CID [ UNDERSCORE TYPE TRANSITION TID TARROW SPID SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET LBRACE IN ID HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+##
+## The known suffix of the stack is as follows:
+## HEXLIT PERIOD
+##
+
+Ends in an error in state: 23.
+
+exp_term: LET ID COLON CID RPAREN
+##
+## Ends in an error in state: 202.
+##
+## simple_exp -> LET ID type_annot . EQ simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
+##
+## The known suffix of the stack is as follows:
+## LET ID type_annot
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production scid -> CID
+## In state 66, spurious reduction of production list(targ) ->
+## In state 75, spurious reduction of production typ -> scid list(targ)
+## In state 78, spurious reduction of production type_annot -> COLON typ
+##
+
+Ends in an error in state: 202.
+
+exp_term: MATCH SPID WITH BAR UNDERSCORE ARROW STRING WITH
+##
+## Ends in an error in state: 210.
+##
+## list(exp_pm_clause) -> exp_pm_clause . list(exp_pm_clause) [ END ]
+##
+## The known suffix of the stack is as follows:
+## exp_pm_clause
+##
+
+match-expression is probably missing `end` keyword.
+
+cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD ID COLON TID EQ STRING WITH
+##
+## Ends in an error in state: 330.
+##
+## list(field) -> field . list(field) [ TRANSITION PROCEDURE EOF ]
+##
+## The known suffix of the stack is as follows:
+## field
+##
+
+A field, transition, procedure or end of file expected (e.g. semicolons are not needed as separators here).
+
+cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD ID COLON TID EQ WITH
+##
+## Ends in an error in state: 231.
+##
+## field -> FIELD id_with_typ EQ . exp [ TRANSITION PROCEDURE FIELD EOF ]
+##
+## The known suffix of the stack is as follows:
+## FIELD id_with_typ EQ
+##
+
+Valid initializing expression expected.
+
+cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD ID COLON TID RPAREN
+##
+## Ends in an error in state: 230.
+##
+## field -> FIELD id_with_typ . EQ exp [ TRANSITION PROCEDURE FIELD EOF ]
+##
+## The known suffix of the stack is as follows:
+## FIELD id_with_typ
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 78, spurious reduction of production type_annot -> COLON typ
+## In state 79, spurious reduction of production id_with_typ -> ID type_annot
+##
+
+Ends in an error in state: 230.
+
+cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN WITH STRING ARROW WITH
+##
+## Ends in an error in state: 233.
+##
+## contract -> CONTRACT CID LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN with_constraint . list(field) list(component) [ EOF ]
+##
+## The known suffix of the stack is as follows:
+## CONTRACT CID LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN with_constraint
+##
+
+Ends in an error in state: 233.
+
+cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN WITH STRING WITH
+##
+## Ends in an error in state: 227.
+##
+## with_constraint -> WITH exp . ARROW [ TRANSITION PROCEDURE FIELD EOF ]
+##
+## The known suffix of the stack is as follows:
+## WITH exp
+##
+
+Ends in an error in state: 227.
+
+cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN WITH WITH
+##
+## Ends in an error in state: 226.
+##
+## with_constraint -> WITH . exp ARROW [ TRANSITION PROCEDURE FIELD EOF ]
+##
+## The known suffix of the stack is as follows:
+## WITH
+##
+
+Ends in an error in state: 226.
+
+cmodule: SCILLA_VERSION NUMLIT LIBRARY CID LET ID COLON CID RPAREN
+##
+## Ends in an error in state: 214.
+##
+## libentry -> LET ID type_annot . EQ exp [ TYPE LET EOF CONTRACT ]
+##
+## The known suffix of the stack is as follows:
+## LET ID type_annot
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production scid -> CID
+## In state 66, spurious reduction of production list(targ) ->
+## In state 75, spurious reduction of production typ -> scid list(targ)
+## In state 78, spurious reduction of production type_annot -> COLON typ
+##
+
+Ends in an error in state: 214.
+
+cmodule: SCILLA_VERSION NUMLIT LIBRARY CID LET ID EQ STRING WITH
+##
+## Ends in an error in state: 218.
+##
+## list(libentry) -> libentry . list(libentry) [ EOF CONTRACT ]
+##
+## The known suffix of the stack is as follows:
+## libentry
+##
+
+Incorrect library entry: probably `let` keyword expected.

--- a/tests/base/parser/bad/gold/address_spid_as_field.scilla.gold
+++ b/tests/base/parser/bad/gold/address_spid_as_field.scilla.gold
@@ -1,7 +1,8 @@
 {
   "errors": [
     {
-      "error_message": "Syntax error, state number 87",
+      "error_message":
+        "Contract fields are not allowed to start with underscore.\n",
       "start_location": {
         "file": "base/parser/bad/address_spid_as_field.scilla",
         "line": 5,

--- a/tests/base/parser/bad/gold/cmodule-field-id-colon-cid-eq-hexlit-with.scilla.gold
+++ b/tests/base/parser/bad/gold/cmodule-field-id-colon-cid-eq-hexlit-with.scilla.gold
@@ -1,7 +1,8 @@
 {
   "errors": [
     {
-      "error_message": "Syntax error, state number 330",
+      "error_message":
+        "A field, transition, procedure or end of file expected (e.g. semicolons are not needed as separators here).\n",
       "start_location": {
         "file":
           "base/parser/bad/cmodule-field-id-colon-cid-eq-hexlit-with.scilla",

--- a/tests/base/parser/bad/gold/cmodule-field-id-colon-tid-eq-with.scilla.gold
+++ b/tests/base/parser/bad/gold/cmodule-field-id-colon-tid-eq-with.scilla.gold
@@ -1,7 +1,7 @@
 {
   "errors": [
     {
-      "error_message": "Syntax error, state number 231",
+      "error_message": "Valid initializing expression expected.\n",
       "start_location": {
         "file": "base/parser/bad/cmodule-field-id-colon-tid-eq-with.scilla",
         "line": 7,

--- a/tests/base/parser/bad/gold/exp_t-match-spid-with-bar-underscore-arrow-hexlit-with.scilexp.gold
+++ b/tests/base/parser/bad/gold/exp_t-match-spid-with-bar-underscore-arrow-hexlit-with.scilexp.gold
@@ -1,7 +1,8 @@
 {
   "errors": [
     {
-      "error_message": "Syntax error, state number 210",
+      "error_message":
+        "match-expression is probably missing `end` keyword.\n",
       "start_location": {
         "file":
           "base/parser/bad/exps/exp_t-match-spid-with-bar-underscore-arrow-hexlit-with.scilexp",

--- a/tests/base/parser/bad/gold/lmodule-library-cid-let-id-eq-hexlit-with.scillib.gold
+++ b/tests/base/parser/bad/gold/lmodule-library-cid-let-id-eq-hexlit-with.scillib.gold
@@ -1,7 +1,8 @@
 {
   "errors": [
     {
-      "error_message": "Syntax error, state number 218",
+      "error_message":
+        "Incorrect library entry: probably `let` keyword expected.\n",
       "start_location": {
         "file":
           "base/parser/bad/lib/lmodule-library-cid-let-id-eq-hexlit-with.scillib",

--- a/tests/base/parser/bad/gold/remote_read_namespace.scilla.gold
+++ b/tests/base/parser/bad/gold/remote_read_namespace.scilla.gold
@@ -1,7 +1,7 @@
 {
   "errors": [
     {
-      "error_message": "Syntax error, state number 284",
+      "error_message": "Remote reads are not allowed to use namespaces.\n",
       "start_location": {
         "file": "base/parser/bad/remote_read_namespace.scilla",
         "line": 8,

--- a/tests/base/parser/bad/gold/stmts_t-id-bind-and-with.scilla.gold
+++ b/tests/base/parser/bad/gold/stmts_t-id-bind-and-with.scilla.gold
@@ -1,7 +1,8 @@
 {
   "errors": [
     {
-      "error_message": "Syntax error, state number 270",
+      "error_message":
+        "Either blockchain state variable or remote field read expected.\n",
       "start_location": {
         "file": "base/parser/bad/stmts_t-id-bind-and-with.scilla",
         "line": 8,

--- a/tests/base/parser/bad/gold/type_t-map-cid-cid-cid-underscore.scilla.gold
+++ b/tests/base/parser/bad/gold/type_t-map-cid-cid-cid-underscore.scilla.gold
@@ -1,7 +1,8 @@
 {
   "errors": [
     {
-      "error_message": "Syntax error, state number 53",
+      "error_message":
+        "Extra parameters or missing parentheses in type signature.\n",
       "start_location": {
         "file": "base/parser/bad/type_t-map-cid-cid-cid-underscore.scilla",
         "line": 6,

--- a/tests/checker/bad/gold/bad_cast_2.scilla.gold
+++ b/tests/checker/bad/gold/bad_cast_2.scilla.gold
@@ -2,7 +2,7 @@
   "gas_remaining": "8000",
   "errors": [
     {
-      "error_message": "Syntax error, state number 286",
+      "error_message": "Ends in an error in state: 286.\n",
       "start_location": {
         "file": "checker/bad/bad_cast_2.scilla",
         "line": 11,

--- a/tests/checker/bad/gold/bad_cast_3.scilla.gold
+++ b/tests/checker/bad/gold/bad_cast_3.scilla.gold
@@ -2,7 +2,7 @@
   "gas_remaining": "8000",
   "errors": [
     {
-      "error_message": "Syntax error, state number 286",
+      "error_message": "Ends in an error in state: 286.\n",
       "start_location": {
         "file": "checker/bad/bad_cast_3.scilla",
         "line": 11,

--- a/tests/checker/bad/gold/bad_map_key_1.scilla.gold
+++ b/tests/checker/bad/gold/bad_map_key_1.scilla.gold
@@ -2,7 +2,7 @@
   "gas_remaining": "8000",
   "errors": [
     {
-      "error_message": "Syntax error, state number 97",
+      "error_message": "Ends in an error in state: 97.\n",
       "start_location": {
         "file": "checker/bad/bad_map_key_1.scilla",
         "line": 7,

--- a/tests/eval/bad/gold/list_to_map.scilexp.gold
+++ b/tests/eval/bad/gold/list_to_map.scilexp.gold
@@ -1,7 +1,7 @@
 {
   "errors": [
     {
-      "error_message": "Syntax error, state number 34",
+      "error_message": "Ends in an error in state: 34.\n",
       "start_location": {
         "file": "eval/bad/list_to_map.scilexp",
         "line": 7,


### PR DESCRIPTION
Run `make parser-messages` to update ParserFaults.messages in case of
changes in the Scilla grammar.