### PR TITLE
Patching grammar for v0.13.1

### DIFF
--- a/debug/contract.scilla
+++ b/debug/contract.scilla
@@ -1,0 +1,6 @@
+scilla_version 0
+
+contract Contract
+()
+
+field f: Map ByStr20 Pair Uint128 Uint128 = Emp ByStr20 Pair Uint128 Uint128

--- a/src/base/ParserFaults.messages
+++ b/src/base/ParserFaults.messages
@@ -1,6 +1,9 @@
 #@ WARNING:
 #@ The following comment has been copied from "src/base/ParserFaults.messages".
 #@ It may need to be proofread, updated, moved, or removed.
+#@ WARNING:
+#@ The following comment has been copied from "src/base/ParserFaults.messages".
+#@ It may need to be proofread, updated, moved, or removed.
 # This file is part of scilla.
 # 
 # Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
@@ -29,7 +32,7 @@
 
 type_term: CID LPAREN TID WITH
 ##
-## Ends in an error in state: 74.
+## Ends in an error in state: 76.
 ##
 ## targ -> LPAREN typ . RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ## typ -> typ . TARROW typ [ TARROW RPAREN ]
@@ -43,7 +46,7 @@ This is an invalid type term, likely the ADT argument brackets are not closed pr
 
 type_term: CID LPAREN WITH
 ##
-## Ends in an error in state: 73.
+## Ends in an error in state: 75.
 ##
 ## targ -> LPAREN . typ RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
@@ -69,7 +72,7 @@ This is an invalid type term, the ADT constructor has invalid type arguments. Th
 
 type_term: CID PERIOD WITH
 ##
-## Ends in an error in state: 57.
+## Ends in an error in state: 56.
 ##
 ## scid -> CID PERIOD . CID [ UNDERSCORE TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN ID HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
@@ -82,7 +85,7 @@ This is an invalid type term, the ADT constructor is incorrect. Following the pe
 
 type_term: CID TID WITH
 ##
-## Ends in an error in state: 77.
+## Ends in an error in state: 79.
 ##
 ## list(targ) -> targ . list(targ) [ TARROW RPAREN RBRACE EQ EOF END COMMA ]
 ##
@@ -95,7 +98,7 @@ This is an invalid type term, the ADT constructor arguments are incorrect.
 
 type_term: FORALL TID PERIOD TID WITH
 ##
-## Ends in an error in state: 69.
+## Ends in an error in state: 71.
 ##
 ## typ -> typ . TARROW typ [ TARROW RPAREN EQ EOF END COMMA ]
 ## typ -> FORALL TID PERIOD typ . [ TARROW RPAREN EQ EOF END COMMA ]
@@ -109,7 +112,7 @@ This is an invalid forall type, the type term is finished after the last type id
 
 type_term: FORALL TID PERIOD WITH
 ##
-## Ends in an error in state: 68.
+## Ends in an error in state: 70.
 ##
 ## typ -> FORALL TID PERIOD . typ [ TARROW RPAREN EQ EOF END COMMA ]
 ##
@@ -122,7 +125,7 @@ This is an invalid forall type, after the period (following forall and a type id
 
 type_term: FORALL TID WITH
 ##
-## Ends in an error in state: 67.
+## Ends in an error in state: 69.
 ##
 ## typ -> FORALL TID . PERIOD typ [ TARROW RPAREN EQ EOF END COMMA ]
 ##
@@ -135,7 +138,7 @@ This is an invalid forall type, after the type id (following forall) the parser 
 
 type_term: FORALL WITH
 ##
-## Ends in an error in state: 66.
+## Ends in an error in state: 68.
 ##
 ## typ -> FORALL . TID PERIOD typ [ TARROW RPAREN EQ EOF END COMMA ]
 ##
@@ -148,7 +151,7 @@ This is an invalid forall type, after the forall the parser expects a type ident
 
 type_term: LPAREN TID WITH
 ##
-## Ends in an error in state: 82.
+## Ends in an error in state: 84.
 ##
 ## typ -> typ . TARROW typ [ TARROW RPAREN ]
 ## typ -> LPAREN typ . RPAREN [ TARROW RPAREN EQ EOF END COMMA ]
@@ -162,7 +165,7 @@ This is an invalid type term because the brackets are not closed after the type 
 
 type_term: LPAREN WITH
 ##
-## Ends in an error in state: 65.
+## Ends in an error in state: 67.
 ##
 ## typ -> LPAREN . typ RPAREN [ TARROW RPAREN EQ EOF END COMMA ]
 ##
@@ -175,13 +178,23 @@ This is an invalid type term, please put a valid type term in the brackets.
 
 type_term: MAP CID LPAREN CID CID TYPE
 ##
-## Ends in an error in state: 56.
+## Ends in an error in state: 43.
 ##
-## scid -> CID . [ UNDERSCORE RPAREN MAP LPAREN ID HEXLIT CID ARROW ]
-## scid -> CID . PERIOD CID [ UNDERSCORE RPAREN MAP LPAREN ID HEXLIT CID ARROW ]
+## t_map_value -> LPAREN t_map_value_allow_targs . RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
-## CID
+## LPAREN t_map_value_allow_targs
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 55, spurious reduction of production scid -> CID
+## In state 59, spurious reduction of production t_map_value_args -> scid
+## In state 58, spurious reduction of production nonempty_list(t_map_value_args) -> t_map_value_args
+## In state 64, spurious reduction of production t_map_value_allow_targs_deprecated -> scid nonempty_list(t_map_value_args)
+## In state 42, spurious reduction of production t_map_value -> t_map_value_allow_targs_deprecated
+## In state 45, spurious reduction of production t_map_value_allow_targs -> t_map_value
 ##
 # see tests/parser/bad/type_t-map-cid-lparen-cid-cid-type.scilla
 # The same parser state can be reached in a pattern-match when using a single-arrow instead of a double-arrow. See tests/parser/bad/stmts_t-match-spid-with-bar-cid-cid-with.scilla
@@ -262,7 +275,7 @@ This is an invalid type term, the map key type is incorrect.
 
 type_term: TID TARROW TID WITH
 ##
-## Ends in an error in state: 71.
+## Ends in an error in state: 73.
 ##
 ## typ -> typ . TARROW typ [ TARROW RPAREN EQ EOF END COMMA ]
 ## typ -> typ TARROW typ . [ TARROW RPAREN EQ EOF END COMMA ]
@@ -276,7 +289,7 @@ This function is not terminated early enough or malformed. A possible alteration
 
 type_term: TID TARROW WITH
 ##
-## Ends in an error in state: 70.
+## Ends in an error in state: 72.
 ##
 ## typ -> typ TARROW . typ [ TARROW RPAREN EQ EOF END COMMA ]
 ##
@@ -306,7 +319,7 @@ Invalid or incomplete type.
 
 type_term: TID WITH
 ##
-## Ends in an error in state: 370.
+## Ends in an error in state: 371.
 ##
 ## typ -> typ . TARROW typ [ TARROW EOF ]
 ## type_term -> typ . EOF [ # ]
@@ -320,7 +333,7 @@ This is an invalid type term, the ADT constructor arguments are likely incorrect
 
 type_term: WITH
 ##
-## Ends in an error in state: 368.
+## Ends in an error in state: 369.
 ##
 ## type_term' -> . type_term [ # ]
 ##
@@ -333,7 +346,7 @@ This is an invalid type term.
 
 stmts_term: ACCEPT WITH
 ##
-## Ends in an error in state: 320.
+## Ends in an error in state: 321.
 ##
 ## separated_nonempty_list(SEMICOLON,stmt) -> stmt . [ EOF END BAR ]
 ## separated_nonempty_list(SEMICOLON,stmt) -> stmt . SEMICOLON separated_nonempty_list(SEMICOLON,stmt) [ EOF END BAR ]
@@ -348,7 +361,7 @@ This is likely an improperly terminated statement (lacking the semicolon).
 
 stmts_term: CID WITH
 ##
-## Ends in an error in state: 324.
+## Ends in an error in state: 325.
 ##
 ## stmt -> component_id . list(sident) [ SEMICOLON EOF END BAR ]
 ##
@@ -361,7 +374,7 @@ This is an invalid statements term.
 
 stmts_term: DELETE ID WITH
 ##
-## Ends in an error in state: 317.
+## Ends in an error in state: 318.
 ##
 ## stmt -> DELETE ID . nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ##
@@ -374,7 +387,7 @@ This is an invalid delete statement, it lacks the keys to delete.
 
 stmts_term: DELETE WITH
 ##
-## Ends in an error in state: 316.
+## Ends in an error in state: 317.
 ##
 ## stmt -> DELETE . ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ##
@@ -387,7 +400,7 @@ This is an invalid delete statement, it lacks a map to delete from.
 
 stmts_term: EVENT WITH
 ##
-## Ends in an error in state: 314.
+## Ends in an error in state: 315.
 ##
 ## stmt -> EVENT . sid [ SEMICOLON EOF END BAR ]
 ##
@@ -400,7 +413,7 @@ This is an invalid event statement, it lacks a separated identifier for the even
 
 stmts_term: ID ASSIGN WITH
 ##
-## Ends in an error in state: 306.
+## Ends in an error in state: 307.
 ##
 ## stmt -> ID ASSIGN . sid [ SEMICOLON EOF END BAR ]
 ##
@@ -413,7 +426,7 @@ This is an invalid assign statement, it lacks a separated identifier.
 
 stmts_term: ID FETCH AND WITH
 ##
-## Ends in an error in state: 272.
+## Ends in an error in state: 274.
 ##
 ## remote_fetch_stmt -> ID FETCH AND . ID PERIOD sident [ SEMICOLON EOF END BAR ]
 ## remote_fetch_stmt -> ID FETCH AND . SPID PERIOD SPID [ SEMICOLON EOF END BAR ]
@@ -432,7 +445,7 @@ This is an invalid bind and statement. The parser expects a capital identifier a
 
 stmts_term: ID FETCH EXISTS ID WITH
 ##
-## Ends in an error in state: 270.
+## Ends in an error in state: 272.
 ##
 ## stmt -> ID FETCH EXISTS ID . nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ##
@@ -445,7 +458,7 @@ This is an invalid existence bind statement. It lacks a non-empty list of access
 
 stmts_term: ID FETCH EXISTS WITH
 ##
-## Ends in an error in state: 269.
+## Ends in an error in state: 271.
 ##
 ## stmt -> ID FETCH EXISTS . ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ##
@@ -458,7 +471,7 @@ This is an invalid existence bind statement. It lacks a map to check existence o
 
 stmts_term: ID FETCH ID WITH
 ##
-## Ends in an error in state: 265.
+## Ends in an error in state: 267.
 ##
 ## sid -> ID . [ SEMICOLON EOF END BAR ]
 ## stmt -> ID FETCH ID . nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
@@ -472,7 +485,7 @@ This is an invalid bind statement, it is lacking a non empty list of map accesse
 
 stmts_term: ID FETCH WITH
 ##
-## Ends in an error in state: 264.
+## Ends in an error in state: 266.
 ##
 ## remote_fetch_stmt -> ID FETCH . AND ID PERIOD sident [ SEMICOLON EOF END BAR ]
 ## remote_fetch_stmt -> ID FETCH . AND SPID PERIOD SPID [ SEMICOLON EOF END BAR ]
@@ -494,7 +507,7 @@ This is an invalid bind statement, the bind can be followed by '&', 'exists' or 
 
 stmts_term: ID EQ WITH
 ##
-## Ends in an error in state: 304.
+## Ends in an error in state: 305.
 ##
 ## stmt -> ID EQ . exp [ SEMICOLON EOF END BAR ]
 ##
@@ -507,7 +520,7 @@ This is an invalid equal statement, it is lacking a valid expression on the righ
 
 stmts_term: ID LSQB SPID RSQB ASSIGN WITH
 ##
-## Ends in an error in state: 309.
+## Ends in an error in state: 310.
 ##
 ## stmt -> ID nonempty_list(map_access) ASSIGN . sid [ SEMICOLON EOF END BAR ]
 ##
@@ -520,7 +533,7 @@ The map key must be assigned to some separated identifier.
 
 stmts_term: ID LSQB SPID RSQB SEMICOLON
 ##
-## Ends in an error in state: 308.
+## Ends in an error in state: 309.
 ##
 ## stmt -> ID nonempty_list(map_access) . ASSIGN sid [ SEMICOLON EOF END BAR ]
 ##
@@ -531,7 +544,7 @@ stmts_term: ID LSQB SPID RSQB SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 267, spurious reduction of production nonempty_list(map_access) -> map_access
+## In state 269, spurious reduction of production nonempty_list(map_access) -> map_access
 ##
 # see tests/parser/bad/stmts_t-id-lsqb-spid-rsqb-semicolon.scilla
 
@@ -539,7 +552,7 @@ This is likely an invalid map assign statement, it lacks the assign.
 
 stmts_term: ID LSQB SPID RSQB WITH
 ##
-## Ends in an error in state: 267.
+## Ends in an error in state: 269.
 ##
 ## nonempty_list(map_access) -> map_access . [ SEMICOLON EOF END BAR ASSIGN ]
 ## nonempty_list(map_access) -> map_access . nonempty_list(map_access) [ SEMICOLON EOF END BAR ASSIGN ]
@@ -553,7 +566,7 @@ This is an invalid statements term. A possible continuation may be assigning a m
 
 stmts_term: ID LSQB SPID WITH
 ##
-## Ends in an error in state: 262.
+## Ends in an error in state: 264.
 ##
 ## map_access -> LSQB sident . RSQB [ SEMICOLON LSQB EOF END BAR ASSIGN ]
 ##
@@ -566,7 +579,7 @@ This is an invalid statements term. A possible continuation may be accessing a k
 
 stmts_term: ID LSQB WITH
 ##
-## Ends in an error in state: 261.
+## Ends in an error in state: 263.
 ##
 ## map_access -> LSQB . sident RSQB [ SEMICOLON LSQB EOF END BAR ASSIGN ]
 ##
@@ -579,7 +592,7 @@ This is an invalid statements term. The map access list is malformed.
 
 stmts_term: ID SPID WITH
 ##
-## Ends in an error in state: 199.
+## Ends in an error in state: 201.
 ##
 ## list(sident) -> sident . list(sident) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -592,7 +605,7 @@ This is an invalid statements term, likely a bad procedure call with faulty argu
 
 stmts_term: ID WITH
 ##
-## Ends in an error in state: 260.
+## Ends in an error in state: 262.
 ##
 ## component_id -> ID . [ SPID SEMICOLON ID EOF END CID BAR ]
 ## remote_fetch_stmt -> ID . FETCH AND ID PERIOD sident [ SEMICOLON EOF END BAR ]
@@ -618,7 +631,7 @@ This is an invalid statements term. Scilla expects to do something with the iden
 
 stmts_term: MATCH SPID UNDERSCORE
 ##
-## Ends in an error in state: 255.
+## Ends in an error in state: 257.
 ##
 ## stmt -> MATCH sid . WITH list(stmt_pm_clause) END [ SEMICOLON EOF END BAR ]
 ##
@@ -631,7 +644,7 @@ This is an invalid match statement, 'with' is expected after what is specified t
 
 stmts_term: MATCH SPID WITH BAR UNDERSCORE ARROW ACCEPT EOF
 ##
-## Ends in an error in state: 328.
+## Ends in an error in state: 329.
 ##
 ## list(stmt_pm_clause) -> stmt_pm_clause . list(stmt_pm_clause) [ END ]
 ##
@@ -642,9 +655,9 @@ stmts_term: MATCH SPID WITH BAR UNDERSCORE ARROW ACCEPT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 320, spurious reduction of production separated_nonempty_list(SEMICOLON,stmt) -> stmt
-## In state 326, spurious reduction of production loption(separated_nonempty_list(SEMICOLON,stmt)) -> separated_nonempty_list(SEMICOLON,stmt)
-## In state 327, spurious reduction of production stmt_pm_clause -> BAR pattern ARROW loption(separated_nonempty_list(SEMICOLON,stmt))
+## In state 321, spurious reduction of production separated_nonempty_list(SEMICOLON,stmt) -> stmt
+## In state 327, spurious reduction of production loption(separated_nonempty_list(SEMICOLON,stmt)) -> separated_nonempty_list(SEMICOLON,stmt)
+## In state 328, spurious reduction of production stmt_pm_clause -> BAR pattern ARROW loption(separated_nonempty_list(SEMICOLON,stmt))
 ##
 # see tests/parser/bad/stmts_t-match-spid-with-bar-underscore-arrow-accept-eof.scilla
 
@@ -652,7 +665,7 @@ When the match statement is finished, the parser expects 'end'.
 
 stmts_term: MATCH SPID WITH BAR UNDERSCORE ARROW WITH
 ##
-## Ends in an error in state: 259.
+## Ends in an error in state: 261.
 ##
 ## stmt_pm_clause -> BAR pattern ARROW . loption(separated_nonempty_list(SEMICOLON,stmt)) [ END BAR ]
 ##
@@ -665,7 +678,7 @@ This is an invalid statements term. In the match expression, after an arrow the 
 
 stmts_term: MATCH SPID WITH BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 258.
+## Ends in an error in state: 260.
 ##
 ## stmt_pm_clause -> BAR pattern . ARROW loption(separated_nonempty_list(SEMICOLON,stmt)) [ END BAR ]
 ##
@@ -678,7 +691,7 @@ This is an invalid statements term. In the match expression, after a pattern is 
 
 stmts_term: MATCH SPID WITH BAR WITH
 ##
-## Ends in an error in state: 257.
+## Ends in an error in state: 259.
 ##
 ## stmt_pm_clause -> BAR . pattern ARROW loption(separated_nonempty_list(SEMICOLON,stmt)) [ END BAR ]
 ##
@@ -691,7 +704,7 @@ In the match statement there is a malformed pattern.
 
 stmts_term: MATCH SPID WITH WITH
 ##
-## Ends in an error in state: 256.
+## Ends in an error in state: 258.
 ##
 ## stmt -> MATCH sid WITH . list(stmt_pm_clause) END [ SEMICOLON EOF END BAR ]
 ##
@@ -704,7 +717,7 @@ There is a malformed pattern matching clause, the bar is likely missing.
 
 stmts_term: MATCH WITH
 ##
-## Ends in an error in state: 254.
+## Ends in an error in state: 256.
 ##
 ## stmt -> MATCH . sid WITH list(stmt_pm_clause) END [ SEMICOLON EOF END BAR ]
 ##
@@ -717,7 +730,7 @@ In a match statement, the parser expects a separated identifier to match with.
 
 stmts_term: SEND CID PERIOD WITH
 ##
-## Ends in an error in state: 126.
+## Ends in an error in state: 128.
 ##
 ## sid -> CID PERIOD . ID [ WITH TID SEMICOLON RBRACE MAP LPAREN HEXLIT EOF END COLON CID BAR ]
 ##
@@ -730,7 +743,7 @@ This is an invalid send statement, the identifier is incorrect. After the period
 
 stmts_term: SEND CID WITH
 ##
-## Ends in an error in state: 125.
+## Ends in an error in state: 127.
 ##
 ## sid -> CID . PERIOD ID [ WITH TID SEMICOLON MAP LPAREN HEXLIT EOF END COLON CID BAR ]
 ##
@@ -743,7 +756,7 @@ This send statement is either unfinished or not properly terminated.
 
 stmts_term: SEND WITH
 ##
-## Ends in an error in state: 252.
+## Ends in an error in state: 254.
 ##
 ## stmt -> SEND . sid [ SEMICOLON EOF END BAR ]
 ##
@@ -756,7 +769,7 @@ It is expected to send to a separated identifier.
 
 stmts_term: THROW END
 ##
-## Ends in an error in state: 366.
+## Ends in an error in state: 367.
 ##
 ## stmts_term -> stmts . EOF [ # ]
 ##
@@ -767,11 +780,11 @@ stmts_term: THROW END
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 249, spurious reduction of production option(sid) ->
-## In state 251, spurious reduction of production stmt -> THROW option(sid)
-## In state 320, spurious reduction of production separated_nonempty_list(SEMICOLON,stmt) -> stmt
-## In state 326, spurious reduction of production loption(separated_nonempty_list(SEMICOLON,stmt)) -> separated_nonempty_list(SEMICOLON,stmt)
-## In state 334, spurious reduction of production stmts -> loption(separated_nonempty_list(SEMICOLON,stmt))
+## In state 251, spurious reduction of production option(sid) ->
+## In state 253, spurious reduction of production stmt -> THROW option(sid)
+## In state 321, spurious reduction of production separated_nonempty_list(SEMICOLON,stmt) -> stmt
+## In state 327, spurious reduction of production loption(separated_nonempty_list(SEMICOLON,stmt)) -> separated_nonempty_list(SEMICOLON,stmt)
+## In state 335, spurious reduction of production stmts -> loption(separated_nonempty_list(SEMICOLON,stmt))
 ##
 # special case, only via stmts_term entry point should never happen
 # throw itself is a valid statement term and a procedure or transition
@@ -781,7 +794,7 @@ This is an invalid statements term, bad throw.
 
 stmts_term: THROW SEMICOLON WITH
 ##
-## Ends in an error in state: 321.
+## Ends in an error in state: 322.
 ##
 ## separated_nonempty_list(SEMICOLON,stmt) -> stmt SEMICOLON . separated_nonempty_list(SEMICOLON,stmt) [ EOF END BAR ]
 ##
@@ -796,7 +809,7 @@ What follows the statement was unexpected, for example, possibly a statement or 
 
 stmts_term: THROW WITH
 ##
-## Ends in an error in state: 249.
+## Ends in an error in state: 251.
 ##
 ## stmt -> THROW . option(sid) [ SEMICOLON EOF END BAR ]
 ##
@@ -809,7 +822,7 @@ This throw does not throw a valid exception or is not properly terminated.
 
 stmts_term: WITH
 ##
-## Ends in an error in state: 364.
+## Ends in an error in state: 365.
 ##
 ## stmts_term' -> . stmts_term [ # ]
 ##
@@ -862,7 +875,7 @@ To import another library mention the new library name directly after the previo
 
 lmodule: SCILLA_VERSION NUMLIT IMPORT CONTRACT
 ##
-## Ends in an error in state: 360.
+## Ends in an error in state: 361.
 ##
 ## lmodule -> SCILLA_VERSION NUMLIT imports . library EOF [ # ]
 ##
@@ -895,7 +908,7 @@ If import is mentioned there must be one or more imported libraries with capital
 
 lmodule: SCILLA_VERSION NUMLIT LIBRARY CID CONTRACT
 ##
-## Ends in an error in state: 361.
+## Ends in an error in state: 362.
 ##
 ## lmodule -> SCILLA_VERSION NUMLIT imports library . EOF [ # ]
 ##
@@ -907,7 +920,7 @@ lmodule: SCILLA_VERSION NUMLIT LIBRARY CID CONTRACT
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 12, spurious reduction of production list(libentry) ->
-## In state 223, spurious reduction of production library -> LIBRARY CID list(libentry)
+## In state 225, spurious reduction of production library -> LIBRARY CID list(libentry)
 ##
 # see tests/parser/bad/lib/lmodule-library-cid-contract.scillib
 
@@ -915,7 +928,7 @@ When writing solely Scilla libraries, there is no need for a contract.
 
 lmodule: SCILLA_VERSION NUMLIT LIBRARY CID LET ID COLON TID EQ WITH
 ##
-## Ends in an error in state: 221.
+## Ends in an error in state: 223.
 ##
 ## libentry -> LET ID type_annot EQ . exp [ TYPE LET EOF CONTRACT ]
 ##
@@ -928,7 +941,7 @@ This (type-annotated) let expression is missing an expression to assign to an id
 
 lmodule: SCILLA_VERSION NUMLIT LIBRARY CID LET ID EQ HEXLIT WITH
 ##
-## Ends in an error in state: 165.
+## Ends in an error in state: 167.
 ##
 ## lit -> HEXLIT . [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ## scid -> HEXLIT . PERIOD CID [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET LBRACE IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
@@ -942,7 +955,7 @@ Invalid module. A module entry (a type or variable definition for libraries, a f
 
 lmodule: SCILLA_VERSION NUMLIT LIBRARY CID LET ID EQ WITH
 ##
-## Ends in an error in state: 117.
+## Ends in an error in state: 119.
 ##
 ## libentry -> LET ID EQ . exp [ TYPE LET EOF CONTRACT ]
 ##
@@ -955,7 +968,7 @@ This library let expression is missing a valid expression to assign to the ident
 
 lmodule: SCILLA_VERSION NUMLIT LIBRARY CID LET ID WITH
 ##
-## Ends in an error in state: 116.
+## Ends in an error in state: 118.
 ##
 ## libentry -> LET ID . EQ exp [ TYPE LET EOF CONTRACT ]
 ## libentry -> LET ID . type_annot EQ exp [ TYPE LET EOF CONTRACT ]
@@ -969,7 +982,7 @@ This library let expression is missing an equals, '='.
 
 lmodule: SCILLA_VERSION NUMLIT LIBRARY CID LET WITH
 ##
-## Ends in an error in state: 115.
+## Ends in an error in state: 117.
 ##
 ## libentry -> LET . ID EQ exp [ TYPE LET EOF CONTRACT ]
 ## libentry -> LET . ID type_annot EQ exp [ TYPE LET EOF CONTRACT ]
@@ -983,7 +996,7 @@ The let expression is missing an identifier to assign an expression to.
 
 lmodule: SCILLA_VERSION NUMLIT LIBRARY CID TYPE CID EQ BAR CID OF CID TRANSITION
 ##
-## Ends in an error in state: 112.
+## Ends in an error in state: 114.
 ##
 ## nonempty_list(tconstr) -> tconstr . [ TYPE LET EOF CONTRACT ]
 ## nonempty_list(tconstr) -> tconstr . nonempty_list(tconstr) [ TYPE LET EOF CONTRACT ]
@@ -996,9 +1009,9 @@ lmodule: SCILLA_VERSION NUMLIT LIBRARY CID TYPE CID EQ BAR CID OF CID TRANSITION
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 25, spurious reduction of production scid -> CID
-## In state 78, spurious reduction of production targ -> scid
-## In state 109, spurious reduction of production nonempty_list(targ) -> targ
-## In state 111, spurious reduction of production tconstr -> BAR CID OF nonempty_list(targ)
+## In state 80, spurious reduction of production targ -> scid
+## In state 111, spurious reduction of production nonempty_list(targ) -> targ
+## In state 113, spurious reduction of production tconstr -> BAR CID OF nonempty_list(targ)
 ##
 # see tests/parser/bad/lib/lmodule-library-cid-type-cid-eq-bar-cid-of-cid-transition.scillib
 
@@ -1114,7 +1127,7 @@ This is an invalid library module because it lacks a capital identifier for a na
 
 lmodule: SCILLA_VERSION NUMLIT WITH
 ##
-## Ends in an error in state: 359.
+## Ends in an error in state: 360.
 ##
 ## lmodule -> SCILLA_VERSION NUMLIT . imports library EOF [ # ]
 ##
@@ -1127,7 +1140,7 @@ This is an invalid library module, Scilla version must be followed by 'library' 
 
 lmodule: WITH
 ##
-## Ends in an error in state: 357.
+## Ends in an error in state: 358.
 ##
 ## lmodule' -> . lmodule [ # ]
 ##
@@ -1140,7 +1153,7 @@ Scilla version number unspecified.
 
 exp_term: AT SPID TID WITH
 ##
-## Ends in an error in state: 109.
+## Ends in an error in state: 111.
 ##
 ## nonempty_list(targ) -> targ . [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ## nonempty_list(targ) -> targ . nonempty_list(targ) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
@@ -1154,7 +1167,7 @@ The type application is wrong. The list of types is problematic.
 
 exp_term: AT SPID WITH
 ##
-## Ends in an error in state: 192.
+## Ends in an error in state: 194.
 ##
 ## simple_exp -> AT sid . nonempty_list(targ) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1167,7 +1180,7 @@ The type application is wrong. The parser expects a non-empty list of type argum
 
 exp_term: AT WITH
 ##
-## Ends in an error in state: 191.
+## Ends in an error in state: 193.
 ##
 ## simple_exp -> AT . sid nonempty_list(targ) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1180,7 +1193,7 @@ This type application is wrong. A separated identifier is expected to apply type
 
 exp_term: BUILTIN ID LPAREN WITH
 ##
-## Ends in an error in state: 180.
+## Ends in an error in state: 182.
 ##
 ## builtin_args -> LPAREN . RPAREN [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1193,7 +1206,7 @@ Builtin functions only take a pair of brackets when of unit input type (e.g. "()
 
 exp_term: BUILTIN ID WITH
 ##
-## Ends in an error in state: 174.
+## Ends in an error in state: 176.
 ##
 ## simple_exp -> BUILTIN ID . option(ctargs) builtin_args [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1206,7 +1219,7 @@ The usage of the builtin function is incorrect.
 
 exp_term: BUILTIN WITH
 ##
-## Ends in an error in state: 173.
+## Ends in an error in state: 175.
 ##
 ## simple_exp -> BUILTIN . ID option(ctargs) builtin_args [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1219,7 +1232,7 @@ This expression is incorrect because it does not specify a specific builtin func
 
 exp_term: CID LBRACE TID EQ
 ##
-## Ends in an error in state: 176.
+## Ends in an error in state: 178.
 ##
 ## ctargs -> LBRACE list(targ) . RBRACE [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LPAREN LET IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
 ##
@@ -1230,8 +1243,8 @@ exp_term: CID LBRACE TID EQ
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 77, spurious reduction of production list(targ) ->
-## In state 79, spurious reduction of production list(targ) -> targ list(targ)
+## In state 79, spurious reduction of production list(targ) ->
+## In state 81, spurious reduction of production list(targ) -> targ list(targ)
 ##
 # see tests/parser/bad/exps/exp_t-cid-lbrace-tid-eq.scilexp
 
@@ -1239,7 +1252,7 @@ The data constructor, list of type arguments is incorrect. The parser expects an
 
 exp_term: CID LBRACE WITH
 ##
-## Ends in an error in state: 175.
+## Ends in an error in state: 177.
 ##
 ## ctargs -> LBRACE . list(targ) RBRACE [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LPAREN LET IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
 ##
@@ -1252,7 +1265,7 @@ The data constructor, list of type arguments is incorrect. The parser expects a 
 
 exp_term: CID PERIOD CID WITH
 ##
-## Ends in an error in state: 197.
+## Ends in an error in state: 199.
 ##
 ## simple_exp -> scid . option(ctargs) list(sident) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1265,7 +1278,7 @@ This is an invalid expression, most likely the data constructor is missing argum
 
 exp_term: CID PERIOD WITH
 ##
-## Ends in an error in state: 172.
+## Ends in an error in state: 174.
 ##
 ## scid -> CID PERIOD . CID [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET LBRACE IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
 ## sid -> CID PERIOD . ID [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
@@ -1279,7 +1292,7 @@ This is an invalid expression, most likely the data constructor name is unfinish
 
 exp_term: CID WITH
 ##
-## Ends in an error in state: 171.
+## Ends in an error in state: 173.
 ##
 ## lit -> CID . NUMLIT [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ## scid -> CID . [ TYPE TRANSITION SPID SEMICOLON PROCEDURE LET LBRACE IN ID FIELD EOF END CONTRACT CID BAR ARROW ]
@@ -1295,7 +1308,7 @@ This is a malformed expression, it may be an incorrect data constructor usage.
 
 exp_term: EMP WITH
 ##
-## Ends in an error in state: 152.
+## Ends in an error in state: 154.
 ##
 ## lit -> EMP . t_map_key t_map_value [ TYPE TRANSITION SEMICOLON RBRACE PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1308,7 +1321,7 @@ The empty map has invalid key type (capitalised identifier).
 
 exp_term: FUN LPAREN ID COLON TID RPAREN ARROW WITH
 ##
-## Ends in an error in state: 170.
+## Ends in an error in state: 172.
 ##
 ## simple_exp -> FUN LPAREN id_with_typ RPAREN ARROW . exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1321,7 +1334,7 @@ This function is lacking a valid result expression.
 
 exp_term: FUN LPAREN ID COLON TID RPAREN WITH
 ##
-## Ends in an error in state: 169.
+## Ends in an error in state: 171.
 ##
 ## simple_exp -> FUN LPAREN id_with_typ RPAREN . ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1334,7 +1347,7 @@ This function needs an arrow (e.g. '=>') pointing to an expression.
 
 exp_term: FUN LPAREN ID COLON TID WITH
 ##
-## Ends in an error in state: 84.
+## Ends in an error in state: 86.
 ##
 ## typ -> typ . TARROW typ [ TARROW RPAREN EQ END COMMA ]
 ## type_annot -> COLON typ . [ RPAREN EQ END COMMA ]
@@ -1374,7 +1387,7 @@ Missing type annotation (a colon followed by a legal type).
 
 exp_term: FUN LPAREN WITH
 ##
-## Ends in an error in state: 167.
+## Ends in an error in state: 169.
 ##
 ## simple_exp -> FUN LPAREN . id_with_typ RPAREN ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1387,7 +1400,7 @@ This function is missing a valid argument identifier, beginning with a lower cas
 
 exp_term: FUN WITH
 ##
-## Ends in an error in state: 166.
+## Ends in an error in state: 168.
 ##
 ## simple_exp -> FUN . LPAREN id_with_typ RPAREN ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1400,7 +1413,7 @@ This function needs brackets for the argument.
 
 exp_term: LBRACE SPID COLON CID WITH
 ##
-## Ends in an error in state: 155.
+## Ends in an error in state: 157.
 ##
 ## lit -> CID . NUMLIT [ SEMICOLON RBRACE ]
 ## sid -> CID . PERIOD ID [ SEMICOLON RBRACE ]
@@ -1414,7 +1427,7 @@ This is an invalid message construction. The parser expects another message entr
 
 exp_term: LBRACE SPID COLON HEXLIT SEMICOLON WITH
 ##
-## Ends in an error in state: 161.
+## Ends in an error in state: 163.
 ##
 ## separated_nonempty_list(SEMICOLON,msg_entry) -> msg_entry SEMICOLON . separated_nonempty_list(SEMICOLON,msg_entry) [ RBRACE ]
 ##
@@ -1427,7 +1440,7 @@ This is an invalid message construction. The parser after a semicolon expects an
 
 exp_term: LBRACE SPID COLON HEXLIT WITH
 ##
-## Ends in an error in state: 160.
+## Ends in an error in state: 162.
 ##
 ## separated_nonempty_list(SEMICOLON,msg_entry) -> msg_entry . [ RBRACE ]
 ## separated_nonempty_list(SEMICOLON,msg_entry) -> msg_entry . SEMICOLON separated_nonempty_list(SEMICOLON,msg_entry) [ RBRACE ]
@@ -1441,7 +1454,7 @@ This is likely an invalid message construction. The parser expects another messa
 
 exp_term: LBRACE SPID COLON WITH
 ##
-## Ends in an error in state: 150.
+## Ends in an error in state: 152.
 ##
 ## msg_entry -> sid COLON . lit [ SEMICOLON RBRACE ]
 ## msg_entry -> sid COLON . sid [ SEMICOLON RBRACE ]
@@ -1455,7 +1468,7 @@ This is an invalid message construction. Following the colon, a literal or separ
 
 exp_term: LBRACE SPID WITH
 ##
-## Ends in an error in state: 149.
+## Ends in an error in state: 151.
 ##
 ## msg_entry -> sid . COLON lit [ SEMICOLON RBRACE ]
 ## msg_entry -> sid . COLON sid [ SEMICOLON RBRACE ]
@@ -1469,7 +1482,7 @@ This is an invalid message construction. With a message entry, the parser expect
 
 exp_term: LBRACE WITH
 ##
-## Ends in an error in state: 148.
+## Ends in an error in state: 150.
 ##
 ## simple_exp -> LBRACE . loption(separated_nonempty_list(SEMICOLON,msg_entry)) RBRACE [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1483,7 +1496,7 @@ This is an invalid message construction. The parser expects a semi-colon separat
 
 exp_term: LET ID COLON TID EQ STRING IN WITH
 ##
-## Ends in an error in state: 211.
+## Ends in an error in state: 213.
 ##
 ## simple_exp -> LET ID type_annot EQ simple_exp IN . exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1496,7 +1509,7 @@ This let expression (type-annotated) is likely missing an expression to substitu
 
 exp_term: LET ID EQ STRING IN WITH
 ##
-## Ends in an error in state: 206.
+## Ends in an error in state: 208.
 ##
 ## simple_exp -> LET ID EQ simple_exp IN . exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1509,7 +1522,7 @@ This let expression likely does not substitute a variable into a valid expressio
 
 exp_term: LET ID EQ STRING WITH
 ##
-## Ends in an error in state: 205.
+## Ends in an error in state: 207.
 ##
 ## simple_exp -> LET ID EQ simple_exp . IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1522,7 +1535,7 @@ This let expression is likely missing an 'in'.
 
 exp_term: LET ID EQ WITH
 ##
-## Ends in an error in state: 147.
+## Ends in an error in state: 149.
 ##
 ## simple_exp -> LET ID EQ . simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1535,7 +1548,7 @@ This let expression is missing an expression to substitute a variable in.
 
 exp_term: LET ID WITH
 ##
-## Ends in an error in state: 146.
+## Ends in an error in state: 148.
 ##
 ## simple_exp -> LET ID . EQ simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ## simple_exp -> LET ID . type_annot EQ simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
@@ -1549,7 +1562,7 @@ This let expression is missing an equals ('=') or type annotation, directly afte
 
 exp_term: LET WITH
 ##
-## Ends in an error in state: 145.
+## Ends in an error in state: 147.
 ##
 ## simple_exp -> LET . ID EQ simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ## simple_exp -> LET . ID type_annot EQ simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
@@ -1564,7 +1577,7 @@ This let expression is missing an identifier for the variable.
 
 exp_term: MATCH SPID UNDERSCORE
 ##
-## Ends in an error in state: 128.
+## Ends in an error in state: 130.
 ##
 ## simple_exp -> MATCH sid . WITH list(exp_pm_clause) END [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1577,7 +1590,7 @@ This match expression is missing 'with'.
 
 exp_term: MATCH SPID WITH BAR CID LPAREN UNDERSCORE WITH
 ##
-## Ends in an error in state: 136.
+## Ends in an error in state: 138.
 ##
 ## arg_pattern -> LPAREN pattern . RPAREN [ UNDERSCORE RPAREN LPAREN ID HEXLIT CID ARROW ]
 ##
@@ -1590,7 +1603,7 @@ This is an invalid match expression, possibly unterminated brackets for pattern 
 
 exp_term: MATCH SPID WITH BAR CID LPAREN WITH
 ##
-## Ends in an error in state: 135.
+## Ends in an error in state: 137.
 ##
 ## arg_pattern -> LPAREN . pattern RPAREN [ UNDERSCORE RPAREN LPAREN ID HEXLIT CID ARROW ]
 ##
@@ -1603,7 +1616,7 @@ This match expression has invalid pattern arguments, in the brackets we expect a
 
 exp_term: MATCH SPID WITH BAR CID UNDERSCORE WITH
 ##
-## Ends in an error in state: 141.
+## Ends in an error in state: 143.
 ##
 ## list(arg_pattern) -> arg_pattern . list(arg_pattern) [ RPAREN ARROW ]
 ##
@@ -1616,7 +1629,7 @@ In this match expression, following the pattern the parser expects an arrow (e.g
 
 exp_term: MATCH SPID WITH BAR UNDERSCORE ARROW WITH
 ##
-## Ends in an error in state: 144.
+## Ends in an error in state: 146.
 ##
 ## exp_pm_clause -> BAR pattern ARROW . exp [ END BAR ]
 ##
@@ -1629,7 +1642,7 @@ This is an invalid match expression. Following an arrow we expect a valid expres
 
 exp_term: MATCH SPID WITH BAR UNDERSCORE WITH
 ##
-## Ends in an error in state: 143.
+## Ends in an error in state: 145.
 ##
 ## exp_pm_clause -> BAR pattern . ARROW exp [ END BAR ]
 ##
@@ -1642,7 +1655,7 @@ This is in an invalid match expression. Following a pattern, we expect an arrow 
 
 exp_term: MATCH SPID WITH BAR WITH
 ##
-## Ends in an error in state: 130.
+## Ends in an error in state: 132.
 ##
 ## exp_pm_clause -> BAR . pattern ARROW exp [ END BAR ]
 ##
@@ -1655,7 +1668,7 @@ This is an invalid match expression. In a pattern matching clause following the 
 
 exp_term: MATCH SPID WITH WITH
 ##
-## Ends in an error in state: 129.
+## Ends in an error in state: 131.
 ##
 ## simple_exp -> MATCH sid WITH . list(exp_pm_clause) END [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1668,7 +1681,7 @@ This is an invalid match expression, a pattern matching clause is necessary (pos
 
 exp_term: MATCH WITH
 ##
-## Ends in an error in state: 123.
+## Ends in an error in state: 125.
 ##
 ## simple_exp -> MATCH . sid WITH list(exp_pm_clause) END [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1681,7 +1694,7 @@ This is an invalid match expression, it is lacking a valid identifier to match w
 
 exp_term: SPID CID PERIOD WITH
 ##
-## Ends in an error in state: 184.
+## Ends in an error in state: 186.
 ##
 ## sident -> CID PERIOD . ID [ TYPE TRANSITION SPID SEMICOLON RSQB RPAREN PROCEDURE LET IN ID FIELD EOF END CONTRACT COMMA CID BAR AS ARROW ]
 ##
@@ -1694,7 +1707,7 @@ This is an invalid expression, the identifier is incomplete or erroneous.
 
 exp_term: SPID CID WITH
 ##
-## Ends in an error in state: 183.
+## Ends in an error in state: 185.
 ##
 ## sident -> CID . PERIOD ID [ TYPE TRANSITION SPID SEMICOLON RSQB RPAREN PROCEDURE LET IN ID FIELD EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
@@ -1707,7 +1720,7 @@ This may be a type application missing '@' or an incorrect function application 
 
 exp_term: SPID SPID WITH
 ##
-## Ends in an error in state: 186.
+## Ends in an error in state: 188.
 ##
 ## nonempty_list(sident) -> sident . [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ## nonempty_list(sident) -> sident . nonempty_list(sident) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
@@ -1723,7 +1736,7 @@ If this is an application of a function, it is necessary to supply a list of val
 
 exp_term: SPID WITH
 ##
-## Ends in an error in state: 195.
+## Ends in an error in state: 197.
 ##
 ## atomic_exp -> sid . [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ## simple_exp -> sid . nonempty_list(sident) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
@@ -1737,7 +1750,7 @@ This is an invalid expression. If it is an application of a function, it is nece
 
 exp_term: STRING WITH
 ##
-## Ends in an error in state: 355.
+## Ends in an error in state: 356.
 ##
 ## exp_term -> exp . EOF [ # ]
 ##
@@ -1750,7 +1763,7 @@ This is not a valid expression, possible bad literal.
 
 exp_term: TFUN TID ARROW WITH
 ##
-## Ends in an error in state: 120.
+## Ends in an error in state: 122.
 ##
 ## simple_exp -> TFUN TID ARROW . exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1763,7 +1776,7 @@ Type functions expect a valid expression after the arrow.
 
 exp_term: TFUN TID WITH
 ##
-## Ends in an error in state: 119.
+## Ends in an error in state: 121.
 ##
 ## simple_exp -> TFUN TID . ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1776,7 +1789,7 @@ Type functions following the type id expect an arrow (e.g. '=>').
 
 exp_term: TFUN WITH
 ##
-## Ends in an error in state: 118.
+## Ends in an error in state: 120.
 ##
 ## simple_exp -> TFUN . TID ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -1789,7 +1802,7 @@ Type functions expect a type id (e.g. 'A).
 
 exp_term: WITH
 ##
-## Ends in an error in state: 353.
+## Ends in an error in state: 354.
 ##
 ## exp_term' -> . exp_term [ # ]
 ##
@@ -1802,7 +1815,7 @@ This is an invalid expression term, possibly avoid unnecessary brackets.
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN ID COLON CID COMMA WITH
 ##
-## Ends in an error in state: 88.
+## Ends in an error in state: 90.
 ##
 ## separated_nonempty_list(COMMA,param_pair) -> param_pair COMMA . separated_nonempty_list(COMMA,param_pair) [ RPAREN ]
 ##
@@ -1816,7 +1829,7 @@ Following a comma in the list of immutable fields, the parser expects another im
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD WITH
 ##
-## Ends in an error in state: 235.
+## Ends in an error in state: 237.
 ##
 ## field -> FIELD . id_with_typ EQ exp [ TRANSITION PROCEDURE FIELD EOF ]
 ##
@@ -1830,7 +1843,7 @@ For a mutable field declaration, the parser expects a valid lower case beginning
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN PROCEDURE ID LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 338.
+## Ends in an error in state: 339.
 ##
 ## procedure -> PROCEDURE component_id component_params . component_body [ TRANSITION PROCEDURE EOF ]
 ##
@@ -1843,7 +1856,7 @@ In the transition body the parser expects a list of semi-colon separated stateme
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN PROCEDURE ID WITH
 ##
-## Ends in an error in state: 337.
+## Ends in an error in state: 338.
 ##
 ## procedure -> PROCEDURE component_id . component_params component_body [ TRANSITION PROCEDURE EOF ]
 ##
@@ -1857,7 +1870,7 @@ be a left parenthesis.
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN PROCEDURE WITH
 ##
-## Ends in an error in state: 336.
+## Ends in an error in state: 337.
 ##
 ## procedure -> PROCEDURE . component_id component_params component_body [ TRANSITION PROCEDURE EOF ]
 ##
@@ -1870,7 +1883,7 @@ A procedure requires a valid name.
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN TRANSITION ID LPAREN RPAREN END WITH
 ##
-## Ends in an error in state: 343.
+## Ends in an error in state: 344.
 ##
 ## list(component) -> component . list(component) [ EOF ]
 ##
@@ -1883,7 +1896,7 @@ Following a transition definition, the parser expects a transition or a procedur
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN TRANSITION ID LPAREN RPAREN THROW BAR
 ##
-## Ends in an error in state: 332.
+## Ends in an error in state: 333.
 ##
 ## component_body -> stmts . END [ TRANSITION PROCEDURE EOF ]
 ##
@@ -1894,11 +1907,11 @@ cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN TRANSITION ID LPAREN R
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 249, spurious reduction of production option(sid) ->
-## In state 251, spurious reduction of production stmt -> THROW option(sid)
-## In state 320, spurious reduction of production separated_nonempty_list(SEMICOLON,stmt) -> stmt
-## In state 326, spurious reduction of production loption(separated_nonempty_list(SEMICOLON,stmt)) -> separated_nonempty_list(SEMICOLON,stmt)
-## In state 334, spurious reduction of production stmts -> loption(separated_nonempty_list(SEMICOLON,stmt))
+## In state 251, spurious reduction of production option(sid) ->
+## In state 253, spurious reduction of production stmt -> THROW option(sid)
+## In state 321, spurious reduction of production separated_nonempty_list(SEMICOLON,stmt) -> stmt
+## In state 327, spurious reduction of production loption(separated_nonempty_list(SEMICOLON,stmt)) -> separated_nonempty_list(SEMICOLON,stmt)
+## In state 335, spurious reduction of production stmts -> loption(separated_nonempty_list(SEMICOLON,stmt))
 ##
 # see tests/parser/cmodule-transition-id-lparen-rparen-throw-bar.scilla
 
@@ -1906,7 +1919,7 @@ Possible typo.
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN TRANSITION ID LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 248.
+## Ends in an error in state: 250.
 ##
 ## transition -> TRANSITION component_id component_params . component_body [ TRANSITION PROCEDURE EOF ]
 ##
@@ -1919,7 +1932,7 @@ After a transition has the parameters defined, we expect a semi-colon separated 
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN TRANSITION ID LPAREN WITH
 ##
-## Ends in an error in state: 245.
+## Ends in an error in state: 247.
 ##
 ## component_params -> LPAREN . loption(separated_nonempty_list(COMMA,param_pair)) RPAREN [ THROW SEND MATCH ID FORALL EVENT END DELETE CID ACCEPT ]
 ##
@@ -1933,7 +1946,7 @@ The transition parameter name is invalid. This should start with a lower case le
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN TRANSITION ID WITH
 ##
-## Ends in an error in state: 244.
+## Ends in an error in state: 246.
 ##
 ## transition -> TRANSITION component_id . component_params component_body [ TRANSITION PROCEDURE EOF ]
 ##
@@ -1946,7 +1959,7 @@ After a transition has been named, the parameters must be specified in brackets.
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN TRANSITION WITH
 ##
-## Ends in an error in state: 241.
+## Ends in an error in state: 243.
 ##
 ## transition -> TRANSITION . component_id component_params component_body [ TRANSITION PROCEDURE EOF ]
 ##
@@ -1959,7 +1972,7 @@ Transitions must begin with a valid name, this can be a lower case or capital le
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN UNDERSCORE
 ##
-## Ends in an error in state: 231.
+## Ends in an error in state: 233.
 ##
 ## contract -> CONTRACT CID LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN . list(field) list(component) [ EOF ]
 ## contract -> CONTRACT CID LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN . with_constraint list(field) list(component) [ EOF ]
@@ -1973,7 +1986,7 @@ After the definition of the immutable fields, either a contract constraint, the 
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN WITH
 ##
-## Ends in an error in state: 229.
+## Ends in an error in state: 231.
 ##
 ## contract -> CONTRACT CID LPAREN . loption(separated_nonempty_list(COMMA,param_pair)) RPAREN list(field) list(component) [ EOF ]
 ## contract -> CONTRACT CID LPAREN . loption(separated_nonempty_list(COMMA,param_pair)) RPAREN with_constraint list(field) list(component) [ EOF ]
@@ -1988,7 +2001,7 @@ The name of an immutable field should begin with a lower case letter ('a' - 'z')
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID WITH
 ##
-## Ends in an error in state: 228.
+## Ends in an error in state: 230.
 ##
 ## contract -> CONTRACT CID . LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN list(field) list(component) [ EOF ]
 ## contract -> CONTRACT CID . LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN with_constraint list(field) list(component) [ EOF ]
@@ -2002,7 +2015,7 @@ The declaration of zero or more immutable fields in brackets is expected.
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT WITH
 ##
-## Ends in an error in state: 227.
+## Ends in an error in state: 229.
 ##
 ## contract -> CONTRACT . CID LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN list(field) list(component) [ EOF ]
 ## contract -> CONTRACT . CID LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN with_constraint list(field) list(component) [ EOF ]
@@ -2016,7 +2029,7 @@ When a contract is being defined a valid identifier is expected.
 
 cmodule: SCILLA_VERSION NUMLIT LIBRARY CID EOF
 ##
-## Ends in an error in state: 226.
+## Ends in an error in state: 228.
 ##
 ## cmodule -> SCILLA_VERSION NUMLIT imports option(library) . contract EOF [ # ]
 ##
@@ -2028,8 +2041,8 @@ cmodule: SCILLA_VERSION NUMLIT LIBRARY CID EOF
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 12, spurious reduction of production list(libentry) ->
-## In state 223, spurious reduction of production library -> LIBRARY CID list(libentry)
-## In state 351, spurious reduction of production option(library) -> library
+## In state 225, spurious reduction of production library -> LIBRARY CID list(libentry)
+## In state 352, spurious reduction of production option(library) -> library
 ##
 # see tests/parser/bad/cmodule-version-number-library-name
 
@@ -2076,7 +2089,7 @@ Scilla version number unspecified.
 
 exp_term: CID LBRACE RBRACE AT
 ##
-## Ends in an error in state: 198.
+## Ends in an error in state: 200.
 ##
 ## simple_exp -> scid option(ctargs) . list(sident) [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -2089,7 +2102,7 @@ In a data constructor application, the parser expects valid separated uncapitali
 
 exp_term: LET ID COLON TID EQ STRING WITH
 ##
-## Ends in an error in state: 210.
+## Ends in an error in state: 212.
 ##
 ## simple_exp -> LET ID type_annot EQ simple_exp . IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -2102,7 +2115,7 @@ This typed let expression does not have a well placed 'in'.
 
 exp_term: LET ID COLON TID EQ WITH
 ##
-## Ends in an error in state: 209.
+## Ends in an error in state: 211.
 ##
 ## simple_exp -> LET ID type_annot EQ . simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -2115,7 +2128,7 @@ This typed let expression does not have a valid expression to use for the substi
 
 type_term: CID MAP CID TYPE
 ##
-## Ends in an error in state: 107.
+## Ends in an error in state: 109.
 ##
 ## targ -> MAP t_map_key . t_map_value [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
@@ -2127,14 +2140,14 @@ type_term: CID MAP CID TYPE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 25, spurious reduction of production scid -> CID
-## In state 51, spurious reduction of production t_map_key -> scid
+## In state 62, spurious reduction of production t_map_key -> scid
 ##
 
 Ends in an error in state: 101.
 
 type_term: CID TYPE
 ##
-## Ends in an error in state: 72.
+## Ends in an error in state: 74.
 ##
 ## typ -> scid . list(targ) [ TARROW RPAREN EQ EOF END COMMA ]
 ##
@@ -2152,7 +2165,7 @@ Ends in an error in state: 66.
 
 type_term: CID WITH CONTRACT FIELD ID COLON TID COMMA WITH
 ##
-## Ends in an error in state: 99.
+## Ends in an error in state: 101.
 ##
 ## separated_nonempty_list(COMMA,address_type_field) -> address_type_field COMMA . separated_nonempty_list(COMMA,address_type_field) [ END ]
 ##
@@ -2164,7 +2177,7 @@ Ends in an error in state: 93.
 
 type_term: CID WITH CONTRACT FIELD ID COLON TID RPAREN
 ##
-## Ends in an error in state: 98.
+## Ends in an error in state: 100.
 ##
 ## separated_nonempty_list(COMMA,address_type_field) -> address_type_field . [ END ]
 ## separated_nonempty_list(COMMA,address_type_field) -> address_type_field . COMMA separated_nonempty_list(COMMA,address_type_field) [ END ]
@@ -2176,16 +2189,16 @@ type_term: CID WITH CONTRACT FIELD ID COLON TID RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 84, spurious reduction of production type_annot -> COLON typ
-## In state 85, spurious reduction of production id_with_typ -> ID type_annot
-## In state 94, spurious reduction of production address_type_field -> FIELD id_with_typ
+## In state 86, spurious reduction of production type_annot -> COLON typ
+## In state 87, spurious reduction of production id_with_typ -> ID type_annot
+## In state 96, spurious reduction of production address_type_field -> FIELD id_with_typ
 ##
 
 Ends in an error in state: 92.
 
 type_term: CID WITH CONTRACT FIELD WITH
 ##
-## Ends in an error in state: 93.
+## Ends in an error in state: 95.
 ##
 ## address_type_field -> FIELD . id_with_typ [ END COMMA ]
 ##
@@ -2197,7 +2210,7 @@ Contract fields are not allowed to start with underscore.
 
 type_term: CID WITH CONTRACT LPAREN ID COLON TID EQ
 ##
-## Ends in an error in state: 87.
+## Ends in an error in state: 89.
 ##
 ## separated_nonempty_list(COMMA,param_pair) -> param_pair . [ RPAREN ]
 ## separated_nonempty_list(COMMA,param_pair) -> param_pair . COMMA separated_nonempty_list(COMMA,param_pair) [ RPAREN ]
@@ -2209,16 +2222,16 @@ type_term: CID WITH CONTRACT LPAREN ID COLON TID EQ
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 84, spurious reduction of production type_annot -> COLON typ
-## In state 85, spurious reduction of production id_with_typ -> ID type_annot
-## In state 90, spurious reduction of production param_pair -> id_with_typ
+## In state 86, spurious reduction of production type_annot -> COLON typ
+## In state 87, spurious reduction of production id_with_typ -> ID type_annot
+## In state 92, spurious reduction of production param_pair -> id_with_typ
 ##
 
 Ends in an error in state: 81.
 
 type_term: CID WITH CONTRACT LPAREN RPAREN WITH
 ##
-## Ends in an error in state: 92.
+## Ends in an error in state: 94.
 ##
 ## address_typ -> CID WITH CONTRACT LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN . loption(separated_nonempty_list(COMMA,address_type_field)) END [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
@@ -2279,7 +2292,7 @@ type_term: MAP CID MAP CID TYPE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 25, spurious reduction of production scid -> CID
-## In state 51, spurious reduction of production t_map_key -> scid
+## In state 62, spurious reduction of production t_map_key -> scid
 ##
 
 Ends in an error in state: 36.
@@ -2298,14 +2311,14 @@ type_term: MAP CID TYPE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 25, spurious reduction of production scid -> CID
-## In state 51, spurious reduction of production t_map_key -> scid
+## In state 62, spurious reduction of production t_map_key -> scid
 ##
 
 Likely an incorrect map value type: arrow types, forall-types and type variables are not supported.
 
 type_term: MAP LPAREN CID TYPE
 ##
-## Ends in an error in state: 103.
+## Ends in an error in state: 105.
 ##
 ## t_map_key -> LPAREN scid . RPAREN [ MAP LPAREN HEXLIT CID ]
 ##
@@ -2323,7 +2336,7 @@ Likely an incorrect map key type: only primitive types are supported.
 
 type_term: MAP LPAREN CID WITH END WITH
 ##
-## Ends in an error in state: 105.
+## Ends in an error in state: 107.
 ##
 ## t_map_key -> LPAREN address_typ . RPAREN [ MAP LPAREN HEXLIT CID ]
 ##
@@ -2335,7 +2348,7 @@ Ends in an error in state: 99.
 
 stmts_term: FORALL SPID WITH
 ##
-## Ends in an error in state: 312.
+## Ends in an error in state: 313.
 ##
 ## stmt -> FORALL sident . component_id [ SEMICOLON EOF END BAR ]
 ##
@@ -2347,7 +2360,7 @@ Ends in an error in state: 297.
 
 stmts_term: FORALL WITH
 ##
-## Ends in an error in state: 311.
+## Ends in an error in state: 312.
 ##
 ## stmt -> FORALL . sident component_id [ SEMICOLON EOF END BAR ]
 ##
@@ -2359,7 +2372,7 @@ Ends in an error in state: 296.
 
 stmts_term: ID FETCH AND CID PERIOD ID WITH
 ##
-## Ends in an error in state: 299.
+## Ends in an error in state: 300.
 ##
 ## remote_fetch_stmt -> ID FETCH AND sident . AS address_typ [ SEMICOLON EOF END BAR ]
 ##
@@ -2371,7 +2384,7 @@ Remote reads are not allowed to use namespaces.
 
 stmts_term: ID FETCH AND CID WITH
 ##
-## Ends in an error in state: 289.
+## Ends in an error in state: 291.
 ##
 ## sident -> CID . PERIOD ID [ AS ]
 ## stmt -> ID FETCH AND CID . option(bcfetch_args) [ SEMICOLON EOF END BAR ]
@@ -2384,7 +2397,7 @@ Ends in an error in state: 283.
 
 stmts_term: ID FETCH AND EXISTS ID PERIOD ID WITH
 ##
-## Ends in an error in state: 287.
+## Ends in an error in state: 289.
 ##
 ## remote_fetch_stmt -> ID FETCH AND EXISTS ID PERIOD ID . nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ##
@@ -2396,7 +2409,7 @@ Ends in an error in state: 281.
 
 stmts_term: ID FETCH AND EXISTS ID PERIOD WITH
 ##
-## Ends in an error in state: 286.
+## Ends in an error in state: 288.
 ##
 ## remote_fetch_stmt -> ID FETCH AND EXISTS ID PERIOD . ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ##
@@ -2408,7 +2421,7 @@ Ends in an error in state: 280.
 
 stmts_term: ID FETCH AND EXISTS ID WITH
 ##
-## Ends in an error in state: 285.
+## Ends in an error in state: 287.
 ##
 ## remote_fetch_stmt -> ID FETCH AND EXISTS ID . PERIOD ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ##
@@ -2420,7 +2433,7 @@ Ends in an error in state: 279.
 
 stmts_term: ID FETCH AND EXISTS WITH
 ##
-## Ends in an error in state: 284.
+## Ends in an error in state: 286.
 ##
 ## remote_fetch_stmt -> ID FETCH AND EXISTS . ID PERIOD ID nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ##
@@ -2432,7 +2445,7 @@ Ends in an error in state: 278.
 
 stmts_term: ID FETCH AND ID PERIOD ID WITH
 ##
-## Ends in an error in state: 281.
+## Ends in an error in state: 283.
 ##
 ## remote_fetch_stmt -> ID FETCH AND ID PERIOD ID . nonempty_list(map_access) [ SEMICOLON EOF END BAR ]
 ## sident -> ID . [ SEMICOLON EOF END BAR ]
@@ -2445,7 +2458,7 @@ Ends in an error in state: 275.
 
 stmts_term: ID FETCH AND ID PERIOD LPAREN SPID WITH
 ##
-## Ends in an error in state: 279.
+## Ends in an error in state: 281.
 ##
 ## remote_fetch_stmt -> ID FETCH AND ID PERIOD LPAREN sident . RPAREN [ SEMICOLON EOF END BAR ]
 ##
@@ -2457,7 +2470,7 @@ Ends in an error in state: 273.
 
 stmts_term: ID FETCH AND ID PERIOD LPAREN WITH
 ##
-## Ends in an error in state: 278.
+## Ends in an error in state: 280.
 ##
 ## remote_fetch_stmt -> ID FETCH AND ID PERIOD LPAREN . sident RPAREN [ SEMICOLON EOF END BAR ]
 ##
@@ -2469,7 +2482,7 @@ Ends in an error in state: 272.
 
 stmts_term: ID FETCH AND ID PERIOD WITH
 ##
-## Ends in an error in state: 277.
+## Ends in an error in state: 279.
 ##
 ## remote_fetch_stmt -> ID FETCH AND ID PERIOD . sident [ SEMICOLON EOF END BAR ]
 ## remote_fetch_stmt -> ID FETCH AND ID PERIOD . LPAREN sident RPAREN [ SEMICOLON EOF END BAR ]
@@ -2483,7 +2496,7 @@ Ends in an error in state: 271.
 
 stmts_term: ID FETCH AND ID WITH
 ##
-## Ends in an error in state: 276.
+## Ends in an error in state: 278.
 ##
 ## remote_fetch_stmt -> ID FETCH AND ID . PERIOD sident [ SEMICOLON EOF END BAR ]
 ## remote_fetch_stmt -> ID FETCH AND ID . PERIOD LPAREN sident RPAREN [ SEMICOLON EOF END BAR ]
@@ -2498,7 +2511,7 @@ Either blockchain state variable or remote field read expected.
 
 stmts_term: ID FETCH AND SPID AS CID UNDERSCORE
 ##
-## Ends in an error in state: 301.
+## Ends in an error in state: 302.
 ##
 ## address_typ -> CID . WITH END [ SEMICOLON EOF END BAR ]
 ## address_typ -> CID . WITH CONTRACT loption(separated_nonempty_list(COMMA,address_type_field)) END [ SEMICOLON EOF END BAR ]
@@ -2514,7 +2527,7 @@ Casts to non-ByStr20 types are not allowed.
 
 stmts_term: ID FETCH AND SPID AS WITH
 ##
-## Ends in an error in state: 300.
+## Ends in an error in state: 301.
 ##
 ## remote_fetch_stmt -> ID FETCH AND sident AS . address_typ [ SEMICOLON EOF END BAR ]
 ##
@@ -2526,7 +2539,7 @@ Ends in an error in state: 285.
 
 stmts_term: ID FETCH AND SPID PERIOD WITH
 ##
-## Ends in an error in state: 274.
+## Ends in an error in state: 276.
 ##
 ## remote_fetch_stmt -> ID FETCH AND SPID PERIOD . SPID [ SEMICOLON EOF END BAR ]
 ##
@@ -2538,7 +2551,7 @@ Ends in an error in state: 268.
 
 stmts_term: ID FETCH AND SPID WITH
 ##
-## Ends in an error in state: 273.
+## Ends in an error in state: 275.
 ##
 ## remote_fetch_stmt -> ID FETCH AND SPID . PERIOD SPID [ SEMICOLON EOF END BAR ]
 ## sident -> SPID . [ AS ]
@@ -2551,7 +2564,7 @@ Ends in an error in state: 267.
 
 lmodule: SCILLA_VERSION WITH
 ##
-## Ends in an error in state: 358.
+## Ends in an error in state: 359.
 ##
 ## lmodule -> SCILLA_VERSION . NUMLIT imports library EOF [ # ]
 ##
@@ -2563,7 +2576,7 @@ Ends in an error in state: 343.
 
 exp_term: BUILTIN ID LBRACE RBRACE CATCH
 ##
-## Ends in an error in state: 178.
+## Ends in an error in state: 180.
 ##
 ## simple_exp -> BUILTIN ID option(ctargs) . builtin_args [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -2575,7 +2588,7 @@ Ends in an error in state: 172.
 
 exp_term: EMP CID TYPE
 ##
-## Ends in an error in state: 153.
+## Ends in an error in state: 155.
 ##
 ## lit -> EMP t_map_key . t_map_value [ TYPE TRANSITION SEMICOLON RBRACE PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -2587,14 +2600,14 @@ exp_term: EMP CID TYPE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 25, spurious reduction of production scid -> CID
-## In state 51, spurious reduction of production t_map_key -> scid
+## In state 62, spurious reduction of production t_map_key -> scid
 ##
 
 Ends in an error in state: 147.
 
 exp_term: FUN LPAREN ID COLON TID EQ
 ##
-## Ends in an error in state: 168.
+## Ends in an error in state: 170.
 ##
 ## simple_exp -> FUN LPAREN id_with_typ . RPAREN ARROW exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -2605,8 +2618,8 @@ exp_term: FUN LPAREN ID COLON TID EQ
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 84, spurious reduction of production type_annot -> COLON typ
-## In state 85, spurious reduction of production id_with_typ -> ID type_annot
+## In state 86, spurious reduction of production type_annot -> COLON typ
+## In state 87, spurious reduction of production id_with_typ -> ID type_annot
 ##
 
 Ends in an error in state: 162.
@@ -2625,7 +2638,7 @@ Ends in an error in state: 23.
 
 exp_term: LET ID COLON CID RPAREN
 ##
-## Ends in an error in state: 208.
+## Ends in an error in state: 210.
 ##
 ## simple_exp -> LET ID type_annot . EQ simple_exp IN exp [ TYPE TRANSITION SEMICOLON PROCEDURE LET IN FIELD EOF END CONTRACT BAR ARROW ]
 ##
@@ -2637,16 +2650,16 @@ exp_term: LET ID COLON CID RPAREN
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 25, spurious reduction of production scid -> CID
-## In state 72, spurious reduction of production list(targ) ->
-## In state 81, spurious reduction of production typ -> scid list(targ)
-## In state 84, spurious reduction of production type_annot -> COLON typ
+## In state 74, spurious reduction of production list(targ) ->
+## In state 83, spurious reduction of production typ -> scid list(targ)
+## In state 86, spurious reduction of production type_annot -> COLON typ
 ##
 
 Ends in an error in state: 202.
 
 exp_term: MATCH SPID WITH BAR UNDERSCORE ARROW STRING WITH
 ##
-## Ends in an error in state: 216.
+## Ends in an error in state: 218.
 ##
 ## list(exp_pm_clause) -> exp_pm_clause . list(exp_pm_clause) [ END ]
 ##
@@ -2658,7 +2671,7 @@ match-expression is probably missing `end` keyword.
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD ID COLON TID EQ STRING WITH
 ##
-## Ends in an error in state: 345.
+## Ends in an error in state: 346.
 ##
 ## list(field) -> field . list(field) [ TRANSITION PROCEDURE EOF ]
 ##
@@ -2670,7 +2683,7 @@ A field, transition, procedure or end of file expected (e.g. semicolons are not 
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD ID COLON TID EQ WITH
 ##
-## Ends in an error in state: 237.
+## Ends in an error in state: 239.
 ##
 ## field -> FIELD id_with_typ EQ . exp [ TRANSITION PROCEDURE FIELD EOF ]
 ##
@@ -2682,7 +2695,7 @@ Valid initializing expression expected.
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD ID COLON TID RPAREN
 ##
-## Ends in an error in state: 236.
+## Ends in an error in state: 238.
 ##
 ## field -> FIELD id_with_typ . EQ exp [ TRANSITION PROCEDURE FIELD EOF ]
 ##
@@ -2693,15 +2706,15 @@ cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN FIELD ID COLON TID RPA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 84, spurious reduction of production type_annot -> COLON typ
-## In state 85, spurious reduction of production id_with_typ -> ID type_annot
+## In state 86, spurious reduction of production type_annot -> COLON typ
+## In state 87, spurious reduction of production id_with_typ -> ID type_annot
 ##
 
 Ends in an error in state: 230.
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN WITH STRING ARROW WITH
 ##
-## Ends in an error in state: 239.
+## Ends in an error in state: 241.
 ##
 ## contract -> CONTRACT CID LPAREN loption(separated_nonempty_list(COMMA,param_pair)) RPAREN with_constraint . list(field) list(component) [ EOF ]
 ##
@@ -2713,7 +2726,7 @@ Ends in an error in state: 233.
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN WITH STRING WITH
 ##
-## Ends in an error in state: 233.
+## Ends in an error in state: 235.
 ##
 ## with_constraint -> WITH exp . ARROW [ TRANSITION PROCEDURE FIELD EOF ]
 ##
@@ -2725,7 +2738,7 @@ Ends in an error in state: 227.
 
 cmodule: SCILLA_VERSION NUMLIT CONTRACT CID LPAREN RPAREN WITH WITH
 ##
-## Ends in an error in state: 232.
+## Ends in an error in state: 234.
 ##
 ## with_constraint -> WITH . exp ARROW [ TRANSITION PROCEDURE FIELD EOF ]
 ##
@@ -2737,7 +2750,7 @@ Ends in an error in state: 226.
 
 cmodule: SCILLA_VERSION NUMLIT LIBRARY CID LET ID COLON CID RPAREN
 ##
-## Ends in an error in state: 220.
+## Ends in an error in state: 222.
 ##
 ## libentry -> LET ID type_annot . EQ exp [ TYPE LET EOF CONTRACT ]
 ##
@@ -2749,16 +2762,16 @@ cmodule: SCILLA_VERSION NUMLIT LIBRARY CID LET ID COLON CID RPAREN
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 25, spurious reduction of production scid -> CID
-## In state 72, spurious reduction of production list(targ) ->
-## In state 81, spurious reduction of production typ -> scid list(targ)
-## In state 84, spurious reduction of production type_annot -> COLON typ
+## In state 74, spurious reduction of production list(targ) ->
+## In state 83, spurious reduction of production typ -> scid list(targ)
+## In state 86, spurious reduction of production type_annot -> COLON typ
 ##
 
 Ends in an error in state: 214.
 
 cmodule: SCILLA_VERSION NUMLIT LIBRARY CID LET ID EQ STRING WITH
 ##
-## Ends in an error in state: 224.
+## Ends in an error in state: 226.
 ##
 ## list(libentry) -> libentry . list(libentry) [ EOF CONTRACT ]
 ##
@@ -2770,10 +2783,10 @@ Incorrect library entry: probably `let` keyword expected.
 
 type_term: MAP CID LPAREN CID CID UNDERSCORE
 ##
-## Ends in an error in state: 59.
+## Ends in an error in state: 58.
 ##
-## nonempty_list(t_map_value_args) -> t_map_value_args . [ RPAREN ]
-## nonempty_list(t_map_value_args) -> t_map_value_args . nonempty_list(t_map_value_args) [ RPAREN ]
+## nonempty_list(t_map_value_args) -> t_map_value_args . [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+## nonempty_list(t_map_value_args) -> t_map_value_args . nonempty_list(t_map_value_args) [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## t_map_value_args
@@ -2782,8 +2795,8 @@ type_term: MAP CID LPAREN CID CID UNDERSCORE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 56, spurious reduction of production scid -> CID
-## In state 60, spurious reduction of production t_map_value_args -> scid
+## In state 55, spurious reduction of production scid -> CID
+## In state 59, spurious reduction of production t_map_value_args -> scid
 ##
 # See tests/parser/bad/type_t-map-cid-lparen-cid-cid-underscore.scilla
 
@@ -2791,9 +2804,9 @@ This is an invalid map type, the map value type is likely incorrect. The map typ
 
 type_term: MAP CID LPAREN CID LPAREN MAP CID CID RBRACE
 ##
-## Ends in an error in state: 54.
+## Ends in an error in state: 52.
 ##
-## t_map_value_args -> LPAREN t_map_value_allow_targs . RPAREN [ RPAREN MAP LPAREN HEXLIT CID ]
+## t_map_value_args -> LPAREN t_map_value_allow_targs . RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN t_map_value_allow_targs
@@ -2803,9 +2816,9 @@ type_term: MAP CID LPAREN CID LPAREN MAP CID CID RBRACE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 25, spurious reduction of production scid -> CID
-## In state 49, spurious reduction of production t_map_value -> scid
-## In state 63, spurious reduction of production t_map_value -> MAP t_map_key t_map_value
-## In state 44, spurious reduction of production t_map_value_allow_targs -> t_map_value
+## In state 50, spurious reduction of production t_map_value -> scid
+## In state 65, spurious reduction of production t_map_value -> MAP t_map_key t_map_value
+## In state 45, spurious reduction of production t_map_value_allow_targs -> t_map_value
 ##
 # See tests/parser/bad/type_t-map-cid-lparen-cid-lparen-map-cid-cid-rbrace.scilla
 
@@ -2813,9 +2826,9 @@ This is an invalid map type, the map value type is likely incorrect. The map typ
 
 type_term: MAP CID LPAREN CID LPAREN WITH
 ##
-## Ends in an error in state: 53.
+## Ends in an error in state: 51.
 ##
-## t_map_value_args -> LPAREN . t_map_value_allow_targs RPAREN [ RPAREN MAP LPAREN HEXLIT CID ]
+## t_map_value_args -> LPAREN . t_map_value_allow_targs RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -2826,9 +2839,9 @@ This is an invalid map type, the map value type is likely incorrect, possibly be
 
 type_term: MAP CID LPAREN CID MAP CID TYPE
 ##
-## Ends in an error in state: 47.
+## Ends in an error in state: 48.
 ##
-## t_map_value_args -> MAP t_map_key . t_map_value [ RPAREN MAP LPAREN HEXLIT CID ]
+## t_map_value_args -> MAP t_map_key . t_map_value [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## MAP t_map_key
@@ -2838,7 +2851,7 @@ type_term: MAP CID LPAREN CID MAP CID TYPE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 25, spurious reduction of production scid -> CID
-## In state 51, spurious reduction of production t_map_key -> scid
+## In state 62, spurious reduction of production t_map_key -> scid
 ##
 # See tests/parser/bad/type_t-map-cid-lparen-cid-map-cid-type.scilla
 
@@ -2846,9 +2859,9 @@ This is an invalid map type, the map value type is likely incorrect. The map typ
 
 type_term: MAP CID LPAREN CID MAP WITH
 ##
-## Ends in an error in state: 46.
+## Ends in an error in state: 47.
 ##
-## t_map_value_args -> MAP . t_map_key t_map_value [ RPAREN MAP LPAREN HEXLIT CID ]
+## t_map_value_args -> MAP . t_map_key t_map_value [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
 ##
 ## The known suffix of the stack is as follows:
 ## MAP
@@ -2859,10 +2872,11 @@ This is an invalid map type, the map value type is likely incorrect. The map typ
 
 type_term: MAP CID LPAREN CID TYPE
 ##
-## Ends in an error in state: 45.
+## Ends in an error in state: 46.
 ##
 ## t_map_value -> scid . [ RPAREN ]
 ## t_map_value_allow_targs -> scid . nonempty_list(t_map_value_args) [ RPAREN ]
+## t_map_value_allow_targs_deprecated -> scid . nonempty_list(t_map_value_args) [ RPAREN ]
 ##
 ## The known suffix of the stack is as follows:
 ## scid
@@ -2877,31 +2891,9 @@ type_term: MAP CID LPAREN CID TYPE
 
 This is an invalid map type, the map value type is likely incorrect. The map type must be a storable type, i.e., a base type, a valid ADT, or a map type.
 
-type_term: MAP CID LPAREN MAP CID CID TYPE
-##
-## Ends in an error in state: 42.
-##
-## t_map_value -> LPAREN t_map_value_allow_targs . RPAREN [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN t_map_value_allow_targs
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 25, spurious reduction of production scid -> CID
-## In state 49, spurious reduction of production t_map_value -> scid
-## In state 63, spurious reduction of production t_map_value -> MAP t_map_key t_map_value
-## In state 44, spurious reduction of production t_map_value_allow_targs -> t_map_value
-##
-# See tests/parser/bad/type_t-map-cid-lparen-map-cid-cid-type.scilla
-
-This is an invalid map type, the map value type is likely incorrect. The map type must be a storable type, i.e., a base type, a valid ADT, or a map type.
-
 exp_term: MATCH SPID WITH BAR CID MAP
 ##
-## Ends in an error in state: 133.
+## Ends in an error in state: 135.
 ##
 ## pattern -> scid . list(arg_pattern) [ RPAREN ARROW ]
 ##
@@ -2912,7 +2904,7 @@ exp_term: MATCH SPID WITH BAR CID MAP
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 56, spurious reduction of production scid -> CID
+## In state 55, spurious reduction of production scid -> CID
 ##
 # See tests/parser/bad/stmts_t-match-spid-with-bar-cid-map.scilla
 
@@ -2944,9 +2936,9 @@ Ends in an error in state: 29. Please report your example at https://github.com/
 
 stmts_term: ID FETCH AND CID LPAREN WITH
 ##
-## Ends in an error in state: 290.
+## Ends in an error in state: 292.
 ##
-## bcfetch_args -> LPAREN . loption(separated_nonempty_list(COMMA,sident)) RPAREN [ SEMICOLON EOF END BAR ]
+## bcfetch_args -> LPAREN . separated_nonempty_list(COMMA,sident) RPAREN [ SEMICOLON EOF END BAR ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -2956,7 +2948,7 @@ Ends in an error in state: 290. Please report your example at https://github.com
 
 stmts_term: ID FETCH AND CID LPAREN ID WITH
 ##
-## Ends in an error in state: 291.
+## Ends in an error in state: 293.
 ##
 ## separated_nonempty_list(COMMA,sident) -> sident . [ RPAREN ]
 ## separated_nonempty_list(COMMA,sident) -> sident . COMMA separated_nonempty_list(COMMA,sident) [ RPAREN ]
@@ -2969,7 +2961,7 @@ Ends in an error in state: 291. Please report your example at https://github.com
 
 stmts_term: ID FETCH AND CID LPAREN ID COMMA WITH
 ##
-## Ends in an error in state: 292.
+## Ends in an error in state: 294.
 ##
 ## separated_nonempty_list(COMMA,sident) -> sident COMMA . separated_nonempty_list(COMMA,sident) [ RPAREN ]
 ##
@@ -2978,3 +2970,29 @@ stmts_term: ID FETCH AND CID LPAREN ID COMMA WITH
 ##
 
 Ends in an error in state: 292. Please report your example at https://github.com/Zilliqa/scilla/issues.
+
+exp_term: EMP CID CID PERIOD CID WITH
+##
+## Ends in an error in state: 50.
+##
+## t_map_value -> scid . [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+## t_map_value_allow_targs_deprecated -> scid . nonempty_list(t_map_value_args) [ TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+##
+## The known suffix of the stack is as follows:
+## scid
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+exp_term: EMP CID CID CID WITH
+##
+## Ends in an error in state: 55.
+##
+## scid -> CID . [ UNDERSCORE TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN ID HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+## scid -> CID . PERIOD CID [ UNDERSCORE TYPE TRANSITION TID TARROW SEMICOLON RPAREN RBRACE PROCEDURE MAP LPAREN LET IN ID HEXLIT FIELD EQ EOF END CONTRACT COMMA CID BAR ARROW ]
+##
+## The known suffix of the stack is as follows:
+## CID
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>

--- a/src/base/ScillaParser.mly
+++ b/src/base/ScillaParser.mly
@@ -233,6 +233,14 @@ t_map_value :
     { (* We only allow targs when the type is surrounded by parentheses *)
       t }
 | vt = address_typ; { vt }
+| t = t_map_value_allow_targs_deprecated { t }
+
+t_map_value_allow_targs_deprecated :
+| d = scid; targs = nonempty_list(t_map_value_args)
+  {
+    match targs with
+    | [] -> to_type d (toLoc $startpos(d))
+    | _ -> ADT (SIdentifier.mk_id d (toLoc $startpos(d)), targs) }
 
 t_map_value_allow_targs :
 | d = scid; targs = nonempty_list(t_map_value_args)

--- a/tests/base/parser/bad/gold/stmts_t-match-spid-with-bar-cid-cid-with.scilla.gold
+++ b/tests/base/parser/bad/gold/stmts_t-match-spid-with-bar-cid-cid-with.scilla.gold
@@ -2,7 +2,7 @@
   "errors": [
     {
       "error_message":
-        "Invalid type or pattern. If this is a type, then this is likely due to an illegal map value type. If this is a pattern-match, then it is likely due to a misplaced or missing double arrow ('=>').\n",
+        "In this match expression, following the pattern the parser expects an arrow (e.g. '=>').\n",
       "start_location": {
         "file":
           "base/parser/bad/stmts_t-match-spid-with-bar-cid-cid-with.scilla",

--- a/tests/base/parser/bad/gold/type_t-map-cid-cid-cid-underscore.scilla.gold
+++ b/tests/base/parser/bad/gold/type_t-map-cid-cid-cid-underscore.scilla.gold
@@ -2,11 +2,11 @@
   "errors": [
     {
       "error_message":
-        "This type annotation is not closed properly, or is missing parentheses to group the types, or has a missing or misplaced '='.\n",
+        "This is an invalid map type, the map value type is likely incorrect. The map type must be a storable type, i.e., a base type, a valid ADT, or a map type.\n",
       "start_location": {
         "file": "base/parser/bad/type_t-map-cid-cid-cid-underscore.scilla",
         "line": 6,
-        "column": 32
+        "column": 37
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/base/parser/bad/gold/type_t-map-cid-cid-lparen-cid-underscore.scilla.gold
+++ b/tests/base/parser/bad/gold/type_t-map-cid-cid-lparen-cid-underscore.scilla.gold
@@ -2,12 +2,12 @@
   "errors": [
     {
       "error_message":
-        "This type annotation is not closed properly, or is missing parentheses to group the types, or has a missing or misplaced '='.\n",
+        "This map type likely has an invalid map value type.\n",
       "start_location": {
         "file":
           "base/parser/bad/type_t-map-cid-cid-lparen-cid-underscore.scilla",
         "line": 5,
-        "column": 29
+        "column": 42
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/base/parser/bad/gold/type_t-map-cid-cid-lparen-with.scilla.gold
+++ b/tests/base/parser/bad/gold/type_t-map-cid-cid-lparen-with.scilla.gold
@@ -2,11 +2,11 @@
   "errors": [
     {
       "error_message":
-        "This type annotation is not closed properly, or is missing parentheses to group the types, or has a missing or misplaced '='.\n",
+        "This is an invalid map type, the map value type is likely incorrect, possibly because of an unclosed parenthesis. The map type must be a storable type, i.e., a base type, a valid ADT, or a map type.\n",
       "start_location": {
         "file": "base/parser/bad/type_t-map-cid-cid-lparen-with.scilla",
         "line": 5,
-        "column": 29
+        "column": 35
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/base/parser/bad/gold/type_t-map-cid-cid-map-cid-underscore.scilla.gold
+++ b/tests/base/parser/bad/gold/type_t-map-cid-cid-map-cid-underscore.scilla.gold
@@ -2,12 +2,12 @@
   "errors": [
     {
       "error_message":
-        "This type annotation is not closed properly, or is missing parentheses to group the types, or has a missing or misplaced '='.\n",
+        "This map type likely has an invalid map value type.\n",
       "start_location": {
         "file":
           "base/parser/bad/type_t-map-cid-cid-map-cid-underscore.scilla",
         "line": 5,
-        "column": 31
+        "column": 46
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/base/parser/bad/gold/type_t-map-cid-cid-map-with.scilla.gold
+++ b/tests/base/parser/bad/gold/type_t-map-cid-cid-map-with.scilla.gold
@@ -2,11 +2,11 @@
   "errors": [
     {
       "error_message":
-        "This type annotation is not closed properly, or is missing parentheses to group the types, or has a missing or misplaced '='.\n",
+        "This is an invalid map type, the map value type is likely incorrect. The map type must be a storable type, i.e., a base type, a valid ADT, or a map type.\n",
       "start_location": {
         "file": "base/parser/bad/type_t-map-cid-cid-map-with.scilla",
         "line": 6,
-        "column": 31
+        "column": 38
       },
       "end_location": { "file": "", "line": 0, "column": 0 }
     }

--- a/tests/base/parser/bad/gold/type_t-map-cid-lparen-map-cid-cid-type.scilla.gold
+++ b/tests/base/parser/bad/gold/type_t-map-cid-lparen-map-cid-cid-type.scilla.gold
@@ -2,7 +2,7 @@
   "errors": [
     {
       "error_message":
-        "This is an invalid map type, the map value type is likely incorrect. The map type must be a storable type, i.e., a base type, a valid ADT, or a map type.\n",
+        "Invalid type or pattern. If this is a type, then this is likely due to an illegal map value type. If this is a pattern-match, then it is likely due to a misplaced or missing double arrow ('=>').\n",
       "start_location": {
         "file":
           "base/parser/bad/type_t-map-cid-lparen-map-cid-cid-type.scilla",


### PR DESCRIPTION
Test results against contract set:
```
$ python test_scilla.py
Passed: 120752, Failed: 0
Test failed: contracts/0x3c3c3013929c4fa1d4de0747ab7bbbb516712db5.scilla
Passed: 131419, Failed: 1
Finished testing.
```
This is similar to what we have on master.