### PR TITLE
Fix `0:0` locations of warnings

### DIFF
--- a/src/base/Accept.ml
+++ b/src/base/Accept.ml
@@ -123,10 +123,11 @@ struct
     in
 
     if List.for_all all_accept_groups ~f:List.is_empty then
-      warn0
+      warn1
         (sprintf "No transition in contract %s contains an accept statement\n"
            (ACIdentifier.as_error_string contr.cname))
         warning_level_missing_accept
+        (SR.get_loc (ACIdentifier.get_rep contr.cname))
 
   (* ************************************** *)
   (* ******** Interface to Accept ********* *)

--- a/src/base/PatternChecker.ml
+++ b/src/base/PatternChecker.ml
@@ -401,7 +401,7 @@ struct
     let { cname = ctr_cname; cparams; cconstraint; cfields; ccomps } = contr in
     let kind = "Type error(s) in contract"
     and inst = PCIdentifier.as_error_string ctr_cname ^ "\n" in
-    wrap_with_info ~kind ~inst dummy_loc
+    wrap_with_info ~kind ~inst (SR.get_loc (PCIdentifier.get_rep ctr_cname))
     @@ let%bind checked_rlibs = pm_check_libentries rlibs in
        let%bind checked_elibs = mapM elibs ~f:pm_check_libtree in
 

--- a/tests/checker/bad/gold/bad_lib_pm_import.scilla.gold
+++ b/tests/checker/bad/gold/bad_lib_pm_import.scilla.gold
@@ -3,12 +3,15 @@
   "errors": [
     {
       "error_message": "Type error(s) in contract: BadLibPM\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "start_location": {
+        "file": "checker/bad/bad_lib_pm_import.scilla",
+        "line": 7,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message":
-        "Error during pattern-match checking of library: badpm",
+      "error_message": "Error during pattern-match checking of library: badpm",
       "start_location": {
         "file": "checker/bad/lib/BadPMLib.scillib",
         "line": 5,
@@ -17,8 +20,7 @@
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message":
-        "Type error in pattern matching on `b` of type Bool (or one of its branches):\nNon-exhaustive pattern match.",
+      "error_message": "Type error in pattern matching on `b` of type Bool (or one of its branches):\nNon-exhaustive pattern match.",
       "start_location": {
         "file": "checker/bad/lib/BadPMLib.scillib",
         "line": 7,

--- a/tests/checker/bad/gold/bad_message2.scilla.gold
+++ b/tests/checker/bad/gold/bad_message2.scilla.gold
@@ -22,9 +22,12 @@
   ],
   "warnings": [
     {
-      "warning_message":
-        "No transition in contract Empty contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract Empty contains an accept statement\n",
+      "start_location": {
+        "file": "checker/bad/bad_message2.scilla",
+        "line": 11,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/bad/gold/bad_version.scilla.gold
+++ b/tests/checker/bad/gold/bad_version.scilla.gold
@@ -1,17 +1,19 @@
 {
   "errors": [
     {
-      "error_message":
-        "Scilla version mismatch. Expected 0 vs Contract 99999\n",
+      "error_message": "Scilla version mismatch. Expected 0 vs Contract 99999\n",
       "start_location": { "file": "", "line": 0, "column": 0 },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }
   ],
   "warnings": [
     {
-      "warning_message":
-        "No transition in contract Empty contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract Empty contains an accept statement\n",
+      "start_location": {
+        "file": "checker/bad/bad_version.scilla",
+        "line": 3,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/bad/gold/mappair2.scilla.gold
+++ b/tests/checker/bad/gold/mappair2.scilla.gold
@@ -60,9 +60,12 @@
       "warning_id": 1
     },
     {
-      "warning_message":
-        "No transition in contract Test contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract Test contains an accept statement\n",
+      "start_location": {
+        "file": "checker/bad/mappair2.scilla",
+        "line": 30,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/bad/gold/match-in-transition.scilla.gold
+++ b/tests/checker/bad/gold/match-in-transition.scilla.gold
@@ -3,12 +3,15 @@
   "errors": [
     {
       "error_message": "Type error(s) in contract: Matcher\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "start_location": {
+        "file": "checker/bad/match-in-transition.scilla",
+        "line": 3,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message":
-        "Error during pattern-match checking of component: transition foo:\n",
+      "error_message": "Error during pattern-match checking of component: transition foo:\n",
       "start_location": {
         "file": "checker/bad/match-in-transition.scilla",
         "line": 7,
@@ -17,8 +20,7 @@
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message":
-        "Type error in pattern matching on `x` (or one of its branches):\nNon-exhaustive pattern match.",
+      "error_message": "Type error in pattern matching on `x` (or one of its branches):\nNon-exhaustive pattern match.",
       "start_location": {
         "file": "checker/bad/match-in-transition.scilla",
         "line": 10,

--- a/tests/checker/bad/gold/name_clashes.scilla.gold
+++ b/tests/checker/bad/gold/name_clashes.scilla.gold
@@ -40,9 +40,12 @@
   ],
   "warnings": [
     {
-      "warning_message":
-        "No transition in contract TransitionAndProcedureNameClashes contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract TransitionAndProcedureNameClashes contains an accept statement\n",
+      "start_location": {
+        "file": "checker/bad/name_clashes.scilla",
+        "line": 5,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/bad/gold/zil_mod.scilla.gold
+++ b/tests/checker/bad/gold/zil_mod.scilla.gold
@@ -3,12 +3,15 @@
   "errors": [
     {
       "error_message": "Type error(s) in contract: ZilGame\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "start_location": {
+        "file": "checker/bad/zil_mod.scilla",
+        "line": 141,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message":
-        "Error during pattern-match checking of library: check_validity",
+      "error_message": "Error during pattern-match checking of library: check_validity",
       "start_location": {
         "file": "checker/bad/zil_mod.scilla",
         "line": 69,
@@ -17,8 +20,7 @@
       "end_location": { "file": "", "line": 0, "column": 0 }
     },
     {
-      "error_message":
-        "Type error in pattern matching on `xa` of type Pair (Bool) (Option (ByStr32)) (or one of its branches):\nPattern is unreachable: 3",
+      "error_message": "Type error in pattern matching on `xa` of type Pair (Bool) (Option (ByStr32)) (or one of its branches):\nPattern is unreachable: 3",
       "start_location": {
         "file": "checker/bad/zil_mod.scilla",
         "line": 80,

--- a/tests/checker/good/gold/UintParam.scilla.gold
+++ b/tests/checker/good/gold/UintParam.scilla.gold
@@ -79,9 +79,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract UintParam contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract UintParam contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/UintParam.scilla",
+        "line": 5,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/address_eq_test.scilla.gold
+++ b/tests/checker/good/gold/address_eq_test.scilla.gold
@@ -31,15 +31,13 @@
       { "vname": "concat_res", "type": "ByStr40", "depth": 0 },
       {
         "vname": "test_map",
-        "type":
-          "Map (ByStr20 with contract field f : Uint32 end) (ByStr20 with contract end)",
+        "type": "Map (ByStr20 with contract field f : Uint32 end) (ByStr20 with contract end)",
         "depth": 1
       },
       { "vname": "map_res_1", "type": "Bool", "depth": 0 },
       {
         "vname": "map_res_2",
-        "type":
-          "Map (ByStr20 with contract field f : Uint32 end) (ByStr20 with contract end)",
+        "type": "Map (ByStr20 with contract field f : Uint32 end) (ByStr20 with contract end)",
         "depth": 1
       },
       {
@@ -49,14 +47,12 @@
       },
       {
         "vname": "map_res_4",
-        "type":
-          "Map (ByStr20 with contract field f : Uint32 end) (ByStr20 with contract end)",
+        "type": "Map (ByStr20 with contract field f : Uint32 end) (ByStr20 with contract end)",
         "depth": 1
       },
       {
         "vname": "map_res_5",
-        "type":
-          "List (Pair (ByStr20 with contract field f : Uint32 end) (ByStr20 with contract end))",
+        "type": "List (Pair (ByStr20 with contract field f : Uint32 end) (ByStr20 with contract end))",
         "depth": 0
       },
       { "vname": "map_res_6", "type": "Uint32", "depth": 0 },
@@ -80,13 +76,11 @@
         "params": [
           {
             "vname": "param1",
-            "type":
-              "ByStr20 with contract field f : Uint128, field g : Int32 end"
+            "type": "ByStr20 with contract field f : Uint128, field g : Int32 end"
           },
           {
             "vname": "param2",
-            "type":
-              "ByStr20 with contract field f : Uint128, field h : Bool end"
+            "type": "ByStr20 with contract field f : Uint128, field h : Bool end"
           }
         ]
       },
@@ -95,13 +89,11 @@
         "params": [
           {
             "vname": "param1",
-            "type":
-              "ByStr20 with contract field f : Uint32, field g : Int32 end"
+            "type": "ByStr20 with contract field f : Uint32, field g : Int32 end"
           },
           {
             "vname": "param2",
-            "type":
-              "ByStr20 with contract field f : Uint128, field h : Bool end"
+            "type": "ByStr20 with contract field f : Uint128, field h : Bool end"
           }
         ]
       },
@@ -110,8 +102,7 @@
         "params": [
           {
             "vname": "param1",
-            "type":
-              "ByStr20 with contract field f : Uint32, field g : Int32 end"
+            "type": "ByStr20 with contract field f : Uint32, field g : Int32 end"
           },
           { "vname": "param2", "type": "ByStr20" }
         ]
@@ -121,8 +112,7 @@
         "params": [
           {
             "vname": "param1",
-            "type":
-              "ByStr20 with contract field f : Uint32, field g : Int32 end"
+            "type": "ByStr20 with contract field f : Uint32, field g : Int32 end"
           },
           { "vname": "param2", "type": "ByStr20 with end" }
         ]
@@ -132,8 +122,7 @@
         "params": [
           {
             "vname": "param1",
-            "type":
-              "ByStr20 with contract field f : Uint32, field g : Int32 end"
+            "type": "ByStr20 with contract field f : Uint32, field g : Int32 end"
           },
           { "vname": "param2", "type": "ByStr20 with contract end" }
         ]
@@ -143,8 +132,7 @@
         "params": [
           {
             "vname": "param1",
-            "type":
-              "ByStr20 with contract field f : Uint32, field g : Int32 end"
+            "type": "ByStr20 with contract field f : Uint32, field g : Int32 end"
           }
         ]
       },
@@ -153,8 +141,7 @@
         "params": [
           {
             "vname": "param1",
-            "type":
-              "ByStr20 with contract field f : Uint32, field g : Int32 end"
+            "type": "ByStr20 with contract field f : Uint32, field g : Int32 end"
           }
         ]
       },
@@ -163,8 +150,7 @@
         "params": [
           {
             "vname": "param1",
-            "type":
-              "ByStr20 with contract field f : Uint32, field g : Int32 end"
+            "type": "ByStr20 with contract field f : Uint32, field g : Int32 end"
           },
           { "vname": "param2", "type": "ByStr20 with contract end" }
         ]
@@ -174,8 +160,7 @@
         "params": [
           {
             "vname": "param1",
-            "type":
-              "ByStr20 with contract field f : Uint32, field g : Int32 end"
+            "type": "ByStr20 with contract field f : Uint32, field g : Int32 end"
           },
           { "vname": "param2", "type": "ByStr20 with contract end" }
         ]
@@ -185,8 +170,7 @@
         "params": [
           {
             "vname": "param1",
-            "type":
-              "ByStr20 with contract field f : Uint32, field g : Int32 end"
+            "type": "ByStr20 with contract field f : Uint32, field g : Int32 end"
           }
         ]
       },
@@ -195,8 +179,7 @@
         "params": [
           {
             "vname": "param1",
-            "type":
-              "ByStr20 with contract field f : Uint32, field g : Int32 end"
+            "type": "ByStr20 with contract field f : Uint32, field g : Int32 end"
           }
         ]
       }
@@ -375,8 +358,7 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "Read only field, consider making it a contract parameter: test_map",
+      "warning_message": "Read only field, consider making it a contract parameter: test_map",
       "start_location": {
         "file": "contracts/address_eq_test.scilla",
         "line": 73,
@@ -416,9 +398,12 @@
       "warning_id": 1
     },
     {
-      "warning_message":
-        "No transition in contract AddressEqTest contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract AddressEqTest contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/address_eq_test.scilla",
+        "line": 3,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/address_list_as_cparam.scilla.gold
+++ b/tests/checker/good/gold/address_list_as_cparam.scilla.gold
@@ -1,8 +1,7 @@
 {
   "cashflow_tags": {
     "State variables": [
-      { "field": "x", "tag": "NoInfo" },
-      { "field": "f", "tag": "NoInfo" }
+      { "field": "x", "tag": "NoInfo" }, { "field": "f", "tag": "NoInfo" }
     ],
     "ADT constructors": []
   },
@@ -77,9 +76,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract T contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract T contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/address_list_as_cparam.scilla",
+        "line": 3,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/address_list_traversal.scilla.gold
+++ b/tests/checker/good/gold/address_list_traversal.scilla.gold
@@ -119,9 +119,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract AddressListTraversal contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract AddressListTraversal contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/address_list_traversal.scilla",
+        "line": 19,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/adt_test.scilla.gold
+++ b/tests/checker/good/gold/adt_test.scilla.gold
@@ -116,7 +116,11 @@
     },
     {
       "warning_message": "No transition in contract BadLib contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "start_location": {
+        "file": "checker/good/adt_test.scilla",
+        "line": 18,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/backward_definition_procedure.scilla.gold
+++ b/tests/checker/good/gold/backward_definition_procedure.scilla.gold
@@ -86,9 +86,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract BackwardDefinitionProcedure contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract BackwardDefinitionProcedure contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/backward_definition_procedure.scilla",
+        "line": 5,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/blowup_1.scilla.gold
+++ b/tests/checker/good/gold/blowup_1.scilla.gold
@@ -103,9 +103,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract Blowup contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract Blowup contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/blowup_1.scilla",
+        "line": 19,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/blowup_2.scilla.gold
+++ b/tests/checker/good/gold/blowup_2.scilla.gold
@@ -103,9 +103,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract Blowup contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract Blowup contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/blowup_2.scilla",
+        "line": 20,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/bookstore.scilla.gold
+++ b/tests/checker/good/gold/bookstore.scilla.gold
@@ -238,9 +238,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract BookStore contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract BookStore contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/bookstore.scilla",
+        "line": 54,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/builtin_type_args.scilla.gold
+++ b/tests/checker/good/gold/builtin_type_args.scilla.gold
@@ -60,9 +60,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract Contr contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract Contr contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/builtin_type_args.scilla",
+        "line": 12,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/cashflow_test.scilla.gold
+++ b/tests/checker/good/gold/cashflow_test.scilla.gold
@@ -29,8 +29,7 @@
       }
     ],
     "transitions": [
-      { "vname": "Test1", "params": [] },
-      { "vname": "Test2", "params": [] }
+      { "vname": "Test1", "params": [] }, { "vname": "Test2", "params": [] }
     ],
     "procedures": [],
     "events": [],
@@ -86,8 +85,7 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "Read only field, consider making it a contract parameter: transaction_pairs",
+      "warning_message": "Read only field, consider making it a contract parameter: transaction_pairs",
       "start_location": {
         "file": "checker/good/cashflow_test.scilla",
         "line": 21,
@@ -127,9 +125,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract CashflowTest contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract CashflowTest contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/cashflow_test.scilla",
+        "line": 13,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/chainid.scilla.gold
+++ b/tests/checker/good/gold/chainid.scilla.gold
@@ -55,9 +55,12 @@
   },
   "warnings": [
     {
-      "warning_message":
-        "No transition in contract HelloWorld contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract HelloWorld contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/chainid.scilla",
+        "line": 7,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/codehash.scilla.gold
+++ b/tests/checker/good/gold/codehash.scilla.gold
@@ -77,9 +77,12 @@
   },
   "warnings": [
     {
-      "warning_message":
-        "No transition in contract Codehash contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract Codehash contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/codehash.scilla",
+        "line": 3,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/constraint.scilla.gold
+++ b/tests/checker/good/gold/constraint.scilla.gold
@@ -53,9 +53,12 @@
   },
   "warnings": [
     {
-      "warning_message":
-        "No transition in contract Constraint contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract Constraint contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/constraint.scilla",
+        "line": 7,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/constraint_scope.scilla.gold
+++ b/tests/checker/good/gold/constraint_scope.scilla.gold
@@ -130,9 +130,12 @@
       "warning_id": 2
     },
     {
-      "warning_message":
-        "No transition in contract Constraint contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract Constraint contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/constraint_scope.scilla",
+        "line": 15,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/dead_code_test1.scilla.gold
+++ b/tests/checker/good/gold/dead_code_test1.scilla.gold
@@ -371,12 +371,16 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract BookstoreDead1 contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract BookstoreDead1 contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/dead_code_test1.scilla",
+        "line": 47,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }
   ],
   "gas_remaining": "7999"
 }
+

--- a/tests/checker/good/gold/dead_code_test10.scilla.gold
+++ b/tests/checker/good/gold/dead_code_test10.scilla.gold
@@ -95,10 +95,15 @@
     },
     {
       "warning_message": "No transition in contract Dead contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "start_location": {
+        "file": "contracts/dead_code_test10.scilla",
+        "line": 15,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }
   ],
   "gas_remaining": "7999"
 }
+

--- a/tests/checker/good/gold/dead_code_test11.scilla.gold
+++ b/tests/checker/good/gold/dead_code_test11.scilla.gold
@@ -86,7 +86,11 @@
     },
     {
       "warning_message": "No transition in contract Dead contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "start_location": {
+        "file": "contracts/dead_code_test11.scilla",
+        "line": 12,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/dead_code_test12.scilla.gold
+++ b/tests/checker/good/gold/dead_code_test12.scilla.gold
@@ -94,7 +94,11 @@
     },
     {
       "warning_message": "No transition in contract Dead12 contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "start_location": {
+        "file": "contracts/dead_code_test12.scilla",
+        "line": 14,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/dead_code_test13.scilla.gold
+++ b/tests/checker/good/gold/dead_code_test13.scilla.gold
@@ -129,7 +129,11 @@
     },
     {
       "warning_message": "No transition in contract Dead13 contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "start_location": {
+        "file": "contracts/dead_code_test13.scilla",
+        "line": 30,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/dead_code_test14.scilla.gold
+++ b/tests/checker/good/gold/dead_code_test14.scilla.gold
@@ -61,7 +61,11 @@
     },
     {
       "warning_message": "No transition in contract UnusedLibraryEntryBug contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "start_location": {
+        "file": "contracts/dead_code_test14.scilla",
+        "line": 7,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/dead_code_test3.scilla.gold
+++ b/tests/checker/good/gold/dead_code_test3.scilla.gold
@@ -80,9 +80,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract SimpleImplDead contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract SimpleImplDead contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/dead_code_test3.scilla",
+        "line": 6,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/dead_code_test4.scilla.gold
+++ b/tests/checker/good/gold/dead_code_test4.scilla.gold
@@ -1,8 +1,7 @@
 {
   "cashflow_tags": {
     "State variables": [
-      { "field": "z1", "tag": "NoInfo" },
-      { "field": "z2", "tag": "NoInfo" }
+      { "field": "z1", "tag": "NoInfo" }, { "field": "z2", "tag": "NoInfo" }
     ],
     "ADT constructors": []
   },
@@ -64,8 +63,7 @@
   },
   "warnings": [
     {
-      "warning_message":
-        "Read only field, consider making it a contract parameter: z2",
+      "warning_message": "Read only field, consider making it a contract parameter: z2",
       "start_location": {
         "file": "contracts/dead_code_test4.scilla",
         "line": 25,
@@ -75,8 +73,7 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "Read only field, consider making it a contract parameter: z1",
+      "warning_message": "Read only field, consider making it a contract parameter: z1",
       "start_location": {
         "file": "contracts/dead_code_test4.scilla",
         "line": 24,
@@ -116,8 +113,7 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "x is a new variable. It does not reassign the previously defined variable.",
+      "warning_message": "x is a new variable. It does not reassign the previously defined variable.",
       "start_location": {
         "file": "contracts/dead_code_test4.scilla",
         "line": 15,
@@ -127,9 +123,12 @@
       "warning_id": 2
     },
     {
-      "warning_message":
-        "No transition in contract Dead4 contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract Dead4 contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/dead_code_test4.scilla",
+        "line": 6,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/dead_code_test5.scilla.gold
+++ b/tests/checker/good/gold/dead_code_test5.scilla.gold
@@ -113,7 +113,11 @@
     },
     {
       "warning_message": "No transition in contract Dead5 contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "start_location": {
+        "file": "contracts/dead_code_test5.scilla",
+        "line": 25,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/dead_code_test6.scilla.gold
+++ b/tests/checker/good/gold/dead_code_test6.scilla.gold
@@ -89,7 +89,11 @@
     },
     {
       "warning_message": "No transition in contract Dead6 contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "start_location": {
+        "file": "contracts/dead_code_test6.scilla",
+        "line": 20,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/dead_code_test7.scilla.gold
+++ b/tests/checker/good/gold/dead_code_test7.scilla.gold
@@ -66,10 +66,15 @@
     },
     {
       "warning_message": "No transition in contract Dead7 contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "start_location": {
+        "file": "contracts/dead_code_test7.scilla",
+        "line": 8,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }
   ],
   "gas_remaining": "7999"
 }
+

--- a/tests/checker/good/gold/dead_code_test8.scilla.gold
+++ b/tests/checker/good/gold/dead_code_test8.scilla.gold
@@ -61,10 +61,15 @@
     },
     {
       "warning_message": "No transition in contract Dead8 contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "start_location": {
+        "file": "contracts/dead_code_test8.scilla",
+        "line": 5,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }
   ],
   "gas_remaining": "7999"
 }
+

--- a/tests/checker/good/gold/dead_code_test9.scilla.gold
+++ b/tests/checker/good/gold/dead_code_test9.scilla.gold
@@ -81,10 +81,15 @@
     },
     {
       "warning_message": "No transition in contract Dead contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "start_location": {
+        "file": "contracts/dead_code_test9.scilla",
+        "line": 8,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }
   ],
   "gas_remaining": "7999"
 }
+

--- a/tests/checker/good/gold/ecdsa.scilla.gold
+++ b/tests/checker/good/gold/ecdsa.scilla.gold
@@ -65,8 +65,7 @@
   },
   "warnings": [
     {
-      "warning_message":
-        "Read only field, consider making it a contract parameter: pub_key",
+      "warning_message": "Read only field, consider making it a contract parameter: pub_key",
       "start_location": {
         "file": "contracts/ecdsa.scilla",
         "line": 21,
@@ -106,9 +105,12 @@
       "warning_id": 2
     },
     {
-      "warning_message":
-        "No transition in contract Ecdsa contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract Ecdsa contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/ecdsa.scilla",
+        "line": 15,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/empty.scilla.gold
+++ b/tests/checker/good/gold/empty.scilla.gold
@@ -100,9 +100,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract Empty contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract Empty contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/empty.scilla",
+        "line": 6,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/event_reordered_fields.scilla.gold
+++ b/tests/checker/good/gold/event_reordered_fields.scilla.gold
@@ -93,9 +93,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract MyContract contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract MyContract contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/event_reordered_fields.scilla",
+        "line": 5,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/fungible-token.scilla.gold
+++ b/tests/checker/good/gold/fungible-token.scilla.gold
@@ -149,9 +149,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract FungibleToken contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract FungibleToken contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/fungible-token.scilla",
+        "line": 47,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/helloWorld.scilla.gold
+++ b/tests/checker/good/gold/helloWorld.scilla.gold
@@ -87,9 +87,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract HelloWorld contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract HelloWorld contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/helloWorld.scilla",
+        "line": 24,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/import-test-lib.scilla.gold
+++ b/tests/checker/good/gold/import-test-lib.scilla.gold
@@ -5,8 +5,7 @@
       {
         "0x986556789012345678901234567890123456abcd.TestType1": [
           {
-            "constructor":
-              "0x986556789012345678901234567890123456abcd.TestConstructor1",
+            "constructor": "0x986556789012345678901234567890123456abcd.TestConstructor1",
             "tags": [ "NoInfo" ]
           }
         ]
@@ -44,13 +43,11 @@
         "tparams": [],
         "tmap": [
           {
-            "cname":
-              "0x986556789012345678901234567890123456abcd.TestConstructor1",
+            "cname": "0x986556789012345678901234567890123456abcd.TestConstructor1",
             "argtypes": [ "Uint128" ]
           },
           {
-            "cname":
-              "0x986556789012345678901234567890123456abcd.TestConstructor2",
+            "cname": "0x986556789012345678901234567890123456abcd.TestConstructor2",
             "argtypes": [ "Bool" ]
           }
         ]
@@ -97,8 +94,7 @@
         "tparams": [],
         "tmap": [
           {
-            "cname":
-              "0x111256789012345678901234567890123456abef.WrapperConstructor",
+            "cname": "0x111256789012345678901234567890123456abef.WrapperConstructor",
             "argtypes": [
               "0x986556789012345678901234567890123456abcd.TestType1"
             ]
@@ -119,9 +115,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract Hello contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract Hello contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/import-test-lib.scilla",
+        "line": 23,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/import-test-lib2.scilla.gold
+++ b/tests/checker/good/gold/import-test-lib2.scilla.gold
@@ -5,8 +5,7 @@
       {
         "0x222256789012345678901234567890123456abef.BaseType": [
           {
-            "constructor":
-              "0x222256789012345678901234567890123456abef.BaseConstructor",
+            "constructor": "0x222256789012345678901234567890123456abef.BaseConstructor",
             "tags": [ "NoInfo" ]
           }
         ]
@@ -23,13 +22,11 @@
     "events": [],
     "ADTs": [
       {
-        "tname":
-          "0x333256789012345678901234567890123456abef.Level1WrapperType",
+        "tname": "0x333256789012345678901234567890123456abef.Level1WrapperType",
         "tparams": [],
         "tmap": [
           {
-            "cname":
-              "0x333256789012345678901234567890123456abef.Level1WrapperConstructor",
+            "cname": "0x333256789012345678901234567890123456abef.Level1WrapperConstructor",
             "argtypes": [
               "0x222256789012345678901234567890123456abef.BaseType"
             ]
@@ -45,13 +42,11 @@
         ]
       },
       {
-        "tname":
-          "0x444256789012345678901234567890123456abef.Level2WrapperType",
+        "tname": "0x444256789012345678901234567890123456abef.Level2WrapperType",
         "tparams": [],
         "tmap": [
           {
-            "cname":
-              "0x444256789012345678901234567890123456abef.Level2WrapperConstructor",
+            "cname": "0x444256789012345678901234567890123456abef.Level2WrapperConstructor",
             "argtypes": [
               "0x333256789012345678901234567890123456abef.Level1WrapperType"
             ]
@@ -63,8 +58,7 @@
         "tparams": [],
         "tmap": [
           {
-            "cname":
-              "0x222256789012345678901234567890123456abef.BaseConstructor",
+            "cname": "0x222256789012345678901234567890123456abef.BaseConstructor",
             "argtypes": [ "Uint128" ]
           }
         ]
@@ -112,9 +106,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract ImportTestLib2 contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract ImportTestLib2 contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/import-test-lib2.scilla",
+        "line": 26,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/import-test-lib3.scilla.gold
+++ b/tests/checker/good/gold/import-test-lib3.scilla.gold
@@ -5,8 +5,7 @@
       {
         "0x555256789012345678901234567890123456abef.BaseType": [
           {
-            "constructor":
-              "0x555256789012345678901234567890123456abef.BaseConstructor",
+            "constructor": "0x555256789012345678901234567890123456abef.BaseConstructor",
             "tags": [ "NoInfo" ]
           }
         ]
@@ -27,8 +26,7 @@
         "tparams": [],
         "tmap": [
           {
-            "cname":
-              "0x555256789012345678901234567890123456abef.BaseConstructor",
+            "cname": "0x555256789012345678901234567890123456abef.BaseConstructor",
             "argtypes": [ "Uint128" ]
           }
         ]
@@ -74,9 +72,12 @@
   },
   "warnings": [
     {
-      "warning_message":
-        "No transition in contract ImportTestLib3 contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract ImportTestLib3 contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/import-test-lib3.scilla",
+        "line": 26,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/inplace-map.scilla.gold
+++ b/tests/checker/good/gold/inplace-map.scilla.gold
@@ -134,9 +134,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract Test contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract Test contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/inplace-map.scilla",
+        "line": 7,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/lib_typing.scilla.gold
+++ b/tests/checker/good/gold/lib_typing.scilla.gold
@@ -80,9 +80,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract LibTyping contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract LibTyping contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/lib_typing.scilla",
+        "line": 9,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/lib_typing2.scilla.gold
+++ b/tests/checker/good/gold/lib_typing2.scilla.gold
@@ -60,9 +60,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract LibTyping2 contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract LibTyping2 contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/lib_typing2.scilla",
+        "line": 25,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/libchain1.scilla.gold
+++ b/tests/checker/good/gold/libchain1.scilla.gold
@@ -88,9 +88,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract TestContr1 contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract TestContr1 contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/libchain1.scilla",
+        "line": 9,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/libchain2.scilla.gold
+++ b/tests/checker/good/gold/libchain2.scilla.gold
@@ -88,9 +88,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract TestContr2 contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract TestContr2 contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/libchain2.scilla",
+        "line": 9,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/libdiamond.scilla.gold
+++ b/tests/checker/good/gold/libdiamond.scilla.gold
@@ -60,9 +60,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract TestContr1 contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract TestContr1 contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/libdiamond.scilla",
+        "line": 7,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/libdiamond2.scilla.gold
+++ b/tests/checker/good/gold/libdiamond2.scilla.gold
@@ -70,9 +70,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract TestContr1 contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract TestContr1 contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/libdiamond2.scilla",
+        "line": 10,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/listiter.scilla.gold
+++ b/tests/checker/good/gold/listiter.scilla.gold
@@ -88,9 +88,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract ListIter contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract ListIter contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/listiter.scilla",
+        "line": 8,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/map-inplace-update-with-_sender.scilla.gold
+++ b/tests/checker/good/gold/map-inplace-update-with-_sender.scilla.gold
@@ -65,9 +65,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract Test contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract Test contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/map-inplace-update-with-_sender.scilla",
+        "line": 3,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/map_as_cparam.scilla.gold
+++ b/tests/checker/good/gold/map_as_cparam.scilla.gold
@@ -1,8 +1,7 @@
 {
   "cashflow_tags": {
     "State variables": [
-      { "field": "x", "tag": "NoInfo" },
-      { "field": "f", "tag": "NoInfo" }
+      { "field": "x", "tag": "NoInfo" }, { "field": "f", "tag": "NoInfo" }
     ],
     "ADT constructors": []
   },
@@ -12,15 +11,13 @@
     "params": [
       {
         "vname": "x",
-        "type":
-          "Map (ByStr20 with contract field f : Uint128 end) (ByStr20 with contract field g : Bool end)"
+        "type": "Map (ByStr20 with contract field f : Uint128 end) (ByStr20 with contract field g : Bool end)"
       }
     ],
     "fields": [
       {
         "vname": "f",
-        "type":
-          "Map (ByStr20 with contract field f : Uint128 end) (ByStr20 with contract field g : Bool end)",
+        "type": "Map (ByStr20 with contract field f : Uint128 end) (ByStr20 with contract field g : Bool end)",
         "depth": 1
       }
     ],
@@ -79,9 +76,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract T contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract T contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/map_as_cparam.scilla",
+        "line": 3,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/map_corners_test.scilla.gold
+++ b/tests/checker/good/gold/map_corners_test.scilla.gold
@@ -258,9 +258,12 @@
       "warning_id": 1
     },
     {
-      "warning_message":
-        "No transition in contract MapCornersTest contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract MapCornersTest contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 18,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/map_corners_test.scilla.typeinfo.gold
+++ b/tests/checker/good/gold/map_corners_test.scilla.typeinfo.gold
@@ -9863,9 +9863,12 @@
       "warning_id": 1
     },
     {
-      "warning_message":
-        "No transition in contract MapCornersTest contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract MapCornersTest contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/map_corners_test.scilla",
+        "line": 18,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/map_key_test.scilla.gold
+++ b/tests/checker/good/gold/map_key_test.scilla.gold
@@ -74,9 +74,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract Test contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract Test contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/map_key_test.scilla",
+        "line": 8,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/map_no_inplace_warn.scilla.gold
+++ b/tests/checker/good/gold/map_no_inplace_warn.scilla.gold
@@ -156,9 +156,12 @@
       "warning_id": 1
     },
     {
-      "warning_message":
-        "No transition in contract TestNonInplaceMapWarn contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract TestNonInplaceMapWarn contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/map_no_inplace_warn.scilla",
+        "line": 3,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/mappair.scilla.gold
+++ b/tests/checker/good/gold/mappair.scilla.gold
@@ -107,8 +107,7 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "Read only field, consider making it a contract parameter: plist",
+      "warning_message": "Read only field, consider making it a contract parameter: plist",
       "start_location": {
         "file": "contracts/mappair.scilla",
         "line": 102,
@@ -118,8 +117,7 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "Read only field, consider making it a contract parameter: llist",
+      "warning_message": "Read only field, consider making it a contract parameter: llist",
       "start_location": {
         "file": "contracts/mappair.scilla",
         "line": 92,
@@ -139,8 +137,7 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "x is a new variable. It does not reassign the previously defined variable.",
+      "warning_message": "x is a new variable. It does not reassign the previously defined variable.",
       "start_location": {
         "file": "contracts/mappair.scilla",
         "line": 113,
@@ -150,9 +147,12 @@
       "warning_id": 2
     },
     {
-      "warning_message":
-        "No transition in contract Test contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract Test contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/mappair.scilla",
+        "line": 30,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/missing-accepts.scilla.gold
+++ b/tests/checker/good/gold/missing-accepts.scilla.gold
@@ -11,8 +11,7 @@
     ],
     "procedures": [],
     "events": [
-      { "vname": "bar", "params": [] },
-      { "vname": "foo", "params": [] }
+      { "vname": "bar", "params": [] }, { "vname": "foo", "params": [] }
     ],
     "ADTs": [
       {
@@ -76,9 +75,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract MissingAccepts contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract MissingAccepts contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/missing-accepts.scilla",
+        "line": 3,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/multiple-msgs.scilla.gold
+++ b/tests/checker/good/gold/multiple-msgs.scilla.gold
@@ -60,9 +60,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract HelloWorld contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract HelloWorld contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/multiple-msgs.scilla",
+        "line": 21,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/namespace1.scilla.gold
+++ b/tests/checker/good/gold/namespace1.scilla.gold
@@ -88,9 +88,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract TestContr1 contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract TestContr1 contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/namespace1.scilla",
+        "line": 9,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/namespace2.scilla.gold
+++ b/tests/checker/good/gold/namespace2.scilla.gold
@@ -60,9 +60,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract TestContr1 contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract TestContr1 contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/namespace2.scilla",
+        "line": 9,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/namespace3.scilla.gold
+++ b/tests/checker/good/gold/namespace3.scilla.gold
@@ -117,9 +117,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract TestContr1 contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract TestContr1 contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/namespace3.scilla",
+        "line": 10,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/nested-comments.scilla.gold
+++ b/tests/checker/good/gold/nested-comments.scilla.gold
@@ -50,9 +50,12 @@
   },
   "warnings": [
     {
-      "warning_message":
-        "No transition in contract NestedComments contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract NestedComments contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/nested-comments.scilla",
+        "line": 13,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/nonfungible-token.scilla.gold
+++ b/tests/checker/good/gold/nonfungible-token.scilla.gold
@@ -335,9 +335,12 @@
       "warning_id": 1
     },
     {
-      "warning_message":
-        "No transition in contract NonfungibleToken contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract NonfungibleToken contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/nonfungible-token.scilla",
+        "line": 97,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/one-msg.scilla.gold
+++ b/tests/checker/good/gold/one-msg.scilla.gold
@@ -60,9 +60,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract HelloWorld contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract HelloWorld contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/one-msg.scilla",
+        "line": 21,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/one-msg1.scilla.gold
+++ b/tests/checker/good/gold/one-msg1.scilla.gold
@@ -70,9 +70,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract HelloWorld contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract HelloWorld contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/one-msg1.scilla",
+        "line": 21,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/one-msg2.scilla.gold
+++ b/tests/checker/good/gold/one-msg2.scilla.gold
@@ -65,9 +65,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract HelloWorld contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract HelloWorld contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/one-msg2.scilla",
+        "line": 22,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/one-msg3.scilla.gold
+++ b/tests/checker/good/gold/one-msg3.scilla.gold
@@ -75,9 +75,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract HelloWorld contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract HelloWorld contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/one-msg3.scilla",
+        "line": 22,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/ping.scilla.gold
+++ b/tests/checker/good/gold/ping.scilla.gold
@@ -69,9 +69,12 @@
   },
   "warnings": [
     {
-      "warning_message":
-        "No transition in contract Ping contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract Ping contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/ping.scilla",
+        "line": 13,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/polymorphic_address.scilla.gold
+++ b/tests/checker/good/gold/polymorphic_address.scilla.gold
@@ -20,8 +20,7 @@
         "params": [
           {
             "vname": "param1",
-            "type":
-              "ByStr20 with contract field f : Uint32, field x : Uint128 end"
+            "type": "ByStr20 with contract field f : Uint32, field x : Uint128 end"
           }
         ]
       },
@@ -30,8 +29,7 @@
         "params": [
           {
             "vname": "param1",
-            "type":
-              "ByStr20 with contract field f : Uint128, field x : Uint128 end"
+            "type": "ByStr20 with contract field f : Uint128, field x : Uint128 end"
           }
         ]
       }
@@ -110,9 +108,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract AddressListTraversal contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract AddressListTraversal contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/polymorphic_address.scilla",
+        "line": 11,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/pong.scilla.gold
+++ b/tests/checker/good/gold/pong.scilla.gold
@@ -69,9 +69,12 @@
   },
   "warnings": [
     {
-      "warning_message":
-        "No transition in contract Pong contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract Pong contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/pong.scilla",
+        "line": 13,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/remote_state_reads_2.scilla.gold
+++ b/tests/checker/good/gold/remote_state_reads_2.scilla.gold
@@ -46,8 +46,7 @@
         "params": [
           {
             "vname": "remote",
-            "type":
-              "ByStr20 with contract field admin : ByStr20 with contract field f : ByStr20 with contract field g : Uint128 end end end"
+            "type": "ByStr20 with contract field admin : ByStr20 with contract field f : ByStr20 with contract field g : Uint128 end end end"
           }
         ]
       },
@@ -56,8 +55,7 @@
         "params": [
           {
             "vname": "remote",
-            "type":
-              "ByStr20 with contract field admin : ByStr20 with contract field f : ByStr20 with contract field g : Map (Uint128) (Uint128) end end end"
+            "type": "ByStr20 with contract field admin : ByStr20 with contract field f : ByStr20 with contract field g : Map (Uint128) (Uint128) end end end"
           }
         ]
       },
@@ -149,9 +147,12 @@
       "warning_id": 1
     },
     {
-      "warning_message":
-        "No transition in contract RRContract contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract RRContract contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/remote_state_reads_2.scilla",
+        "line": 3,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/schnorr.scilla.gold
+++ b/tests/checker/good/gold/schnorr.scilla.gold
@@ -63,8 +63,7 @@
   },
   "warnings": [
     {
-      "warning_message":
-        "Read only field, consider making it a contract parameter: pub_key",
+      "warning_message": "Read only field, consider making it a contract parameter: pub_key",
       "start_location": {
         "file": "contracts/schnorr.scilla",
         "line": 21,
@@ -104,9 +103,12 @@
       "warning_id": 2
     },
     {
-      "warning_message":
-        "No transition in contract Schnorr contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract Schnorr contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/schnorr.scilla",
+        "line": 15,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/shadow_import.scilla.gold
+++ b/tests/checker/good/gold/shadow_import.scilla.gold
@@ -79,9 +79,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract Resolver contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract Resolver contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/shadow_import.scilla",
+        "line": 11,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/shadowwarn1.scilla.gold
+++ b/tests/checker/good/gold/shadowwarn1.scilla.gold
@@ -85,9 +85,12 @@
       "warning_id": 2
     },
     {
-      "warning_message":
-        "No transition in contract ShadowWarn1 contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract ShadowWarn1 contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/shadowwarn1.scilla",
+        "line": 3,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/shadowwarn2.scilla.gold
+++ b/tests/checker/good/gold/shadowwarn2.scilla.gold
@@ -122,9 +122,12 @@
       "warning_id": 2
     },
     {
-      "warning_message":
-        "No transition in contract ShadowWarn2 contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract ShadowWarn2 contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/shadowwarn2.scilla",
+        "line": 3,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/shadowwarn3.scilla.gold
+++ b/tests/checker/good/gold/shadowwarn3.scilla.gold
@@ -100,8 +100,7 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "Deprecated: variable a shadows a previous binding in the same pattern.",
+      "warning_message": "Deprecated: variable a shadows a previous binding in the same pattern.",
       "start_location": {
         "file": "checker/good/shadowwarn3.scilla",
         "line": 19,
@@ -111,8 +110,7 @@
       "warning_id": 2
     },
     {
-      "warning_message":
-        "Deprecated: variable a shadows a previous binding in the same pattern.",
+      "warning_message": "Deprecated: variable a shadows a previous binding in the same pattern.",
       "start_location": {
         "file": "checker/good/shadowwarn3.scilla",
         "line": 11,
@@ -122,9 +120,12 @@
       "warning_id": 2
     },
     {
-      "warning_message":
-        "No transition in contract ShadowWarn3 contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract ShadowWarn3 contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/shadowwarn3.scilla",
+        "line": 15,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/shogi.scilla.gold
+++ b/tests/checker/good/gold/shogi.scilla.gold
@@ -238,9 +238,12 @@
       "warning_id": 1
     },
     {
-      "warning_message":
-        "No transition in contract Shogi contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract Shogi contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/shogi.scilla",
+        "line": 571,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/shogi_proc.scilla.gold
+++ b/tests/checker/good/gold/shogi_proc.scilla.gold
@@ -290,9 +290,12 @@
       "warning_id": 1
     },
     {
-      "warning_message":
-        "No transition in contract ShogiProc contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract ShogiProc contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/shogi_proc.scilla",
+        "line": 571,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/simple-dex-remote-reads.scilla.gold
+++ b/tests/checker/good/gold/simple-dex-remote-reads.scilla.gold
@@ -26,8 +26,7 @@
       { "vname": "admin", "type": "ByStr20 with end", "depth": 0 },
       {
         "vname": "listed_tokens",
-        "type":
-          "Map (String) (ByStr20 with contract field allowances : Map (ByStr20) (Map (ByStr20) (Uint128)) end)",
+        "type": "Map (String) (ByStr20 with contract field allowances : Map (ByStr20) (Map (ByStr20) (Uint128)) end)",
         "depth": 1
       },
       {
@@ -48,8 +47,7 @@
           { "vname": "token_code", "type": "String" },
           {
             "vname": "new_token",
-            "type":
-              "ByStr20 with contract field allowances : Map (ByStr20) (Map (ByStr20) (Uint128)) end"
+            "type": "ByStr20 with contract field allowances : Map (ByStr20) (Map (ByStr20) (Uint128)) end"
           }
         ]
       },
@@ -121,8 +119,7 @@
         "params": [
           {
             "vname": "token",
-            "type":
-              "ByStr20 with contract field allowances : Map (ByStr20) (Map (ByStr20) (Uint128)) end"
+            "type": "ByStr20 with contract field allowances : Map (ByStr20) (Map (ByStr20) (Uint128)) end"
           },
           { "vname": "expected", "type": "Uint128" }
         ]
@@ -287,9 +284,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract SimpleExchange contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract SimpleExchange contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/simple-dex-remote-reads.scilla",
+        "line": 81,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/simple-dex-shadowwarn.scilla.gold
+++ b/tests/checker/good/gold/simple-dex-shadowwarn.scilla.gold
@@ -184,8 +184,7 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "A hashing builtin is applied to argument \"order\" whose compound type makes it prone to hash collisions. Consider using values of more primitive types in your hashing scheme.",
+      "warning_message": "A hashing builtin is applied to argument \"order\" whose compound type makes it prone to hash collisions. Consider using values of more primitive types in your hashing scheme.",
       "start_location": {
         "file": "checker/good/simple-dex-shadowwarn.scilla",
         "line": 28,
@@ -205,9 +204,12 @@
       "warning_id": 2
     },
     {
-      "warning_message":
-        "No transition in contract SimpleDex contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract SimpleDex contains an accept statement\n",
+      "start_location": {
+        "file": "checker/good/simple-dex-shadowwarn.scilla",
+        "line": 71,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/simple-dex.scilla.gold
+++ b/tests/checker/good/gold/simple-dex.scilla.gold
@@ -184,8 +184,7 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "A hashing builtin is applied to argument \"order\" whose compound type makes it prone to hash collisions. Consider using values of more primitive types in your hashing scheme.",
+      "warning_message": "A hashing builtin is applied to argument \"order\" whose compound type makes it prone to hash collisions. Consider using values of more primitive types in your hashing scheme.",
       "start_location": {
         "file": "contracts/simple-dex.scilla",
         "line": 28,
@@ -195,9 +194,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract SimpleDex contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract SimpleDex contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/simple-dex.scilla",
+        "line": 71,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/timestamp.scilla.gold
+++ b/tests/checker/good/gold/timestamp.scilla.gold
@@ -55,9 +55,12 @@
   },
   "warnings": [
     {
-      "warning_message":
-        "No transition in contract HelloWorld contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract HelloWorld contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/timestamp.scilla",
+        "line": 7,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/type_casts.scilla.gold
+++ b/tests/checker/good/gold/type_casts.scilla.gold
@@ -386,7 +386,11 @@
     },
     {
       "warning_message": "No transition in contract CastContract contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "start_location": {
+        "file": "contracts/type_casts.scilla",
+        "line": 9,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/ud-proxy.scilla.gold
+++ b/tests/checker/good/gold/ud-proxy.scilla.gold
@@ -107,9 +107,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract Admin contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract Admin contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/ud-proxy.scilla",
+        "line": 21,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }

--- a/tests/checker/good/gold/zil-game.scilla.gold
+++ b/tests/checker/good/gold/zil-game.scilla.gold
@@ -110,9 +110,12 @@
       "warning_id": 3
     },
     {
-      "warning_message":
-        "No transition in contract ZilGame contains an accept statement\n",
-      "start_location": { "file": "", "line": 0, "column": 0 },
+      "warning_message": "No transition in contract ZilGame contains an accept statement\n",
+      "start_location": {
+        "file": "contracts/zil-game.scilla",
+        "line": 140,
+        "column": 10
+      },
       "end_location": { "file": "", "line": 0, "column": 0 },
       "warning_id": 1
     }


### PR DESCRIPTION
When we report a warning in a smart-contract, we should set it location on a contract name instead of `0:0` when possible.

I've seen a few more cases when we report `0:0`:
* [checker/bad/gold/bad_version.scilla.gold](https://github.com/Zilliqa/scilla/tree/b361f3bb0be633bec935e900ff7f1e3d27acb409/tests/checker/bad/gold/bad_version.scilla.gold#L5): scilla version missmatch
* [checker/bad/gold/bad_init.scilla.gold](https://github.com/Zilliqa/scilla/tree/b361f3bb0be633bec935e900ff7f1e3d27acb409/tests/checker/bad/gold/bad_init.scilla.gold) and [checker/bad/gold/extlib_dup_entry.scilla.gold](https://github.com/Zilliqa/scilla/tree/b361f3bb0be633bec935e900ff7f1e3d27acb409/tests/checker/bad/gold/extlib_dup_entry.scilla.gold): related to JSON parsing when we don't have locations
* [checker/bad/gold/blowup.scilla.gold](https://github.com/Zilliqa/scilla/tree/b361f3bb0be633bec935e900ff7f1e3d27acb409/tests/checker/bad/gold/blowup.scilla.gold): insufficient gas error

