### PR TITLE
fix(server): Log a backtrace when RPC fails. Closes #1223

### DIFF
--- a/src/server/server.ml
+++ b/src/server/server.ml
@@ -23,6 +23,7 @@ open DebugMessage
 open ErrorUtils
 open Api
 open IPCUtil
+open Printexc
 
 (* You can swap the RPC engine, by using a different monad here,
    note however that if you are using an asynchronous one, like
@@ -58,11 +59,12 @@ let handler rpc conn =
      should ensure that the computation is started by a runner *)
   let res =
     try M.run (rpc req)
-    with _ ->
+    with e ->
+          let exc_str = Caml.Printexc.get_backtrace() in
       Rpc.failure
-        (RPCError.rpc_of_t
-           RPCError.
-             { code = 0; message = "scilla-server: incorrect invocation" })
+        ( RPCError.rpc_of_t
+            RPCError.
+          { code = 0; message = "scilla-server: exception " ^ exc_str } )
   in
   let str = Jsonrpc.string_of_response ~version:Jsonrpc.V2 res in
   IPCUtil.send_delimited oc str


### PR DESCRIPTION
Log an exception when an RPC error occurs, to cue observers in on where the issue might lie.
It would be better in future to decode these properly and return a meaningful error message in a well-formed JSON reply, but for now this is at least better than claiming that all errors are RPC format problems.
I have avoided returning valid JSON in case it causes us to leak security-sensitive data to callers.