### PR TITLE
fix(runner): An exception on `--help` argument

### DIFF
--- a/src/base/RunnerUtil.ml
+++ b/src/base/RunnerUtil.ml
@@ -307,7 +307,8 @@ let parse_cli args ~exe_name =
           Arg.parse_argv ~current:(ref 0)
             (List.to_array @@ (exe_name :: argv))
             speclist anon_handler mandatory_usage
-        with Arg.Bad msg -> fatal_error_noformat (Printf.sprintf "%s\n" msg))
+        with Arg.Bad msg | Arg.Help msg ->
+          fatal_error_noformat (Printf.sprintf "%s\n" msg))
   in
   if String.is_empty !r_input_file then fatal_error_noformat usage;
   let gas_limit =


### PR DESCRIPTION
The internal implementation of `Arg.parse_argv` throws a `Help` exception if it see `-help` or `--help` key.

See: https://github.com/ocaml/ocaml/blob/182fd48a41d5bb0ab80089065306342cdc6941c7/stdlib/arg.ml#L160

Closes #1201