### PR TITLE
Messages sent to libraries should not fail

### DIFF
--- a/src/eval/Runner.ml
+++ b/src/eval/Runner.ml
@@ -404,12 +404,10 @@ let run_with_args args =
   in
 
   if is_library then
-    if is_deployment then 
-      deploy_library args gas_remaining
+    if is_deployment then deploy_library args gas_remaining
     else
       (* Messages to libraries are ignored, but tolerated *)
-      `Assoc
-        [ ("gas_remaining", `String (Uint64.to_string gas_remaining)) ]
+      `Assoc [ ("gas_remaining", `String (Uint64.to_string gas_remaining)) ]
   else
     match FEParser.parse_cmodule args.input with
     | Error e ->

--- a/tests/runner/TestLib2/message_1.json
+++ b/tests/runner/TestLib2/message_1.json
@@ -1,0 +1,37 @@
+{
+    "_tag": "PlayerAction",
+    "_amount": "0",
+    "_sender": "0x1234567890123456789012345678906784567890",
+    "params": [
+        {
+            "vname": "action",
+            "type": "ShogiLib.Action",
+            "value": {
+                "constructor": "ShogiLib.Move",
+                "argtypes": [],
+                "arguments": [
+                    {
+                        "constructor": "ShogiLib.Square",
+                        "argtypes": [],
+                        "arguments": [
+                            "1",
+                            "1"
+                        ]
+                    },
+                    {
+                        "constructor": "ShogiLib.North",
+                        "argtypes": [],
+                        "arguments": []
+                    },
+                    "3",
+                    {
+                        "constructor": "False",
+                        "argtypes": [],
+                        "arguments": []
+                    }
+                ]
+            }
+        }
+    ],
+    "_origin": "0x1234567890123456789012345678906784567890"
+}

--- a/tests/runner/TestLib2/output_1.json
+++ b/tests/runner/TestLib2/output_1.json
@@ -1,0 +1,1 @@
+{ "gas_remaining": "62896" }

--- a/tests/runner/TestLib2/state_1.json
+++ b/tests/runner/TestLib2/state_1.json
@@ -1,0 +1,106 @@
+[
+    { "vname": "_balance",
+      "type": "Uint128",
+      "value": "0" },
+    {
+      "vname": "board",
+      "type": "Map Uint32 (Map Uint32 ShogiLib.SquareContents)",
+      "value": [
+          {
+              "key": "1",
+              "val": [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "ShogiLib.Occupied",
+                          "argtypes" : [],
+                          "arguments" : [
+                              {
+                                  "constructor" : "ShogiLib.Lance",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              {
+                                  "constructor" : "ShogiLib.NotPromoted",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              "0x1234567890123456789012345678906784567890"
+                          ]
+                      }
+                  }
+              ]
+          },
+          {
+              "key" : "2",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "ShogiLib.Free",
+                          "argtypes" : [],
+                          "arguments" : []
+                      }
+                  }
+              ]
+          },
+          {   
+              "key" : "3",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "ShogiLib.Free",
+                          "argtypes" : [],
+                          "arguments" : []
+                      }
+                  }
+              ]
+          },
+          {
+              "key" : "4",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "ShogiLib.Free",
+                          "argtypes" : [],
+                          "arguments" : []
+                      }
+                  }
+              ]
+          }
+      ]
+    },
+    {
+      "vname": "captured_pieces",
+      "type": "Map (ByStr20) (Map (Uint32) (Uint32))",
+      "value": []
+    },
+    { 
+      "vname": "player_in_turn",
+      "type": "Option ByStr20",
+      "value":
+        {
+            "constructor": "Some",
+            "argtypes"   : [ "ByStr20" ],
+            "arguments"  : [
+                "0x1234567890123456789012345678906784567890"
+            ]
+        }
+    },
+    { 
+      "vname": "winner",
+      "type": "Option ByStr20",
+      "value":
+        {
+            "constructor": "None",
+            "argtypes"   : [ "ByStr20" ],
+            "arguments"  : []
+        }
+    }
+]

--- a/tests/runner/Testcontracts.ml
+++ b/tests/runner/Testcontracts.ml
@@ -128,7 +128,7 @@ let rec build_contract_tests_with_init_file ?(pplit = true) env name exit_code i
           "-init";
           dir ^/ init_name ^. "json";
           "-i";
-          contract_dir ^/ name ^. (if is_library then "scillib" else "scilla");
+          (contract_dir ^/ name ^. if is_library then "scillib" else "scilla");
           (* stdlib is in src/stdlib *)
           "-libdir";
           env.stdlib_dir test_ctxt;
@@ -212,8 +212,7 @@ let build_contract_tests ?(pplit = true) env name exit_code i n additional_libs
  * Used to test message passing to libraries. This should cost gas for message processing,
  * but should otherwise be ignored silently
  *)
-let build_library_tests env name i n
-    =
+let build_library_tests env name i n =
   build_contract_tests_with_init_file ~pplit:false env name succ_code i n []
     "init" true
 
@@ -341,8 +340,7 @@ let contract_tests env =
                 "testlib2_init"
                 >: build_contract_init_test env succ_code "TestLib2" "init"
                      ~is_library:true ~ipc_mode:false;
-                "testlib2"
-                >::: build_library_tests env "TestLib2" 1 1;
+                "testlib2" >::: build_library_tests env "TestLib2" 1 1;
                 "testlib3_init"
                 >: build_contract_init_test env succ_code
                      "0x111256789012345678901234567890123456abef" "init"

--- a/tests/runner/Testcontracts.ml
+++ b/tests/runner/Testcontracts.ml
@@ -106,7 +106,7 @@ let foutput_deploy env test_ctxt test_name ipc_mode ipc_addr_thread exit_code
  * multiple test cases, each suffixed with _i up to _n (both inclusive)
  *)
 let rec build_contract_tests_with_init_file ?(pplit = true) env name exit_code i
-    n additional_libs init_name =
+    n additional_libs init_name is_library =
   if i > n then []
   else
     (* Create a contract test with an option to disable JSON validation (fast parsing). *)
@@ -128,7 +128,7 @@ let rec build_contract_tests_with_init_file ?(pplit = true) env name exit_code i
           "-init";
           dir ^/ init_name ^. "json";
           "-i";
-          contract_dir ^/ name ^. "scilla";
+          contract_dir ^/ name ^. (if is_library then "scillib" else "scilla");
           (* stdlib is in src/stdlib *)
           "-libdir";
           env.stdlib_dir test_ctxt;
@@ -185,18 +185,18 @@ let rec build_contract_tests_with_init_file ?(pplit = true) env name exit_code i
     (* If this test is expected to succeed, we know that the JSONs are all "good".
      * So test both the JSON parsers, one that does validation, one that doesn't.
      * Both should succeed. *)
-    if Poly.(exit_code = succ_code) then
+    if Poly.(exit_code = succ_code && not is_library) then
       test ~ipc_mode:true
       ::
       test ~ipc_mode:false
       ::
       build_contract_tests_with_init_file ~pplit env name exit_code (i + 1) n
-        additional_libs init_name
+        additional_libs init_name is_library
     else
       test ~ipc_mode:false
       ::
       build_contract_tests_with_init_file ~pplit env name exit_code (i + 1) n
-        additional_libs init_name
+        additional_libs init_name is_library
 
 (*
  * Build tests to invoke scilla-runner with the right arguments, for
@@ -206,7 +206,16 @@ let rec build_contract_tests_with_init_file ?(pplit = true) env name exit_code i
 let build_contract_tests ?(pplit = true) env name exit_code i n additional_libs
     =
   build_contract_tests_with_init_file ~pplit env name exit_code i n
-    additional_libs "init"
+    additional_libs "init" false
+
+(*
+ * Used to test message passing to libraries. This should cost gas for message processing,
+ * but should otherwise be ignored silently
+ *)
+let build_library_tests env name i n
+    =
+  build_contract_tests_with_init_file ~pplit:false env name succ_code i n []
+    "init" true
 
 let build_contract_init_test env exit_code name init_name ~is_library ~ipc_mode
     =
@@ -332,6 +341,8 @@ let contract_tests env =
                 "testlib2_init"
                 >: build_contract_init_test env succ_code "TestLib2" "init"
                      ~is_library:true ~ipc_mode:false;
+                "testlib2"
+                >::: build_library_tests env "TestLib2" 1 1;
                 "testlib3_init"
                 >: build_contract_init_test env succ_code
                      "0x111256789012345678901234567890123456abef" "init"
@@ -381,16 +392,16 @@ let contract_tests env =
                 >::: build_contract_tests env "wallet" succ_code 1 11 [];
                 "wallet_2"
                 >::: build_contract_tests_with_init_file env "wallet_2"
-                       succ_code 1 8 [] "init";
+                       succ_code 1 8 [] "init" false;
                 "wallet_2"
                 >::: build_contract_tests_with_init_file env "wallet_2"
-                       succ_code 11 12 [] "init";
+                       succ_code 11 12 [] "init" false;
                 "wallet_2"
                 >::: build_contract_tests_with_init_file env "wallet_2"
-                       succ_code 14 40 [] "init";
+                       succ_code 14 40 [] "init" false;
                 "wallet_2"
                 >::: build_contract_tests_with_init_file env "wallet_2"
-                       succ_code 42 42 [] "init";
+                       succ_code 42 42 [] "init" false;
                 "one_msg_test"
                 >::: build_contract_tests env "one-msg" succ_code 1 1 [];
                 "one_msg1_test"


### PR DESCRIPTION
Based on a discussion on Slack it's been decided that `ByStr20 with end` should include library addresses, because library addresses are in use.

This means that existing contracts containing with the following code snippet should expect the transaction to not abort:
```
transition MyC (x : ByStr20 with end)
  msg = { _tag: "RemoteTransition"; _recipient : x; ... };
  send msg
end
```
I have therefore removed the code branch causing a failure when a library receives a message. Instead, gas is charged for the message, and nothing else happens.