### PR TITLE
Disable REPLICATE_CONTRACT

### DIFF
--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -82,10 +82,13 @@
       match args with
       | [ id ] -> Timestamp(id)
       | _ -> raise (SyntaxError ("TIMESTAMP takes a single blocknumber argument", loc)))
+(*
+  See https://github.com/Zilliqa/scilla/issues/1180
     | "REPLICATE_CONTRACT" -> (
       match args with
       | [ addr; iparams ] -> ReplicateContr(addr, iparams)
       | _ -> raise (SyntaxError ("Usage: REPLICATE_CONTRACT(addr, iparams)", loc)))
+*)
     | _ -> raise (SyntaxError ("Unknown blockchain fetch operation " ^ op, loc))
 
 %}
@@ -389,7 +392,7 @@ builtin_args :
 | LPAREN; RPAREN { [] }
 
 bcfetch_args :
-| LPAREN; args = separated_list(COMMA, sident); RPAREN { args }
+  | LPAREN; args = separated_nonempty_list(COMMA, sident); RPAREN { args }
 
 exp_term :
 | e = exp; EOF { e }

--- a/tests/formatter/ast_does_not_change.t/run.t
+++ b/tests/formatter/ast_does_not_change.t/run.t
@@ -8,3 +8,7 @@
   >     break
   >   fi
   > done
+  scilla-fmt: 
+              replicate.scilla:7:3: error: Syntax error: Unknown blockchain fetch operation REPLICATE_CONTRACT
+              
+              

--- a/tests/formatter/look_and_feel/replicate.t/run.t
+++ b/tests/formatter/look_and_feel/replicate.t/run.t
@@ -1,46 +1,6 @@
   $ scilla-fmt replicate.scilla
-  scilla_version 0
-  
-  contract Foo ()
-  
-  
-  transition rep (bar : ByStr20 with contract end)
-    foo = { _replicate_contract : "" };
-    foo_addr <-& REPLICATE_CONTRACT(bar, foo);
-    e = { _eventname : "Replicated"; new_addr : foo_addr };
-    event e
-  end
-  
-  transition cfdeploy (cfaddr : ByStr20 with contract end)
-    owner = _sender;
-    max_block = BNum 100;
-    goal = Uint128 1000;
-    m =
-      {
-        _replicate_contract : "";
-        owner : owner;
-        max_block : max_block;
-        goal : goal
-      };
-    newcf_addr <-& REPLICATE_CONTRACT(cfaddr, m);
-    e = { _eventname : "Replicated"; new_addr : newcf_addr };
-    event e
-  end
-  
-  transition cfdeploy_incorrect (cfaddr : ByStr20 with contract end)
-    owner = _sender;
-    (* This is incorrect, max_block must be BNum. *)
-    max_block = Uint32 100;
-    goal = Uint128 1000;
-    m =
-      {
-        _replicate_contract : "";
-        owner : owner;
-        max_block : max_block;
-        goal : goal
-      };
-    newcf_addr <-& REPLICATE_CONTRACT(cfaddr, m);
-    e = { _eventname : "Replicated"; new_addr : newcf_addr };
-    event e
-  end
-  
+  scilla-fmt: 
+              replicate.scilla:7:3: error: Syntax error: Unknown blockchain fetch operation REPLICATE_CONTRACT
+              
+              
+  [124]

--- a/tests/runner/Testcontracts.ml
+++ b/tests/runner/Testcontracts.ml
@@ -490,8 +490,11 @@ let contract_tests env =
                 >::: build_contract_tests env "timestamp" succ_code 1 2 [];
                 "chainid"
                 >::: build_contract_tests env "chainid" succ_code 1 1 [];
+                (*
+  See https://github.com/Zilliqa/scilla/issues/1180
                 "replicate"
                 >::: build_contract_tests env "replicate" succ_code 1 1 [];
+*)
                 "ark-store-hashes-in-mutable-maps"
                 >::: build_contract_tests env "ark" succ_code 1 1 [];
               ];
@@ -501,8 +504,11 @@ let contract_tests env =
                 >::: build_contract_tests env "helloWorld" fail_code 5 11 [];
                 "codehash"
                 >::: build_contract_tests env "codehash" fail_code 100 102 [];
+                (*
+  See https://github.com/Zilliqa/scilla/issues/1180
                 "replicate"
                 >::: build_contract_tests env "replicate" fail_code 100 100 [];
+*)
                 "mappair"
                 >::: build_contract_tests env "mappair" fail_code 8 8 [];
                 "mappair"


### PR DESCRIPTION
Disabling the `REPLICATE_CONTRACT` feature, since it is still not supported by the blockchain.