### PR TITLE
fix(build): Specify the directory for `make coverage`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ coverage :
 	BISECT_ENABLE=YES make
 	dune build @install
 	ulimit -n 1024; dune exec -- tests/testsuite.exe
-	bisect-ppx-report html
+	bisect-ppx-report html -o ./coverage
 	make clean
 	-find . -type f -name 'bisect*.coverage' | xargs rm
 


### PR DESCRIPTION
We should explicitly set the output directory for the `make coverage` target. Otherwise, the report will be saved in the `_build/coverage` directory which will be removed when calling `dune clean`.

Here is a part of the `Makefile` that removes the created report: https://github.com/Zilliqa/scilla/blob/e9ee5c84a68f4cccdc91432dd140e50c6f33d672/Makefile#L181-L182