### PR TITLE
Refactor is_storable_serializable_helper

### DIFF
--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -398,7 +398,7 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let hash_elab sc targs ts =
       match (targs, ts) with
-      | [], [ _ ] -> elab_tfun_with_args_no_gas sc ts
+      | [], [ t ] when is_legal_hash_argument_type t -> elab_tfun_with_args_no_gas sc ts
       | _, _ -> fail0 "Failed to elaborate"
 
     (* RIPEMD-160 is a 160 bit hash, so define a separate type for it. *)

--- a/src/base/BuiltIns.ml
+++ b/src/base/BuiltIns.ml
@@ -398,7 +398,8 @@ module ScillaBuiltIns (SR : Rep) (ER : Rep) = struct
 
     let hash_elab sc targs ts =
       match (targs, ts) with
-      | [], [ t ] when is_legal_hash_argument_type t -> elab_tfun_with_args_no_gas sc ts
+      | [], [ t ] when is_legal_hash_argument_type t ->
+          elab_tfun_with_args_no_gas sc ts
       | _, _ -> fail0 "Failed to elaborate"
 
     (* RIPEMD-160 is a 160 bit hash, so define a separate type for it. *)

--- a/src/base/TypeUtil.ml
+++ b/src/base/TypeUtil.ml
@@ -356,23 +356,19 @@ module TypeUtilities = struct
         true
     | _ -> true
 
-  let rec is_serializable_storable_helper accept_maps allow_unserializable
-      check_addresses t seen_adts =
-    let rec recurser t seen_adts =
+  let rec is_legal_type_helper ~allow_maps ~allow_messages_events ~allow_closures ~allow_polymorphism ~allow_unit ~check_addresses t seen_adts seen_tvars =
+    let rec recurser t seen_adts seen_tvars =
       match t with
-      | FunType (a, r) ->
-          allow_unserializable && recurser a seen_adts && recurser r seen_adts
-      | PolyFun (_, t) -> allow_unserializable && recurser t seen_adts
-      | Unit -> allow_unserializable
-      | MapType (kt, vt) ->
-          accept_maps && recurser kt seen_adts && recurser vt seen_adts
-      | TypeVar _ ->
-          (* If we are inside an ADT, then type variable
-             instantiations are handled outside *)
-          not @@ List.is_empty seen_adts
+      | FunType (a, r) -> allow_closures && recurser a seen_adts seen_tvars && recurser r seen_adts seen_tvars
+      | PolyFun (tvar, t) -> allow_polymorphism && recurser t seen_adts (tvar :: seen_tvars)
+      | Unit -> allow_unit
+      | MapType (kt, vt) -> allow_maps && recurser kt seen_adts seen_tvars && recurser vt seen_adts seen_tvars
+      | TypeVar tvar ->
+          (* Type variables can occur legally inside PolyFuns (if polymorphism is allowed) or inside ADTs *)
+          List.mem seen_tvars tvar ~equal:String.(=)
       | PrimType _ ->
-          (* Messages and Events are not serialisable in terms of contract parameters *)
-          allow_unserializable
+          (* Messages and Events are considered primitive types *)
+          allow_messages_events
           || TUType.(
                (not @@ [%equal: TUType.t] t msg_typ)
                || [%equal: TUType.t] t event_typ)
@@ -388,41 +384,51 @@ module TypeUtilities = struct
                 let adt_serializable =
                   List.for_all adt.tmap ~f:(fun (_, carg_list) ->
                       List.for_all carg_list ~f:(fun carg ->
-                          recurser carg (tname :: seen_adts)))
+                          recurser carg (tname :: seen_adts) (adt.tparams @ seen_tvars)))
                 in
                 adt_serializable
-                && List.for_all ts ~f:(fun t -> recurser t seen_adts))
+                && List.for_all ts ~f:(fun t -> recurser t seen_adts seen_tvars))
       | Address (Some fts) when check_addresses ->
           (* If check_addresses is true, then all field types in the address type should be legal field types.
              No need to check for serialisability or storability, since addresses are stored and passed as ByStr20. *)
-          IdLoc_Comp.Map.for_all fts ~f:(fun t -> is_legal_field_type t)
+          IdLoc_Comp.Map.for_all fts ~f:(fun t -> is_legal_field_type_helper t seen_adts seen_tvars)
       | Address _ -> true
     in
-    recurser t seen_adts
+    recurser t seen_adts seen_tvars
 
-  and is_legal_message_field_type t =
-    (* Maps are not allowed. Address values are considered ByStr20 when used as message field value. *)
-    is_serializable_storable_helper false false false t []
-
-  and is_legal_transition_parameter_type t =
-    (* Maps are not allowed. Address values should be checked for storable field types. *)
-    is_serializable_storable_helper false false true t []
-
-  and is_legal_procedure_parameter_type t =
-    (* Like transition parametes, except that polymorphic parameters are allowed,
-       since parameters do not need to be serializable. *)
-    is_serializable_storable_helper false true true t []
-
-  and is_legal_contract_parameter_type t =
-    (* Like fields. Maps are allowed. Address values should be checked for storable field types. *)
-    is_serializable_storable_helper true false true t []
-
-  and is_legal_field_type t =
+  and is_legal_field_type_helper t seen_adts seen_tvars =
     (* Maps are allowed. Address values should be checked for storable field types. *)
-    is_serializable_storable_helper true false true t []
+    is_legal_type_helper ~allow_maps:true ~allow_messages_events:false ~allow_closures:false ~allow_polymorphism:false ~allow_unit:false ~check_addresses:true t seen_adts seen_tvars
 
-  let is_legal_map_key_type t = is_prim_type t || is_address_type t
+  
+  let is_legal_message_field_type t =
+    (* Maps are not allowed. Address values are considered ByStr20 when used as message field value. *)
+    is_legal_type_helper ~allow_maps:false ~allow_messages_events:false ~allow_closures:false ~allow_polymorphism:false ~allow_unit:false ~check_addresses:false t [] []
 
+  let is_legal_transition_parameter_type t =
+    (* Maps are not allowed. Address values should be checked for storable field types. *) 
+    is_legal_type_helper ~allow_maps:false ~allow_messages_events:false ~allow_closures:false ~allow_polymorphism:false ~allow_unit:false ~check_addresses:true t [] []
+
+  let is_legal_procedure_parameter_type t =
+    (* Like transition parametes, except messages, events and closures are allowed,
+       since parameters do not need to be serializable. *)
+    is_legal_type_helper ~allow_maps:false ~allow_messages_events:true ~allow_closures:false ~allow_polymorphism:false ~allow_unit:false ~check_addresses:true t [] []
+
+  let is_legal_contract_parameter_type t =
+    (* Like transitions parameters, except maps are allowed (due to an exploited bug). Address values should be checked for storable field types. *)
+    is_legal_type_helper ~allow_maps:true ~allow_messages_events:false ~allow_closures:false ~allow_polymorphism:false ~allow_unit:false ~check_addresses:true t [] []
+
+  let is_legal_field_type t =
+    is_legal_field_type_helper t [] []
+
+  let is_legal_hash_argument_type t =
+    (* Only closures and type closures are disallowed. Addresses behave like ByStr20. *)
+    is_legal_type_helper ~allow_maps:true ~allow_messages_events:true ~allow_closures:false ~allow_polymorphism:false ~allow_unit:false ~check_addresses:false t [] []
+  
+  let is_legal_map_key_type t =
+    (* Only primitive (non-message and non-event) types are allowed. Addresses behave like ByStr20, and are thus allowed. *)
+    is_legal_type_helper ~allow_maps:false ~allow_messages_events:false ~allow_closures:false ~allow_polymorphism:false ~allow_unit:false ~check_addresses:false t [] []
+  
   let get_msgevnt_type m lc =
     let open ContractUtil.MessagePayload in
     if List.exists m ~f:(fun (x, _, _) -> String.(tag_label = x)) then

--- a/src/base/TypeUtil.mli
+++ b/src/base/TypeUtil.mli
@@ -154,6 +154,8 @@ module TypeUtilities : sig
 
   val is_legal_field_type : TUType.t -> bool
 
+  val is_legal_hash_argument_type : TUType.t -> bool
+
   val is_ground_type : TUType.t -> bool
 
   val get_msgevnt_type :

--- a/tests/checker/bad/Bad.ml
+++ b/tests/checker/bad/Bad.ml
@@ -86,6 +86,7 @@ module Tests = Scilla_test.Util.DiffBasedTests (struct
       "procedure_bad_type.scilla";
       "procedure_bad_args.scilla";
       "procedure_map_arg.scilla";
+      "hash_arg.scilla";
       "name_clashes.scilla";
       "procedure_env.scilla";
       "global_scope_procedures.scilla";

--- a/tests/checker/bad/gold/hash_arg.scilla.gold
+++ b/tests/checker/bad/gold/hash_arg.scilla.gold
@@ -1,0 +1,36 @@
+{
+  "gas_remaining": "8000",
+  "errors": [
+    {
+      "error_message":
+        "Type error: cannot apply \"sha256hash\" built-in to argument(s) of type(s) ['A].",
+      "start_location": {
+        "file": "checker/bad/hash_arg.scilla",
+        "line": 9,
+        "column": 11
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Type error: cannot apply \"sha256hash\" built-in to argument(s) of type(s) [Uint128 -> Uint128].",
+      "start_location": {
+        "file": "checker/bad/hash_arg.scilla",
+        "line": 14,
+        "column": 11
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Type error: cannot apply \"sha256hash\" built-in to argument(s) of type(s) [forall 'A. 'A -> 'A].",
+      "start_location": {
+        "file": "checker/bad/hash_arg.scilla",
+        "line": 19,
+        "column": 11
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": []
+}

--- a/tests/checker/bad/gold/procedure_map_arg.scilla.gold
+++ b/tests/checker/bad/gold/procedure_map_arg.scilla.gold
@@ -48,6 +48,25 @@
         "column": 17
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message":
+        "Type Bool -> Bool cannot be used as procedure parameter",
+      "start_location": {
+        "file": "checker/bad/procedure_map_arg.scilla",
+        "line": 37,
+        "column": 17
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Procedure Proc4 not found.",
+      "start_location": {
+        "file": "checker/bad/procedure_map_arg.scilla",
+        "line": 43,
+        "column": 3
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ],
   "warnings": []

--- a/tests/checker/bad/hash_arg.scilla
+++ b/tests/checker/bad/hash_arg.scilla
@@ -1,0 +1,57 @@
+scilla_version 0
+
+library MyLib
+
+(* Not all instantiations of 'A are legal hash argument types *)
+let poly_hash =
+  tfun 'A =>
+  fun (x : 'A) =>
+  builtin sha256hash x
+
+(* Not possible to hash a closure *)
+let fun_hash =
+  fun (x : Uint128 -> Uint128) =>
+  builtin sha256hash x
+
+(* Not possible to hash a closure *)
+let typ_fun_hash =
+  fun (x : forall 'A. 'A -> 'A) =>
+  builtin sha256hash x
+
+type MyTyp =
+| MyC of Int32
+
+(* ADTs may be hashed *)
+let adt_hash =
+  fun (x : MyTyp) =>
+  builtin sha256hash x
+
+(* Polymorphic ADTs may be hashed if instantiated *)
+let list_hash =
+  fun (x : List Uint128) =>
+  builtin sha256hash x
+
+
+(* Messages may be hashed *)
+let msg_hash =
+  fun (x : ByStr20) =>
+  let msg = { _tag : ""; _recipient : x; _amount : Uint128 0 } in
+  builtin sha256hash msg
+
+(* Events may be hashed *)
+let ev_hash =
+  let e = { _eventname : "hashtest" } in
+  builtin sha256hash e
+
+(* Addresses may be hashed *)
+let addr_hash =
+  fun (x : ByStr20 with contract end) =>
+  builtin sha256hash x
+
+(* Maps may be hashed *)
+let map_hash =
+  fun (x : Map ByStr20 Uint128) =>
+  builtin sha256hash x
+
+contract HashArg ()
+

--- a/tests/checker/bad/procedure_map_arg.scilla
+++ b/tests/checker/bad/procedure_map_arg.scilla
@@ -33,7 +33,7 @@ procedure Proc3(f : forall 'A . 'A -> Bool )
   new_arg = Int32 0
 end
 
-(* Function arguments to procedures are allowed *)
+(* Function arguments to procedures not allowed *)
 procedure Proc4(f : Bool -> Bool )
   new_arg = Int32 0
 end


### PR DESCRIPTION
The purpose of this refactoring is to add check for legal hash argument types.

We haven't yet settled on which types are actually allowed as hash argument types, but now it's easy to change it. See 

Note also that we disallow maps, closures and type closures as procedure arguments, which there isn't actually any need to do. We do have testcases for it, though, so it's probably intentional. Again, with this refactoring it's easy to change if we feel like it.