### PR TITLE
make release image really slim

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -41,3 +41,26 @@ RUN bash scripts/install_cmake_ubuntu.sh \
     && echo '. ~/.opam/opam-init/init.sh > /dev/null 2> /dev/null || true ' >> ~/.bashrc \
     && eval $(opam env) && \
     make slim
+
+# Generate a minified release image
+RUN mkdir -p /scilla/0/bin2/ && cp -L /scilla/0/bin/* /scilla/0/bin2/ && strip /scilla/0/bin2/*
+
+FROM ${BASE_IMAGE}
+
+RUN mkdir -p \
+    /scilla/0/bin \
+    /scilla/0/src/stdlib
+WORKDIR /scilla/0
+# pour in scilla binaries
+COPY --from=builder  /scilla/0/bin2            /scilla/0/bin
+# pour in scilla conntract stdlibs
+COPY --from=builder  /scilla/0/src/stdlib     /scilla/0/src/stdlib
+# put bins into one of dir in PATH
+RUN ln -s /scilla/0/bin/* /usr/local/bin/ \
+    && apt-get update \
+    && apt-get install -y software-properties-common \
+    && add-apt-repository ppa:avsm/ppa -y \
+    && apt-get update && apt-get install -y --no-install-recommends \
+    libssl-dev \
+    libsecp256k1-dev \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
like Zilliqa release image, make scilla release image size from 3.36GB to ~270MB (uncompressed)

> trying to run scilla on my macbook, but current release image takes too much time to pull
> and the .slim image is not slim at all