### PR TITLE
DeadCodeDetector: Fix false positive for ADTs that come after `TypeCast`

### DIFF
--- a/src/base/DeadCodeDetector.ml
+++ b/src/base/DeadCodeDetector.ml
@@ -295,7 +295,7 @@ module DeadCodeDetector (SR : Rep) (ER : Rep) = struct
                     ~f:(fun i -> not @@ SCIdentifier.equal x i)
                     live_vars
                 in
-                (r :: live_vars_no_x, user_types_in_adt [ t ])
+                (r :: live_vars_no_x, adts @ user_types_in_adt [ t ])
               else (
                 warn "Unused type case statement to: " x ER.get_loc;
                 (live_vars, adts))

--- a/tests/checker/good/Good.ml
+++ b/tests/checker/good/Good.ml
@@ -79,6 +79,7 @@ module Tests = Scilla_test.Util.DiffBasedTests (struct
       "dead_code_test4.scilla";
       "dead_code_test5.scilla";
       "dead_code_test6.scilla";
+      "dead_code_test7.scilla";
       "simple-dex-remote-reads.scilla";
       "type_casts.scilla";
       "timestamp.scilla";

--- a/tests/checker/good/gold/dead_code_test7.scilla.gold
+++ b/tests/checker/good/gold/dead_code_test7.scilla.gold
@@ -1,0 +1,75 @@
+{
+  "cashflow_tags": { "State variables": [], "ADT constructors": [] },
+  "contract_info": {
+    "scilla_major_version": "0",
+    "vname": "Dead7",
+    "params": [],
+    "fields": [],
+    "transitions": [ { "vname": "Dead7", "params": [] } ],
+    "procedures": [],
+    "events": [],
+    "ADTs": [
+      {
+        "tname": "dead_code_test7.Ty",
+        "tparams": [],
+        "tmap": [ { "cname": "dead_code_test7.Ty", "argtypes": [] } ]
+      },
+      {
+        "tname": "Option",
+        "tparams": [ "'A" ],
+        "tmap": [
+          { "cname": "Some", "argtypes": [ "'A" ] },
+          { "cname": "None", "argtypes": [] }
+        ]
+      },
+      {
+        "tname": "Bool",
+        "tparams": [],
+        "tmap": [
+          { "cname": "True", "argtypes": [] },
+          { "cname": "False", "argtypes": [] }
+        ]
+      },
+      {
+        "tname": "Nat",
+        "tparams": [],
+        "tmap": [
+          { "cname": "Zero", "argtypes": [] },
+          { "cname": "Succ", "argtypes": [ "Nat" ] }
+        ]
+      },
+      {
+        "tname": "List",
+        "tparams": [ "'A" ],
+        "tmap": [
+          { "cname": "Cons", "argtypes": [ "'A", "List ('A)" ] },
+          { "cname": "Nil", "argtypes": [] }
+        ]
+      },
+      {
+        "tname": "Pair",
+        "tparams": [ "'A", "'B" ],
+        "tmap": [ { "cname": "Pair", "argtypes": [ "'A", "'B" ] } ]
+      }
+    ]
+  },
+  "warnings": [
+    {
+      "warning_message": "Unused bind statement to: ty",
+      "start_location": {
+        "file": "contracts/dead_code_test7.scilla",
+        "line": 16,
+        "column": 5
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 3
+    },
+    {
+      "warning_message": "No transition in contract Dead7 contains an accept statement\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 1
+    }
+  ],
+  "gas_remaining": "7999"
+}

--- a/tests/contracts/dead_code_test7.scilla
+++ b/tests/contracts/dead_code_test7.scilla
@@ -1,0 +1,21 @@
+scilla_version 0
+
+library Dead7
+
+type Ty =
+  | Ty
+
+contract Dead7 ()
+
+transition Dead7()
+  address = 0x0000000000000000000000000000000000000000;
+  maybe_contract_address <-& address as ByStr20 with contract end;
+  match maybe_contract_address with
+  | None =>
+  | Some _ =>
+    ty = Ty;
+    code = Int32 -1;
+    e = { _exception : "Error"; code : code };
+    throw e
+  end
+end


### PR DESCRIPTION
Closes #1100