### PR TITLE
Remove now redundant brew build flag for secp256k1

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -9,6 +9,6 @@ brew "libffi"
 brew "openssl@1.1"
 brew "boost"
 brew "pcre"
-brew "domt4/crypto/secp256k1", args: ["with-enable-module-recovery"]
+brew "domt4/crypto/secp256k1"
 brew "cmake"
 brew "gmp"


### PR DESCRIPTION
The homebrew formula for secp256k1 now builds with all the modules enabled by default, so no "with-enable-module-recovery" is required and this setting actually causes a build error on mac.
It changed since their commit on March 4: https://github.com/DomT4/homebrew-crypto/commit/c183a067a0574c48df473b058cca4c866ab399c9