### PR TITLE
Fix OpenSSL version at 1.1 for macOS installation

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -6,7 +6,7 @@ brew "ocaml"
 brew "opam"
 brew "pkg-config"
 brew "libffi"
-brew "openssl"
+brew "openssl@1.1"
 brew "boost"
 brew "pcre"
 brew "domt4/crypto/secp256k1", args: ["with-enable-module-recovery"]


### PR DESCRIPTION
We don't support OpenSSL 3.0 for now -- this is the default
version for Homebrew at the moment.

Just in case, I put a small note into the wiki: https://github.com/Zilliqa/scilla/wiki/macOS-troubleshooting#openssl-related-build-errors.