### PR TITLE
A flag to disable analyses warnings

### DIFF
--- a/src/base/Checker.ml
+++ b/src/base/Checker.ml
@@ -262,7 +262,7 @@ let check_lmodule cli =
       @@ check_patterns_lmodule typed_lmod typed_rlibs typed_elibs
     in
     let%bind () =
-      if cli.silence_warnings then pure ()
+      if cli.disable_analy_warn then pure ()
       else
         Result.ignore_m
         @@ wrap_error_with_gas remaining_gas
@@ -336,7 +336,7 @@ let check_cmodule cli =
       if cli.p_type_info then TI.type_info_cmod typed_cmod else []
     in
     let%bind () =
-      if cli.silence_warnings then pure ()
+      if cli.disable_analy_warn then pure ()
       else
         wrap_error_with_gas remaining_gas
         @@ check_sanity typed_cmod typed_rlibs typed_elibs

--- a/src/base/Checker.ml
+++ b/src/base/Checker.ml
@@ -262,9 +262,11 @@ let check_lmodule cli =
       @@ check_patterns_lmodule typed_lmod typed_rlibs typed_elibs
     in
     let%bind () =
-      Result.ignore_m
-      @@ wrap_error_with_gas remaining_gas
-      @@ check_sanity_lmod typed_lmod typed_rlibs typed_elibs
+      if cli.silence_warnings then pure ()
+      else
+        Result.ignore_m
+        @@ wrap_error_with_gas remaining_gas
+        @@ check_sanity_lmod typed_lmod typed_rlibs typed_elibs
     in
     let type_info =
       if cli.p_type_info then TI.type_info_lmod typed_lmod else []
@@ -334,8 +336,10 @@ let check_cmodule cli =
       if cli.p_type_info then TI.type_info_cmod typed_cmod else []
     in
     let%bind () =
-      wrap_error_with_gas remaining_gas
-      @@ check_sanity typed_cmod typed_rlibs typed_elibs
+      if cli.silence_warnings then pure ()
+      else
+        wrap_error_with_gas remaining_gas
+        @@ check_sanity typed_cmod typed_rlibs typed_elibs
     in
     let%bind event_info =
       wrap_error_with_gas remaining_gas @@ EI.event_info pm_checked_cmod

--- a/src/base/RunnerUtil.ml
+++ b/src/base/RunnerUtil.ml
@@ -192,7 +192,7 @@ type runner_cli = {
   cf_token_fields : string list;
   p_contract_info : bool;
   p_type_info : bool;
-  silence_warnings : bool;
+  disable_analy_warn : bool;
 }
 
 let parse_cli args ~exe_name =
@@ -207,7 +207,7 @@ let parse_cli args ~exe_name =
   let r_cf = ref false in
   let r_cf_token_fields = ref [] in
   let r_validate_json = ref true in
-  let r_silence_warnings = ref false in
+  let r_disable_analy_warn = ref false in
 
   let speclist =
     [
@@ -267,7 +267,7 @@ let parse_cli args ~exe_name =
         Arg.Unit (fun () -> r_validate_json := false),
         "Disable validation of input JSONs" );
       ( "-disable-developer-warnings",
-        Arg.Unit (fun () -> r_silence_warnings := true),
+        Arg.Unit (fun () -> r_disable_analy_warn := true),
         "Disable analyses' warnings" );
     ]
   in
@@ -311,5 +311,5 @@ let parse_cli args ~exe_name =
     cf_token_fields = !r_cf_token_fields;
     init_file = !r_init_file;
     p_type_info = !r_type_info;
-    silence_warnings = !r_silence_warnings;
+    disable_analy_warn = !r_disable_analy_warn;
   }

--- a/src/base/RunnerUtil.ml
+++ b/src/base/RunnerUtil.ml
@@ -192,6 +192,7 @@ type runner_cli = {
   cf_token_fields : string list;
   p_contract_info : bool;
   p_type_info : bool;
+  silence_warnings : bool;
 }
 
 let parse_cli args ~exe_name =
@@ -206,6 +207,7 @@ let parse_cli args ~exe_name =
   let r_cf = ref false in
   let r_cf_token_fields = ref [] in
   let r_validate_json = ref true in
+  let r_silence_warnings = ref false in
 
   let speclist =
     [
@@ -264,6 +266,9 @@ let parse_cli args ~exe_name =
       ( "-disable-validate-json",
         Arg.Unit (fun () -> r_validate_json := false),
         "Disable validation of input JSONs" );
+      ( "-disable-developer-warnings",
+        Arg.Unit (fun () -> r_silence_warnings := true),
+        "Disable analyses' warnings" );
     ]
   in
 
@@ -306,4 +311,5 @@ let parse_cli args ~exe_name =
     cf_token_fields = !r_cf_token_fields;
     init_file = !r_init_file;
     p_type_info = !r_type_info;
+    silence_warnings = !r_silence_warnings;
   }


### PR DESCRIPTION
The flag `-disable-developer-warnings` silences the warnings from sanity checking.