### PR TITLE
DeadCodeDetector: Fix false positive for an unused ADT in an unused `Bind`

### DIFF
--- a/src/base/DeadCodeDetector.ml
+++ b/src/base/DeadCodeDetector.ml
@@ -258,7 +258,8 @@ module DeadCodeDetector (SR : Rep) (ER : Rep) = struct
                   dedup_name_list @@ adts' @ adts )
               else (
                 warn "Unused bind statement to: " i ER.get_loc;
-                (live_vars, adts))
+                let _, adts' = expr_iter e in
+                (live_vars, dedup_name_list @@ adts' @ adts))
           | MatchStmt (i, pslist) ->
               let live_vars', adts' =
                 (* No live variables when analysing MatchStmt, as seen when checking tests/contracts/dead_code_test4.scilla *)

--- a/tests/checker/good/gold/map_key_test.scilla.gold
+++ b/tests/checker/good/gold/map_key_test.scilla.gold
@@ -64,16 +64,6 @@
   },
   "warnings": [
     {
-      "warning_message": "Unused library ADT: TestType",
-      "start_location": {
-        "file": "contracts/map_key_test.scilla",
-        "line": 5,
-        "column": 1
-      },
-      "end_location": { "file": "", "line": 0, "column": 0 },
-      "warning_id": 3
-    },
-    {
       "warning_message": "Unused bind statement to: map",
       "start_location": {
         "file": "contracts/map_key_test.scilla",


### PR DESCRIPTION
We should not report that an ADT is unused if it used in the dead `Bind` statement:

```
type A =
| A of Uint32

transition dummy ()
  zero = Uint32 0;
  v = A zero
  (* v is unused *)
end
```

In this case the user should fix the unused `Bind` statement, because they probably made a mistake there. But the ADT was used in the code.