### PR TITLE
Move cost of parsing from deployment in interpreter to checker

### DIFF
--- a/src/base/JSON.ml
+++ b/src/base/JSON.ml
@@ -81,7 +81,9 @@ let build_prim_lit_exn t v =
     mk_invalid_json ("Invalid " ^ pp_typ t ^ " value " ^ v ^ " in JSON")
   in
   let build_prim_literal_of_type t v =
-    match build_prim_literal t v with Some v' -> v' | None -> raise (exn ())
+    try
+      match build_prim_literal t v with Some v' -> v' | None -> raise (exn ())
+    with Invalid_argument _ -> raise (exn ())
   in
   match t with
   | PrimType pt -> build_prim_literal_of_type pt v

--- a/src/eval/Runner.ml
+++ b/src/eval/Runner.ml
@@ -370,18 +370,8 @@ let run_with_args args =
   in
   let initial_gas_limit = Uint64.mul args.gas_limit Gas.scale_factor in
   let gas_remaining =
-    (* Subtract gas based on (contract+init) size / message size. *)
-    if is_deployment then
-      let cost' =
-        UnixLabels.((stat args.input).st_size + (stat args.input_init).st_size)
-      in
-      let cost = Uint64.of_int cost' in
-      if Uint64.compare initial_gas_limit cost < 0 then
-        fatal_error_gas_scale Gas.scale_factor
-          (mk_error0
-             (sprintf "Ran out of gas when parsing contract/init files.\n"))
-          Uint64.zero
-      else Uint64.sub initial_gas_limit cost
+    (* Subtract gas based message size. *)
+    if is_deployment then initial_gas_limit
     else
       let cost = Uint64.of_int (UnixLabels.stat args.input_message).st_size in
       (* libraries can only be deployed, not "run". *)

--- a/tests/checker/bad/gold/BadPMLib.scillib.gold
+++ b/tests/checker/bad/gold/BadPMLib.scillib.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7985",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/TestLibNS1.scillib.gold
+++ b/tests/checker/bad/gold/TestLibNS1.scillib.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7976",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/address_eq_test_bad.scilla.gold
+++ b/tests/checker/bad/gold/address_eq_test_bad.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7869",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/address_list_traversal_bad.scilla.gold
+++ b/tests/checker/bad/gold/address_list_traversal_bad.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7914",
+  "gas_remaining": "7739",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/address_non_storable_type.scilla.gold
+++ b/tests/checker/bad/gold/address_non_storable_type.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7936",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/bad-exception1.scilla.gold
+++ b/tests/checker/bad/gold/bad-exception1.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7931",
   "errors": [
     {
       "error_message": "Cannot serialize values of type Uint32 -> Uint32.",

--- a/tests/checker/bad/gold/bad_adt_1.scilla.gold
+++ b/tests/checker/bad/gold/bad_adt_1.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7962",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/bad_adt_2.scilla.gold
+++ b/tests/checker/bad/gold/bad_adt_2.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7962",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/bad_adt_3.scilla.gold
+++ b/tests/checker/bad/gold/bad_adt_3.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7962",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/bad_adt_4.scilla.gold
+++ b/tests/checker/bad/gold/bad_adt_4.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7962",
   "errors": [
     {
       "error_message": "Type error(s) in contract BadLib:\n",

--- a/tests/checker/bad/gold/bad_adt_7.scilla.gold
+++ b/tests/checker/bad/gold/bad_adt_7.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7983",
   "errors": [
     {
       "error_message": "Type error(s) in contract Test:\n",

--- a/tests/checker/bad/gold/bad_adt_8.scilla.gold
+++ b/tests/checker/bad/gold/bad_adt_8.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7989",
   "errors": [
     {
       "error_message": "Type error(s) in contract Test:\n",

--- a/tests/checker/bad/gold/bad_adt_lib_3.scilla.gold
+++ b/tests/checker/bad/gold/bad_adt_lib_3.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7971",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/bad_adt_lib_4.scilla.gold
+++ b/tests/checker/bad/gold/bad_adt_lib_4.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7971",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/bad_adt_lib_5.scilla.gold
+++ b/tests/checker/bad/gold/bad_adt_lib_5.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7967",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/bad_adt_lib_6.scilla.gold
+++ b/tests/checker/bad/gold/bad_adt_lib_6.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7967",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/bad_cast_1.scilla.gold
+++ b/tests/checker/bad/gold/bad_cast_1.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7977",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/bad_cast_2.scilla.gold
+++ b/tests/checker/bad/gold/bad_cast_2.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7975",
   "errors": [
     {
       "error_message": "Ends in an error in state: 286.\n",

--- a/tests/checker/bad/gold/bad_cast_3.scilla.gold
+++ b/tests/checker/bad/gold/bad_cast_3.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7975",
   "errors": [
     {
       "error_message": "Ends in an error in state: 286.\n",

--- a/tests/checker/bad/gold/bad_comment_1.scilla.gold
+++ b/tests/checker/bad/gold/bad_comment_1.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7987",
   "errors": [
     {
       "error_message": "Lexical error: Comment unfinished",

--- a/tests/checker/bad/gold/bad_comment_2.scilla.gold
+++ b/tests/checker/bad/gold/bad_comment_2.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7985",
   "errors": [
     {
       "error_message": "Lexical error: Comment unfinished",

--- a/tests/checker/bad/gold/bad_fields1.scilla.gold
+++ b/tests/checker/bad/gold/bad_fields1.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7985",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/bad_fields2.scilla.gold
+++ b/tests/checker/bad/gold/bad_fields2.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7983",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/bad_fields3.scilla.gold
+++ b/tests/checker/bad/gold/bad_fields3.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7984",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/bad_fields4.scilla.gold
+++ b/tests/checker/bad/gold/bad_fields4.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7984",
   "errors": [
     {
       "error_message": "Values of the type \"Message\" cannot be stored.",

--- a/tests/checker/bad/gold/bad_lib_pm_import.scilla.gold
+++ b/tests/checker/bad/gold/bad_lib_pm_import.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7990",
   "errors": [
     {
       "error_message": "Type error(s) in contract BadLibPM:\n",

--- a/tests/checker/bad/gold/bad_lib_type.scilla.gold
+++ b/tests/checker/bad/gold/bad_lib_type.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7946",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/bad_lib_type2.scilla.gold
+++ b/tests/checker/bad/gold/bad_lib_type2.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7894",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/bad_lib_type3.scilla.gold
+++ b/tests/checker/bad/gold/bad_lib_type3.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7892",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/bad_map_key_1.scilla.gold
+++ b/tests/checker/bad/gold/bad_map_key_1.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7976",
   "errors": [
     {
       "error_message": "Ends in an error in state: 97.\n",

--- a/tests/checker/bad/gold/bad_map_key_5.scilla.gold
+++ b/tests/checker/bad/gold/bad_map_key_5.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7956",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/bad_message1.scilla.gold
+++ b/tests/checker/bad/gold/bad_message1.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7970",
   "errors": [
     {
       "error_message": "Cannot serialize values of type Message.",

--- a/tests/checker/bad/gold/bad_message2.scilla.gold
+++ b/tests/checker/bad/gold/bad_message2.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7921",
   "errors": [
     {
       "error_message": "Missing _amount or _recipient in Message\n",

--- a/tests/checker/bad/gold/bad_param.scilla.gold
+++ b/tests/checker/bad/gold/bad_param.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7989",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/bad_transition_param.scilla.gold
+++ b/tests/checker/bad/gold/bad_transition_param.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7980",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/balance_field.scilla.gold
+++ b/tests/checker/bad/gold/balance_field.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7989",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/builtin_type_args.scilla.gold
+++ b/tests/checker/bad/gold/builtin_type_args.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7977",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/constraint_field_not_in_scope.scilla.gold
+++ b/tests/checker/bad/gold/constraint_field_not_in_scope.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7988",
   "errors": [
     {
       "error_message": "Couldn't resolve the identifier \"f\".\n",

--- a/tests/checker/bad/gold/constraint_locals_not_in_scope.scilla.gold
+++ b/tests/checker/bad/gold/constraint_locals_not_in_scope.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7982",
   "errors": [
     {
       "error_message": "Couldn't resolve the identifier \"x\".\n",

--- a/tests/checker/bad/gold/constraint_type_illegal.scilla.gold
+++ b/tests/checker/bad/gold/constraint_type_illegal.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7988",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/event_bad1.scilla.gold
+++ b/tests/checker/bad/gold/event_bad1.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7429",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/event_bad2.scilla.gold
+++ b/tests/checker/bad/gold/event_bad2.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7442",
   "errors": [
     {
       "error_message": "Error determining event name\n",

--- a/tests/checker/bad/gold/forward_definition_procedure.scilla.gold
+++ b/tests/checker/bad/gold/forward_definition_procedure.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7957",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/global_scope_procedures.scilla.gold
+++ b/tests/checker/bad/gold/global_scope_procedures.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7959",
   "errors": [
     {
       "error_message": "Type error(s) in contract GlobalScopeProcedure:\n",

--- a/tests/checker/bad/gold/homonymous_vars.scilla.gold
+++ b/tests/checker/bad/gold/homonymous_vars.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7945",
   "errors": [
     {
       "error_message": "Couldn't resolve the identifier \"sxamount\".\n",

--- a/tests/checker/bad/gold/homonymous_vars2.scilla.gold
+++ b/tests/checker/bad/gold/homonymous_vars2.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7935",
   "errors": [
     {
       "error_message": "Couldn't resolve the identifier \"sxamount\".\n",

--- a/tests/checker/bad/gold/homonymous_vars3.scilla.gold
+++ b/tests/checker/bad/gold/homonymous_vars3.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7945",
   "errors": [
     {
       "error_message": "Couldn't resolve the identifier \"sxamount\".\n",

--- a/tests/checker/bad/gold/import-test-lib-bad_1.scilla.gold
+++ b/tests/checker/bad/gold/import-test-lib-bad_1.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7812",
   "errors": [
     {
       "error_message": "Cannot serialize values of type BaseType2.",

--- a/tests/checker/bad/gold/import-test-lib-bad_2.scilla.gold
+++ b/tests/checker/bad/gold/import-test-lib-bad_2.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7945",
   "errors": [
     {
       "error_message": "Type error(s) in contract ImportNestedTestLibBad2:\n",

--- a/tests/checker/bad/gold/import-test-lib-bad_3.scilla.gold
+++ b/tests/checker/bad/gold/import-test-lib-bad_3.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7953",
   "errors": [
     {
       "error_message": "Type error(s) in contract ImportNestedTestLibBad3:\n",

--- a/tests/checker/bad/gold/inplace-map.scilla.gold
+++ b/tests/checker/bad/gold/inplace-map.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7913",
+  "gas_remaining": "7677",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/lib_bad1.scilla.gold
+++ b/tests/checker/bad/gold/lib_bad1.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7819",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/libdup1.scilla.gold
+++ b/tests/checker/bad/gold/libdup1.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7992",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/libdup2.scilla.gold
+++ b/tests/checker/bad/gold/libdup2.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7985",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/libindirect.scilla.gold
+++ b/tests/checker/bad/gold/libindirect.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7917",
+  "gas_remaining": "7896",
   "errors": [
     {
       "error_message": "Couldn't resolve the identifier \"list_sort\".\n",

--- a/tests/checker/bad/gold/listiter-bad.scilla.gold
+++ b/tests/checker/bad/gold/listiter-bad.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7957",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/map_value_function.scilla.gold
+++ b/tests/checker/bad/gold/map_value_function.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7970",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/mappair.scilla.gold
+++ b/tests/checker/bad/gold/mappair.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7909",
+  "gas_remaining": "7618",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/mappair2.scilla.gold
+++ b/tests/checker/bad/gold/mappair2.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7909",
+  "gas_remaining": "7572",
   "errors": [
     {
       "error_message": "Identifier malMessage1 used more than once\n",

--- a/tests/checker/bad/gold/match-in-transition.scilla.gold
+++ b/tests/checker/bad/gold/match-in-transition.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7970",
   "errors": [
     {
       "error_message": "Type error(s) in contract Matcher:\n",

--- a/tests/checker/bad/gold/message_field.scilla.gold
+++ b/tests/checker/bad/gold/message_field.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7913",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/message_field2.scilla.gold
+++ b/tests/checker/bad/gold/message_field2.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7947",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/message_field3.scilla.gold
+++ b/tests/checker/bad/gold/message_field3.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7946",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/mutually_recursive_procedure.scilla.gold
+++ b/tests/checker/bad/gold/mutually_recursive_procedure.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7962",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/name_clashes.scilla.gold
+++ b/tests/checker/bad/gold/name_clashes.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7916",
   "errors": [
     {
       "error_message": "Identifier Proc1 used more than once\n",

--- a/tests/checker/bad/gold/namespace1.scilla.gold
+++ b/tests/checker/bad/gold/namespace1.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7981",
   "errors": [
     {
       "error_message": "Unknown namespace Bar",

--- a/tests/checker/bad/gold/procedure_bad_args.scilla.gold
+++ b/tests/checker/bad/gold/procedure_bad_args.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7916",
   "errors": [
     {
       "error_message": "Incorrect number of arguments to procedure",

--- a/tests/checker/bad/gold/procedure_bad_type.scilla.gold
+++ b/tests/checker/bad/gold/procedure_bad_type.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7952",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/procedure_env.scilla.gold
+++ b/tests/checker/bad/gold/procedure_env.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7958",
   "errors": [
     {
       "error_message": "Couldn't resolve the identifier \"_tag\".\n",

--- a/tests/checker/bad/gold/procedure_map_arg.scilla.gold
+++ b/tests/checker/bad/gold/procedure_map_arg.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7898",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/recursive_procedure.scilla.gold
+++ b/tests/checker/bad/gold/recursive_procedure.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7975",
   "errors": [
     {
       "error_message": "Type error(s) in contract RecursiveProcedure:\n",

--- a/tests/checker/bad/gold/remote_read_bad_1.scilla.gold
+++ b/tests/checker/bad/gold/remote_read_bad_1.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7916",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/remote_read_bad_2.scilla.gold
+++ b/tests/checker/bad/gold/remote_read_bad_2.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7915",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/remote_read_bad_3.scilla.gold
+++ b/tests/checker/bad/gold/remote_read_bad_3.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7933",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/remote_read_non_address.scilla.gold
+++ b/tests/checker/bad/gold/remote_read_non_address.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7981",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/remote_read_spid.scilla.gold
+++ b/tests/checker/bad/gold/remote_read_spid.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7981",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/send_event1.scilla.gold
+++ b/tests/checker/bad/gold/send_event1.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7160",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/send_event2.scilla.gold
+++ b/tests/checker/bad/gold/send_event2.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7161",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/unbound.scilla.gold
+++ b/tests/checker/bad/gold/unbound.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7418",
   "errors": [
     {
       "error_message": "Type error(s) in contract Crowdfunding:\n",

--- a/tests/checker/bad/gold/unserializable_param.scilla.gold
+++ b/tests/checker/bad/gold/unserializable_param.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7934",
   "errors": [
     {
       "error_message": "Type Test cannot be used as transition parameter",

--- a/tests/checker/bad/gold/unstorable_adt.scilla.gold
+++ b/tests/checker/bad/gold/unstorable_adt.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7939",
   "errors": [
     {
       "error_message":

--- a/tests/checker/bad/gold/zil_mod.scilla.gold
+++ b/tests/checker/bad/gold/zil_mod.scilla.gold
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "8000",
+  "gas_remaining": "7158",
   "errors": [
     {
       "error_message": "Type error(s) in contract ZilGame:\n",

--- a/tests/checker/good/gold/InstantiatedListUtils.scillib.gold
+++ b/tests/checker/good/gold/InstantiatedListUtils.scillib.gold
@@ -1,2 +1,2 @@
-{ "warnings": [], "gas_remaining": "7917" }
+{ "warnings": [], "gas_remaining": "7903" }
 

--- a/tests/checker/good/gold/TestLibNS1.scillib.gold
+++ b/tests/checker/good/gold/TestLibNS1.scillib.gold
@@ -1,2 +1,2 @@
-{ "warnings": [], "gas_remaining": "7999" }
+{ "warnings": [], "gas_remaining": "7984" }
 

--- a/tests/checker/good/gold/TestLibNS2.scillib.gold
+++ b/tests/checker/good/gold/TestLibNS2.scillib.gold
@@ -1,2 +1,2 @@
-{ "warnings": [], "gas_remaining": "7999" }
+{ "warnings": [], "gas_remaining": "7989" }
 

--- a/tests/checker/good/gold/TestLibNS3.scillib.gold
+++ b/tests/checker/good/gold/TestLibNS3.scillib.gold
@@ -1,2 +1,2 @@
-{ "warnings": [], "gas_remaining": "7999" }
+{ "warnings": [], "gas_remaining": "7973" }
 

--- a/tests/checker/good/gold/TestLibNS4.scillib.gold
+++ b/tests/checker/good/gold/TestLibNS4.scillib.gold
@@ -1,2 +1,2 @@
-{ "warnings": [], "gas_remaining": "7999" }
+{ "warnings": [], "gas_remaining": "7975" }
 

--- a/tests/checker/good/gold/UintParam.scilla.gold
+++ b/tests/checker/good/gold/UintParam.scilla.gold
@@ -86,6 +86,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7964"
 }
 

--- a/tests/checker/good/gold/address_eq_test.scilla.gold
+++ b/tests/checker/good/gold/address_eq_test.scilla.gold
@@ -423,6 +423,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7512"
 }
 

--- a/tests/checker/good/gold/address_list_as_cparam.scilla.gold
+++ b/tests/checker/good/gold/address_list_as_cparam.scilla.gold
@@ -84,6 +84,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7981"
 }
 

--- a/tests/checker/good/gold/address_list_traversal.scilla.gold
+++ b/tests/checker/good/gold/address_list_traversal.scilla.gold
@@ -126,6 +126,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7913"
+  "gas_remaining": "7714"
 }
 

--- a/tests/checker/good/gold/adt_test.scilla.gold
+++ b/tests/checker/good/gold/adt_test.scilla.gold
@@ -112,6 +112,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7957"
 }
 

--- a/tests/checker/good/gold/auction.scilla.gold
+++ b/tests/checker/good/gold/auction.scilla.gold
@@ -105,6 +105,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7406"
 }
 

--- a/tests/checker/good/gold/auction.scilla.typeinfo.gold
+++ b/tests/checker/good/gold/auction.scilla.typeinfo.gold
@@ -2699,6 +2699,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7406"
 }
 

--- a/tests/checker/good/gold/backward_definition_procedure.scilla.gold
+++ b/tests/checker/good/gold/backward_definition_procedure.scilla.gold
@@ -93,6 +93,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7959"
 }
 

--- a/tests/checker/good/gold/blockchain_import.scilla.gold
+++ b/tests/checker/good/gold/blockchain_import.scilla.gold
@@ -11,6 +11,6 @@
       "warning_id": 3
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7914"
 }
 

--- a/tests/checker/good/gold/blowup_1.scilla.gold
+++ b/tests/checker/good/gold/blowup_1.scilla.gold
@@ -110,6 +110,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "5951"
+  "gas_remaining": "5864"
 }
 

--- a/tests/checker/good/gold/blowup_2.scilla.gold
+++ b/tests/checker/good/gold/blowup_2.scilla.gold
@@ -110,6 +110,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "3903"
+  "gas_remaining": "3811"
 }
 

--- a/tests/checker/good/gold/bookstore.scilla.gold
+++ b/tests/checker/good/gold/bookstore.scilla.gold
@@ -245,6 +245,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "6832"
 }
 

--- a/tests/checker/good/gold/builtin_type_args.scilla.gold
+++ b/tests/checker/good/gold/builtin_type_args.scilla.gold
@@ -67,6 +67,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7977"
 }
 

--- a/tests/checker/good/gold/cashflow_test.scilla.gold
+++ b/tests/checker/good/gold/cashflow_test.scilla.gold
@@ -134,6 +134,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7829"
 }
 

--- a/tests/checker/good/gold/cfinvoke.scilla.gold
+++ b/tests/checker/good/gold/cfinvoke.scilla.gold
@@ -85,6 +85,6 @@
       "warning_id": 3
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7800"
 }
 

--- a/tests/checker/good/gold/chain-call-balance-1.scilla.gold
+++ b/tests/checker/good/gold/chain-call-balance-1.scilla.gold
@@ -58,6 +58,6 @@
     ]
   },
   "warnings": [],
-  "gas_remaining": "7999"
+  "gas_remaining": "7941"
 }
 

--- a/tests/checker/good/gold/chain-call-balance-2.scilla.gold
+++ b/tests/checker/good/gold/chain-call-balance-2.scilla.gold
@@ -55,6 +55,6 @@
     ]
   },
   "warnings": [],
-  "gas_remaining": "7999"
+  "gas_remaining": "7947"
 }
 

--- a/tests/checker/good/gold/chain-call-balance-3.scilla.gold
+++ b/tests/checker/good/gold/chain-call-balance-3.scilla.gold
@@ -52,6 +52,6 @@
     ]
   },
   "warnings": [],
-  "gas_remaining": "7999"
+  "gas_remaining": "7950"
 }
 

--- a/tests/checker/good/gold/constraint.scilla.gold
+++ b/tests/checker/good/gold/constraint.scilla.gold
@@ -60,6 +60,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7976"
 }
 

--- a/tests/checker/good/gold/constraint_scope.scilla.gold
+++ b/tests/checker/good/gold/constraint_scope.scilla.gold
@@ -137,6 +137,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7933"
 }
 

--- a/tests/checker/good/gold/crowdfunding.scilla.gold
+++ b/tests/checker/good/gold/crowdfunding.scilla.gold
@@ -139,6 +139,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7477"
 }
 

--- a/tests/checker/good/gold/crowdfunding_proc.scilla.gold
+++ b/tests/checker/good/gold/crowdfunding_proc.scilla.gold
@@ -132,6 +132,6 @@
     ]
   },
   "warnings": [],
-  "gas_remaining": "7999"
+  "gas_remaining": "7417"
 }
 

--- a/tests/checker/good/gold/dead_code_test1.scilla.gold
+++ b/tests/checker/good/gold/dead_code_test1.scilla.gold
@@ -378,6 +378,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "6833"
 }
 

--- a/tests/checker/good/gold/dead_code_test2.scilla.gold
+++ b/tests/checker/good/gold/dead_code_test2.scilla.gold
@@ -88,6 +88,6 @@
       "warning_id": 3
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7947"
 }
 

--- a/tests/checker/good/gold/dead_code_test3.scilla.gold
+++ b/tests/checker/good/gold/dead_code_test3.scilla.gold
@@ -87,6 +87,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7959"
 }
 

--- a/tests/checker/good/gold/dead_code_test4.scilla.gold
+++ b/tests/checker/good/gold/dead_code_test4.scilla.gold
@@ -134,6 +134,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7930"
 }
 

--- a/tests/checker/good/gold/earmarked-coin.scilla.gold
+++ b/tests/checker/good/gold/earmarked-coin.scilla.gold
@@ -142,6 +142,6 @@
       "warning_id": 3
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7554"
 }
 

--- a/tests/checker/good/gold/ecdsa.scilla.gold
+++ b/tests/checker/good/gold/ecdsa.scilla.gold
@@ -113,6 +113,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7997"
+  "gas_remaining": "7875"
 }
 

--- a/tests/checker/good/gold/empty.scilla.gold
+++ b/tests/checker/good/gold/empty.scilla.gold
@@ -107,6 +107,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7855"
+  "gas_remaining": "7834"
 }
 

--- a/tests/checker/good/gold/event_reordered_fields.scilla.gold
+++ b/tests/checker/good/gold/event_reordered_fields.scilla.gold
@@ -100,6 +100,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7973"
 }
 

--- a/tests/checker/good/gold/fungible-token.scilla.gold
+++ b/tests/checker/good/gold/fungible-token.scilla.gold
@@ -156,6 +156,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7232"
 }
 

--- a/tests/checker/good/gold/helloWorld.scilla.gold
+++ b/tests/checker/good/gold/helloWorld.scilla.gold
@@ -94,6 +94,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7918"
+  "gas_remaining": "7744"
 }
 

--- a/tests/checker/good/gold/import-test-lib.scilla.gold
+++ b/tests/checker/good/gold/import-test-lib.scilla.gold
@@ -126,6 +126,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7859"
+  "gas_remaining": "7515"
 }
 

--- a/tests/checker/good/gold/import-test-lib2.scilla.gold
+++ b/tests/checker/good/gold/import-test-lib2.scilla.gold
@@ -119,6 +119,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7711"
 }
 

--- a/tests/checker/good/gold/import-test-lib3.scilla.gold
+++ b/tests/checker/good/gold/import-test-lib3.scilla.gold
@@ -81,6 +81,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7767"
 }
 

--- a/tests/checker/good/gold/inplace-map.scilla.gold
+++ b/tests/checker/good/gold/inplace-map.scilla.gold
@@ -141,6 +141,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7913"
+  "gas_remaining": "7688"
 }
 

--- a/tests/checker/good/gold/lib_typing.scilla.gold
+++ b/tests/checker/good/gold/lib_typing.scilla.gold
@@ -87,6 +87,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7984"
 }
 

--- a/tests/checker/good/gold/lib_typing2.scilla.gold
+++ b/tests/checker/good/gold/lib_typing2.scilla.gold
@@ -67,6 +67,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7996"
+  "gas_remaining": "7895"
 }
 

--- a/tests/checker/good/gold/libchain1.scilla.gold
+++ b/tests/checker/good/gold/libchain1.scilla.gold
@@ -95,6 +95,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7917"
+  "gas_remaining": "7904"
 }
 

--- a/tests/checker/good/gold/libchain2.scilla.gold
+++ b/tests/checker/good/gold/libchain2.scilla.gold
@@ -95,6 +95,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7916"
+  "gas_remaining": "7903"
 }
 

--- a/tests/checker/good/gold/libdiamond.scilla.gold
+++ b/tests/checker/good/gold/libdiamond.scilla.gold
@@ -67,6 +67,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7989"
 }
 

--- a/tests/checker/good/gold/libdiamond2.scilla.gold
+++ b/tests/checker/good/gold/libdiamond2.scilla.gold
@@ -77,6 +77,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7980"
 }
 

--- a/tests/checker/good/gold/listiter.scilla.gold
+++ b/tests/checker/good/gold/listiter.scilla.gold
@@ -95,6 +95,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7957"
 }
 

--- a/tests/checker/good/gold/map-inplace-update-with-_sender.scilla.gold
+++ b/tests/checker/good/gold/map-inplace-update-with-_sender.scilla.gold
@@ -72,6 +72,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7981"
 }
 

--- a/tests/checker/good/gold/map_as_cparam.scilla.gold
+++ b/tests/checker/good/gold/map_as_cparam.scilla.gold
@@ -86,6 +86,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7966"
 }
 

--- a/tests/checker/good/gold/map_corners_test.scilla.gold
+++ b/tests/checker/good/gold/map_corners_test.scilla.gold
@@ -265,6 +265,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "5967"
 }
 

--- a/tests/checker/good/gold/map_corners_test.scilla.typeinfo.gold
+++ b/tests/checker/good/gold/map_corners_test.scilla.typeinfo.gold
@@ -9870,6 +9870,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "5967"
 }
 

--- a/tests/checker/good/gold/map_key_test.scilla.gold
+++ b/tests/checker/good/gold/map_key_test.scilla.gold
@@ -131,6 +131,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7970"
 }
 

--- a/tests/checker/good/gold/map_no_inplace_warn.scilla.gold
+++ b/tests/checker/good/gold/map_no_inplace_warn.scilla.gold
@@ -163,6 +163,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7936"
 }
 

--- a/tests/checker/good/gold/mappair.scilla.gold
+++ b/tests/checker/good/gold/mappair.scilla.gold
@@ -157,6 +157,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7907"
+  "gas_remaining": "7547"
 }
 

--- a/tests/checker/good/gold/missing-accepts.scilla.gold
+++ b/tests/checker/good/gold/missing-accepts.scilla.gold
@@ -83,6 +83,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7976"
 }
 

--- a/tests/checker/good/gold/multiple-accepts.scilla.gold
+++ b/tests/checker/good/gold/multiple-accepts.scilla.gold
@@ -309,6 +309,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7941"
+  "gas_remaining": "7705"
 }
 

--- a/tests/checker/good/gold/multiple-msgs.scilla.gold
+++ b/tests/checker/good/gold/multiple-msgs.scilla.gold
@@ -67,6 +67,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7918"
+  "gas_remaining": "7822"
 }
 

--- a/tests/checker/good/gold/namespace1.scilla.gold
+++ b/tests/checker/good/gold/namespace1.scilla.gold
@@ -95,6 +95,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7917"
+  "gas_remaining": "7904"
 }
 

--- a/tests/checker/good/gold/namespace2.scilla.gold
+++ b/tests/checker/good/gold/namespace2.scilla.gold
@@ -67,6 +67,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7918"
+  "gas_remaining": "7906"
 }
 

--- a/tests/checker/good/gold/namespace3.scilla.gold
+++ b/tests/checker/good/gold/namespace3.scilla.gold
@@ -124,6 +124,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7917"
+  "gas_remaining": "7888"
 }
 

--- a/tests/checker/good/gold/nested-comments.scilla.gold
+++ b/tests/checker/good/gold/nested-comments.scilla.gold
@@ -57,6 +57,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7971"
 }
 

--- a/tests/checker/good/gold/nonfungible-token.scilla.gold
+++ b/tests/checker/good/gold/nonfungible-token.scilla.gold
@@ -342,6 +342,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "6462"
 }
 

--- a/tests/checker/good/gold/one-accept.scilla.gold
+++ b/tests/checker/good/gold/one-accept.scilla.gold
@@ -65,6 +65,6 @@
     ]
   },
   "warnings": [],
-  "gas_remaining": "7999"
+  "gas_remaining": "7919"
 }
 

--- a/tests/checker/good/gold/one-msg.scilla.gold
+++ b/tests/checker/good/gold/one-msg.scilla.gold
@@ -67,6 +67,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7918"
+  "gas_remaining": "7815"
 }
 

--- a/tests/checker/good/gold/one-msg1.scilla.gold
+++ b/tests/checker/good/gold/one-msg1.scilla.gold
@@ -77,6 +77,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7918"
+  "gas_remaining": "7794"
 }
 

--- a/tests/checker/good/gold/one-msg2.scilla.gold
+++ b/tests/checker/good/gold/one-msg2.scilla.gold
@@ -72,6 +72,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7918"
+  "gas_remaining": "7804"
 }
 

--- a/tests/checker/good/gold/one-msg3.scilla.gold
+++ b/tests/checker/good/gold/one-msg3.scilla.gold
@@ -82,6 +82,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7918"
+  "gas_remaining": "7813"
 }
 

--- a/tests/checker/good/gold/one-transition-accepts.scilla.gold
+++ b/tests/checker/good/gold/one-transition-accepts.scilla.gold
@@ -76,6 +76,6 @@
       "warning_id": 3
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7978"
 }
 

--- a/tests/checker/good/gold/one-transition-might-accept.scilla.gold
+++ b/tests/checker/good/gold/one-transition-might-accept.scilla.gold
@@ -69,6 +69,6 @@
       "warning_id": 3
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7964"
 }
 

--- a/tests/checker/good/gold/ping.scilla.gold
+++ b/tests/checker/good/gold/ping.scilla.gold
@@ -76,6 +76,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7856"
 }
 

--- a/tests/checker/good/gold/polymorphic_address.scilla.gold
+++ b/tests/checker/good/gold/polymorphic_address.scilla.gold
@@ -117,6 +117,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7916"
+  "gas_remaining": "7823"
 }
 

--- a/tests/checker/good/gold/pong.scilla.gold
+++ b/tests/checker/good/gold/pong.scilla.gold
@@ -76,6 +76,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7856"
 }
 

--- a/tests/checker/good/gold/remote_state_reads.scilla.gold
+++ b/tests/checker/good/gold/remote_state_reads.scilla.gold
@@ -592,6 +592,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7157"
 }
 

--- a/tests/checker/good/gold/remote_state_reads_2.scilla.gold
+++ b/tests/checker/good/gold/remote_state_reads_2.scilla.gold
@@ -156,6 +156,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7750"
 }
 

--- a/tests/checker/good/gold/schnorr.scilla.gold
+++ b/tests/checker/good/gold/schnorr.scilla.gold
@@ -111,6 +111,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7997"
+  "gas_remaining": "7874"
 }
 

--- a/tests/checker/good/gold/shadow_import.scilla.gold
+++ b/tests/checker/good/gold/shadow_import.scilla.gold
@@ -86,6 +86,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7918"
+  "gas_remaining": "7856"
 }
 

--- a/tests/checker/good/gold/shadowwarn1.scilla.gold
+++ b/tests/checker/good/gold/shadowwarn1.scilla.gold
@@ -92,6 +92,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7989"
 }
 

--- a/tests/checker/good/gold/shadowwarn2.scilla.gold
+++ b/tests/checker/good/gold/shadowwarn2.scilla.gold
@@ -129,6 +129,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7982"
 }
 

--- a/tests/checker/good/gold/shadowwarn3.scilla.gold
+++ b/tests/checker/good/gold/shadowwarn3.scilla.gold
@@ -129,6 +129,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7965"
 }
 

--- a/tests/checker/good/gold/shogi.scilla.gold
+++ b/tests/checker/good/gold/shogi.scilla.gold
@@ -245,6 +245,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7915"
+  "gas_remaining": "4597"
 }
 

--- a/tests/checker/good/gold/shogi_proc.scilla.gold
+++ b/tests/checker/good/gold/shogi_proc.scilla.gold
@@ -297,6 +297,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7915"
+  "gas_remaining": "4797"
 }
 

--- a/tests/checker/good/gold/simple-dex-remote-reads.scilla.gold
+++ b/tests/checker/good/gold/simple-dex-remote-reads.scilla.gold
@@ -294,6 +294,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7941"
+  "gas_remaining": "6577"
 }
 

--- a/tests/checker/good/gold/simple-dex-shadowwarn.scilla.gold
+++ b/tests/checker/good/gold/simple-dex-shadowwarn.scilla.gold
@@ -201,6 +201,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7993"
+  "gas_remaining": "6876"
 }
 

--- a/tests/checker/good/gold/simple-dex.scilla.gold
+++ b/tests/checker/good/gold/simple-dex.scilla.gold
@@ -191,6 +191,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7993"
+  "gas_remaining": "6874"
 }
 

--- a/tests/checker/good/gold/type_casts.scilla.gold
+++ b/tests/checker/good/gold/type_casts.scilla.gold
@@ -382,6 +382,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7314"
 }
 

--- a/tests/checker/good/gold/ud-proxy.scilla.gold
+++ b/tests/checker/good/gold/ud-proxy.scilla.gold
@@ -114,6 +114,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7918"
+  "gas_remaining": "7748"
 }
 

--- a/tests/checker/good/gold/ud-registry.scilla.gold
+++ b/tests/checker/good/gold/ud-registry.scilla.gold
@@ -245,6 +245,6 @@
       "warning_id": 3
     }
   ],
-  "gas_remaining": "7916"
+  "gas_remaining": "6429"
 }
 

--- a/tests/checker/good/gold/wallet.scilla.gold
+++ b/tests/checker/good/gold/wallet.scilla.gold
@@ -375,6 +375,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7856"
+  "gas_remaining": "5731"
 }
 

--- a/tests/checker/good/gold/wallet_2.scilla.gold
+++ b/tests/checker/good/gold/wallet_2.scilla.gold
@@ -231,6 +231,6 @@
       "warning_id": 3
     }
   ],
-  "gas_remaining": "7856"
+  "gas_remaining": "6088"
 }
 

--- a/tests/checker/good/gold/zil-game.scilla.gold
+++ b/tests/checker/good/gold/zil-game.scilla.gold
@@ -117,6 +117,6 @@
       "warning_id": 1
     }
   ],
-  "gas_remaining": "7999"
+  "gas_remaining": "7160"
 }
 

--- a/tests/runner/0x111256789012345678901234567890123456abef/init_output.json
+++ b/tests/runner/0x111256789012345678901234567890123456abef/init_output.json
@@ -1,1 +1,1 @@
-{ "gas_remaining": "7825" }
+{ "gas_remaining": "7995" }

--- a/tests/runner/TestLib2/init_output.json
+++ b/tests/runner/TestLib2/init_output.json
@@ -1,1 +1,1 @@
-{ "gas_remaining": "7881" }
+{ "gas_remaining": "7993" }

--- a/tests/runner/TestLib2/init_wrong_version_output.json
+++ b/tests/runner/TestLib2/init_wrong_version_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7869",
+  "gas_remaining": "7981",
   "errors": [
     {
       "error_message": "Scilla version mismatch\n",

--- a/tests/runner/Testcontracts.ml
+++ b/tests/runner/Testcontracts.ml
@@ -292,6 +292,8 @@ let build_misc_tests env =
       [
         "-init";
         tests_dir_file env.tests_dir test_ctxt ("init_bad" ^ snum ^. "json");
+        "-gaslimit";
+        testsuit_gas_limit;
         "-libdir";
         "src" ^/ "stdlib";
         "-jsonerrors";

--- a/tests/runner/address_list_as_cparam/init_address_type_ipc_output.json
+++ b/tests/runner/address_list_as_cparam/init_address_type_ipc_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7867",
+  "gas_remaining": "7999",
   "errors": [
     {
       "error_message": "Address type not allowed in json file",

--- a/tests/runner/address_list_as_cparam/init_illegal_type_ipc_output.json
+++ b/tests/runner/address_list_as_cparam/init_illegal_type_ipc_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7877",
+  "gas_remaining": "7999",
   "errors": [
     {
       "error_message": "Address type not allowed in json file",

--- a/tests/runner/address_list_as_cparam/init_illegal_value_ipc_output.json
+++ b/tests/runner/address_list_as_cparam/init_illegal_value_ipc_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7880",
+  "gas_remaining": "7998",
   "errors": [
     {
       "error_message":

--- a/tests/runner/address_list_as_cparam/init_ipc_output.json
+++ b/tests/runner/address_list_as_cparam/init_ipc_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "63044",
+  "gas_remaining": "63988",
   "_accepted": "false",
   "messages": null,
   "states": [ { "vname": "_balance", "type": "Uint128", "value": "0" } ],

--- a/tests/runner/constraint/init_output.json
+++ b/tests/runner/constraint/init_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7914",
+  "gas_remaining": "7998",
   "errors": [
     {
       "error_message": "Contract constraint violation.\n",

--- a/tests/runner/creationtest/init_output.json
+++ b/tests/runner/creationtest/init_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "63501",
+  "gas_remaining": "63987",
   "_accepted": "false",
   "messages": null,
   "states": [

--- a/tests/runner/crowdfunding/init_output.json
+++ b/tests/runner/crowdfunding/init_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "59111",
+  "gas_remaining": "63947",
   "_accepted": "false",
   "messages": null,
   "states": [

--- a/tests/runner/crowdfunding_proc/init_goal_is_zero_output.json
+++ b/tests/runner/crowdfunding_proc/init_goal_is_zero_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7327",
+  "gas_remaining": "7992",
   "errors": [
     {
       "error_message": "Contract constraint violation.\n",

--- a/tests/runner/map_as_cparam/init_illegal_key_ipc_output.json
+++ b/tests/runner/map_as_cparam/init_illegal_key_ipc_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7860",
+  "gas_remaining": "7999",
   "errors": [
     {
       "error_message": "Address type not allowed in json file",

--- a/tests/runner/map_as_cparam/init_illegal_value_ipc_output.json
+++ b/tests/runner/map_as_cparam/init_illegal_value_ipc_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7861",
+  "gas_remaining": "7999",
   "errors": [
     {
       "error_message": "Address type not allowed in json file",

--- a/tests/runner/map_as_cparam/init_ipc_output.json
+++ b/tests/runner/map_as_cparam/init_ipc_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "62937",
+  "gas_remaining": "63988",
   "_accepted": "false",
   "messages": null,
   "states": [ { "vname": "_balance", "type": "Uint128", "value": "0" } ],

--- a/tests/runner/map_as_cparam/init_unassignable_2_ipc_output.json
+++ b/tests/runner/map_as_cparam/init_unassignable_2_ipc_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "62937",
+  "gas_remaining": "63988",
   "_accepted": "false",
   "messages": null,
   "states": [ { "vname": "_balance", "type": "Uint128", "value": "0" } ],

--- a/tests/runner/map_as_cparam/init_unassignable_ipc_output.json
+++ b/tests/runner/map_as_cparam/init_unassignable_ipc_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "62937",
+  "gas_remaining": "63988",
   "_accepted": "false",
   "messages": null,
   "states": [ { "vname": "_balance", "type": "Uint128", "value": "0" } ],

--- a/tests/runner/remote_state_reads/init_address_type_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_address_type_ipc_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7063",
+  "gas_remaining": "7999",
   "errors": [
     {
       "error_message": "Address type not allowed in json file",

--- a/tests/runner/remote_state_reads/init_assignable_map_types_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_assignable_map_types_ipc_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "56479",
+  "gas_remaining": "63960",
   "_accepted": "false",
   "messages": null,
   "states": [ { "vname": "_balance", "type": "Uint128", "value": "0" } ],

--- a/tests/runner/remote_state_reads/init_balance_and_nonce_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_balance_and_nonce_ipc_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "56479",
+  "gas_remaining": "63960",
   "_accepted": "false",
   "messages": null,
   "states": [ { "vname": "_balance", "type": "Uint128", "value": "0" } ],

--- a/tests/runner/remote_state_reads/init_balance_no_nonce_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_balance_no_nonce_ipc_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "56479",
+  "gas_remaining": "63960",
   "_accepted": "false",
   "messages": null,
   "states": [ { "vname": "_balance", "type": "Uint128", "value": "0" } ],

--- a/tests/runner/remote_state_reads/init_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_ipc_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "56479",
+  "gas_remaining": "63960",
   "_accepted": "false",
   "messages": null,
   "states": [ { "vname": "_balance", "type": "Uint128", "value": "0" } ],

--- a/tests/runner/remote_state_reads/init_missing_field_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_missing_field_ipc_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7058",
+  "gas_remaining": "7994",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/init_no_address_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_no_address_ipc_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7058",
+  "gas_remaining": "7993",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/init_nonce_no_balance_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_nonce_no_balance_ipc_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "56479",
+  "gas_remaining": "63960",
   "_accepted": "false",
   "messages": null,
   "states": [ { "vname": "_balance", "type": "Uint128", "value": "0" } ],

--- a/tests/runner/remote_state_reads/init_wrong_address_field_type_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_wrong_address_field_type_ipc_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7058",
+  "gas_remaining": "7994",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/init_wrong_field_type_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_wrong_field_type_ipc_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7058",
+  "gas_remaining": "7994",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/init_wrong_map_type_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_wrong_map_type_ipc_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7058",
+  "gas_remaining": "7994",
   "errors": [
     {
       "error_message":

--- a/tests/runner/wallet_2/init_no_owners_output.json
+++ b/tests/runner/wallet_2/init_no_owners_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "6082",
+  "gas_remaining": "7932",
   "errors": [
     {
       "error_message": "Contract constraint violation.\n",

--- a/tests/runner/wallet_2/init_not_enough_owners_output.json
+++ b/tests/runner/wallet_2/init_not_enough_owners_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "5965",
+  "gas_remaining": "7927",
   "errors": [
     {
       "error_message": "Contract constraint violation.\n",

--- a/tests/runner/wallet_2/init_req_sigs_zero_output.json
+++ b/tests/runner/wallet_2/init_req_sigs_zero_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "5965",
+  "gas_remaining": "7927",
   "errors": [
     {
       "error_message": "Contract constraint violation.\n",

--- a/tests/runner/zil-game/init_output.json
+++ b/tests/runner/zil-game/init_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "56323",
+  "gas_remaining": "63936",
   "_accepted": "false",
   "messages": null,
   "states": [


### PR DESCRIPTION
The blockchain runs the checker prior to running the interpreter during a deployment. Since this check must be done at the earliest, move it to the checker.