### PR TITLE
Only once: Initialize libraries, fields and check constraint

### DIFF
--- a/src/eval/Runner.ml
+++ b/src/eval/Runner.ml
@@ -543,7 +543,6 @@ let run_with_args args =
                     perform_dynamic_typechecks dyn_checks gas_remaining
                   in
                   match
-                    (* TODO: Move gas accounting for initialization here? It's currently inside init_module. *)
                     let%bind () =
                       Result.ignore_m
                       @@ mapM field_vals' ~f:(fun (s, _t, v) ->

--- a/src/eval/Runner.ml
+++ b/src/eval/Runner.ml
@@ -57,7 +57,15 @@ let check_libs clibs elibs name gas_limit =
               (List.rev_map res ~f:(fun x ->
                    EvalUtil.EvalName.as_string (fst x))))
            name);
-      gas_remaining
+      (res, gas_remaining)
+  | Error (err, gas_remaining) ->
+      fatal_error_gas_scale Gas.scale_factor err gas_remaining
+
+let check_contr_wrapper libs_env cconstraint cfields initargs curargs gas_limit
+    =
+  let ls = check_contr libs_env cconstraint cfields initargs curargs in
+  match ls Eval.init_gas_kont gas_limit with
+  | Ok (res, gas_remaining) -> (res, gas_remaining)
   | Error (err, gas_remaining) ->
       fatal_error_gas_scale Gas.scale_factor err gas_remaining
 
@@ -68,9 +76,9 @@ let check_extract_cstate name res gas_limit =
   match res Eval.init_gas_kont gas_limit with
   | Error (err, remaining_gas) ->
       fatal_error_gas_scale Gas.scale_factor err remaining_gas
-  | Ok ((_, cstate, field_vals, dyn_checks), remaining_gas) ->
+  | Ok ((_, cstate, dyn_checks), remaining_gas) ->
       plog (sprintf "[Initializing %s's fields]\nSuccess!\n" name);
-      (cstate, remaining_gas, field_vals, dyn_checks)
+      (cstate, remaining_gas, dyn_checks)
 
 (****************************************************)
 (*           Checking prepared message              *)
@@ -353,7 +361,7 @@ let deploy_library args gas_remaining =
           let clibs = Some dis_lmod.libs in
 
           (* Checking initialized libraries! *)
-          let gas_remaining' =
+          let _, gas_remaining' =
             check_libs clibs elibs args.input gas_remaining
           in
           let _ =
@@ -465,7 +473,7 @@ let run_with_args args =
             let clibs = dis_cmod.libs in
 
             (* Checking initialized libraries! *)
-            let gas_remaining =
+            let libs_env, gas_remaining =
               check_libs clibs elibs args.input gas_remaining
             in
             let initargs =
@@ -490,13 +498,17 @@ let run_with_args args =
                     accepted_b ),
                   gas ) =
               if is_deployment then (
+                let field_vals, gas_remaining =
+                  check_contr_wrapper libs_env dis_cmod.contr.cconstraint
+                    dis_cmod.contr.cfields initargs [] gas_remaining
+                in
                 (* Initializing the contract's state, just for checking things. *)
                 let init_res =
-                  init_module dis_cmod initargs [] Uint128.zero bstate elibs
+                  init_module libs_env dis_cmod initargs Uint128.zero bstate
                 in
                 (* Prints stats after the initialization and returns the initial state *)
                 (* Will throw an exception if unsuccessful. *)
-                let cstate', gas_remaining, field_vals, dyn_checks =
+                let cstate', gas_remaining, dyn_checks =
                   check_extract_cstate args.input init_res gas_remaining
                 in
                 (* If the data store is not local, we must update the store with the initial field values.
@@ -580,9 +592,9 @@ let run_with_args args =
                   if is_ipc then
                     let cur_bal = args.balance in
                     let init_res =
-                      init_module dis_cmod initargs [] cur_bal bstate elibs
+                      init_module libs_env dis_cmod initargs cur_bal bstate
                     in
-                    let cstate, gas_remaining, _, _dyn_checks =
+                    let cstate, gas_remaining, _dyn_checks =
                       check_extract_cstate args.input init_res gas_remaining
                     in
 
@@ -612,14 +624,17 @@ let run_with_args args =
                                  args.input_state))
                           gas_remaining
                     in
-
+                    let field_vals, _ignore_gas_remaining =
+                      check_contr_wrapper libs_env dis_cmod.contr.cconstraint
+                        dis_cmod.contr.cfields initargs curargs gas_remaining
+                    in
                     (* Initializing the contract's state *)
                     let init_res =
-                      init_module dis_cmod initargs curargs cur_bal bstate elibs
+                      init_module libs_env dis_cmod initargs cur_bal bstate
                     in
                     (* Prints stats after the initialization and returns the initial state *)
                     (* Will throw an exception if unsuccessful. *)
-                    let cstate, gas_remaining, field_vals, _dyn_checks =
+                    let cstate, gas_remaining, _dyn_checks =
                       check_extract_cstate args.input init_res gas_remaining
                     in
 

--- a/tests/runner/Polynetwork/output_1.json
+++ b/tests/runner/Polynetwork/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "2984",
+  "gas_remaining": "3025",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/Polynetwork/output_2.json
+++ b/tests/runner/Polynetwork/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "4621",
+  "gas_remaining": "4662",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/Polynetwork/output_25.json
+++ b/tests/runner/Polynetwork/output_25.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7198",
+  "gas_remaining": "7239",
   "errors": [
     {
       "error_message":

--- a/tests/runner/Polynetwork/output_26.json
+++ b/tests/runner/Polynetwork/output_26.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "4685",
+  "gas_remaining": "4726",
   "errors": [
     {
       "error_message":

--- a/tests/runner/Polynetwork/output_27.json
+++ b/tests/runner/Polynetwork/output_27.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "3642",
+  "gas_remaining": "3684",
   "errors": [
     {
       "error_message":

--- a/tests/runner/Polynetwork/output_28.json
+++ b/tests/runner/Polynetwork/output_28.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "2318",
+  "gas_remaining": "2359",
   "errors": [
     {
       "error_message":

--- a/tests/runner/Polynetwork/output_3.json
+++ b/tests/runner/Polynetwork/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "1843",
+  "gas_remaining": "1884",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/Polynetwork/output_4.json
+++ b/tests/runner/Polynetwork/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "2254",
+  "gas_remaining": "2295",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/addfunds/output_1.json
+++ b/tests/runner/addfunds/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7944",
+  "gas_remaining": "7945",
   "_accepted": "true",
   "messages": [],
   "states": [ { "vname": "_balance", "type": "Uint128", "value": "100" } ],

--- a/tests/runner/addfunds_proxy/output_1.json
+++ b/tests/runner/addfunds_proxy/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7951",
+  "gas_remaining": "7952",
   "_accepted": "true",
   "messages": [
     {

--- a/tests/runner/addfunds_proxy/output_2.json
+++ b/tests/runner/addfunds_proxy/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7958",
+  "gas_remaining": "7959",
   "_accepted": "true",
   "messages": [],
   "states": [

--- a/tests/runner/address_eq_test/output_1.json
+++ b/tests/runner/address_eq_test/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7930",
+  "gas_remaining": "7933",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/address_eq_test/output_10.json
+++ b/tests/runner/address_eq_test/output_10.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7943",
+  "gas_remaining": "7946",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/address_eq_test/output_11.json
+++ b/tests/runner/address_eq_test/output_11.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7935",
+  "gas_remaining": "7938",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/address_eq_test/output_2.json
+++ b/tests/runner/address_eq_test/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7930",
+  "gas_remaining": "7933",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/address_eq_test/output_3.json
+++ b/tests/runner/address_eq_test/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7931",
+  "gas_remaining": "7934",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/address_eq_test/output_4.json
+++ b/tests/runner/address_eq_test/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7931",
+  "gas_remaining": "7934",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/address_eq_test/output_5.json
+++ b/tests/runner/address_eq_test/output_5.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7931",
+  "gas_remaining": "7934",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/address_eq_test/output_6.json
+++ b/tests/runner/address_eq_test/output_6.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7948",
+  "gas_remaining": "7951",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/address_eq_test/output_7.json
+++ b/tests/runner/address_eq_test/output_7.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7945",
+  "gas_remaining": "7948",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/address_eq_test/output_8.json
+++ b/tests/runner/address_eq_test/output_8.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7923",
+  "gas_remaining": "7926",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/address_eq_test/output_9.json
+++ b/tests/runner/address_eq_test/output_9.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7919",
+  "gas_remaining": "7922",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/address_list_as_cparam/init_ipc_output.json
+++ b/tests/runner/address_list_as_cparam/init_ipc_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "63044",
+  "gas_remaining": "63049",
   "_accepted": "false",
   "messages": null,
   "states": [ { "vname": "_balance", "type": "Uint128", "value": "0" } ],

--- a/tests/runner/address_list_traversal/output_1.json
+++ b/tests/runner/address_list_traversal/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7896",
+  "gas_remaining": "7900",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/address_list_traversal/output_2.json
+++ b/tests/runner/address_list_traversal/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7901",
+  "gas_remaining": "7904",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/address_list_traversal/output_3.json
+++ b/tests/runner/address_list_traversal/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7891",
+  "gas_remaining": "7895",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/auction/output_1.json
+++ b/tests/runner/auction/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7915",
+  "gas_remaining": "7919",
   "_accepted": "true",
   "messages": [],
   "states": [

--- a/tests/runner/auction/output_2.json
+++ b/tests/runner/auction/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7910",
+  "gas_remaining": "7913",
   "_accepted": "true",
   "messages": [],
   "states": [

--- a/tests/runner/auction/output_3.json
+++ b/tests/runner/auction/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7920",
+  "gas_remaining": "7923",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/auction/output_4.json
+++ b/tests/runner/auction/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7923",
+  "gas_remaining": "7927",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/auction/output_5.json
+++ b/tests/runner/auction/output_5.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7923",
+  "gas_remaining": "7927",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/auction/output_6.json
+++ b/tests/runner/auction/output_6.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7936",
+  "gas_remaining": "7939",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/auction/output_7.json
+++ b/tests/runner/auction/output_7.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7936",
+  "gas_remaining": "7939",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/auction/output_8.json
+++ b/tests/runner/auction/output_8.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7919",
+  "gas_remaining": "7923",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/bookstore/output_1.json
+++ b/tests/runner/bookstore/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7904",
+  "gas_remaining": "7906",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/bookstore/output_10.json
+++ b/tests/runner/bookstore/output_10.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7906",
+  "gas_remaining": "7908",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/bookstore/output_11.json
+++ b/tests/runner/bookstore/output_11.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7933",
+  "gas_remaining": "7935",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/bookstore/output_12.json
+++ b/tests/runner/bookstore/output_12.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7912",
+  "gas_remaining": "7914",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/bookstore/output_2.json
+++ b/tests/runner/bookstore/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7908",
+  "gas_remaining": "7910",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/bookstore/output_3.json
+++ b/tests/runner/bookstore/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7907",
+  "gas_remaining": "7909",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/bookstore/output_4.json
+++ b/tests/runner/bookstore/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7906",
+  "gas_remaining": "7908",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/bookstore/output_5.json
+++ b/tests/runner/bookstore/output_5.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7940",
+  "gas_remaining": "7942",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/bookstore/output_6.json
+++ b/tests/runner/bookstore/output_6.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7911",
+  "gas_remaining": "7913",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/bookstore/output_7.json
+++ b/tests/runner/bookstore/output_7.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7940",
+  "gas_remaining": "7942",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/bookstore/output_8.json
+++ b/tests/runner/bookstore/output_8.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7913",
+  "gas_remaining": "7915",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/bookstore/output_9.json
+++ b/tests/runner/bookstore/output_9.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7912",
+  "gas_remaining": "7914",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/cfinvoke/output_1.json
+++ b/tests/runner/cfinvoke/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7939",
+  "gas_remaining": "7940",
   "_accepted": "true",
   "messages": [
     {

--- a/tests/runner/cfinvoke/output_2.json
+++ b/tests/runner/cfinvoke/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7936",
+  "gas_remaining": "7937",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/cfinvoke/output_3.json
+++ b/tests/runner/cfinvoke/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7933",
+  "gas_remaining": "7934",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/cfinvoke/output_4.json
+++ b/tests/runner/cfinvoke/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7959",
+  "gas_remaining": "7960",
   "_accepted": "true",
   "messages": [
     {

--- a/tests/runner/chain-call-balance-1/output_1.json
+++ b/tests/runner/chain-call-balance-1/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7915",
+  "gas_remaining": "7916",
   "_accepted": "true",
   "messages": [
     {

--- a/tests/runner/chain-call-balance-2/output_1.json
+++ b/tests/runner/chain-call-balance-2/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7939",
+  "gas_remaining": "7940",
   "_accepted": "true",
   "messages": [
     {

--- a/tests/runner/chain-call-balance-3/output_1.json
+++ b/tests/runner/chain-call-balance-3/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7959",
+  "gas_remaining": "7960",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/constraint/init_output.json
+++ b/tests/runner/constraint/init_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7914",
+  "gas_remaining": "7915",
   "errors": [
     {
       "error_message": "Contract constraint violation.\n",

--- a/tests/runner/creationtest/init_output.json
+++ b/tests/runner/creationtest/init_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "63501",
+  "gas_remaining": "63506",
   "_accepted": "false",
   "messages": null,
   "states": [

--- a/tests/runner/crowdfunding/init_output.json
+++ b/tests/runner/crowdfunding/init_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "59111",
+  "gas_remaining": "59136",
   "_accepted": "false",
   "messages": null,
   "states": [

--- a/tests/runner/crowdfunding/output_1.json
+++ b/tests/runner/crowdfunding/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7936",
+  "gas_remaining": "7939",
   "_accepted": "true",
   "messages": [],
   "states": [

--- a/tests/runner/crowdfunding/output_2.json
+++ b/tests/runner/crowdfunding/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7927",
+  "gas_remaining": "7930",
   "_accepted": "true",
   "messages": [],
   "states": [

--- a/tests/runner/crowdfunding/output_3.json
+++ b/tests/runner/crowdfunding/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7932",
+  "gas_remaining": "7935",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/crowdfunding/output_4.json
+++ b/tests/runner/crowdfunding/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7949",
+  "gas_remaining": "7952",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/crowdfunding/output_5.json
+++ b/tests/runner/crowdfunding/output_5.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7911",
+  "gas_remaining": "7915",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/crowdfunding/output_6.json
+++ b/tests/runner/crowdfunding/output_6.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7927",
+  "gas_remaining": "7931",
   "_accepted": "true",
   "messages": [],
   "states": [

--- a/tests/runner/crowdfunding_proc/init_goal_is_zero_output.json
+++ b/tests/runner/crowdfunding_proc/init_goal_is_zero_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7327",
+  "gas_remaining": "7331",
   "errors": [
     {
       "error_message": "Contract constraint violation.\n",

--- a/tests/runner/crowdfunding_proc/output_1.json
+++ b/tests/runner/crowdfunding_proc/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7938",
+  "gas_remaining": "7942",
   "_accepted": "true",
   "messages": [],
   "states": [

--- a/tests/runner/crowdfunding_proc/output_2.json
+++ b/tests/runner/crowdfunding_proc/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7938",
+  "gas_remaining": "7942",
   "_accepted": "true",
   "messages": [],
   "states": [

--- a/tests/runner/crowdfunding_proc/output_3.json
+++ b/tests/runner/crowdfunding_proc/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7940",
+  "gas_remaining": "7945",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/crowdfunding_proc/output_4.json
+++ b/tests/runner/crowdfunding_proc/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7947",
+  "gas_remaining": "7952",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/crowdfunding_proc/output_5.json
+++ b/tests/runner/crowdfunding_proc/output_5.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7919",
+  "gas_remaining": "7924",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/crowdfunding_proc/output_6.json
+++ b/tests/runner/crowdfunding_proc/output_6.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7938",
+  "gas_remaining": "7943",
   "_accepted": "true",
   "messages": [],
   "states": [

--- a/tests/runner/earmarked-coin/output_1.json
+++ b/tests/runner/earmarked-coin/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7928",
+  "gas_remaining": "7930",
   "_accepted": "true",
   "messages": [],
   "states": [

--- a/tests/runner/earmarked-coin/output_2.json
+++ b/tests/runner/earmarked-coin/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7907",
+  "gas_remaining": "7909",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/earmarked-coin/output_3.json
+++ b/tests/runner/earmarked-coin/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7923",
+  "gas_remaining": "7925",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/earmarked-coin/output_4.json
+++ b/tests/runner/earmarked-coin/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7930",
+  "gas_remaining": "7933",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/earmarked-coin/output_5.json
+++ b/tests/runner/earmarked-coin/output_5.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7931",
+  "gas_remaining": "7933",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/earmarked-coin/output_6.json
+++ b/tests/runner/earmarked-coin/output_6.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7952",
+  "gas_remaining": "7954",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/ecdsa/output_1.json
+++ b/tests/runner/ecdsa/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7862",
+  "gas_remaining": "7864",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/ecdsa/output_2.json
+++ b/tests/runner/ecdsa/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7861",
+  "gas_remaining": "7863",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/ecdsa/output_3.json
+++ b/tests/runner/ecdsa/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7862",
+  "gas_remaining": "7864",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/ecdsa/output_4.json
+++ b/tests/runner/ecdsa/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7867",
+  "gas_remaining": "7869",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/empty/output_1.json
+++ b/tests/runner/empty/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7916",
+  "gas_remaining": "7946",
   "_accepted": "false",
   "messages": [],
   "states": [ { "vname": "_balance", "type": "Uint128", "value": "0" } ],

--- a/tests/runner/exception-example/output_1.json
+++ b/tests/runner/exception-example/output_1.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7950",
+  "gas_remaining": "7951",
   "errors": [
     {
       "error_message":

--- a/tests/runner/fungible-token/output_0.json
+++ b/tests/runner/fungible-token/output_0.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7926",
+  "gas_remaining": "7928",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/fungible-token/output_1.json
+++ b/tests/runner/fungible-token/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7948",
+  "gas_remaining": "7950",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/fungible-token/output_2.json
+++ b/tests/runner/fungible-token/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7900",
+  "gas_remaining": "7902",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/fungible-token/output_3.json
+++ b/tests/runner/fungible-token/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7905",
+  "gas_remaining": "7906",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/fungible-token/output_4.json
+++ b/tests/runner/fungible-token/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7908",
+  "gas_remaining": "7910",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/fungible-token/output_5.json
+++ b/tests/runner/fungible-token/output_5.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7908",
+  "gas_remaining": "7910",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/fungible-token/output_6.json
+++ b/tests/runner/fungible-token/output_6.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7874",
+  "gas_remaining": "7876",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/fungible-token/output_7.json
+++ b/tests/runner/fungible-token/output_7.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7882",
+  "gas_remaining": "7884",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/fungible-token/output_8.json
+++ b/tests/runner/fungible-token/output_8.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7902",
+  "gas_remaining": "7904",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/helloWorld/output_1.json
+++ b/tests/runner/helloWorld/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7941",
+  "gas_remaining": "7944",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/helloWorld/output_2.json
+++ b/tests/runner/helloWorld/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7943",
+  "gas_remaining": "7947",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/helloWorld/output_3.json
+++ b/tests/runner/helloWorld/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7956",
+  "gas_remaining": "7960",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/helloWorld/output_4.json
+++ b/tests/runner/helloWorld/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7959",
+  "gas_remaining": "7962",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/helloWorld/output_5.json
+++ b/tests/runner/helloWorld/output_5.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7969",
+  "gas_remaining": "7972",
   "errors": [
     {
       "error_message": "Field Unknown : Int32 not defined in the contract\n",

--- a/tests/runner/helloWorld/output_6.json
+++ b/tests/runner/helloWorld/output_6.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7955",
+  "gas_remaining": "7959",
   "errors": [
     {
       "error_message": "No parameter found matching message entry Unknown",

--- a/tests/runner/helloWorld/output_7.json
+++ b/tests/runner/helloWorld/output_7.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7954",
+  "gas_remaining": "7958",
   "errors": [
     {
       "error_message": "Duplicate field entries found",

--- a/tests/runner/helloWorld/output_8.json
+++ b/tests/runner/helloWorld/output_8.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7969",
+  "gas_remaining": "7973",
   "errors": [
     {
       "error_message":

--- a/tests/runner/import-test-lib/output_1.json
+++ b/tests/runner/import-test-lib/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7886",
+  "gas_remaining": "7916",
   "_accepted": "false",
   "messages": [],
   "states": [ { "vname": "_balance", "type": "Uint128", "value": "0" } ],

--- a/tests/runner/import-test-lib/output_2.json
+++ b/tests/runner/import-test-lib/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7885",
+  "gas_remaining": "7914",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/import-test-lib/output_3.json
+++ b/tests/runner/import-test-lib/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7887",
+  "gas_remaining": "7916",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/import-test-lib2/output_1.json
+++ b/tests/runner/import-test-lib2/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7938",
+  "gas_remaining": "7939",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/import-test-lib3/output_1.json
+++ b/tests/runner/import-test-lib3/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7947",
+  "gas_remaining": "7949",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/inplace-map/output_1.json
+++ b/tests/runner/inplace-map/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7962",
+  "gas_remaining": "7968",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/inplace-map/output_10.json
+++ b/tests/runner/inplace-map/output_10.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7965",
+  "gas_remaining": "7971",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/inplace-map/output_11.json
+++ b/tests/runner/inplace-map/output_11.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7966",
+  "gas_remaining": "7971",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/inplace-map/output_12.json
+++ b/tests/runner/inplace-map/output_12.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7964",
+  "gas_remaining": "7969",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/inplace-map/output_13.json
+++ b/tests/runner/inplace-map/output_13.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7964",
+  "gas_remaining": "7970",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/inplace-map/output_14.json
+++ b/tests/runner/inplace-map/output_14.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7964",
+  "gas_remaining": "7969",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/inplace-map/output_2.json
+++ b/tests/runner/inplace-map/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7962",
+  "gas_remaining": "7967",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/inplace-map/output_3.json
+++ b/tests/runner/inplace-map/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7962",
+  "gas_remaining": "7967",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/inplace-map/output_4.json
+++ b/tests/runner/inplace-map/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7963",
+  "gas_remaining": "7968",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/inplace-map/output_5.json
+++ b/tests/runner/inplace-map/output_5.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7964",
+  "gas_remaining": "7969",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/inplace-map/output_6.json
+++ b/tests/runner/inplace-map/output_6.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7962",
+  "gas_remaining": "7967",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/inplace-map/output_7.json
+++ b/tests/runner/inplace-map/output_7.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7964",
+  "gas_remaining": "7969",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/inplace-map/output_8.json
+++ b/tests/runner/inplace-map/output_8.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7965",
+  "gas_remaining": "7971",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/inplace-map/output_9.json
+++ b/tests/runner/inplace-map/output_9.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7965",
+  "gas_remaining": "7971",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/listiter/output_1.json
+++ b/tests/runner/listiter/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7872",
+  "gas_remaining": "7873",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/loopy-tree-call/output_1.json
+++ b/tests/runner/loopy-tree-call/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7581",
+  "gas_remaining": "7586",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/map_as_cparam/init_ipc_output.json
+++ b/tests/runner/map_as_cparam/init_ipc_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "62937",
+  "gas_remaining": "62942",
   "_accepted": "false",
   "messages": null,
   "states": [ { "vname": "_balance", "type": "Uint128", "value": "0" } ],

--- a/tests/runner/map_as_cparam/init_unassignable_2_ipc_output.json
+++ b/tests/runner/map_as_cparam/init_unassignable_2_ipc_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "62937",
+  "gas_remaining": "62942",
   "_accepted": "false",
   "messages": null,
   "states": [ { "vname": "_balance", "type": "Uint128", "value": "0" } ],

--- a/tests/runner/map_as_cparam/init_unassignable_ipc_output.json
+++ b/tests/runner/map_as_cparam/init_unassignable_ipc_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "62937",
+  "gas_remaining": "62942",
   "_accepted": "false",
   "messages": null,
   "states": [ { "vname": "_balance", "type": "Uint128", "value": "0" } ],

--- a/tests/runner/map_corners_test/output_1.json
+++ b/tests/runner/map_corners_test/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7964",
+  "gas_remaining": "7967",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_10.json
+++ b/tests/runner/map_corners_test/output_10.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7963",
+  "gas_remaining": "7966",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_11.json
+++ b/tests/runner/map_corners_test/output_11.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7971",
+  "gas_remaining": "7973",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_111.json
+++ b/tests/runner/map_corners_test/output_111.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7959",
+  "gas_remaining": "7961",
   "errors": [
     {
       "error_message":

--- a/tests/runner/map_corners_test/output_112.json
+++ b/tests/runner/map_corners_test/output_112.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7959",
+  "gas_remaining": "7961",
   "errors": [
     {
       "error_message":

--- a/tests/runner/map_corners_test/output_113.json
+++ b/tests/runner/map_corners_test/output_113.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7961",
+  "gas_remaining": "7963",
   "errors": [
     {
       "error_message":

--- a/tests/runner/map_corners_test/output_12.json
+++ b/tests/runner/map_corners_test/output_12.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7970",
+  "gas_remaining": "7973",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_13.json
+++ b/tests/runner/map_corners_test/output_13.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7964",
+  "gas_remaining": "7966",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_14.json
+++ b/tests/runner/map_corners_test/output_14.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7966",
+  "gas_remaining": "7968",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_15.json
+++ b/tests/runner/map_corners_test/output_15.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7926",
+  "gas_remaining": "7928",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_16.json
+++ b/tests/runner/map_corners_test/output_16.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7938",
+  "gas_remaining": "7941",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_17.json
+++ b/tests/runner/map_corners_test/output_17.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7971",
+  "gas_remaining": "7974",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_18.json
+++ b/tests/runner/map_corners_test/output_18.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7972",
+  "gas_remaining": "7974",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_19.json
+++ b/tests/runner/map_corners_test/output_19.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7967",
+  "gas_remaining": "7969",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_2.json
+++ b/tests/runner/map_corners_test/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7964",
+  "gas_remaining": "7966",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_20.json
+++ b/tests/runner/map_corners_test/output_20.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7967",
+  "gas_remaining": "7969",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_21.json
+++ b/tests/runner/map_corners_test/output_21.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7971",
+  "gas_remaining": "7974",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_22.json
+++ b/tests/runner/map_corners_test/output_22.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7971",
+  "gas_remaining": "7974",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_23.json
+++ b/tests/runner/map_corners_test/output_23.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7966",
+  "gas_remaining": "7968",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_24.json
+++ b/tests/runner/map_corners_test/output_24.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7966",
+  "gas_remaining": "7968",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_3.json
+++ b/tests/runner/map_corners_test/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7965",
+  "gas_remaining": "7968",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_4.json
+++ b/tests/runner/map_corners_test/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7968",
+  "gas_remaining": "7971",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_5.json
+++ b/tests/runner/map_corners_test/output_5.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7954",
+  "gas_remaining": "7956",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_51.json
+++ b/tests/runner/map_corners_test/output_51.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7949",
+  "gas_remaining": "7951",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/map_corners_test/output_52.json
+++ b/tests/runner/map_corners_test/output_52.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7949",
+  "gas_remaining": "7951",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/map_corners_test/output_53.json
+++ b/tests/runner/map_corners_test/output_53.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7951",
+  "gas_remaining": "7953",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/map_corners_test/output_6.json
+++ b/tests/runner/map_corners_test/output_6.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7952",
+  "gas_remaining": "7955",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_7.json
+++ b/tests/runner/map_corners_test/output_7.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7959",
+  "gas_remaining": "7962",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_8.json
+++ b/tests/runner/map_corners_test/output_8.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7959",
+  "gas_remaining": "7961",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test/output_9.json
+++ b/tests/runner/map_corners_test/output_9.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7965",
+  "gas_remaining": "7968",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_corners_test_combined/output_1.json
+++ b/tests/runner/map_corners_test_combined/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7722",
+  "gas_remaining": "7724",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/map_key_test/output_1.json
+++ b/tests/runner/map_key_test/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7973",
+  "gas_remaining": "7974",
   "_accepted": "false",
   "messages": [],
   "states": [ { "vname": "_balance", "type": "Uint128", "value": "0" } ],

--- a/tests/runner/mappair/output_1.json
+++ b/tests/runner/mappair/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7958",
+  "gas_remaining": "7965",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/mappair/output_14.json
+++ b/tests/runner/mappair/output_14.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7963",
+  "gas_remaining": "7969",
   "errors": [
     {
       "error_message":

--- a/tests/runner/mappair/output_2.json
+++ b/tests/runner/mappair/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7922",
+  "gas_remaining": "7930",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/mappair/output_3.json
+++ b/tests/runner/mappair/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7919",
+  "gas_remaining": "7926",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/mappair/output_4.json
+++ b/tests/runner/mappair/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7940",
+  "gas_remaining": "7948",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/mappair/output_5.json
+++ b/tests/runner/mappair/output_5.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7939",
+  "gas_remaining": "7946",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/mappair/output_6.json
+++ b/tests/runner/mappair/output_6.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7911",
+  "gas_remaining": "7918",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/mappair/output_7.json
+++ b/tests/runner/mappair/output_7.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7938",
+  "gas_remaining": "7945",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/mappair/output_9.json
+++ b/tests/runner/mappair/output_9.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7946",
+  "gas_remaining": "7954",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/multiple-msgs/output_1.json
+++ b/tests/runner/multiple-msgs/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7939",
+  "gas_remaining": "7942",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/nonfungible-token/output_1.json
+++ b/tests/runner/nonfungible-token/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7904",
+  "gas_remaining": "7908",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/nonfungible-token/output_10.json
+++ b/tests/runner/nonfungible-token/output_10.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7838",
+  "gas_remaining": "7842",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/nonfungible-token/output_11.json
+++ b/tests/runner/nonfungible-token/output_11.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7835",
+  "gas_remaining": "7839",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/nonfungible-token/output_12.json
+++ b/tests/runner/nonfungible-token/output_12.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7885",
+  "gas_remaining": "7889",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/nonfungible-token/output_2.json
+++ b/tests/runner/nonfungible-token/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7892",
+  "gas_remaining": "7896",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/nonfungible-token/output_21.json
+++ b/tests/runner/nonfungible-token/output_21.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7920",
+  "gas_remaining": "7924",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/nonfungible-token/output_22.json
+++ b/tests/runner/nonfungible-token/output_22.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7913",
+  "gas_remaining": "7917",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/nonfungible-token/output_23.json
+++ b/tests/runner/nonfungible-token/output_23.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7877",
+  "gas_remaining": "7881",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/nonfungible-token/output_24.json
+++ b/tests/runner/nonfungible-token/output_24.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7890",
+  "gas_remaining": "7894",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/nonfungible-token/output_25.json
+++ b/tests/runner/nonfungible-token/output_25.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7879",
+  "gas_remaining": "7883",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/nonfungible-token/output_26.json
+++ b/tests/runner/nonfungible-token/output_26.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7901",
+  "gas_remaining": "7905",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/nonfungible-token/output_27.json
+++ b/tests/runner/nonfungible-token/output_27.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7904",
+  "gas_remaining": "7908",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/nonfungible-token/output_3.json
+++ b/tests/runner/nonfungible-token/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7844",
+  "gas_remaining": "7848",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/nonfungible-token/output_4.json
+++ b/tests/runner/nonfungible-token/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7937",
+  "gas_remaining": "7941",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/nonfungible-token/output_5.json
+++ b/tests/runner/nonfungible-token/output_5.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7937",
+  "gas_remaining": "7941",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/nonfungible-token/output_6.json
+++ b/tests/runner/nonfungible-token/output_6.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7935",
+  "gas_remaining": "7939",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/nonfungible-token/output_7.json
+++ b/tests/runner/nonfungible-token/output_7.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7891",
+  "gas_remaining": "7895",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/nonfungible-token/output_8.json
+++ b/tests/runner/nonfungible-token/output_8.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7896",
+  "gas_remaining": "7900",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/nonfungible-token/output_9.json
+++ b/tests/runner/nonfungible-token/output_9.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7890",
+  "gas_remaining": "7894",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/one-msg/output_1.json
+++ b/tests/runner/one-msg/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7954",
+  "gas_remaining": "7957",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/one-msg1/output_1.json
+++ b/tests/runner/one-msg1/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7953",
+  "gas_remaining": "7956",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/ping/output_0.json
+++ b/tests/runner/ping/output_0.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7952",
+  "gas_remaining": "7953",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/ping/output_1.json
+++ b/tests/runner/ping/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7949",
+  "gas_remaining": "7950",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/ping/output_2.json
+++ b/tests/runner/ping/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7949",
+  "gas_remaining": "7950",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/ping/output_3.json
+++ b/tests/runner/ping/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7965",
+  "gas_remaining": "7966",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/pong/output_0.json
+++ b/tests/runner/pong/output_0.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7952",
+  "gas_remaining": "7953",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/pong/output_1.json
+++ b/tests/runner/pong/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7949",
+  "gas_remaining": "7950",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/pong/output_2.json
+++ b/tests/runner/pong/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7949",
+  "gas_remaining": "7950",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/pong/output_3.json
+++ b/tests/runner/pong/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7969",
+  "gas_remaining": "7970",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/remote_state_reads/init_assignable_map_types_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_assignable_map_types_ipc_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "56479",
+  "gas_remaining": "56484",
   "_accepted": "false",
   "messages": null,
   "states": [ { "vname": "_balance", "type": "Uint128", "value": "0" } ],

--- a/tests/runner/remote_state_reads/init_balance_and_nonce_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_balance_and_nonce_ipc_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "56479",
+  "gas_remaining": "56484",
   "_accepted": "false",
   "messages": null,
   "states": [ { "vname": "_balance", "type": "Uint128", "value": "0" } ],

--- a/tests/runner/remote_state_reads/init_balance_no_nonce_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_balance_no_nonce_ipc_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "56479",
+  "gas_remaining": "56484",
   "_accepted": "false",
   "messages": null,
   "states": [ { "vname": "_balance", "type": "Uint128", "value": "0" } ],

--- a/tests/runner/remote_state_reads/init_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_ipc_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "56479",
+  "gas_remaining": "56484",
   "_accepted": "false",
   "messages": null,
   "states": [ { "vname": "_balance", "type": "Uint128", "value": "0" } ],

--- a/tests/runner/remote_state_reads/init_missing_field_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_missing_field_ipc_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7058",
+  "gas_remaining": "7059",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/init_nonce_no_balance_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_nonce_no_balance_ipc_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "56479",
+  "gas_remaining": "56484",
   "_accepted": "false",
   "messages": null,
   "states": [ { "vname": "_balance", "type": "Uint128", "value": "0" } ],

--- a/tests/runner/remote_state_reads/init_wrong_address_field_type_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_wrong_address_field_type_ipc_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7058",
+  "gas_remaining": "7059",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/init_wrong_field_type_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_wrong_field_type_ipc_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7058",
+  "gas_remaining": "7059",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/init_wrong_map_type_ipc_output.json
+++ b/tests/runner/remote_state_reads/init_wrong_map_type_ipc_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7058",
+  "gas_remaining": "7059",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_1.json
+++ b/tests/runner/remote_state_reads/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7870",
+  "gas_remaining": "7874",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/remote_state_reads/output_10.json
+++ b/tests/runner/remote_state_reads/output_10.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7870",
+  "gas_remaining": "7874",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/remote_state_reads/output_101.json
+++ b/tests/runner/remote_state_reads/output_101.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7911",
+  "gas_remaining": "7916",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_102.json
+++ b/tests/runner/remote_state_reads/output_102.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7912",
+  "gas_remaining": "7916",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_103.json
+++ b/tests/runner/remote_state_reads/output_103.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7912",
+  "gas_remaining": "7916",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_104.json
+++ b/tests/runner/remote_state_reads/output_104.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7912",
+  "gas_remaining": "7916",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_105.json
+++ b/tests/runner/remote_state_reads/output_105.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7912",
+  "gas_remaining": "7916",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_106.json
+++ b/tests/runner/remote_state_reads/output_106.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7912",
+  "gas_remaining": "7916",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_107.json
+++ b/tests/runner/remote_state_reads/output_107.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7912",
+  "gas_remaining": "7916",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_108.json
+++ b/tests/runner/remote_state_reads/output_108.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7912",
+  "gas_remaining": "7916",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_109.json
+++ b/tests/runner/remote_state_reads/output_109.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7484",
+  "gas_remaining": "7488",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_11.json
+++ b/tests/runner/remote_state_reads/output_11.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7870",
+  "gas_remaining": "7874",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/remote_state_reads/output_110.json
+++ b/tests/runner/remote_state_reads/output_110.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7484",
+  "gas_remaining": "7488",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_111.json
+++ b/tests/runner/remote_state_reads/output_111.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7484",
+  "gas_remaining": "7488",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_115.json
+++ b/tests/runner/remote_state_reads/output_115.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7486",
+  "gas_remaining": "7491",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_116.json
+++ b/tests/runner/remote_state_reads/output_116.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7486",
+  "gas_remaining": "7491",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_117.json
+++ b/tests/runner/remote_state_reads/output_117.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7487",
+  "gas_remaining": "7491",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_118.json
+++ b/tests/runner/remote_state_reads/output_118.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7485",
+  "gas_remaining": "7489",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_121.json
+++ b/tests/runner/remote_state_reads/output_121.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7486",
+  "gas_remaining": "7490",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_122.json
+++ b/tests/runner/remote_state_reads/output_122.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7486",
+  "gas_remaining": "7490",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_123.json
+++ b/tests/runner/remote_state_reads/output_123.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7486",
+  "gas_remaining": "7490",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_125.json
+++ b/tests/runner/remote_state_reads/output_125.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7487",
+  "gas_remaining": "7491",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_126.json
+++ b/tests/runner/remote_state_reads/output_126.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7960",
+  "gas_remaining": "7965",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_127.json
+++ b/tests/runner/remote_state_reads/output_127.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7966",
+  "gas_remaining": "7970",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_128.json
+++ b/tests/runner/remote_state_reads/output_128.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7911",
+  "gas_remaining": "7915",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_130.json
+++ b/tests/runner/remote_state_reads/output_130.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7486",
+  "gas_remaining": "7490",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_131.json
+++ b/tests/runner/remote_state_reads/output_131.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7486",
+  "gas_remaining": "7490",
   "errors": [
     {
       "error_message":

--- a/tests/runner/remote_state_reads/output_2.json
+++ b/tests/runner/remote_state_reads/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7870",
+  "gas_remaining": "7874",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/remote_state_reads/output_3.json
+++ b/tests/runner/remote_state_reads/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7870",
+  "gas_remaining": "7874",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/remote_state_reads/output_4.json
+++ b/tests/runner/remote_state_reads/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7870",
+  "gas_remaining": "7874",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/remote_state_reads/output_5.json
+++ b/tests/runner/remote_state_reads/output_5.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7870",
+  "gas_remaining": "7874",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/remote_state_reads/output_6.json
+++ b/tests/runner/remote_state_reads/output_6.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7483",
+  "gas_remaining": "7488",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/remote_state_reads/output_7.json
+++ b/tests/runner/remote_state_reads/output_7.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7929",
+  "gas_remaining": "7934",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/remote_state_reads/output_8.json
+++ b/tests/runner/remote_state_reads/output_8.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7954",
+  "gas_remaining": "7958",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/remote_state_reads/output_9.json
+++ b/tests/runner/remote_state_reads/output_9.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7958",
+  "gas_remaining": "7962",
   "_accepted": "true",
   "messages": [],
   "states": [

--- a/tests/runner/remote_state_reads_2/output_1.json
+++ b/tests/runner/remote_state_reads_2/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7943",
+  "gas_remaining": "7945",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/remote_state_reads_2/output_2.json
+++ b/tests/runner/remote_state_reads_2/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7943",
+  "gas_remaining": "7944",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/remote_state_reads_2/output_3.json
+++ b/tests/runner/remote_state_reads_2/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7967",
+  "gas_remaining": "7969",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/remote_state_reads_2/output_4.json
+++ b/tests/runner/remote_state_reads_2/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7970",
+  "gas_remaining": "7971",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/remote_state_reads_2/output_5.json
+++ b/tests/runner/remote_state_reads_2/output_5.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7967",
+  "gas_remaining": "7969",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/salarybot/output_0.json
+++ b/tests/runner/salarybot/output_0.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7965",
+  "gas_remaining": "7969",
   "_accepted": "true",
   "messages": [],
   "states": [

--- a/tests/runner/salarybot/output_1.json
+++ b/tests/runner/salarybot/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7919",
+  "gas_remaining": "7923",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/salarybot/output_2.json
+++ b/tests/runner/salarybot/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7919",
+  "gas_remaining": "7923",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/salarybot/output_3.json
+++ b/tests/runner/salarybot/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7919",
+  "gas_remaining": "7923",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/salarybot/output_4.json
+++ b/tests/runner/salarybot/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7934",
+  "gas_remaining": "7938",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/salarybot/output_5.json
+++ b/tests/runner/salarybot/output_5.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7920",
+  "gas_remaining": "7924",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/schnorr/output_1.json
+++ b/tests/runner/schnorr/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7862",
+  "gas_remaining": "7864",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/schnorr/output_2.json
+++ b/tests/runner/schnorr/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7861",
+  "gas_remaining": "7863",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/schnorr/output_3.json
+++ b/tests/runner/schnorr/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7862",
+  "gas_remaining": "7864",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/shadow_import/output_1.json
+++ b/tests/runner/shadow_import/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7962",
+  "gas_remaining": "7966",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/shogi/output_1.json
+++ b/tests/runner/shogi/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7666",
+  "gas_remaining": "7770",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/shogi/output_2.json
+++ b/tests/runner/shogi/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7665",
+  "gas_remaining": "7769",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/shogi/output_3.json
+++ b/tests/runner/shogi/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7655",
+  "gas_remaining": "7759",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/shogi/output_4.json
+++ b/tests/runner/shogi/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7743",
+  "gas_remaining": "7847",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/shogi/output_5.json
+++ b/tests/runner/shogi/output_5.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7763",
+  "gas_remaining": "7868",
   "errors": [
     {
       "error_message":

--- a/tests/runner/shogi/output_7.json
+++ b/tests/runner/shogi/output_7.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "7761",
+  "gas_remaining": "7865",
   "errors": [
     {
       "error_message":

--- a/tests/runner/shogi_proc/output_1.json
+++ b/tests/runner/shogi_proc/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7665",
+  "gas_remaining": "7769",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/shogi_proc/output_2.json
+++ b/tests/runner/shogi_proc/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7664",
+  "gas_remaining": "7769",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/shogi_proc/output_3.json
+++ b/tests/runner/shogi_proc/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7654",
+  "gas_remaining": "7758",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/shogi_proc/output_4.json
+++ b/tests/runner/shogi_proc/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7743",
+  "gas_remaining": "7847",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/simple-dex/output_1.json
+++ b/tests/runner/simple-dex/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7818",
+  "gas_remaining": "7821",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/simple-dex/output_2.json
+++ b/tests/runner/simple-dex/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7872",
+  "gas_remaining": "7874",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/simple-dex/output_3.json
+++ b/tests/runner/simple-dex/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7932",
+  "gas_remaining": "7935",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/simple-dex/output_4.json
+++ b/tests/runner/simple-dex/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7898",
+  "gas_remaining": "7901",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/simple-dex/output_5.json
+++ b/tests/runner/simple-dex/output_5.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7898",
+  "gas_remaining": "7901",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/simple-dex/output_6.json
+++ b/tests/runner/simple-dex/output_6.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7931",
+  "gas_remaining": "7934",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/simple-dex/output_7.json
+++ b/tests/runner/simple-dex/output_7.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7909",
+  "gas_remaining": "7911",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/simple-dex/output_8.json
+++ b/tests/runner/simple-dex/output_8.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7916",
+  "gas_remaining": "7919",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_1.json
+++ b/tests/runner/type_casts/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7950",
+  "gas_remaining": "7953",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_10.json
+++ b/tests/runner/type_casts/output_10.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7948",
+  "gas_remaining": "7952",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_11.json
+++ b/tests/runner/type_casts/output_11.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7952",
+  "gas_remaining": "7956",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_12.json
+++ b/tests/runner/type_casts/output_12.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7952",
+  "gas_remaining": "7956",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_13.json
+++ b/tests/runner/type_casts/output_13.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7948",
+  "gas_remaining": "7951",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_14.json
+++ b/tests/runner/type_casts/output_14.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7948",
+  "gas_remaining": "7951",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_15.json
+++ b/tests/runner/type_casts/output_15.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7952",
+  "gas_remaining": "7955",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_16.json
+++ b/tests/runner/type_casts/output_16.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7948",
+  "gas_remaining": "7951",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_17.json
+++ b/tests/runner/type_casts/output_17.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7948",
+  "gas_remaining": "7951",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_18.json
+++ b/tests/runner/type_casts/output_18.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7952",
+  "gas_remaining": "7955",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_19.json
+++ b/tests/runner/type_casts/output_19.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7952",
+  "gas_remaining": "7955",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_2.json
+++ b/tests/runner/type_casts/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7950",
+  "gas_remaining": "7953",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_20.json
+++ b/tests/runner/type_casts/output_20.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7952",
+  "gas_remaining": "7955",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_21.json
+++ b/tests/runner/type_casts/output_21.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7952",
+  "gas_remaining": "7955",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_22.json
+++ b/tests/runner/type_casts/output_22.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7943",
+  "gas_remaining": "7946",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_23.json
+++ b/tests/runner/type_casts/output_23.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7943",
+  "gas_remaining": "7946",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_24.json
+++ b/tests/runner/type_casts/output_24.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7952",
+  "gas_remaining": "7955",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_25.json
+++ b/tests/runner/type_casts/output_25.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7952",
+  "gas_remaining": "7955",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_26.json
+++ b/tests/runner/type_casts/output_26.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7952",
+  "gas_remaining": "7955",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_27.json
+++ b/tests/runner/type_casts/output_27.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7952",
+  "gas_remaining": "7955",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_28.json
+++ b/tests/runner/type_casts/output_28.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7943",
+  "gas_remaining": "7946",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_29.json
+++ b/tests/runner/type_casts/output_29.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7943",
+  "gas_remaining": "7946",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_3.json
+++ b/tests/runner/type_casts/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7950",
+  "gas_remaining": "7953",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_30.json
+++ b/tests/runner/type_casts/output_30.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7952",
+  "gas_remaining": "7955",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_31.json
+++ b/tests/runner/type_casts/output_31.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7952",
+  "gas_remaining": "7955",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_32.json
+++ b/tests/runner/type_casts/output_32.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7952",
+  "gas_remaining": "7955",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_33.json
+++ b/tests/runner/type_casts/output_33.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7943",
+  "gas_remaining": "7946",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_34.json
+++ b/tests/runner/type_casts/output_34.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7943",
+  "gas_remaining": "7946",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_35.json
+++ b/tests/runner/type_casts/output_35.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7952",
+  "gas_remaining": "7955",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_36.json
+++ b/tests/runner/type_casts/output_36.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7951",
+  "gas_remaining": "7954",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_37.json
+++ b/tests/runner/type_casts/output_37.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7940",
+  "gas_remaining": "7944",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_4.json
+++ b/tests/runner/type_casts/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7950",
+  "gas_remaining": "7953",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_5.json
+++ b/tests/runner/type_casts/output_5.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7950",
+  "gas_remaining": "7953",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_6.json
+++ b/tests/runner/type_casts/output_6.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7950",
+  "gas_remaining": "7953",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_7.json
+++ b/tests/runner/type_casts/output_7.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7953",
+  "gas_remaining": "7956",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_8.json
+++ b/tests/runner/type_casts/output_8.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7948",
+  "gas_remaining": "7952",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/type_casts/output_9.json
+++ b/tests/runner/type_casts/output_9.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7948",
+  "gas_remaining": "7952",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet/output_1.json
+++ b/tests/runner/wallet/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7898",
+  "gas_remaining": "7928",
   "_accepted": "true",
   "messages": [],
   "states": [

--- a/tests/runner/wallet/output_10.json
+++ b/tests/runner/wallet/output_10.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7880",
+  "gas_remaining": "7910",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet/output_11.json
+++ b/tests/runner/wallet/output_11.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7878",
+  "gas_remaining": "7908",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet/output_2.json
+++ b/tests/runner/wallet/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7864",
+  "gas_remaining": "7895",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet/output_3.json
+++ b/tests/runner/wallet/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7879",
+  "gas_remaining": "7910",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet/output_4.json
+++ b/tests/runner/wallet/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7874",
+  "gas_remaining": "7904",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet/output_5.json
+++ b/tests/runner/wallet/output_5.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7848",
+  "gas_remaining": "7879",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/wallet/output_6.json
+++ b/tests/runner/wallet/output_6.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7915",
+  "gas_remaining": "7946",
   "_accepted": "true",
   "messages": [],
   "states": [

--- a/tests/runner/wallet/output_7.json
+++ b/tests/runner/wallet/output_7.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7889",
+  "gas_remaining": "7920",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet/output_8.json
+++ b/tests/runner/wallet/output_8.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7883",
+  "gas_remaining": "7913",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet/output_9.json
+++ b/tests/runner/wallet/output_9.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7857",
+  "gas_remaining": "7887",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/init_no_owners_output.json
+++ b/tests/runner/wallet_2/init_no_owners_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "6082",
+  "gas_remaining": "6112",
   "errors": [
     {
       "error_message": "Contract constraint violation.\n",

--- a/tests/runner/wallet_2/init_not_enough_owners_output.json
+++ b/tests/runner/wallet_2/init_not_enough_owners_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "5965",
+  "gas_remaining": "5995",
   "errors": [
     {
       "error_message": "Contract constraint violation.\n",

--- a/tests/runner/wallet_2/init_req_sigs_zero_output.json
+++ b/tests/runner/wallet_2/init_req_sigs_zero_output.json
@@ -1,5 +1,5 @@
 {
-  "gas_remaining": "5965",
+  "gas_remaining": "5995",
   "errors": [
     {
       "error_message": "Contract constraint violation.\n",

--- a/tests/runner/wallet_2/output_1.json
+++ b/tests/runner/wallet_2/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7891",
+  "gas_remaining": "7945",
   "_accepted": "true",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_11.json
+++ b/tests/runner/wallet_2/output_11.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7865",
+  "gas_remaining": "7919",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_12.json
+++ b/tests/runner/wallet_2/output_12.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7865",
+  "gas_remaining": "7919",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_14.json
+++ b/tests/runner/wallet_2/output_14.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7864",
+  "gas_remaining": "7919",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_15.json
+++ b/tests/runner/wallet_2/output_15.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7864",
+  "gas_remaining": "7919",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_16.json
+++ b/tests/runner/wallet_2/output_16.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7864",
+  "gas_remaining": "7919",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_17.json
+++ b/tests/runner/wallet_2/output_17.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7856",
+  "gas_remaining": "7911",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_18.json
+++ b/tests/runner/wallet_2/output_18.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7856",
+  "gas_remaining": "7911",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_19.json
+++ b/tests/runner/wallet_2/output_19.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7856",
+  "gas_remaining": "7911",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_2.json
+++ b/tests/runner/wallet_2/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7891",
+  "gas_remaining": "7945",
   "_accepted": "true",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_20.json
+++ b/tests/runner/wallet_2/output_20.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7856",
+  "gas_remaining": "7911",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_21.json
+++ b/tests/runner/wallet_2/output_21.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7864",
+  "gas_remaining": "7919",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_22.json
+++ b/tests/runner/wallet_2/output_22.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7864",
+  "gas_remaining": "7919",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_23.json
+++ b/tests/runner/wallet_2/output_23.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7864",
+  "gas_remaining": "7919",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_24.json
+++ b/tests/runner/wallet_2/output_24.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7853",
+  "gas_remaining": "7908",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_25.json
+++ b/tests/runner/wallet_2/output_25.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7850",
+  "gas_remaining": "7905",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_26.json
+++ b/tests/runner/wallet_2/output_26.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7850",
+  "gas_remaining": "7904",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_27.json
+++ b/tests/runner/wallet_2/output_27.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7848",
+  "gas_remaining": "7903",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_28.json
+++ b/tests/runner/wallet_2/output_28.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7819",
+  "gas_remaining": "7873",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/wallet_2/output_29.json
+++ b/tests/runner/wallet_2/output_29.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7819",
+  "gas_remaining": "7873",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/wallet_2/output_3.json
+++ b/tests/runner/wallet_2/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7833",
+  "gas_remaining": "7888",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_30.json
+++ b/tests/runner/wallet_2/output_30.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7819",
+  "gas_remaining": "7873",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/wallet_2/output_31.json
+++ b/tests/runner/wallet_2/output_31.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7819",
+  "gas_remaining": "7873",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/wallet_2/output_32.json
+++ b/tests/runner/wallet_2/output_32.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7819",
+  "gas_remaining": "7873",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/wallet_2/output_33.json
+++ b/tests/runner/wallet_2/output_33.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7864",
+  "gas_remaining": "7919",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_34.json
+++ b/tests/runner/wallet_2/output_34.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7864",
+  "gas_remaining": "7919",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_35.json
+++ b/tests/runner/wallet_2/output_35.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7864",
+  "gas_remaining": "7919",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_36.json
+++ b/tests/runner/wallet_2/output_36.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7864",
+  "gas_remaining": "7919",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_37.json
+++ b/tests/runner/wallet_2/output_37.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7864",
+  "gas_remaining": "7919",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_38.json
+++ b/tests/runner/wallet_2/output_38.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7863",
+  "gas_remaining": "7918",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_39.json
+++ b/tests/runner/wallet_2/output_39.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7863",
+  "gas_remaining": "7918",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_4.json
+++ b/tests/runner/wallet_2/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7799",
+  "gas_remaining": "7854",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_40.json
+++ b/tests/runner/wallet_2/output_40.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7863",
+  "gas_remaining": "7918",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_42.json
+++ b/tests/runner/wallet_2/output_42.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7819",
+  "gas_remaining": "7873",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/wallet_2/output_5.json
+++ b/tests/runner/wallet_2/output_5.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7799",
+  "gas_remaining": "7854",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_6.json
+++ b/tests/runner/wallet_2/output_6.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7833",
+  "gas_remaining": "7888",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_7.json
+++ b/tests/runner/wallet_2/output_7.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7798",
+  "gas_remaining": "7853",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/wallet_2/output_8.json
+++ b/tests/runner/wallet_2/output_8.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7831",
+  "gas_remaining": "7886",
   "_accepted": "false",
   "messages": [],
   "states": [

--- a/tests/runner/zil-game/init_output.json
+++ b/tests/runner/zil-game/init_output.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "56323",
+  "gas_remaining": "56353",
   "_accepted": "false",
   "messages": null,
   "states": [

--- a/tests/runner/zil-game/output_1.json
+++ b/tests/runner/zil-game/output_1.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7903",
+  "gas_remaining": "7907",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/zil-game/output_2.json
+++ b/tests/runner/zil-game/output_2.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7921",
+  "gas_remaining": "7926",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/zil-game/output_3.json
+++ b/tests/runner/zil-game/output_3.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7915",
+  "gas_remaining": "7919",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/zil-game/output_4.json
+++ b/tests/runner/zil-game/output_4.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7906",
+  "gas_remaining": "7910",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/zil-game/output_5.json
+++ b/tests/runner/zil-game/output_5.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7910",
+  "gas_remaining": "7914",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/zil-game/output_6.json
+++ b/tests/runner/zil-game/output_6.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7902",
+  "gas_remaining": "7906",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/zil-game/output_7.json
+++ b/tests/runner/zil-game/output_7.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7930",
+  "gas_remaining": "7934",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/zil-game/output_8.json
+++ b/tests/runner/zil-game/output_8.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7935",
+  "gas_remaining": "7939",
   "_accepted": "false",
   "messages": [
     {

--- a/tests/runner/zil-game/output_9.json
+++ b/tests/runner/zil-game/output_9.json
@@ -1,6 +1,6 @@
 {
   "scilla_major_version": "0",
-  "gas_remaining": "7935",
+  "gas_remaining": "7939",
   "_accepted": "false",
   "messages": [
     {


### PR DESCRIPTION
Today, `init_libraries` is called twice for every transition execution (and hence gas charged twice too). Fix that. Similarly, `check_constraint` need not be called during transition execution (just deployment). Fix that too. Note that we don't remove constraint check for state JSON runs, just IPC (this is fine since state JSON runs are only for local testing).