### PR TITLE
Removed vim scilla-mode instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,22 +203,6 @@ the cursor currently is.
 ;; Scilla mode
 (load-file "/path/to/scilla-mode.el")
 ```
-### Vim plugin
-
-A vim plugin for editing Scilla contracts is provided.
-
-You can install the vim config files through Pathogen by:
-```
-git clone https://github.com/edisonljh/vim-scilla.git ~/.vim/bundle/vim-scilla
-```
-
-Or through Vundle by adding the following line to your `~/.vimrc`:
-```
-Plugin 'edisonljh/vim-scilla'
-```
-
-Repo: [vim-scilla](https://github.com/edisonljh/vim-scilla).
-
 ### VSCode Plugin
 
 Visual Studio Code support for Scilla is avaiable. [Github Source](https://github.com/as1ndu/vscode-scilla)


### PR DESCRIPTION
The vim scilla-mode repo has been compromised, so we no longer want to recommend users installing it.