### PR TITLE
`Merge`: Remove unused code

### DIFF
--- a/src/merge/Merge.ml
+++ b/src/merge/Merge.ml
@@ -459,10 +459,9 @@ module ScillaMerger (SR : Rep) (ER : Rep) = struct
         let rhs' = rename_local_er renames_map rhs in
         (Load (lhs', rhs'), annot)
     | RemoteLoad (lhs, adr, rhs) ->
-        (* Address will be replaced in the Remote pass. *)
+        (* The Remote pass will remove address and rename [rhs]. *)
         let lhs' = rename_local_er renames_map lhs in
-        let rhs' = rename_local_er renames_map rhs in
-        (RemoteLoad (lhs', adr, rhs'), annot)
+        (RemoteLoad (lhs', adr, rhs), annot)
     | Store (lhs, rhs) ->
         let lhs' = rename_local_er renames_map lhs in
         let rhs' = rename_local_er renames_map rhs in

--- a/tests/merge/static/gold/remote_collisions1.scilla.gold
+++ b/tests/merge/static/gold/remote_collisions1.scilla.gold
@@ -14,6 +14,8 @@ field remoteCollisions11_z : Uint32 = Uint32 0
 
 field remoteCollisions12_a_f : Bool = False
 
+field remoteCollisions12_a_f2 : Bool = False
+
 field remoteCollisions12_m_f : Map Uint32 Bool = Emp (Uint32) (Bool)
 
 field remoteCollisions13_a_f : Bool = True
@@ -25,11 +27,12 @@ transition remoteCollisions11_tr (a : ByStr20)
   match a_opt with
   | Some aa =>
     remoteCollisions11_f <- (remoteCollisions12_a_f|remoteCollisions13_a_f);
+    remoteCollisions11_f <- remoteCollisions12_a_f2;
     k <- remoteCollisions11_z;
     remoteCollisions11_f <- (remoteCollisions12_m_f|remoteCollisions13_m_f)[k]
   | None =>
   end
 end
 
-merge/static/remote_collisions11.scilla:19:15: warning: [2] Name collision: Please disambiguate `m_f` in the configuration file
-merge/static/remote_collisions11.scilla:17:15: warning: [2] Name collision: Please disambiguate `a_f` in the configuration file
+merge/static/remote_collisions11.scilla:21:15: warning: [2] Name collision: Please disambiguate `m_f` in the configuration file
+merge/static/remote_collisions11.scilla:18:15: warning: [2] Name collision: Please disambiguate `a_f` in the configuration file

--- a/tests/merge/static/remote_collisions11.scilla
+++ b/tests/merge/static/remote_collisions11.scilla
@@ -10,11 +10,13 @@ field z: Uint32 = Uint32 0
 transition tr(a: ByStr20)
   a_opt <- & a as ByStr20 with contract
     field a_f: Bool,
+    field a_f2: Bool,
     field m_f: Map Uint32 Bool
   end;
   match a_opt with
   | Some aa =>
     f <- & aa.a_f;
+    f <- & aa.a_f2;
     k <- z;
     f <- & aa.m_f[k]
   | None =>

--- a/tests/merge/static/remote_collisions12.scilla
+++ b/tests/merge/static/remote_collisions12.scilla
@@ -5,4 +5,5 @@ library RemoteCollisions12
 contract RemoteCollisions12()
 
 field a_f: Bool = False
+field a_f2: Bool = False
 field m_f: Map Uint32 Bool = Emp Uint32 Bool


### PR DESCRIPTION
`rhs` will be renamed in the Remote pass. This makes the removed rename operation unused.