### PR TITLE
Changed out-of-gas error to something less misleading

### DIFF
--- a/src/base/MonadUtil.ml
+++ b/src/base/MonadUtil.ml
@@ -245,7 +245,7 @@ module EvalMonad = struct
   let fromR r =
     match r with Core_kernel.Error s -> fail s | Core_kernel.Ok a -> pure a
 
-  let out_of_gas_err = mk_error0 ~kind:"Ran out of gas" ?inst:None
+  let out_of_gas_err = mk_error0 ~kind:"Insufficient gas" ?inst:None
 
   (* [Wrappers for Gas Accounting]  *)
   let checkwrap_opR op_thunk cost k remaining_gas =

--- a/src/eval/Eval.ml
+++ b/src/eval/Eval.ml
@@ -312,7 +312,7 @@ let rec exp_eval erep env =
   | GasExpr (g, e') ->
       let thunk () = exp_eval e' env in
       let%bind cost = fromR @@ eval_gas_charge env g in
-      let emsg = sprintf "Ran out of gas" in
+      let emsg = sprintf "Insufficient gas" in
       (* Add end location too: https://github.com/Zilliqa/scilla/issues/134 *)
       checkwrap_op thunk (Uint64.of_int cost)
         (mk_error1 ~kind:emsg ?inst:None loc)

--- a/src/eval/Runner.ml
+++ b/src/eval/Runner.ml
@@ -393,7 +393,7 @@ let run_with_args args =
       let cost = Uint64.of_int cost' in
       if Uint64.compare initial_gas_limit cost < 0 then
         fatal_error_gas_scale Gas.scale_factor
-          (mk_error0 ~kind:"Ran out of gas when parsing contract/init files"
+          (mk_error0 ~kind:"Insufficient gas to parse contract/init files"
              ?inst:None)
           Uint64.zero
       else Uint64.sub initial_gas_limit cost
@@ -401,7 +401,7 @@ let run_with_args args =
       let cost = Uint64.of_int (UnixLabels.stat args.input_message).st_size in
       if Uint64.compare initial_gas_limit cost < 0 then
         fatal_error_gas_scale Gas.scale_factor
-          (mk_error0 ~kind:"Ran out of gas when parsing message" ?inst:None)
+          (mk_error0 ~kind:"Insufficient gas to parse message" ?inst:None)
           Uint64.zero
       else Uint64.sub initial_gas_limit cost
   in
@@ -438,7 +438,7 @@ let run_with_args args =
             in
             plog msg;
             fatal_error_gas_scale Gas.scale_factor
-              (mk_error0 ~kind:"Ran out of gas when parsing contract/init files"
+              (mk_error0 ~kind:"Insufficient gas to parse contract/init files"
                  ?inst:None)
               gas_remaining
         | Some this_address ->

--- a/tests/checker/bad/gold/blowup.scilla.gold
+++ b/tests/checker/bad/gold/blowup.scilla.gold
@@ -2,7 +2,7 @@
   "gas_remaining": "0",
   "errors": [
     {
-      "error_message": "Ran out of gas",
+      "error_message": "Insufficient gas",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/eval/bad/gold/blowup.scilexp.gold
+++ b/tests/eval/bad/gold/blowup.scilexp.gold
@@ -2,7 +2,7 @@
   "gas_remaining": "0",
   "errors": [
     {
-      "error_message": "Ran out of gas",
+      "error_message": "Insufficient gas",
       "start_location": { "file": "Prelude", "line": 1, "column": 37 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }


### PR DESCRIPTION
As @anton-trunov discovered the phrase "Ran out of gas" is misleading when the remaining gas is checked an expensive operation (e.g., `pow`) before the operation is executed.

I've changed the error message "Insufficient gas", which is less confusing.

Note that it is not possible to state the failing operation as part of the error message, because the error occurs when a `GasExpr` is executed rather than when the expensive operation is.