### PR TITLE
Add of_int functions for 256-bit arithmetic

### DIFF
--- a/src/base/Integer256.ml
+++ b/src/base/Integer256.ml
@@ -314,6 +314,8 @@ module Uint256 = struct
 
   let[@warning "-32"] of_uint128 a =
     { low = Uint128.of_uint128 a; high = Uint128.zero }
+
+  let of_int a = { low = Uint128.of_int a; high = Uint128.zero }
 end
 
 (*  https://github.com/andrenth/ocaml-stdint/blob/master/lib/int128_stubs.c *)
@@ -431,6 +433,11 @@ module Int256 = struct
   let of_bytes_big_endian buf off = Uint256.of_bytes_big_endian buf off
 
   let of_bytes_little_endian buf off = Uint256.of_bytes_little_endian buf off
+
+  (* Not the most efficient implementation but it gets the job done.
+     I went for this solution because it is correct if Int256.of_string is correct:
+     it's easy to mess up with the fixed-width arithmetic *)
+  let of_int a = of_string (Int.to_string a)
 end
 
 type int256 = Int256.t

--- a/src/base/Integer256.mli
+++ b/src/base/Integer256.mli
@@ -75,6 +75,8 @@ module Uint256 : sig
   val of_bytes_big_endian : Bytes.t -> int -> t
 
   val of_bytes_little_endian : Bytes.t -> int -> t
+
+  val of_int : int -> t
 end
 
 module Int256 : sig
@@ -133,6 +135,8 @@ module Int256 : sig
   val of_bytes_big_endian : Bytes.t -> int -> t
 
   val of_bytes_little_endian : Bytes.t -> int -> t
+
+  val of_int : int -> t
 end
 
 type int256 = Int256.t


### PR DESCRIPTION
This is needed for the Scilla-Chick project. I went for the simplest implementation for the signed 256-bit integers for the sake of correctness.