### PR TITLE
Clarify some parser error messages

### DIFF
--- a/src/base/ParserFaults.messages
+++ b/src/base/ParserFaults.messages
@@ -1,6 +1,9 @@
 #@ WARNING:
 #@ The following comment has been copied from "src/base/ParserFaults.messages".
 #@ It may need to be proofread, updated, moved, or removed.
+#@ WARNING:
+#@ The following comment has been copied from "src/base/ParserFaults.messages".
+#@ It may need to be proofread, updated, moved, or removed.
 # 
 # This file is part of scilla.
 # 
@@ -645,7 +648,7 @@ stmts_term: ID WITH
 ##
 # see tests/parser/bad/stmts_t-id-with.scilla
 
-This is an invalid statements term. Scilla expects to do something with the identifier.
+This is an invalid statements term. Scilla expects to do something with the identifier. Sometimes it's just a procedure call with parentheses where there should be none.
 
 stmts_term: MATCH SPID UNDERSCORE
 ##
@@ -823,7 +826,7 @@ stmts_term: THROW SEMICOLON WITH
 # to understand this do not look at the tokens 'THROW SEMICOLON WITH'
 # instead look at the stack, these are merely tokens in a way associated
 
-What follows the statement was unexpected, for example possibly a statement or termination is expected.
+What follows the statement was unexpected, for example, possibly a statement or termination is expected, or there is an extra semicolon before this line.
 
 stmts_term: THROW WITH
 ##

--- a/tests/base/parser/bad/gold/stmts_t-cid-with.scilla.gold
+++ b/tests/base/parser/bad/gold/stmts_t-cid-with.scilla.gold
@@ -2,7 +2,7 @@
   "errors": [
     {
       "error_message":
-        "This is an invalid statements term. Scilla expects to do something with the identifier.\n",
+        "This is an invalid statements term. Scilla expects to do something with the identifier. Sometimes it's just a procedure call with parentheses where there should be none.\n",
       "start_location": {
         "file": "base/parser/bad/stmts_t-cid-with.scilla",
         "line": 11,

--- a/tests/base/parser/bad/gold/stmts_t-throw-semicolon-with.scilla.gold
+++ b/tests/base/parser/bad/gold/stmts_t-throw-semicolon-with.scilla.gold
@@ -2,7 +2,7 @@
   "errors": [
     {
       "error_message":
-        "What follows the statement was unexpected, for example possibly a statement or termination is expected.\n",
+        "What follows the statement was unexpected, for example, possibly a statement or termination is expected, or there is an extra semicolon before this line.\n",
       "start_location": {
         "file": "base/parser/bad/stmts_t-throw-semicolon-with.scilla",
         "line": 8,


### PR DESCRIPTION
Some tweaks to parser error messages based on a recent experience with porting the [Phoenix Vault](https://arxiv.org/pdf/2106.01240.pdf) contract to Scilla.