### PR TITLE
vcpkg installation script requires Linux 64-bit

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,11 +20,30 @@ export PKG_CONFIG_PATH="_OpenSSL_prefix_/lib/pkgconfig:$PKG_CONFIG_PATH"
    ```shell
    $ git clone https://github.com/Microsoft/vcpkg.git /path/to/vcpkg
    $ cd /path/to/vcpkg && git checkout 2022.09.27 && ./bootstrap-vcpkg.sh
-   $ cd /path/to/scilla
+   ```
+
+- Set the following environment variables:
+
+   ```shell
    $ export VCPKG_ROOT=/path/to/vcpkg
-   $ $VCPKG_ROOT/vcpkg install --triplet x64-linux-dynamic
    $ export PKG_CONFIG_PATH="/path/to/scilla/vcpkg_installed/x64-linux-dynamic/lib/pkgconfig:$PKG_CONFIG_PATH"
    ```
+
+When building Scilla on Ubuntu systems the relevant vcpkg files are
+automatically installed in the directory
+/path/to/scilla/vcpkg_installed. For other operating systems the vcpkg
+files must be generated manually before building Scilla by running the command
+
+  ```shell
+  $ cd /path/to/scilla & path/to/vcpkg/vcpkg install --triplet <OS and architecture specific package>
+  ```
+
+Please see the vcpkg documentation at
+
+https://vcpkg.io/en/docs/README.html
+
+for more information.
+
 </details>
 
 ## OS-specific setup for building Scilla
@@ -110,6 +129,25 @@ ulimit -n 1024
 ```
 
 After you have proceeded with installation if an error with regards to `version` file during `make` occurs, see [here](https://github.com/Zilliqa/scilla/wiki/macOS-troubleshooting) for the solution.
+
+<summary>vcpkg</summary>
+
+The command for vcpkg installation depends on the underlying chipset.
+
+For ARM-based architectures use 
+
+  ```shell
+  $ cd /path/to/scilla & path/to/vcpkg/vcpkg install --triplet arm64-osx-dynamic
+  ```
+
+For Intel-based architectures use
+
+  ```shell
+  $ cd /path/to/scilla & path/to/vcpkg/vcpkg install --triplet x64-osx-dynamic
+  ```
+
+Please note that building Scilla using vcpkg on MacOS is still experimental.
+
 
 </details>
 

--- a/scripts/vcpkg.sh
+++ b/scripts/vcpkg.sh
@@ -39,6 +39,13 @@ then
     exit 0
 fi
 
+# If not on a linux 64-bit system, exit early.
+if ! uname -a | grep "Linux" | grep "x86_64"
+then
+    echo "Found non-Linux 64-bit system. Please run 'vcpkg install' manually."
+    exit 0
+fi
+
 echo "Installing vcpkg"
 if ! "$VCPKG_ROOT"/vcpkg install --triplet x64-linux-dynamic
 then 


### PR DESCRIPTION
The installation instructions and the vcpkg.sh script assumes the user is on a Linux 64-bit architecture. This PR changes the script to make an explicit check to ensure the assumption is satisfied.

Further, INSTALL.md has been updated to reflect the changes.

@ilyasergey : I think you're the only one in the Scilla team who has access to a Mac. Could you check that this works/doesn't work as expected?